### PR TITLE
Rename gr to gumroad

### DIFF
--- a/.claude/skills/gumroad-cli/SKILL.md
+++ b/.claude/skills/gumroad-cli/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: gr-cli
-description: Use the `gr` CLI to look up and manage Gumroad data from the terminal. Trigger when the user asks about Gumroad products, sales, subscribers, licenses, payouts, offer codes, webhooks, or any Gumroad data lookup. Also trigger on "check my Gumroad", "look up a sale", "verify a license", "list my products", or any request to query or act on Gumroad data. Do NOT trigger for Gumroad web UI, Rails, or codebase questions.
+name: gumroad-cli
+description: Use the `gumroad` CLI to look up and manage Gumroad data from the terminal. Trigger when the user asks about Gumroad products, sales, subscribers, licenses, payouts, offer codes, webhooks, or any Gumroad data lookup. Also trigger on "check my Gumroad", "look up a sale", "verify a license", "list my products", or any request to query or act on Gumroad data. Do NOT trigger for Gumroad web UI, Rails, or codebase questions.
 ---
 
-# gr CLI
+# gumroad CLI
 
-Use `gr` (Gumroad CLI) to query and manage Gumroad data. Always use `--json` for programmatic access and `--no-input` to prevent interactive prompts from hanging.
+Use `gumroad` (Gumroad CLI) to query and manage Gumroad data. Always use `--json` for programmatic access and `--no-input` to prevent interactive prompts from hanging.
 
 ## Key flags
 
@@ -21,31 +21,31 @@ Use `gr` (Gumroad CLI) to query and manage Gumroad data. Always use `--json` for
 
 ```sh
 # Check auth status
-gr auth status --no-input
+gumroad auth status --no-input
 
 # List all products
-gr products list --json --no-input
+gumroad products list --json --no-input
 
 # Get a specific product
-gr products view <id> --json --no-input
+gumroad products view <id> --json --no-input
 
 # Find a sale by email
-gr sales list --json --jq '.sales[] | select(.email == "user@example.com")' --no-input
+gumroad sales list --json --jq '.sales[] | select(.email == "user@example.com")' --no-input
 
 # Get recent sales for a product
-gr sales list --product <id> --after 2026-01-01 --json --no-input
+gumroad sales list --product <id> --after 2026-01-01 --json --no-input
 
 # Extract a single field
-gr user --json --jq '.user.email' --no-input
+gumroad user --json --jq '.user.email' --no-input
 
 # Verify a license key
-gr licenses verify --product <id> --key <key> --no-increment --json --no-input
+gumroad licenses verify --product <id> --key <key> --no-increment --json --no-input
 
 # List subscribers
-gr subscribers list --product <id> --json --no-input
+gumroad subscribers list --product <id> --json --no-input
 
 # Check upcoming payouts
-gr payouts upcoming --json --no-input
+gumroad payouts upcoming --json --no-input
 ```
 
 ## Available commands
@@ -70,6 +70,6 @@ webhooks       list, create, delete
 - Always include `--no-input` to prevent the CLI from blocking on interactive prompts.
 - Use `--json --jq` together to extract exactly what you need without parsing.
 - The API does not support product create/update — only list, view, delete, enable, disable.
-- If `gr auth status` fails, the user needs to run `gr auth login` interactively.
+- If `gumroad auth status` fails, the user needs to run `gumroad auth login` interactively.
 - For destructive operations (delete, refund), add `--yes` to skip confirmation.
-- Run `gr <command> --help` for flag details on any specific command.
+- Run `gumroad <command> --help` for flag details on any specific command.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,10 @@ jobs:
           go-version-file: go.mod
       - run: go test ./...
       - run: go run ./cmd/gen-man
-      - run: go build ./cmd/gr
+      - run: go build ./cmd/gumroad
   live-smoke:
     name: Live API smoke
-    if: ${{ github.event_name != 'pull_request' && secrets.GR_SMOKE_ACCESS_TOKEN != '' }}
+    if: ${{ github.event_name != 'pull_request' && secrets.GUMROAD_SMOKE_ACCESS_TOKEN != '' }}
     needs: quality
     runs-on: ubuntu-latest
     steps:
@@ -52,4 +52,4 @@ jobs:
           go-version-file: go.mod
       - run: make test-smoke
         env:
-          GR_ACCESS_TOKEN: ${{ secrets.GR_SMOKE_ACCESS_TOKEN }}
+          GUMROAD_ACCESS_TOKEN: ${{ secrets.GUMROAD_SMOKE_ACCESS_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,10 +1,10 @@
 version: 2
 
 builds:
-  - main: ./cmd/gr
-    binary: gr
+  - main: ./cmd/gumroad
+    binary: gumroad
     ldflags:
-      - -s -w -X github.com/antiwork/gr/internal/cmd.Version={{.Version}}
+      - -s -w -X github.com/antiwork/gumroad-cli/internal/cmd.Version={{.Version}}
     goos:
       - darwin
       - linux
@@ -23,7 +23,7 @@ archives:
 checksum:
   name_template: "checksums.txt"
 
-# Brew tap — inactive until repo moves to antiwork/gr
+# Brew tap — inactive until packaging is set up
 # brews:
 #   - repository:
 #       owner: antiwork

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Build & test
 
 ```sh
-make build        # Compile to ./gr
+make build        # Compile to ./gumroad
 make test         # Run all tests
 make test-cover   # Tests + coverage gates (85% cmd, 90% infra)
 make lint         # golangci-lint
@@ -11,10 +11,10 @@ make lint         # golangci-lint
 
 ## Project structure
 
-- `cmd/gr/main.go` — entry point, calls `cmd.Execute()`
+- `cmd/gumroad/main.go` — entry point, calls `cmd.Execute()`
 - `internal/cmd/` — one package per noun (products, sales, etc.), each with cobra commands
 - `internal/api/` — HTTP client (`client.go`) and error rewriting (`errors.go`)
-- `internal/config/` — XDG config at `~/.config/gr/config.json`, `0600` perms
+- `internal/config/` — XDG config at `~/.config/gumroad/config.json`, `0600` perms
 - `internal/output/` — table, JSON, plain, color, spinner, pager, image rendering
 - `internal/prompt/` — interactive token input and Y/N confirmations
 - `internal/cmdutil/` — per-command `Options` struct (JSON, quiet, dry-run, etc.) and request runners

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-BINARY := gr
+BINARY := gumroad
 VERSION ?= dev
-LDFLAGS := -ldflags "-s -w -X github.com/antiwork/gr/internal/cmd.Version=$(VERSION)"
+LDFLAGS := -ldflags "-s -w -X github.com/antiwork/gumroad-cli/internal/cmd.Version=$(VERSION)"
 PREFIX ?= /usr/local
 DESTDIR ?=
 BIN_DIR := $(DESTDIR)$(PREFIX)/bin
@@ -9,13 +9,13 @@ MAN_DIR := $(DESTDIR)$(PREFIX)/share/man/man1
 BASH_COMPLETION_DIR := $(SHARE_DIR)/bash-completion/completions
 ZSH_COMPLETION_DIR := $(SHARE_DIR)/zsh/site-functions
 FISH_COMPLETION_DIR := $(SHARE_DIR)/fish/vendor_completions.d
-POWERSHELL_COMPLETION_DIR := $(SHARE_DIR)/powershell/Modules/gr
+POWERSHELL_COMPLETION_DIR := $(SHARE_DIR)/powershell/Modules/gumroad
 INSTALL ?= install
 
 .PHONY: build install test test-cover test-race test-smoke lint clean snapshot man
 
 build:
-	go build $(LDFLAGS) -o $(BINARY) ./cmd/gr
+	go build $(LDFLAGS) -o $(BINARY) ./cmd/gumroad
 
 install: build man
 	@mkdir -p "$(BIN_DIR)" "$(MAN_DIR)" \
@@ -25,28 +25,28 @@ install: build man
 		"$(POWERSHELL_COMPLETION_DIR)"
 	$(INSTALL) -m 0755 "$(BINARY)" "$(BIN_DIR)/$(BINARY)"
 	@find man -name '*.1' -type f -exec $(INSTALL) -m 0644 {} "$(MAN_DIR)/" \;
-	./$(BINARY) completion bash > "$(BASH_COMPLETION_DIR)/gr"
-	./$(BINARY) completion zsh > "$(ZSH_COMPLETION_DIR)/_gr"
-	./$(BINARY) completion fish > "$(FISH_COMPLETION_DIR)/gr.fish"
-	./$(BINARY) completion powershell > "$(POWERSHELL_COMPLETION_DIR)/gr.ps1"
+	./$(BINARY) completion bash > "$(BASH_COMPLETION_DIR)/gumroad"
+	./$(BINARY) completion zsh > "$(ZSH_COMPLETION_DIR)/_gumroad"
+	./$(BINARY) completion fish > "$(FISH_COMPLETION_DIR)/gumroad.fish"
+	./$(BINARY) completion powershell > "$(POWERSHELL_COMPLETION_DIR)/gumroad.ps1"
 
 test:
 	go test ./...
 
 test-smoke:
-	GR_SMOKE=1 go test ./test -run Smoke -count=1
+	GUMROAD_SMOKE=1 go test ./test -run Smoke -count=1
 
 COVER_MIN_PKG := 85
 COVER_MIN_INFRA := 90
 
 # Coverage thresholds intentionally target the substantive internal packages.
-# Thin entrypoints/tooling packages such as cmd/gr, cmd/gen-man, and
+# Thin entrypoints/tooling packages such as cmd/gumroad, cmd/gen-man, and
 # support-only packages like internal/testutil are validated by tests and CI,
 # but are not threshold-gated here.
 test-cover:
-	go test ./... -cover > /tmp/gr-cover.out 2>&1; \
+	go test ./... -cover > /tmp/gumroad-cover.out 2>&1; \
 		TEST_EXIT=$$?; \
-		cat /tmp/gr-cover.out; \
+		cat /tmp/gumroad-cover.out; \
 		if [ $$TEST_EXIT -ne 0 ]; then echo "FAIL: go test exited with status $$TEST_EXIT"; exit $$TEST_EXIT; fi
 	@echo "---"
 	@awk ' \
@@ -60,8 +60,8 @@ test-cover:
 				else { printf "OK: %s %.1f%%\n", pkg, cov } \
 			} \
 		} \
-		END { if (fail) exit 1 }' /tmp/gr-cover.out
-	@rm -f /tmp/gr-cover.out
+		END { if (fail) exit 1 }' /tmp/gumroad-cover.out
+	@rm -f /tmp/gumroad-cover.out
 
 test-race:
 	go test -race ./...

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-# gr
+# gumroad-cli
 
 CLI for the Gumroad API. Designed for humans and AI agents alike.
 
-[![CI](https://github.com/antiwork/gr/actions/workflows/ci.yml/badge.svg)](https://github.com/antiwork/gr/actions/workflows/ci.yml)
-[![Go](https://img.shields.io/github/go-mod/go-version/antiwork/gr)](https://github.com/antiwork/gr)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/antiwork/gr/blob/main/LICENSE)
+[![CI](https://github.com/antiwork/gumroad-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/antiwork/gumroad-cli/actions/workflows/ci.yml)
+[![Go](https://img.shields.io/github/go-mod/go-version/antiwork/gumroad-cli)](https://github.com/antiwork/gumroad-cli)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/antiwork/gumroad-cli/blob/main/LICENSE)
 
 ```
-$ gr products list
+$ gumroad products list
 ID            NAME              STATUS     PRICE
 abc123        Design Templates  published  $25.00
 def456        Icon Pack         published  $10.00
 
-$ gr sales list --json --jq '.sales[0].email'
+$ gumroad sales list --json --jq '.sales[0].email'
 "customer@example.com"
 ```
 
@@ -21,7 +21,7 @@ $ gr sales list --json --jq '.sales[0].email'
 **Go**:
 
 ```sh
-go install github.com/antiwork/gr/cmd/gr@latest
+go install github.com/antiwork/gumroad-cli/cmd/gumroad@latest
 ```
 
 **Local install with man pages and completions**:
@@ -43,46 +43,46 @@ Homebrew packaging is not active yet.
 
 ```sh
 # Authenticate with your Gumroad API token
-gr auth login
+gumroad auth login
 
 # Or use an ephemeral token for this shell / CI job
-export GR_ACCESS_TOKEN=your-token
+export GUMROAD_ACCESS_TOKEN=your-token
 
 # View your account
-gr user
+gumroad user
 
 # List your products
-gr products list
+gumroad products list
 
 # Fetch every page of sales
-gr sales list --all
+gumroad sales list --all
 
 # Get a sale as JSON, filter with jq
-gr sales view abc123 --json --jq '.sale.email'
+gumroad sales view abc123 --json --jq '.sale.email'
 
 # Preview a refund without executing it
-gr sales refund abc123 --amount-cents 500 --dry-run
+gumroad sales refund abc123 --amount-cents 500 --dry-run
 ```
 
 ## Commands
 
 ```
-gr auth          login, status, logout
-gr user          View your account info
-gr products      list, view, delete, enable, disable, skus
-gr sales         list, view, refund, ship, resend-receipt
-gr payouts       list, view, upcoming
-gr subscribers   list, view
-gr licenses      verify, enable, disable, decrement, rotate
-gr offer-codes   list, view, create, update, delete
-gr variant-categories list, view, create, update, delete
-gr variants      list, view, create, update, delete
-gr custom-fields list, create, update, delete
-gr webhooks      list, create, delete
-gr completion    bash, zsh, fish, powershell
+gumroad auth          login, status, logout
+gumroad user          View your account info
+gumroad products      list, view, delete, enable, disable, skus
+gumroad sales         list, view, refund, ship, resend-receipt
+gumroad payouts       list, view, upcoming
+gumroad subscribers   list, view
+gumroad licenses      verify, enable, disable, decrement, rotate
+gumroad offer-codes   list, view, create, update, delete
+gumroad variant-categories list, view, create, update, delete
+gumroad variants      list, view, create, update, delete
+gumroad custom-fields list, create, update, delete
+gumroad webhooks      list, create, delete
+gumroad completion    bash, zsh, fish, powershell
 ```
 
-Every command has built-in help with examples: `gr <command> --help`
+Every command has built-in help with examples: `gumroad <command> --help`
 
 Man pages are available locally after `make install`. You can also generate them directly with `make man`.
 
@@ -92,16 +92,16 @@ Generate and install shell completions directly from the command:
 
 ```sh
 # Bash
-source <(gr completion bash)
+source <(gumroad completion bash)
 
 # Zsh
-gr completion zsh > "${fpath[1]}/_gr"
+gumroad completion zsh > "${fpath[1]}/_gumroad"
 
 # Fish
-gr completion fish | source
+gumroad completion fish | source
 
 # PowerShell
-gr completion powershell | Out-String | Invoke-Expression
+gumroad completion powershell | Out-String | Invoke-Expression
 ```
 
 ## Output modes
@@ -130,16 +130,16 @@ If you decline a confirmation prompt, mutating commands still emit JSON in machi
 
 ## API coverage
 
-`gr` maps 1:1 to the [Gumroad API v2](https://app.gumroad.com/api). The CLI exposes everything the API supports today — but the API has some gaps worth knowing about:
+`gumroad` maps 1:1 to the [Gumroad API v2](https://app.gumroad.com/api). The CLI exposes everything the API supports today — but the API has some gaps worth knowing about:
 
 - **No product create/update** — the API routes exist but are not implemented. Products must be created and edited through the web UI. The CLI supports delete, enable, and disable which do work.
 - **No analytics or audience data** — no API endpoints exist for dashboard stats, traffic, or email lists.
 - **No bulk operations** — all actions are one resource at a time.
-- **Limited filtering** — `gr sales list` supports date/email/product filters, but `gr products list` returns everything with no filtering.
+- **Limited filtering** — `gumroad sales list` supports date/email/product filters, but `gumroad products list` returns everything with no filtering.
 - **Non-standard errors** — Gumroad sometimes returns `200 OK` with `success: false` in the body instead of a 4xx/5xx.
 - **Loose schemas** — some numeric fields arrive as `0` or `0.0`, and optional fields may be `null` or omitted.
 
-`gr` normalizes these quirks where it can.
+`gumroad` normalizes these quirks where it can.
 
 As the Gumroad API expands, the CLI will grow to match. The command structure is designed to accommodate new endpoints without breaking existing usage.
 
@@ -148,8 +148,8 @@ As the Gumroad API expands, the CLI will grow to match. The command structure is
 Built following [clig.dev](https://clig.dev/) guidelines and [`gh`](https://github.com/cli/cli) conventions:
 
 - **Human-first, machine-readable on demand** — tables by default, `--json`/`--plain` for machines
-- **Secrets never in args** — `gr auth login` prompts or reads stdin, token stored with `0600` permissions
-- **Headless-friendly auth** — `GR_ACCESS_TOKEN` overrides stored config for shells, agents, and CI
+- **Secrets never in args** — `gumroad auth login` prompts or reads stdin, token stored with `0600` permissions
+- **Headless-friendly auth** — `GUMROAD_ACCESS_TOKEN` overrides stored config for shells, agents, and CI
 - **Confirm destructive ops** — interactive confirmation for delete/refund, `--yes` to skip
 - **Support safe previews** — `--dry-run` shows mutating requests without executing them
 - **Rewrite errors for humans** — no raw API JSON, actionable suggestions instead
@@ -158,15 +158,15 @@ Built following [clig.dev](https://clig.dev/) guidelines and [`gh`](https://gith
 ## Architecture
 
 ```
-cmd/gr/main.go         Entry point
+cmd/gumroad/main.go    Entry point
 internal/
   cmd/                 Command implementations (cobra)
     auth/              Authentication (login, status, logout)
-    products/          gr products list|view|delete|enable|disable
-    sales/             gr sales list|view|refund|ship|resend-receipt
+    products/          gumroad products list|view|delete|enable|disable
+    sales/             gumroad sales list|view|refund|ship|resend-receipt
     ...                One package per noun
   api/                 HTTP client for Gumroad API v2
-  config/              XDG-compliant config (~/.config/gr/config.json)
+  config/              XDG-compliant config (~/.config/gumroad/config.json)
   output/              Table, JSON, plain, color, spinner, pager, image rendering
   prompt/              Interactive input (token, confirmations)
   cmdutil/             Global flag state
@@ -182,14 +182,14 @@ Each command follows the same pattern: parse flags, call `api.Client`, format ou
 
 ## AI agents
 
-`gr` is designed to be used by AI coding agents. The `--json`, `--jq`, and `--no-input` flags make it easy to query Gumroad data programmatically without interactive prompts, and `GR_ACCESS_TOKEN` gives agents a no-persistence auth path.
+`gumroad` is designed to be used by AI coding agents. The `--json`, `--jq`, and `--no-input` flags make it easy to query Gumroad data programmatically without interactive prompts, and `GUMROAD_ACCESS_TOKEN` gives agents a no-persistence auth path.
 
-A [Claude Code skill](.claude/skills/gr-cli/SKILL.md) is included in this repo. It teaches Claude when and how to use `gr` for Gumroad lookups — install it to let Claude automatically reach for `gr` when you ask about your products, sales, or subscribers.
+A [Claude Code skill](.claude/skills/gumroad-cli/SKILL.md) is included in this repo. It teaches Claude when and how to use `gumroad` for Gumroad lookups — install it to let Claude automatically reach for `gumroad` when you ask about your products, sales, or subscribers.
 
 ## Development
 
 ```sh
-make build        # Compile to ./gr
+make build        # Compile to ./gumroad
 make install      # Install binary, man pages, and shell completions
 make test         # Run all tests
 make test-cover   # Run tests with per-package coverage gates
@@ -202,12 +202,12 @@ make snapshot     # Build release snapshot via goreleaser
 Live smoke test:
 
 ```sh
-GR_ACCESS_TOKEN=your-token make test-smoke
+GUMROAD_ACCESS_TOKEN=your-token make test-smoke
 ```
 
-`make test-smoke` runs a small live, read-only sanity check against the real API only when `GR_SMOKE=1`; the make target sets that flag for you. It covers auth, representative list/view commands, and machine-readable output modes. Destructive flows still rely on mocked integration tests. You can optionally point it at another base URL with `GR_API_BASE_URL`.
+`make test-smoke` runs a small live, read-only sanity check against the real API only when `GUMROAD_SMOKE=1`; the make target sets that flag for you. It covers auth, representative list/view commands, and machine-readable output modes. Destructive flows still rely on mocked integration tests. You can optionally point it at another base URL with `GUMROAD_API_BASE_URL`.
 
-In GitHub Actions, the same smoke suite runs automatically on non-PR workflows when the repository secret `GR_SMOKE_ACCESS_TOKEN` is configured.
+In GitHub Actions, the same smoke suite runs automatically on non-PR workflows when the repository secret `GUMROAD_SMOKE_ACCESS_TOKEN` is configured.
 
 Built with Go, [cobra](https://github.com/spf13/cobra), and [gojq](https://github.com/itchyny/gojq).
 

--- a/cmd/gen-man/main.go
+++ b/cmd/gen-man/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/antiwork/gr/internal/cmd"
+	"github.com/antiwork/gumroad-cli/internal/cmd"
 	cobradoc "github.com/spf13/cobra/doc"
 )
 

--- a/cmd/gen-man/main_test.go
+++ b/cmd/gen-man/main_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestRunRemovesStaleManPagesAndGeneratesCurrentTree(t *testing.T) {
 	outputDir := t.TempDir()
-	stalePath := filepath.Join(outputDir, "gr-skus.1")
+	stalePath := filepath.Join(outputDir, "gumroad-skus.1")
 	if err := os.WriteFile(stalePath, []byte("stale"), 0600); err != nil {
 		t.Fatalf("write stale man page: %v", err)
 	}
@@ -24,20 +24,20 @@ func TestRunRemovesStaleManPagesAndGeneratesCurrentTree(t *testing.T) {
 		t.Fatalf("expected stale man page to be removed, got err=%v", err)
 	}
 
-	productSKUsPath := filepath.Join(outputDir, "gr-products-skus.1")
+	productSKUsPath := filepath.Join(outputDir, "gumroad-products-skus.1")
 	if _, err := os.Stat(productSKUsPath); err != nil {
 		t.Fatalf("expected nested sku man page, got err=%v", err)
 	}
 
-	productPageData, err := os.ReadFile(filepath.Join(outputDir, "gr-products.1"))
+	productPageData, err := os.ReadFile(filepath.Join(outputDir, "gumroad-products.1"))
 	if err != nil {
 		t.Fatalf("read product man page: %v", err)
 	}
 	productPageText := string(productPageData)
-	if !strings.Contains(productPageText, "gr-products-skus(1)") {
+	if !strings.Contains(productPageText, "gumroad-products-skus(1)") {
 		t.Fatalf("product man page missing skus see-also entry: %q", productPageText)
 	}
-	if !strings.Contains(productPageText, "gr products skus <id>") {
+	if !strings.Contains(productPageText, "gumroad products skus <id>") {
 		t.Fatalf("product man page missing skus example: %q", productPageText)
 	}
 

--- a/cmd/gr/main.go
+++ b/cmd/gr/main.go
@@ -1,7 +1,0 @@
-package main
-
-import "github.com/antiwork/gr/internal/cmd"
-
-func main() {
-	cmd.Execute()
-}

--- a/cmd/gumroad/main.go
+++ b/cmd/gumroad/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/antiwork/gumroad-cli/internal/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/antiwork/gr
+module github.com/antiwork/gumroad-cli
 
 go 1.25.4
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -23,7 +23,7 @@ const (
 )
 
 func defaultBaseURL() string {
-	if v := os.Getenv("GR_API_BASE_URL"); v != "" {
+	if v := os.Getenv("GUMROAD_API_BASE_URL"); v != "" {
 		return v
 	}
 	return defaultAPIBaseURL
@@ -137,7 +137,7 @@ func (c *Client) do(method, path string, params url.Values) (json.RawMessage, er
 		}
 
 		req.Header.Set("Authorization", "Bearer "+c.token)
-		req.Header.Set("User-Agent", "gr/"+c.version)
+		req.Header.Set("User-Agent", "gumroad/"+c.version)
 		if body != nil {
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		}

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -107,8 +107,8 @@ func TestClient_UserAgent(t *testing.T) {
 	c := &Client{token: "tok", httpClient: srv.Client(), baseURL: srv.URL, version: "1.2.3"}
 
 	_, _ = c.Get("/user", nil)
-	if gotUA != "gr/1.2.3" {
-		t.Errorf("got User-Agent=%q, want %q", gotUA, "gr/1.2.3")
+	if gotUA != "gumroad/1.2.3" {
+		t.Errorf("got User-Agent=%q, want %q", gotUA, "gumroad/1.2.3")
 	}
 }
 
@@ -543,7 +543,7 @@ func TestClient_HTTP401Error(t *testing.T) {
 	if apiErr.StatusCode != 401 {
 		t.Errorf("got status %d, want 401", apiErr.StatusCode)
 	}
-	if apiErr.Message != "Not authenticated. Run `gr auth login` or set `GR_ACCESS_TOKEN`." {
+	if apiErr.Message != "Not authenticated. Run `gumroad auth login` or set `GUMROAD_ACCESS_TOKEN`." {
 		t.Errorf("got message %q", apiErr.Message)
 	}
 }
@@ -592,7 +592,7 @@ func TestClient_DeleteWithParams(t *testing.T) {
 }
 
 func TestNewClient_UsesEnvBaseURL(t *testing.T) {
-	t.Setenv("GR_API_BASE_URL", "http://custom.local")
+	t.Setenv("GUMROAD_API_BASE_URL", "http://custom.local")
 
 	c := NewClient("tok", "test", false)
 	if c.baseURL != "http://custom.local" {
@@ -601,7 +601,7 @@ func TestNewClient_UsesEnvBaseURL(t *testing.T) {
 }
 
 func TestDefaultBaseURL_WithEnv(t *testing.T) {
-	t.Setenv("GR_API_BASE_URL", "http://test.local")
+	t.Setenv("GUMROAD_API_BASE_URL", "http://test.local")
 	got := defaultBaseURL()
 	if got != "http://test.local" {
 		t.Errorf("got %q, want http://test.local", got)
@@ -609,7 +609,7 @@ func TestDefaultBaseURL_WithEnv(t *testing.T) {
 }
 
 func TestDefaultBaseURL_Default(t *testing.T) {
-	t.Setenv("GR_API_BASE_URL", "")
+	t.Setenv("GUMROAD_API_BASE_URL", "")
 	got := defaultBaseURL()
 	if got != "https://api.gumroad.com/v2" {
 		t.Errorf("got %q, want https://api.gumroad.com/v2", got)

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -53,7 +53,7 @@ func parseAPIError(statusCode int, body []byte) error {
 func rewriteError(statusCode int, msg string) string {
 	switch statusCode {
 	case 401:
-		return "Not authenticated. Run `gr auth login` or set `GR_ACCESS_TOKEN`."
+		return "Not authenticated. Run `gumroad auth login` or set `GUMROAD_ACCESS_TOKEN`."
 	case 403:
 		if msg != "" {
 			return fmt.Sprintf("Access denied: %s", msg)

--- a/internal/api/errors_test.go
+++ b/internal/api/errors_test.go
@@ -37,7 +37,7 @@ func TestParseAPIError_401(t *testing.T) {
 	body := []byte(`{"success":false}`)
 	err := parseAPIError(401, body)
 	apiErr := mustAPIError(t, err)
-	if apiErr.Message != "Not authenticated. Run `gr auth login` or set `GR_ACCESS_TOKEN`." {
+	if apiErr.Message != "Not authenticated. Run `gumroad auth login` or set `GUMROAD_ACCESS_TOKEN`." {
 		t.Errorf("got message %q", apiErr.Message)
 	}
 	if !errors.Is(err, ErrNotAuthenticated) {

--- a/internal/cmd/auth/auth.go
+++ b/internal/cmd/auth/auth.go
@@ -8,9 +8,9 @@ func NewAuthCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "auth",
 		Short: "Manage authentication",
-		Example: `  gr auth login
-  gr auth status
-  gr auth logout`,
+		Example: `  gumroad auth login
+  gumroad auth status
+  gumroad auth logout`,
 	}
 
 	cmd.AddCommand(newLoginCmd())

--- a/internal/cmd/auth/auth_test.go
+++ b/internal/cmd/auth/auth_test.go
@@ -10,25 +10,25 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/antiwork/gr/internal/config"
-	"github.com/antiwork/gr/internal/testutil"
+	"github.com/antiwork/gumroad-cli/internal/config"
+	"github.com/antiwork/gumroad-cli/internal/testutil"
 )
 
 func setupAuth(t *testing.T, handler http.HandlerFunc) {
 	t.Helper()
 
 	srv := httptest.NewServer(handler)
-	t.Setenv("GR_API_BASE_URL", srv.URL)
+	t.Setenv("GUMROAD_API_BASE_URL", srv.URL)
 	t.Cleanup(srv.Close)
 }
 
 func withConfig(t *testing.T, token string) {
 	t.Helper()
 	cfgDir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cfgDir, "gr"), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Join(cfgDir, "gumroad"), 0700); err != nil {
 		t.Fatalf("MkdirAll failed: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(cfgDir, "gr", "config.json"), []byte(`{"access_token":"`+token+`"}`), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(cfgDir, "gumroad", "config.json"), []byte(`{"access_token":"`+token+`"}`), 0600); err != nil {
 		t.Fatalf("WriteFile failed: %v", err)
 	}
 	t.Setenv("XDG_CONFIG_HOME", cfgDir)
@@ -119,7 +119,7 @@ func TestLogin_SavesToken(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	data, readErr := os.ReadFile(filepath.Join(cfgDir, "gr", "config.json"))
+	data, readErr := os.ReadFile(filepath.Join(cfgDir, "gumroad", "config.json"))
 	if readErr != nil {
 		t.Fatalf("config not saved: %v", readErr)
 	}
@@ -140,7 +140,7 @@ func TestLogin_EmptyToken(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "token cannot be empty") {
 		t.Fatalf("expected empty token error, got: %v", err)
 	}
-	for _, want := range []string{"Usage:", "gr auth login", "Examples:"} {
+	for _, want := range []string{"Usage:", "gumroad auth login", "Examples:"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("missing %q in %q", want, err.Error())
 		}
@@ -235,7 +235,7 @@ func TestLogin_DoesNotSaveTokenWhenResponseIsInvalid(t *testing.T) {
 		t.Fatalf("expected parse error, got: %v", err)
 	}
 
-	if _, statErr := os.Stat(filepath.Join(cfgDir, "gr", "config.json")); !os.IsNotExist(statErr) {
+	if _, statErr := os.Stat(filepath.Join(cfgDir, "gumroad", "config.json")); !os.IsNotExist(statErr) {
 		t.Fatalf("config should not be written on parse failure, got err=%v", statErr)
 	}
 }
@@ -245,7 +245,7 @@ func TestLogin_DryRunSkipsVerificationAndSave(t *testing.T) {
 		t.Error("login dry-run should not reach API")
 	})
 	cfgDir := t.TempDir()
-	cfgPath := filepath.Join(cfgDir, "gr", "config.json")
+	cfgPath := filepath.Join(cfgDir, "gumroad", "config.json")
 	t.Setenv("XDG_CONFIG_HOME", cfgDir)
 
 	var out bytes.Buffer
@@ -270,10 +270,10 @@ func TestStatus_NotLoggedIn(t *testing.T) {
 	})
 
 	cfgDir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cfgDir, "gr"), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Join(cfgDir, "gumroad"), 0700); err != nil {
 		t.Fatalf("MkdirAll failed: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(cfgDir, "gr", "config.json"), []byte(`{}`), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(cfgDir, "gumroad", "config.json"), []byte(`{}`), 0600); err != nil {
 		t.Fatalf("WriteFile failed: %v", err)
 	}
 	t.Setenv("XDG_CONFIG_HOME", cfgDir)
@@ -461,10 +461,10 @@ func TestStatus_JSONOutput_NotLoggedIn(t *testing.T) {
 	})
 
 	cfgDir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cfgDir, "gr"), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Join(cfgDir, "gumroad"), 0700); err != nil {
 		t.Fatalf("MkdirAll failed: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(cfgDir, "gr", "config.json"), []byte(`{}`), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(cfgDir, "gumroad", "config.json"), []byte(`{}`), 0600); err != nil {
 		t.Fatalf("WriteFile failed: %v", err)
 	}
 	t.Setenv("XDG_CONFIG_HOME", cfgDir)
@@ -618,10 +618,10 @@ func TestStatus_EnvAccessTokenIgnoresBrokenConfig(t *testing.T) {
 		}
 	})
 	cfgDir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cfgDir, "gr"), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Join(cfgDir, "gumroad"), 0700); err != nil {
 		t.Fatalf("MkdirAll failed: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(cfgDir, "gr", "config.json"), []byte("not json"), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(cfgDir, "gumroad", "config.json"), []byte("not json"), 0600); err != nil {
 		t.Fatalf("WriteFile failed: %v", err)
 	}
 	t.Setenv("XDG_CONFIG_HOME", cfgDir)
@@ -636,10 +636,10 @@ func TestStatus_PlainOutput_NotLoggedIn(t *testing.T) {
 	})
 
 	cfgDir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cfgDir, "gr"), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Join(cfgDir, "gumroad"), 0700); err != nil {
 		t.Fatalf("MkdirAll failed: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(cfgDir, "gr", "config.json"), []byte(`{}`), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(cfgDir, "gumroad", "config.json"), []byte(`{}`), 0600); err != nil {
 		t.Fatalf("WriteFile failed: %v", err)
 	}
 	t.Setenv("XDG_CONFIG_HOME", cfgDir)
@@ -687,10 +687,10 @@ func TestLogout_WithYes(t *testing.T) {
 		t.Error("logout should not reach API")
 	})
 	cfgDir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cfgDir, "gr"), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Join(cfgDir, "gumroad"), 0700); err != nil {
 		t.Fatalf("MkdirAll failed: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(cfgDir, "gr", "config.json"), []byte(`{"access_token":"tok"}`), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(cfgDir, "gumroad", "config.json"), []byte(`{"access_token":"tok"}`), 0600); err != nil {
 		t.Fatalf("WriteFile failed: %v", err)
 	}
 	t.Setenv("XDG_CONFIG_HOME", cfgDir)
@@ -701,7 +701,7 @@ func TestLogout_WithYes(t *testing.T) {
 	}
 
 	// Verify config was deleted
-	_, statErr := os.Stat(filepath.Join(cfgDir, "gr", "config.json"))
+	_, statErr := os.Stat(filepath.Join(cfgDir, "gumroad", "config.json"))
 	if statErr == nil {
 		t.Error("config file should be deleted after logout")
 	}
@@ -726,7 +726,7 @@ func TestLogout_DryRunSkipsConfirmationAndPreservesConfig(t *testing.T) {
 		t.Error("logout should not reach API")
 	})
 	cfgDir := t.TempDir()
-	cfgPath := filepath.Join(cfgDir, "gr", "config.json")
+	cfgPath := filepath.Join(cfgDir, "gumroad", "config.json")
 	if err := os.MkdirAll(filepath.Dir(cfgPath), 0700); err != nil {
 		t.Fatalf("MkdirAll failed: %v", err)
 	}
@@ -752,10 +752,10 @@ func TestLogout_DryRunSkipsConfirmationAndPreservesConfig(t *testing.T) {
 func TestLogout_ShowsMessage(t *testing.T) {
 	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {})
 	cfgDir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cfgDir, "gr"), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Join(cfgDir, "gumroad"), 0700); err != nil {
 		t.Fatalf("MkdirAll failed: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(cfgDir, "gr", "config.json"), []byte(`{"access_token":"tok"}`), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(cfgDir, "gumroad", "config.json"), []byte(`{"access_token":"tok"}`), 0600); err != nil {
 		t.Fatalf("WriteFile failed: %v", err)
 	}
 	t.Setenv("XDG_CONFIG_HOME", cfgDir)
@@ -773,10 +773,10 @@ func TestLogout_ShowsMessage(t *testing.T) {
 func TestLogout_ShowsEnvAccessTokenNotice(t *testing.T) {
 	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {})
 	cfgDir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cfgDir, "gr"), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Join(cfgDir, "gumroad"), 0700); err != nil {
 		t.Fatalf("MkdirAll failed: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(cfgDir, "gr", "config.json"), []byte(`{"access_token":"tok"}`), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(cfgDir, "gumroad", "config.json"), []byte(`{"access_token":"tok"}`), 0600); err != nil {
 		t.Fatalf("WriteFile failed: %v", err)
 	}
 	t.Setenv("XDG_CONFIG_HOME", cfgDir)
@@ -788,7 +788,7 @@ func TestLogout_ShowsEnvAccessTokenNotice(t *testing.T) {
 		t.Fatalf("RunE failed: %v", err)
 	}
 
-	if !strings.Contains(out.String(), config.EnvAccessToken) || !strings.Contains(out.String(), "still set") || !strings.Contains(out.String(), "gr auth status") {
+	if !strings.Contains(out.String(), config.EnvAccessToken) || !strings.Contains(out.String(), "still set") || !strings.Contains(out.String(), "gumroad auth status") {
 		t.Fatalf("expected env token notice, got %q", out.String())
 	}
 }
@@ -798,10 +798,10 @@ func TestLogout_JSONOutput(t *testing.T) {
 		t.Error("logout should not reach API")
 	})
 	cfgDir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cfgDir, "gr"), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Join(cfgDir, "gumroad"), 0700); err != nil {
 		t.Fatalf("MkdirAll failed: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(cfgDir, "gr", "config.json"), []byte(`{"access_token":"tok"}`), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(cfgDir, "gumroad", "config.json"), []byte(`{"access_token":"tok"}`), 0600); err != nil {
 		t.Fatalf("WriteFile failed: %v", err)
 	}
 	t.Setenv("XDG_CONFIG_HOME", cfgDir)
@@ -832,10 +832,10 @@ func TestLogout_JSONOutput_EnvAccessTokenRemainsUnverified(t *testing.T) {
 		t.Error("logout should not reach API")
 	})
 	cfgDir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cfgDir, "gr"), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Join(cfgDir, "gumroad"), 0700); err != nil {
 		t.Fatalf("MkdirAll failed: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(cfgDir, "gr", "config.json"), []byte(`{"access_token":"tok"}`), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(cfgDir, "gumroad", "config.json"), []byte(`{"access_token":"tok"}`), 0600); err != nil {
 		t.Fatalf("WriteFile failed: %v", err)
 	}
 	t.Setenv("XDG_CONFIG_HOME", cfgDir)
@@ -867,10 +867,10 @@ func TestLogout_PlainOutput(t *testing.T) {
 		t.Error("logout should not reach API")
 	})
 	cfgDir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cfgDir, "gr"), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Join(cfgDir, "gumroad"), 0700); err != nil {
 		t.Fatalf("MkdirAll failed: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(cfgDir, "gr", "config.json"), []byte(`{"access_token":"tok"}`), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(cfgDir, "gumroad", "config.json"), []byte(`{"access_token":"tok"}`), 0600); err != nil {
 		t.Fatalf("WriteFile failed: %v", err)
 	}
 	t.Setenv("XDG_CONFIG_HOME", cfgDir)
@@ -890,10 +890,10 @@ func TestLogout_NonInteractiveRequiresYes(t *testing.T) {
 		t.Error("should not reach API")
 	})
 	cfgDir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cfgDir, "gr"), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Join(cfgDir, "gumroad"), 0700); err != nil {
 		t.Fatalf("MkdirAll failed: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(cfgDir, "gr", "config.json"), []byte(`{"access_token":"tok"}`), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(cfgDir, "gumroad", "config.json"), []byte(`{"access_token":"tok"}`), 0600); err != nil {
 		t.Fatalf("WriteFile failed: %v", err)
 	}
 	t.Setenv("XDG_CONFIG_HOME", cfgDir)
@@ -908,7 +908,7 @@ func TestLogout_NonInteractiveRequiresYes(t *testing.T) {
 	}
 
 	// Config should still exist
-	if _, statErr := os.Stat(filepath.Join(cfgDir, "gr", "config.json")); statErr != nil {
+	if _, statErr := os.Stat(filepath.Join(cfgDir, "gumroad", "config.json")); statErr != nil {
 		t.Error("config should not be deleted when confirmation is blocked")
 	}
 }

--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/antiwork/gr/internal/api"
-	"github.com/antiwork/gr/internal/cmdutil"
-	"github.com/antiwork/gr/internal/config"
-	"github.com/antiwork/gr/internal/output"
-	"github.com/antiwork/gr/internal/prompt"
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/config"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
 
@@ -25,10 +25,10 @@ func newLoginCmd() *cobra.Command {
 		Args:  cmdutil.ExactArgs(0),
 		Long:  "Store your Gumroad API token for future use.\nThe token is read interactively (or from stdin when piped).",
 		Example: `  # Interactive login
-  gr auth login
+  gumroad auth login
 
   # Pipe token from stdin
-  echo "your-token" | gr auth login`,
+  echo "your-token" | gumroad auth login`,
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
 			if opts.DryRun {

--- a/internal/cmd/auth/logout.go
+++ b/internal/cmd/auth/logout.go
@@ -3,9 +3,9 @@ package auth
 import (
 	"strconv"
 
-	"github.com/antiwork/gr/internal/cmdutil"
-	"github.com/antiwork/gr/internal/config"
-	"github.com/antiwork/gr/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/config"
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -21,7 +21,7 @@ func newLogoutCmd() *cobra.Command {
 		Use:     "logout",
 		Short:   "Remove stored authentication token",
 		Args:    cmdutil.ExactArgs(0),
-		Example: "  gr auth logout",
+		Example: "  gumroad auth logout",
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
 			confirmed, err := cmdutil.ConfirmAction(opts, "Remove stored API token?")
@@ -47,7 +47,7 @@ func newLogoutCmd() *cobra.Command {
 			tokenInfo, err := config.ResolveToken()
 			if err == nil && tokenInfo.Source == config.TokenSourceEnv {
 				status.Source = config.TokenSourceEnv
-				message = config.EnvAccessToken + " is still set for this shell. Run `gr auth status` to verify it."
+				message = config.EnvAccessToken + " is still set for this shell. Run `gumroad auth status` to verify it."
 			}
 			status.Message = message
 
@@ -64,7 +64,7 @@ func newLogoutCmd() *cobra.Command {
 			}
 			style := opts.Style()
 			if status.Source == config.TokenSourceEnv {
-				return output.Writeln(opts.Out(), style.Green("✓")+" Removed stored token. "+style.Bold(config.EnvAccessToken)+" is still set for this shell. Run "+style.Bold("gr auth status")+" to verify it.")
+				return output.Writeln(opts.Out(), style.Green("✓")+" Removed stored token. "+style.Bold(config.EnvAccessToken)+" is still set for this shell. Run "+style.Bold("gumroad auth status")+" to verify it.")
 			}
 			return output.Writeln(opts.Out(), style.Green("✓")+" "+message)
 		},

--- a/internal/cmd/auth/status.go
+++ b/internal/cmd/auth/status.go
@@ -8,10 +8,10 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/antiwork/gr/internal/api"
-	"github.com/antiwork/gr/internal/cmdutil"
-	"github.com/antiwork/gr/internal/config"
-	"github.com/antiwork/gr/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/config"
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -38,7 +38,7 @@ func newStatusCmd() *cobra.Command {
 		Use:     "status",
 		Short:   "Show current authentication status",
 		Args:    cmdutil.ExactArgs(0),
-		Example: "  gr auth status",
+		Example: "  gumroad auth status",
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
 			style := opts.Style()
@@ -54,7 +54,7 @@ func newStatusCmd() *cobra.Command {
 				if opts.PlainOutput {
 					return printStatusPlain(opts, status)
 				}
-				return output.Writeln(opts.Out(), "Not logged in. Run "+style.Bold("gr auth login")+" or set "+style.Bold(config.EnvAccessToken)+" to authenticate.")
+				return output.Writeln(opts.Out(), "Not logged in. Run "+style.Bold("gumroad auth login")+" or set "+style.Bold(config.EnvAccessToken)+" to authenticate.")
 			}
 
 			status, err := lookupStatus(opts, tokenInfo)
@@ -72,9 +72,9 @@ func newStatusCmd() *cobra.Command {
 			if !status.Authenticated {
 				switch status.Reason {
 				case statusReasonAccessDenied:
-					return output.Writeln(opts.Out(), authSourceMessage(status.Source, "Token was accepted but access is denied. Check that it has the required scope.", "GR_ACCESS_TOKEN was accepted but access is denied. Check that it has the required scope."))
+					return output.Writeln(opts.Out(), authSourceMessage(status.Source, "Token was accepted but access is denied. Check that it has the required scope.", "GUMROAD_ACCESS_TOKEN was accepted but access is denied. Check that it has the required scope."))
 				default:
-					return output.Writeln(opts.Out(), authSourceMessage(status.Source, "Token is invalid or expired. Run "+style.Bold("gr auth login")+" to re-authenticate.", "GR_ACCESS_TOKEN is invalid or expired. Update it in your shell and try again."))
+					return output.Writeln(opts.Out(), authSourceMessage(status.Source, "Token is invalid or expired. Run "+style.Bold("gumroad auth login")+" to re-authenticate.", "GUMROAD_ACCESS_TOKEN is invalid or expired. Update it in your shell and try again."))
 				}
 			}
 

--- a/internal/cmd/categories/categories.go
+++ b/internal/cmd/categories/categories.go
@@ -9,8 +9,8 @@ func NewCategoriesCmd() *cobra.Command {
 		Use:     "variant-categories",
 		Aliases: []string{"vc"},
 		Short:   "Manage product variant categories",
-		Example: `  gr variant-categories list --product <id>
-  gr variant-categories create --product <id> --title "Size"`,
+		Example: `  gumroad variant-categories list --product <id>
+  gumroad variant-categories create --product <id> --title "Size"`,
 	}
 
 	cmd.AddCommand(newListCmd())

--- a/internal/cmd/categories/categories_test.go
+++ b/internal/cmd/categories/categories_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/antiwork/gr/internal/testutil"
+	"github.com/antiwork/gumroad-cli/internal/testutil"
 )
 
 func categoriesHandler(t *testing.T) http.HandlerFunc {

--- a/internal/cmd/categories/create.go
+++ b/internal/cmd/categories/create.go
@@ -3,7 +3,7 @@ package categories
 import (
 	"net/url"
 
-	"github.com/antiwork/gr/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/categories/delete.go
+++ b/internal/cmd/categories/delete.go
@@ -3,7 +3,7 @@ package categories
 import (
 	"net/url"
 
-	"github.com/antiwork/gr/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/categories/list.go
+++ b/internal/cmd/categories/list.go
@@ -4,8 +4,8 @@ import (
 	"io"
 	"net/url"
 
-	"github.com/antiwork/gr/internal/cmdutil"
-	"github.com/antiwork/gr/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/categories/update.go
+++ b/internal/cmd/categories/update.go
@@ -3,7 +3,7 @@ package categories
 import (
 	"net/url"
 
-	"github.com/antiwork/gr/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/categories/view.go
+++ b/internal/cmd/categories/view.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/antiwork/gr/internal/cmdutil"
-	"github.com/antiwork/gr/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/completion/completion.go
+++ b/internal/cmd/completion/completion.go
@@ -1,7 +1,7 @@
 package completion
 
 import (
-	"github.com/antiwork/gr/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
 
@@ -9,21 +9,21 @@ func NewCompletionCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "completion <bash|zsh|fish|powershell>",
 		Short: "Generate shell completion script",
-		Long: `Generate shell completion script for gr.
+		Long: `Generate shell completion script for gumroad.
 
   # Bash
-  source <(gr completion bash)
+  source <(gumroad completion bash)
 
   # Zsh
-  gr completion zsh > "${fpath[1]}/_gr"
+  gumroad completion zsh > "${fpath[1]}/_gumroad"
 
   # Fish
-  gr completion fish | source
+  gumroad completion fish | source
 
   # PowerShell
-  gr completion powershell | Out-String | Invoke-Expression`,
-		Example: `  gr completion bash
-  gr completion zsh`,
+  gumroad completion powershell | Out-String | Invoke-Expression`,
+		Example: `  gumroad completion bash
+  gumroad completion zsh`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if err := cmdutil.ExactArgs(1)(cmd, args); err != nil {
 				return err

--- a/internal/cmd/completion/completion_test.go
+++ b/internal/cmd/completion/completion_test.go
@@ -4,12 +4,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/antiwork/gr/internal/testutil"
+	"github.com/antiwork/gumroad-cli/internal/testutil"
 	"github.com/spf13/cobra"
 )
 
 func rootWithCompletion() *cobra.Command {
-	root := &cobra.Command{Use: "gr"}
+	root := &cobra.Command{Use: "gumroad"}
 	root.AddCommand(NewCompletionCmd())
 	return root
 }
@@ -82,7 +82,7 @@ func TestCompletion_NoArgs(t *testing.T) {
 		"Usage:",
 		"completion <bash|zsh|fish|powershell>",
 		"Examples:",
-		"Run \"gr completion --help\" for more information.",
+		"Run \"gumroad completion --help\" for more information.",
 	} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("missing %q in %q", want, err.Error())
@@ -102,7 +102,7 @@ func TestCompletion_InvalidShell(t *testing.T) {
 		"Usage:",
 		"completion <bash|zsh|fish|powershell>",
 		"Examples:",
-		"Run \"gr completion --help\" for more information.",
+		"Run \"gumroad completion --help\" for more information.",
 	} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("missing %q in %q", want, err.Error())

--- a/internal/cmd/customfields/create.go
+++ b/internal/cmd/customfields/create.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/antiwork/gr/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/customfields/customfields.go
+++ b/internal/cmd/customfields/customfields.go
@@ -10,8 +10,8 @@ func NewCustomFieldsCmd() *cobra.Command {
 		Aliases: []string{"cf"},
 		Short:   "Manage product custom fields",
 		Long:    "Manage custom fields for a product. Update and delete key by name, not ID.",
-		Example: `  gr custom-fields list --product <id>
-  gr custom-fields create --product <id> --name "Company" --required`,
+		Example: `  gumroad custom-fields list --product <id>
+  gumroad custom-fields create --product <id> --name "Company" --required`,
 	}
 
 	cmd.AddCommand(newListCmd())

--- a/internal/cmd/customfields/customfields_test.go
+++ b/internal/cmd/customfields/customfields_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/antiwork/gr/internal/testutil"
+	"github.com/antiwork/gumroad-cli/internal/testutil"
 )
 
 func TestList_CorrectEndpoint(t *testing.T) {

--- a/internal/cmd/customfields/delete.go
+++ b/internal/cmd/customfields/delete.go
@@ -1,7 +1,7 @@
 package customfields
 
 import (
-	"github.com/antiwork/gr/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/customfields/list.go
+++ b/internal/cmd/customfields/list.go
@@ -5,8 +5,8 @@ import (
 	"io"
 	"net/url"
 
-	"github.com/antiwork/gr/internal/cmdutil"
-	"github.com/antiwork/gr/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/customfields/update.go
+++ b/internal/cmd/customfields/update.go
@@ -3,7 +3,7 @@ package customfields
 import (
 	"net/url"
 
-	"github.com/antiwork/gr/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/errors.go
+++ b/internal/cmd/errors.go
@@ -9,11 +9,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/antiwork/gr/internal/api"
-	"github.com/antiwork/gr/internal/cmdutil"
-	"github.com/antiwork/gr/internal/config"
-	"github.com/antiwork/gr/internal/output"
-	"github.com/antiwork/gr/internal/prompt"
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/config"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/prompt"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )

--- a/internal/cmd/errors_test.go
+++ b/internal/cmd/errors_test.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/antiwork/gr/internal/api"
-	"github.com/antiwork/gr/internal/cmdutil"
-	"github.com/antiwork/gr/internal/config"
-	"github.com/antiwork/gr/internal/prompt"
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/config"
+	"github.com/antiwork/gumroad-cli/internal/prompt"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -43,7 +43,7 @@ func TestClassifyCommandError_Nil(t *testing.T) {
 }
 
 func TestClassifyCommandError_Usage(t *testing.T) {
-	cmd := &cobra.Command{Use: "gr user"}
+	cmd := &cobra.Command{Use: "gumroad user"}
 	detail := classifyCommandError(cmdutil.UsageErrorf(cmd, "bad input"))
 	if detail.Type != "usage_error" || detail.Code != "invalid_input" {
 		t.Fatalf("unexpected detail: %+v", detail)
@@ -72,7 +72,7 @@ func TestClassifyCommandError_JQ(t *testing.T) {
 }
 
 func TestClassifyCommandError_LikelyUsageError(t *testing.T) {
-	detail := classifyCommandError(errors.New("unknown command \"bad\" for \"gr\""))
+	detail := classifyCommandError(errors.New("unknown command \"bad\" for \"gumroad\""))
 	if detail.Type != "usage_error" || detail.Code != "invalid_input" {
 		t.Fatalf("unexpected detail: %+v", detail)
 	}

--- a/internal/cmd/licenses/decrement.go
+++ b/internal/cmd/licenses/decrement.go
@@ -3,7 +3,7 @@ package licenses
 import (
 	"net/url"
 
-	"github.com/antiwork/gr/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/licenses/disable.go
+++ b/internal/cmd/licenses/disable.go
@@ -3,7 +3,7 @@ package licenses
 import (
 	"net/url"
 
-	"github.com/antiwork/gr/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/licenses/enable.go
+++ b/internal/cmd/licenses/enable.go
@@ -3,7 +3,7 @@ package licenses
 import (
 	"net/url"
 
-	"github.com/antiwork/gr/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/licenses/key.go
+++ b/internal/cmd/licenses/key.go
@@ -3,8 +3,8 @@ package licenses
 import (
 	"strings"
 
-	"github.com/antiwork/gr/internal/cmdutil"
-	"github.com/antiwork/gr/internal/prompt"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/licenses/licenses.go
+++ b/internal/cmd/licenses/licenses.go
@@ -8,9 +8,9 @@ func NewLicensesCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "licenses",
 		Short: "Manage product licenses",
-		Example: `  echo "$LICENSE_KEY" | gr licenses verify --product <id> --no-increment
-  echo "$LICENSE_KEY" | gr licenses enable --product <id>
-  echo "$LICENSE_KEY" | gr licenses disable --product <id>`,
+		Example: `  echo "$LICENSE_KEY" | gumroad licenses verify --product <id> --no-increment
+  echo "$LICENSE_KEY" | gumroad licenses enable --product <id>
+  echo "$LICENSE_KEY" | gumroad licenses disable --product <id>`,
 	}
 
 	cmd.AddCommand(newVerifyCmd())

--- a/internal/cmd/licenses/licenses_test.go
+++ b/internal/cmd/licenses/licenses_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/antiwork/gr/internal/testutil"
+	"github.com/antiwork/gumroad-cli/internal/testutil"
 )
 
 func TestVerify_UsesFromTopLevel(t *testing.T) {

--- a/internal/cmd/licenses/rotate.go
+++ b/internal/cmd/licenses/rotate.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/antiwork/gr/internal/cmdutil"
-	"github.com/antiwork/gr/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/licenses/verify.go
+++ b/internal/cmd/licenses/verify.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/antiwork/gr/internal/api"
-	"github.com/antiwork/gr/internal/cmdutil"
-	"github.com/antiwork/gr/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/offercodes/create.go
+++ b/internal/cmd/offercodes/create.go
@@ -4,7 +4,7 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/antiwork/gr/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/offercodes/delete.go
+++ b/internal/cmd/offercodes/delete.go
@@ -3,7 +3,7 @@ package offercodes
 import (
 	"net/url"
 
-	"github.com/antiwork/gr/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/offercodes/list.go
+++ b/internal/cmd/offercodes/list.go
@@ -6,9 +6,9 @@ import (
 	"io"
 	"net/url"
 
-	"github.com/antiwork/gr/internal/api"
-	"github.com/antiwork/gr/internal/cmdutil"
-	"github.com/antiwork/gr/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/offercodes/offercodes.go
+++ b/internal/cmd/offercodes/offercodes.go
@@ -9,8 +9,8 @@ func NewOfferCodesCmd() *cobra.Command {
 		Use:     "offer-codes",
 		Aliases: []string{"oc"},
 		Short:   "Manage product offer codes",
-		Example: `  gr offer-codes list --product <id>
-  gr offer-codes create --product <id> --name SAVE10 --percent-off 10`,
+		Example: `  gumroad offer-codes list --product <id>
+  gumroad offer-codes create --product <id> --name SAVE10 --percent-off 10`,
 	}
 
 	cmd.AddCommand(newListCmd())

--- a/internal/cmd/offercodes/offercodes_test.go
+++ b/internal/cmd/offercodes/offercodes_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/antiwork/gr/internal/testutil"
+	"github.com/antiwork/gumroad-cli/internal/testutil"
 )
 
 func offerCodesHandler(t *testing.T) http.HandlerFunc {

--- a/internal/cmd/offercodes/update.go
+++ b/internal/cmd/offercodes/update.go
@@ -4,7 +4,7 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/antiwork/gr/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/offercodes/view.go
+++ b/internal/cmd/offercodes/view.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/antiwork/gr/internal/api"
-	"github.com/antiwork/gr/internal/cmdutil"
-	"github.com/antiwork/gr/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/payouts/details.go
+++ b/internal/cmd/payouts/details.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/antiwork/gr/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/output"
 )
 
 func payoutPlainDetailColumns(noSales, includeTransactions bool, transactions json.RawMessage) []string {

--- a/internal/cmd/payouts/list.go
+++ b/internal/cmd/payouts/list.go
@@ -6,10 +6,10 @@ import (
 	"io"
 	"net/url"
 
-	"github.com/antiwork/gr/internal/api"
-	"github.com/antiwork/gr/internal/cmdutil"
-	"github.com/antiwork/gr/internal/config"
-	"github.com/antiwork/gr/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/config"
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -225,7 +225,7 @@ func renderEmptyPayoutsList(opts cmdutil.Options, before, after string, noUpcomi
 }
 
 func payoutPaginationHint(before, after string, noUpcoming bool, nextPageKey string) string {
-	return cmdutil.ReplayCommand("gr payouts list",
+	return cmdutil.ReplayCommand("gumroad payouts list",
 		cmdutil.CommandArg{Flag: "--before", Value: before},
 		cmdutil.CommandArg{Flag: "--after", Value: after},
 		cmdutil.CommandArg{Flag: "--no-upcoming", Boolean: noUpcoming},

--- a/internal/cmd/payouts/payouts.go
+++ b/internal/cmd/payouts/payouts.go
@@ -8,9 +8,9 @@ func NewPayoutsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "payouts",
 		Short: "View your payouts",
-		Example: `  gr payouts list
-  gr payouts view <id>
-  gr payouts upcoming`,
+		Example: `  gumroad payouts list
+  gumroad payouts view <id>
+  gumroad payouts upcoming`,
 	}
 
 	cmd.AddCommand(newListCmd())

--- a/internal/cmd/payouts/payouts_test.go
+++ b/internal/cmd/payouts/payouts_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/antiwork/gr/internal/testutil"
+	"github.com/antiwork/gumroad-cli/internal/testutil"
 )
 
 func TestList_JSON(t *testing.T) {
@@ -622,7 +622,7 @@ func TestList_NoUpcomingEmptyPageStillShowsPaginationHint(t *testing.T) {
 	if !strings.Contains(out, "No payouts found on this page.") {
 		t.Fatalf("expected empty-page message, got %q", out)
 	}
-	want := "gr payouts list --before 2024-06-01 --after 2024-01-01 --no-upcoming --page-key cursor456"
+	want := "gumroad payouts list --before 2024-06-01 --after 2024-01-01 --no-upcoming --page-key cursor456"
 	if !strings.Contains(out, want) {
 		t.Fatalf("expected pagination hint %q in %q", want, out)
 	}
@@ -642,7 +642,7 @@ func TestList_PaginationHintPreservesFilters(t *testing.T) {
 	cmd.SetArgs([]string{"--before", "2024-06-01", "--after", "2024-01-01", "--no-upcoming"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	want := "gr payouts list --before 2024-06-01 --after 2024-01-01 --no-upcoming --page-key cursor456"
+	want := "gumroad payouts list --before 2024-06-01 --after 2024-01-01 --no-upcoming --page-key cursor456"
 	if !strings.Contains(out, want) {
 		t.Fatalf("expected replayable pagination hint %q in %q", want, out)
 	}

--- a/internal/cmd/payouts/upcoming.go
+++ b/internal/cmd/payouts/upcoming.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/antiwork/gr/internal/cmdutil"
-	"github.com/antiwork/gr/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/payouts/view.go
+++ b/internal/cmd/payouts/view.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/antiwork/gr/internal/cmdutil"
-	"github.com/antiwork/gr/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/products/delete.go
+++ b/internal/cmd/products/delete.go
@@ -3,7 +3,7 @@ package products
 import (
 	"net/url"
 
-	"github.com/antiwork/gr/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/products/disable.go
+++ b/internal/cmd/products/disable.go
@@ -3,7 +3,7 @@ package products
 import (
 	"net/url"
 
-	"github.com/antiwork/gr/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/products/enable.go
+++ b/internal/cmd/products/enable.go
@@ -3,7 +3,7 @@ package products
 import (
 	"net/url"
 
-	"github.com/antiwork/gr/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/products/list.go
+++ b/internal/cmd/products/list.go
@@ -5,9 +5,9 @@ import (
 	"io"
 	"net/url"
 
-	"github.com/antiwork/gr/internal/api"
-	"github.com/antiwork/gr/internal/cmdutil"
-	"github.com/antiwork/gr/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -28,7 +28,7 @@ func newListCmd() *cobra.Command {
 		Use:     "list",
 		Short:   "List your products",
 		Args:    cmdutil.ExactArgs(0),
-		Example: `  gr products list`,
+		Example: `  gumroad products list`,
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
 			return cmdutil.RunRequestDecoded[productsListResponse](opts, "Fetching products...", "GET", "/products", url.Values{}, func(resp productsListResponse) error {
@@ -62,7 +62,7 @@ func newListCmd() *cobra.Command {
 						return err
 					}
 					if !opts.Quiet {
-						return output.Writeln(w, style.Dim("\nTip: view a product with  gr products view <id>"))
+						return output.Writeln(w, style.Dim("\nTip: view a product with  gumroad products view <id>"))
 					}
 					return nil
 				})

--- a/internal/cmd/products/products.go
+++ b/internal/cmd/products/products.go
@@ -1,7 +1,7 @@
 package products
 
 import (
-	"github.com/antiwork/gr/internal/cmd/skus"
+	"github.com/antiwork/gumroad-cli/internal/cmd/skus"
 	"github.com/spf13/cobra"
 )
 
@@ -11,11 +11,11 @@ func NewProductsCmd() *cobra.Command {
 		Short: "Manage your Gumroad products",
 		Long: "Manage your Gumroad products.\n\n" +
 			"Gumroad's API does not support creating or updating products. " +
-			"Use the web UI to create or edit products; `gr` supports listing, viewing, deleting, enabling, and disabling them.",
-		Example: `  gr products list
-  gr products view <id>
-  gr products delete <id>
-  gr products skus <id>`,
+			"Use the web UI to create or edit products; `gumroad` supports listing, viewing, deleting, enabling, and disabling them.",
+		Example: `  gumroad products list
+  gumroad products view <id>
+  gumroad products delete <id>
+  gumroad products skus <id>`,
 	}
 
 	cmd.AddCommand(newListCmd())

--- a/internal/cmd/products/products_test.go
+++ b/internal/cmd/products/products_test.go
@@ -12,7 +12,7 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/antiwork/gr/internal/testutil"
+	"github.com/antiwork/gumroad-cli/internal/testutil"
 )
 
 func TestList_JSON(t *testing.T) {
@@ -529,7 +529,7 @@ func TestNewProductsCmd_HelpIncludesSKUs(t *testing.T) {
 	})
 
 	for _, want := range []string{
-		"gr products skus <id>",
+		"gumroad products skus <id>",
 		"skus        List SKUs for a product",
 	} {
 		if !strings.Contains(out, want) {

--- a/internal/cmd/products/view.go
+++ b/internal/cmd/products/view.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/antiwork/gr/internal/api"
-	"github.com/antiwork/gr/internal/cmdutil"
-	"github.com/antiwork/gr/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -39,7 +39,7 @@ func newViewCmd() *cobra.Command {
 		Use:     "view <id>",
 		Short:   "View a product",
 		Args:    cmdutil.ExactArgs(1),
-		Example: `  gr products view <id>`,
+		Example: `  gumroad products view <id>`,
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
 			return cmdutil.RunRequest(opts, "Fetching product...", "GET", cmdutil.JoinPath("products", args[0]), url.Values{}, func(data json.RawMessage) error {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -8,21 +8,21 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/antiwork/gr/internal/cmd/auth"
-	"github.com/antiwork/gr/internal/cmd/categories"
-	"github.com/antiwork/gr/internal/cmd/completion"
-	"github.com/antiwork/gr/internal/cmd/customfields"
-	"github.com/antiwork/gr/internal/cmd/licenses"
-	"github.com/antiwork/gr/internal/cmd/offercodes"
-	"github.com/antiwork/gr/internal/cmd/payouts"
-	"github.com/antiwork/gr/internal/cmd/products"
-	"github.com/antiwork/gr/internal/cmd/sales"
-	"github.com/antiwork/gr/internal/cmd/subscribers"
-	"github.com/antiwork/gr/internal/cmd/user"
-	"github.com/antiwork/gr/internal/cmd/variants"
-	"github.com/antiwork/gr/internal/cmd/webhooks"
-	"github.com/antiwork/gr/internal/cmdutil"
-	"github.com/antiwork/gr/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/cmd/auth"
+	"github.com/antiwork/gumroad-cli/internal/cmd/categories"
+	"github.com/antiwork/gumroad-cli/internal/cmd/completion"
+	"github.com/antiwork/gumroad-cli/internal/cmd/customfields"
+	"github.com/antiwork/gumroad-cli/internal/cmd/licenses"
+	"github.com/antiwork/gumroad-cli/internal/cmd/offercodes"
+	"github.com/antiwork/gumroad-cli/internal/cmd/payouts"
+	"github.com/antiwork/gumroad-cli/internal/cmd/products"
+	"github.com/antiwork/gumroad-cli/internal/cmd/sales"
+	"github.com/antiwork/gumroad-cli/internal/cmd/subscribers"
+	"github.com/antiwork/gumroad-cli/internal/cmd/user"
+	"github.com/antiwork/gumroad-cli/internal/cmd/variants"
+	"github.com/antiwork/gumroad-cli/internal/cmd/webhooks"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -36,21 +36,21 @@ func NewRootCmd() *cobra.Command {
 	opts := cmdutil.DefaultOptions()
 
 	cmd := &cobra.Command{
-		Use:   "gr",
+		Use:   "gumroad",
 		Short: "CLI for the Gumroad API",
-		Long:  "A command-line interface for the Gumroad API.\nDesigned for humans and AI agents alike.\n\nDocumentation: https://github.com/antiwork/gr\nMan pages:     available locally as `man gr` after `make install`\nReport issues: https://github.com/antiwork/gr/issues",
+		Long:  "A command-line interface for the Gumroad API.\nDesigned for humans and AI agents alike.\n\nDocumentation: https://github.com/antiwork/gumroad\nMan pages:     available locally as `man gumroad` after `make install`\nReport issues: https://github.com/antiwork/gumroad-cli/issues",
 		Example: `  # Log in with your API token
-  gr auth login
+  gumroad auth login
 
   # View your account
-  gr user --json --jq '.user.email'
+  gumroad user --json --jq '.user.email'
 
   # List products and sales
-  gr products list
-  gr sales list --json --jq '.sales[0].id'
+  gumroad products list
+  gumroad sales list --json --jq '.sales[0].id'
 
   # Verify a license without incrementing uses
-  echo "$LICENSE_KEY" | gr licenses verify --product <id> --no-increment`,
+  echo "$LICENSE_KEY" | gumroad licenses verify --product <id> --no-increment`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
@@ -72,7 +72,7 @@ func NewRootCmd() *cobra.Command {
 		Version: Version,
 	}
 
-	cmd.SetVersionTemplate(fmt.Sprintf("gr version %s\n", Version))
+	cmd.SetVersionTemplate(fmt.Sprintf("gumroad version %s\n", Version))
 	cmd.SetFlagErrorFunc(func(c *cobra.Command, err error) error {
 		if err == nil {
 			return nil

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -10,14 +10,14 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/antiwork/gr/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
 
 func usageTestCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:     "gr user",
-		Example: "  gr user",
+		Use:     "gumroad user",
+		Example: "  gumroad user",
 	}
 }
 
@@ -31,7 +31,7 @@ func (w failingWriter) Write([]byte) (int, error) {
 
 func stubCommand(runErr error) *cobra.Command {
 	return &cobra.Command{
-		Use:           "gr",
+		Use:           "gumroad",
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(*cobra.Command, []string) error {
@@ -170,7 +170,7 @@ func TestRootCmd_VersionFlag(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(out.String(), "gr version ") {
+	if !strings.Contains(out.String(), "gumroad version ") {
 		t.Fatalf("expected version output, got %q", out.String())
 	}
 }
@@ -412,13 +412,13 @@ func TestRootCmd_CustomFieldsUpdateHelpUsesRelevantExample(t *testing.T) {
 	}
 
 	text := out.String()
-	if strings.Contains(text, "gr custom-fields list") || strings.Contains(text, "gr custom-fields create") {
+	if strings.Contains(text, "gumroad custom-fields list") || strings.Contains(text, "gumroad custom-fields create") {
 		t.Fatalf("help should not include unrelated examples, got %q", text)
 	}
-	if strings.Contains(text, "gr custom-fields update --name <value> --product <value> --required") {
+	if strings.Contains(text, "gumroad custom-fields update --name <value> --product <value> --required") {
 		t.Fatalf("help example should not include optional flags, got %q", text)
 	}
-	for _, want := range []string{"Examples:", "gr custom-fields update", "--name <value>", "--product <value>"} {
+	for _, want := range []string{"Examples:", "gumroad custom-fields update", "--name <value>", "--product <value>"} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("missing %q in help output %q", want, text)
 		}
@@ -515,7 +515,7 @@ func TestCommandContext_NilCommandUsesBackground(t *testing.T) {
 func TestCommandContext_PrefersCommandContext(t *testing.T) {
 	type contextKey string
 
-	cmd := &cobra.Command{Use: "gr"}
+	cmd := &cobra.Command{Use: "gumroad"}
 	ctx := context.WithValue(context.Background(), contextKey("trace"), "abc123")
 	cmd.SetContext(ctx)
 

--- a/internal/cmd/sales/list.go
+++ b/internal/cmd/sales/list.go
@@ -4,10 +4,10 @@ import (
 	"io"
 	"net/url"
 
-	"github.com/antiwork/gr/internal/api"
-	"github.com/antiwork/gr/internal/cmdutil"
-	"github.com/antiwork/gr/internal/config"
-	"github.com/antiwork/gr/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/config"
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -34,10 +34,10 @@ func newListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List your sales",
 		Args:  cmdutil.ExactArgs(0),
-		Example: `  gr sales list
-  gr sales list --product <id> --after 2024-01-01
-  gr sales list --all
-  gr sales list --json --jq '.sales[0].id'`,
+		Example: `  gumroad sales list
+  gumroad sales list --product <id> --after 2024-01-01
+  gumroad sales list --all
+  gumroad sales list --json --jq '.sales[0].id'`,
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
 			if err := cmdutil.RequireDateFlag(c, "before", before); err != nil {
@@ -197,7 +197,7 @@ func renderEmptySalesList(opts cmdutil.Options, product, email, orderID, before,
 }
 
 func salesPaginationHint(product, email, orderID, before, after, nextPageKey string) string {
-	return cmdutil.ReplayCommand("gr sales list",
+	return cmdutil.ReplayCommand("gumroad sales list",
 		cmdutil.CommandArg{Flag: "--product", Value: product},
 		cmdutil.CommandArg{Flag: "--email", Value: email},
 		cmdutil.CommandArg{Flag: "--order", Value: orderID},

--- a/internal/cmd/sales/refund.go
+++ b/internal/cmd/sales/refund.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/antiwork/gr/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/sales/resend_receipt.go
+++ b/internal/cmd/sales/resend_receipt.go
@@ -3,7 +3,7 @@ package sales
 import (
 	"net/url"
 
-	"github.com/antiwork/gr/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/sales/sales.go
+++ b/internal/cmd/sales/sales.go
@@ -8,9 +8,9 @@ func NewSalesCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sales",
 		Short: "Manage your sales",
-		Example: `  gr sales list
-  gr sales view <id>
-  gr sales refund <id>`,
+		Example: `  gumroad sales list
+  gumroad sales view <id>
+  gumroad sales refund <id>`,
 	}
 
 	cmd.AddCommand(newListCmd())

--- a/internal/cmd/sales/sales_test.go
+++ b/internal/cmd/sales/sales_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/antiwork/gr/internal/testutil"
+	"github.com/antiwork/gumroad-cli/internal/testutil"
 )
 
 func TestList_AllFilters(t *testing.T) {
@@ -273,7 +273,7 @@ func TestList_EmptyPageStillShowsPaginationHint(t *testing.T) {
 	if !strings.Contains(out, "No sales found on this page.") {
 		t.Fatalf("expected empty-page message, got %q", out)
 	}
-	want := "gr sales list --product p1 --email buyer@example.com --order ord_123 --before 2024-12-31 --after 2024-01-01 --page-key cursor123"
+	want := "gumroad sales list --product p1 --email buyer@example.com --order ord_123 --before 2024-12-31 --after 2024-01-01 --page-key cursor123"
 	if !strings.Contains(out, want) {
 		t.Fatalf("expected pagination hint %q in %q", want, out)
 	}
@@ -456,7 +456,7 @@ func TestList_PaginationHintPreservesFilters(t *testing.T) {
 	cmd.SetArgs([]string{"--product", "p1", "--email", "buyer@example.com", "--order", "ord_123", "--before", "2024-12-31", "--after", "2024-01-01"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	want := "gr sales list --product p1 --email buyer@example.com --order ord_123 --before 2024-12-31 --after 2024-01-01 --page-key cursor123"
+	want := "gumroad sales list --product p1 --email buyer@example.com --order ord_123 --before 2024-12-31 --after 2024-01-01 --page-key cursor123"
 	if !strings.Contains(out, want) {
 		t.Fatalf("expected replayable pagination hint %q in %q", want, out)
 	}

--- a/internal/cmd/sales/ship.go
+++ b/internal/cmd/sales/ship.go
@@ -3,7 +3,7 @@ package sales
 import (
 	"net/url"
 
-	"github.com/antiwork/gr/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/sales/view.go
+++ b/internal/cmd/sales/view.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/antiwork/gr/internal/cmdutil"
-	"github.com/antiwork/gr/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/skus/skus.go
+++ b/internal/cmd/skus/skus.go
@@ -6,9 +6,9 @@ import (
 	"io"
 	"net/url"
 
-	"github.com/antiwork/gr/internal/api"
-	"github.com/antiwork/gr/internal/cmdutil"
-	"github.com/antiwork/gr/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -17,7 +17,7 @@ func NewProductSKUsCmd() *cobra.Command {
 		Use:     "skus <id>",
 		Short:   "List SKUs for a product",
 		Args:    cmdutil.ExactArgs(1),
-		Example: "  gr products skus <id>",
+		Example: "  gumroad products skus <id>",
 		RunE: func(c *cobra.Command, args []string) error {
 			return runList(c, args[0])
 		},

--- a/internal/cmd/skus/skus_test.go
+++ b/internal/cmd/skus/skus_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/antiwork/gr/internal/testutil"
+	"github.com/antiwork/gumroad-cli/internal/testutil"
 )
 
 func TestList_ProductIDRequired(t *testing.T) {

--- a/internal/cmd/subscribers/list.go
+++ b/internal/cmd/subscribers/list.go
@@ -4,10 +4,10 @@ import (
 	"io"
 	"net/url"
 
-	"github.com/antiwork/gr/internal/api"
-	"github.com/antiwork/gr/internal/cmdutil"
-	"github.com/antiwork/gr/internal/config"
-	"github.com/antiwork/gr/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/config"
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -179,7 +179,7 @@ func renderEmptySubscribersList(opts cmdutil.Options, product, email, nextPageKe
 }
 
 func subscriberPaginationHint(product, email, nextPageKey string) string {
-	return cmdutil.ReplayCommand("gr subscribers list",
+	return cmdutil.ReplayCommand("gumroad subscribers list",
 		cmdutil.CommandArg{Flag: "--product", Value: product},
 		cmdutil.CommandArg{Flag: "--email", Value: email},
 		cmdutil.CommandArg{Flag: "--page-key", Value: nextPageKey},

--- a/internal/cmd/subscribers/subscribers.go
+++ b/internal/cmd/subscribers/subscribers.go
@@ -8,8 +8,8 @@ func NewSubscribersCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "subscribers",
 		Short: "Manage product subscribers",
-		Example: `  gr subscribers list --product <id>
-  gr subscribers view <id>`,
+		Example: `  gumroad subscribers list --product <id>
+  gumroad subscribers view <id>`,
 	}
 
 	cmd.AddCommand(newListCmd())

--- a/internal/cmd/subscribers/subscribers_test.go
+++ b/internal/cmd/subscribers/subscribers_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/antiwork/gr/internal/testutil"
+	"github.com/antiwork/gumroad-cli/internal/testutil"
 )
 
 func TestList_SendsPaginatedTrue(t *testing.T) {
@@ -280,7 +280,7 @@ func TestList_PaginationHintPreservesFilters(t *testing.T) {
 	cmd.SetArgs([]string{"--product", "p1", "--email", "buyer@example.com"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	want := "gr subscribers list --product p1 --email buyer@example.com --page-key next123"
+	want := "gumroad subscribers list --product p1 --email buyer@example.com --page-key next123"
 	if !strings.Contains(out, want) {
 		t.Fatalf("expected replayable pagination hint %q in %q", want, out)
 	}
@@ -402,7 +402,7 @@ func TestList_EmptyPageStillShowsPaginationHint(t *testing.T) {
 	if !strings.Contains(out, "No subscribers found on this page.") {
 		t.Fatalf("expected empty-page message, got %q", out)
 	}
-	want := "gr subscribers list --product p1 --email buyer@example.com --page-key next123"
+	want := "gumroad subscribers list --product p1 --email buyer@example.com --page-key next123"
 	if !strings.Contains(out, want) {
 		t.Fatalf("expected pagination hint %q in %q", want, out)
 	}

--- a/internal/cmd/subscribers/view.go
+++ b/internal/cmd/subscribers/view.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/antiwork/gr/internal/cmdutil"
-	"github.com/antiwork/gr/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/user/user.go
+++ b/internal/cmd/user/user.go
@@ -3,8 +3,8 @@ package user
 import (
 	"net/url"
 
-	"github.com/antiwork/gr/internal/cmdutil"
-	"github.com/antiwork/gr/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -25,9 +25,9 @@ func NewUserCmd() *cobra.Command {
 		Use:   "user",
 		Short: "Show your Gumroad account info",
 		Args:  cmdutil.ExactArgs(0),
-		Example: `  gr user
-  gr user --json
-  gr user --json --jq '.user.email'`,
+		Example: `  gumroad user
+  gumroad user --json
+  gumroad user --json --jq '.user.email'`,
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
 			return cmdutil.RunRequestDecoded[userResponse](opts, "Fetching user info...", "GET", "/user", url.Values{}, func(resp userResponse) error {

--- a/internal/cmd/user/user_test.go
+++ b/internal/cmd/user/user_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/antiwork/gr/internal/testutil"
+	"github.com/antiwork/gumroad-cli/internal/testutil"
 )
 
 type failingWriter struct{}
@@ -214,8 +214,8 @@ func TestUser_NotAuthenticated(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error without auth")
 	}
-	if !strings.Contains(err.Error(), "gr auth login") {
-		t.Errorf("error should mention gr auth login: %v", err)
+	if !strings.Contains(err.Error(), "gumroad auth login") {
+		t.Errorf("error should mention gumroad auth login: %v", err)
 	}
 }
 

--- a/internal/cmd/variants/create.go
+++ b/internal/cmd/variants/create.go
@@ -4,7 +4,7 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/antiwork/gr/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/variants/delete.go
+++ b/internal/cmd/variants/delete.go
@@ -3,7 +3,7 @@ package variants
 import (
 	"net/url"
 
-	"github.com/antiwork/gr/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/variants/list.go
+++ b/internal/cmd/variants/list.go
@@ -5,9 +5,9 @@ import (
 	"io"
 	"net/url"
 
-	"github.com/antiwork/gr/internal/api"
-	"github.com/antiwork/gr/internal/cmdutil"
-	"github.com/antiwork/gr/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/variants/update.go
+++ b/internal/cmd/variants/update.go
@@ -4,7 +4,7 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/antiwork/gr/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/variants/variants.go
+++ b/internal/cmd/variants/variants.go
@@ -8,8 +8,8 @@ func NewVariantsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "variants",
 		Short: "Manage product variants",
-		Example: `  gr variants list --product <id> --category <cat_id>
-  gr variants create --product <id> --category <cat_id> --name "Large"`,
+		Example: `  gumroad variants list --product <id> --category <cat_id>
+  gumroad variants create --product <id> --category <cat_id> --name "Large"`,
 	}
 
 	cmd.AddCommand(newListCmd())

--- a/internal/cmd/variants/variants_test.go
+++ b/internal/cmd/variants/variants_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/antiwork/gr/internal/testutil"
+	"github.com/antiwork/gumroad-cli/internal/testutil"
 )
 
 func variantsHandler(t *testing.T) http.HandlerFunc {

--- a/internal/cmd/variants/view.go
+++ b/internal/cmd/variants/view.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/antiwork/gr/internal/api"
-	"github.com/antiwork/gr/internal/cmdutil"
-	"github.com/antiwork/gr/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/webhooks/create.go
+++ b/internal/cmd/webhooks/create.go
@@ -3,7 +3,7 @@ package webhooks
 import (
 	"net/url"
 
-	"github.com/antiwork/gr/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/webhooks/delete.go
+++ b/internal/cmd/webhooks/delete.go
@@ -3,7 +3,7 @@ package webhooks
 import (
 	"net/url"
 
-	"github.com/antiwork/gr/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/webhooks/list.go
+++ b/internal/cmd/webhooks/list.go
@@ -4,8 +4,8 @@ import (
 	"io"
 	"net/url"
 
-	"github.com/antiwork/gr/internal/cmdutil"
-	"github.com/antiwork/gr/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/webhooks/webhooks.go
+++ b/internal/cmd/webhooks/webhooks.go
@@ -11,8 +11,8 @@ func NewWebhooksCmd() *cobra.Command {
 		Long: `Manage webhook subscriptions for resource events.
 
 Note: delete only succeeds when the token's OAuth app matches the subscription's app.`,
-		Example: `  gr webhooks list --resource sale
-  gr webhooks create --resource sale --url https://example.com/hook`,
+		Example: `  gumroad webhooks list --resource sale
+  gumroad webhooks create --resource sale --url https://example.com/hook`,
 	}
 
 	cmd.AddCommand(newListCmd())

--- a/internal/cmd/webhooks/webhooks_test.go
+++ b/internal/cmd/webhooks/webhooks_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/antiwork/gr/internal/testutil"
+	"github.com/antiwork/gumroad-cli/internal/testutil"
 )
 
 func TestList_ResourceRequired(t *testing.T) {

--- a/internal/cmdutil/coverage_test.go
+++ b/internal/cmdutil/coverage_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/antiwork/gr/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/api"
 )
 
 type testUserResponse struct {
@@ -39,6 +39,7 @@ func TestFetchPage_NilClient(t *testing.T) {
 }
 
 func TestRunDecoded_RendersTypedResponse(t *testing.T) {
+	t.Setenv("GUMROAD_ACCESS_TOKEN", "test-token")
 	var rendered string
 	err := RunDecoded[testUserResponse](DefaultOptions(), "", func(*api.Client) (json.RawMessage, error) {
 		return json.RawMessage(`{"user":{"email":"decoded@example.com"}}`), nil
@@ -55,6 +56,7 @@ func TestRunDecoded_RendersTypedResponse(t *testing.T) {
 }
 
 func TestRunDecoded_JSONOutputSkipsTypedRender(t *testing.T) {
+	t.Setenv("GUMROAD_ACCESS_TOKEN", "test-token")
 	opts := DefaultOptions()
 	opts.JSONOutput = true
 	var out bytes.Buffer
@@ -75,6 +77,7 @@ func TestRunDecoded_JSONOutputSkipsTypedRender(t *testing.T) {
 }
 
 func TestRunDecoded_InvalidJSONReturnsParseError(t *testing.T) {
+	t.Setenv("GUMROAD_ACCESS_TOKEN", "test-token")
 	err := RunDecoded[testPage](DefaultOptions(), "", func(*api.Client) (json.RawMessage, error) {
 		return json.RawMessage(`not-json`), nil
 	}, func(testPage) error {
@@ -166,7 +169,7 @@ func TestRunAuthenticatedData_UsesStoredToken(t *testing.T) {
 
 func TestRunAuthenticatedData_MissingTokenReturnsError(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-	t.Setenv("GR_ACCESS_TOKEN", "")
+	t.Setenv("GUMROAD_ACCESS_TOKEN", "")
 
 	_, err := runAuthenticatedData(DefaultOptions(), "Fetching...", func(*api.Client) (json.RawMessage, error) {
 		t.Fatal("request should not run without auth")
@@ -208,7 +211,7 @@ func TestPrintCancelledAction_QuietNoOutput(t *testing.T) {
 }
 
 func TestUsageHelperEdgeCases(t *testing.T) {
-	if got := filteredExample("  gr products list\n\n  gr sales list", "gr users"); got != "" {
+	if got := filteredExample("  gumroad products list\n\n  gumroad sales list", "gumroad users"); got != "" {
 		t.Fatalf("expected no matching examples, got %q", got)
 	}
 

--- a/internal/cmdutil/extra_test.go
+++ b/internal/cmdutil/extra_test.go
@@ -242,11 +242,11 @@ func TestPrintCancelledAction_DefaultOutput(t *testing.T) {
 }
 
 func TestReplayCommandQuotesShellValues(t *testing.T) {
-	got := ReplayCommand("gr sales list",
+	got := ReplayCommand("gumroad sales list",
 		CommandArg{Flag: "--all", Boolean: true},
 		CommandArg{Flag: "--email", Value: "buyer name@example.com"},
 	)
-	want := "gr sales list --all --email 'buyer name@example.com'"
+	want := "gumroad sales list --all --email 'buyer name@example.com'"
 	if got != want {
 		t.Fatalf("got %q, want %q", got, want)
 	}

--- a/internal/cmdutil/hints_test.go
+++ b/internal/cmdutil/hints_test.go
@@ -24,7 +24,7 @@ func withHintEnv(t *testing.T, goos string, env map[string]string) {
 func TestReplayCommand_QuotesShellSensitiveValues_POSIX(t *testing.T) {
 	withHintEnv(t, "darwin", map[string]string{})
 
-	got := ReplayCommand("gr sales list",
+	got := ReplayCommand("gumroad sales list",
 		CommandArg{Flag: "--email", Value: "user name@example.com"},
 		CommandArg{Flag: "--page-key", Value: "$NEXT_PAGE"},
 	)
@@ -42,7 +42,7 @@ func TestReplayCommand_QuotesShellSensitiveValues_POSIX(t *testing.T) {
 func TestReplayCommand_EscapesSingleQuotes_POSIX(t *testing.T) {
 	withHintEnv(t, "linux", map[string]string{})
 
-	got := ReplayCommand("gr products list", CommandArg{Flag: "--name", Value: "O'Reilly"})
+	got := ReplayCommand("gumroad products list", CommandArg{Flag: "--name", Value: "O'Reilly"})
 	want := "--name 'O'\"'\"'Reilly'"
 	if !strings.Contains(got, want) {
 		t.Fatalf("missing %q in %q", want, got)
@@ -52,7 +52,7 @@ func TestReplayCommand_EscapesSingleQuotes_POSIX(t *testing.T) {
 func TestReplayCommand_UsesPowerShellQuotingWhenDetected(t *testing.T) {
 	withHintEnv(t, "windows", map[string]string{"PSModulePath": "C:\\Program Files\\PowerShell"})
 
-	got := ReplayCommand("gr sales list",
+	got := ReplayCommand("gumroad sales list",
 		CommandArg{Flag: "--email", Value: "user name@example.com"},
 		CommandArg{Flag: "--page-key", Value: "$NEXT_PAGE"},
 	)
@@ -70,7 +70,7 @@ func TestReplayCommand_UsesPowerShellQuotingWhenDetected(t *testing.T) {
 func TestReplayCommand_UsesCmdQuotingAsWindowsFallback(t *testing.T) {
 	withHintEnv(t, "windows", map[string]string{})
 
-	got := ReplayCommand("gr sales list",
+	got := ReplayCommand("gumroad sales list",
 		CommandArg{Flag: "--email", Value: "user name@example.com"},
 		CommandArg{Flag: "--name", Value: `He said "hi"`},
 	)
@@ -88,7 +88,7 @@ func TestReplayCommand_UsesCmdQuotingAsWindowsFallback(t *testing.T) {
 func TestReplayCommand_PrefersPOSIXOnWindowsWhenShellIsPresent(t *testing.T) {
 	withHintEnv(t, "windows", map[string]string{"SHELL": "/usr/bin/bash"})
 
-	got := ReplayCommand("gr sales list", CommandArg{Flag: "--page-key", Value: "$NEXT_PAGE"})
+	got := ReplayCommand("gumroad sales list", CommandArg{Flag: "--page-key", Value: "$NEXT_PAGE"})
 	want := "--page-key '$NEXT_PAGE'"
 	if !strings.Contains(got, want) {
 		t.Fatalf("missing %q in %q", want, got)

--- a/internal/cmdutil/interactive.go
+++ b/internal/cmdutil/interactive.go
@@ -8,8 +8,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/antiwork/gr/internal/output"
-	"github.com/antiwork/gr/internal/prompt"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/prompt"
 )
 
 const dryRunLabel = "Dry run"

--- a/internal/cmdutil/messages.go
+++ b/internal/cmdutil/messages.go
@@ -1,6 +1,6 @@
 package cmdutil
 
-import "github.com/antiwork/gr/internal/output"
+import "github.com/antiwork/gumroad-cli/internal/output"
 
 // PrintInfo writes a non-essential informational message unless quiet mode is enabled.
 func PrintInfo(opts Options, message string) error {

--- a/internal/cmdutil/misc_test.go
+++ b/internal/cmdutil/misc_test.go
@@ -14,8 +14,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/antiwork/gr/internal/api"
-	"github.com/antiwork/gr/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -113,10 +113,10 @@ func TestDebugEnabled(t *testing.T) {
 		t.Fatal("debug flag should enable debug mode")
 	}
 
-	t.Setenv("GR_DEBUG", "1")
+	t.Setenv("GUMROAD_DEBUG", "1")
 	opts.Debug = false
 	if !opts.DebugEnabled() {
-		t.Fatal("GR_DEBUG=1 should enable debug mode")
+		t.Fatal("GUMROAD_DEBUG=1 should enable debug mode")
 	}
 }
 
@@ -238,7 +238,7 @@ func TestExactArgs(t *testing.T) {
 }
 
 func TestPropagateExamplesFiltersToChildren(t *testing.T) {
-	root := &cobra.Command{Use: "gr", Example: "  gr products list\n  gr products view <id>\n  gr sales list"}
+	root := &cobra.Command{Use: "gumroad", Example: "  gumroad products list\n  gumroad products view <id>\n  gumroad sales list"}
 	products := &cobra.Command{Use: "products", Run: func(*cobra.Command, []string) {}}
 	view := &cobra.Command{Use: "view <id>", Run: func(*cobra.Command, []string) {}}
 	root.AddCommand(products)
@@ -246,19 +246,19 @@ func TestPropagateExamplesFiltersToChildren(t *testing.T) {
 
 	PropagateExamples(root)
 
-	if !strings.Contains(products.Example, "gr products list") {
+	if !strings.Contains(products.Example, "gumroad products list") {
 		t.Fatalf("products example missing inherited products example: %q", products.Example)
 	}
-	if strings.Contains(products.Example, "gr sales list") {
+	if strings.Contains(products.Example, "gumroad sales list") {
 		t.Fatalf("products example should not include sibling example: %q", products.Example)
 	}
-	if !strings.Contains(view.Example, "gr products view <id>") {
+	if !strings.Contains(view.Example, "gumroad products view <id>") {
 		t.Fatalf("view example missing filtered leaf example: %q", view.Example)
 	}
 }
 
 func TestPropagateExamplesGeneratesLeafFallback(t *testing.T) {
-	root := &cobra.Command{Use: "gr", Example: "  gr custom-fields list --product <id>\n  gr custom-fields create --product <id> --name \"Company\" --required"}
+	root := &cobra.Command{Use: "gumroad", Example: "  gumroad custom-fields list --product <id>\n  gumroad custom-fields create --product <id> --name \"Company\" --required"}
 	customFields := &cobra.Command{Use: "custom-fields", Run: func(*cobra.Command, []string) {}}
 	update := &cobra.Command{Use: "update", Run: func(*cobra.Command, []string) {}}
 	update.Flags().String("product", "", "Product ID (required)")
@@ -268,10 +268,10 @@ func TestPropagateExamplesGeneratesLeafFallback(t *testing.T) {
 
 	PropagateExamples(root)
 
-	if strings.Contains(update.Example, "gr custom-fields list") || strings.Contains(update.Example, "gr custom-fields create") {
+	if strings.Contains(update.Example, "gumroad custom-fields list") || strings.Contains(update.Example, "gumroad custom-fields create") {
 		t.Fatalf("update example should not inherit unrelated ancestor examples: %q", update.Example)
 	}
-	for _, want := range []string{"gr custom-fields update", "--name <value>", "--product <value>"} {
+	for _, want := range []string{"gumroad custom-fields update", "--name <value>", "--product <value>"} {
 		if !strings.Contains(update.Example, want) {
 			t.Fatalf("update example missing %q in %q", want, update.Example)
 		}
@@ -469,7 +469,7 @@ func setupAuthedAPI(t *testing.T, handler http.HandlerFunc) {
 	t.Helper()
 
 	cfgDir := t.TempDir()
-	configDir := filepath.Join(cfgDir, "gr")
+	configDir := filepath.Join(cfgDir, "gumroad")
 	configPath := filepath.Join(configDir, "config.json")
 	if err := os.MkdirAll(configDir, 0700); err != nil {
 		t.Fatalf("mkdir config dir: %v", err)
@@ -480,7 +480,7 @@ func setupAuthedAPI(t *testing.T, handler http.HandlerFunc) {
 	t.Setenv("XDG_CONFIG_HOME", cfgDir)
 
 	srv := httptest.NewServer(handler)
-	t.Setenv("GR_API_BASE_URL", srv.URL)
+	t.Setenv("GUMROAD_API_BASE_URL", srv.URL)
 	t.Cleanup(srv.Close)
 }
 

--- a/internal/cmdutil/options.go
+++ b/internal/cmdutil/options.go
@@ -6,13 +6,13 @@ import (
 	"os"
 	"time"
 
-	"github.com/antiwork/gr/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
 type contextKey string
 
-const optionsContextKey contextKey = "gr-cmd-options"
+const optionsContextKey contextKey = "gumroad-cmd-options"
 
 type Options struct {
 	Context     context.Context
@@ -97,5 +97,5 @@ func (o Options) UsesJSONOutput() bool {
 
 // DebugEnabled reports whether debug logging should be enabled.
 func (o Options) DebugEnabled() bool {
-	return o.Debug || os.Getenv("GR_DEBUG") == "1"
+	return o.Debug || os.Getenv("GUMROAD_DEBUG") == "1"
 }

--- a/internal/cmdutil/paginated_output.go
+++ b/internal/cmdutil/paginated_output.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/antiwork/gr/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/output"
 )
 
 // PaginatedPageOutputConfig describes how a paginated command should render

--- a/internal/cmdutil/paginated_output_test.go
+++ b/internal/cmdutil/paginated_output_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/antiwork/gr/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmdutil/pagination.go
+++ b/internal/cmdutil/pagination.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/antiwork/gr/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/api"
 )
 
 type PageVisitor[T any] func(T) (stop bool, err error)

--- a/internal/cmdutil/pagination_test.go
+++ b/internal/cmdutil/pagination_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/antiwork/gr/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/api"
 	"github.com/spf13/cobra"
 )
 
@@ -89,7 +89,7 @@ func TestWalkPagesFollowsNextPageKey(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	t.Setenv("GR_API_BASE_URL", srv.URL)
+	t.Setenv("GUMROAD_API_BASE_URL", srv.URL)
 	client := api.NewClient("test-token", "test", false)
 
 	var seen []string
@@ -120,7 +120,7 @@ func TestWalkPagesStopsEarly(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	t.Setenv("GR_API_BASE_URL", srv.URL)
+	t.Setenv("GUMROAD_API_BASE_URL", srv.URL)
 	client := api.NewClient("test-token", "test", false)
 
 	err := WalkPages[testPage](client, "/items", nil, func(page testPage) string {
@@ -167,7 +167,7 @@ func TestWalkPagesWithDelay_SleepsBetweenPages(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	t.Setenv("GR_API_BASE_URL", srv.URL)
+	t.Setenv("GUMROAD_API_BASE_URL", srv.URL)
 	client := api.NewClient("test-token", "test", false)
 
 	err := WalkPagesWithDelay[testPage](context.Background(), 250*time.Millisecond, client, "/items", nil, func(page testPage) string {
@@ -204,7 +204,7 @@ func TestWalkPagesWithDelay_StopsOnCancelledContext(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	t.Setenv("GR_API_BASE_URL", srv.URL)
+	t.Setenv("GUMROAD_API_BASE_URL", srv.URL)
 	client := api.NewClient("test-token", "test", false)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -249,7 +249,7 @@ func TestWalkPages_PropagatesSecondPageAPIError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	t.Setenv("GR_API_BASE_URL", srv.URL)
+	t.Setenv("GUMROAD_API_BASE_URL", srv.URL)
 	client := api.NewClient("test-token", "test", false)
 
 	var seen []string
@@ -295,7 +295,7 @@ func TestWalkPages_DetectsRepeatedPageKey(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	t.Setenv("GR_API_BASE_URL", srv.URL)
+	t.Setenv("GUMROAD_API_BASE_URL", srv.URL)
 	client := api.NewClient("test-token", "test", false)
 
 	err := WalkPages[testPage](client, "/items", nil, func(page testPage) string {

--- a/internal/cmdutil/read.go
+++ b/internal/cmdutil/read.go
@@ -8,9 +8,9 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/antiwork/gr/internal/api"
-	"github.com/antiwork/gr/internal/config"
-	"github.com/antiwork/gr/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/config"
+	"github.com/antiwork/gumroad-cli/internal/output"
 )
 
 type ClientRunner func(*api.Client) (json.RawMessage, error)

--- a/internal/cmdutil/read_test.go
+++ b/internal/cmdutil/read_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/antiwork/gr/internal/cmdutil"
-	"github.com/antiwork/gr/internal/testutil"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/testutil"
 )
 
 func TestRunRequest_RendersResponse(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,7 +19,7 @@ var goos = runtime.GOOS
 
 var ErrNotAuthenticated = errors.New("not authenticated")
 
-const EnvAccessToken = "GR_ACCESS_TOKEN"
+const EnvAccessToken = "GUMROAD_ACCESS_TOKEN"
 
 type TokenSource string
 
@@ -35,18 +35,18 @@ type TokenInfo struct {
 
 func Dir() (string, error) {
 	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
-		return filepath.Join(xdg, "gr"), nil
+		return filepath.Join(xdg, "gumroad"), nil
 	}
 	if goos == "windows" {
 		if appData := os.Getenv("APPDATA"); appData != "" {
-			return filepath.Join(appData, "gr"), nil
+			return filepath.Join(appData, "gumroad"), nil
 		}
 	}
 	home, err := userHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("could not determine home directory: %w", err)
 	}
-	return filepath.Join(home, ".config", "gr"), nil
+	return filepath.Join(home, ".config", "gumroad"), nil
 }
 
 func Path() (string, error) {
@@ -172,7 +172,7 @@ func ResolveToken() (TokenInfo, error) {
 		return TokenInfo{}, err
 	}
 	if cfg.AccessToken == "" {
-		return TokenInfo{}, fmt.Errorf("%w. Run `gr auth login` first or set `%s`", ErrNotAuthenticated, EnvAccessToken)
+		return TokenInfo{}, fmt.Errorf("%w. Run `gumroad auth login` first or set `%s`", ErrNotAuthenticated, EnvAccessToken)
 	}
 	return TokenInfo{Value: cfg.AccessToken, Source: TokenSourceConfig}, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -47,7 +47,7 @@ func TestSave_ReplacesExistingConfigWithoutTempFiles(t *testing.T) {
 		t.Fatalf("got token %q, want %q", loaded.AccessToken, "second-token")
 	}
 
-	entries, err := os.ReadDir(filepath.Join(tmp, "gr"))
+	entries, err := os.ReadDir(filepath.Join(tmp, "gumroad"))
 	if err != nil {
 		t.Fatalf("ReadDir failed: %v", err)
 	}
@@ -174,7 +174,7 @@ func TestFilePermissions(t *testing.T) {
 		t.Fatalf("Save failed: %v", err)
 	}
 
-	info, err := os.Stat(filepath.Join(tmp, "gr", "config.json"))
+	info, err := os.Stat(filepath.Join(tmp, "gumroad", "config.json"))
 	if err != nil {
 		t.Fatalf("Stat failed: %v", err)
 	}
@@ -192,7 +192,7 @@ func TestLoad_InsecurePermissions(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)
 
-	dir := filepath.Join(tmp, "gr")
+	dir := filepath.Join(tmp, "gumroad")
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		t.Fatalf("MkdirAll failed: %v", err)
 	}
@@ -234,7 +234,7 @@ func TestLoad_InvalidJSON(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)
 
-	dir := filepath.Join(tmp, "gr")
+	dir := filepath.Join(tmp, "gumroad")
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		t.Fatalf("MkdirAll failed: %v", err)
 	}
@@ -255,7 +255,7 @@ func TestLoad_Unreadable(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)
 
-	dir := filepath.Join(tmp, "gr")
+	dir := filepath.Join(tmp, "gumroad")
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		t.Fatalf("MkdirAll failed: %v", err)
 	}
@@ -355,7 +355,7 @@ func TestToken_EnvAccessTokenIgnoresBrokenConfig(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", tmp)
 	t.Setenv(EnvAccessToken, "env-token")
 
-	dir := filepath.Join(tmp, "gr")
+	dir := filepath.Join(tmp, "gumroad")
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		t.Fatalf("MkdirAll failed: %v", err)
 	}
@@ -408,8 +408,8 @@ func TestDirXDG(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Dir failed: %v", err)
 	}
-	if dir != "/tmp/test-xdg/gr" {
-		t.Errorf("got dir %q, want %q", dir, "/tmp/test-xdg/gr")
+	if dir != "/tmp/test-xdg/gumroad" {
+		t.Errorf("got dir %q, want %q", dir, "/tmp/test-xdg/gumroad")
 	}
 }
 
@@ -425,7 +425,7 @@ func TestDir_WindowsAppData(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Dir failed: %v", err)
 	}
-	want := filepath.Join(`C:\Users\test\AppData\Roaming`, "gr")
+	want := filepath.Join(`C:\Users\test\AppData\Roaming`, "gumroad")
 	if dir != want {
 		t.Errorf("got dir %q, want %q", dir, want)
 	}
@@ -442,7 +442,7 @@ func TestDir_Default(t *testing.T) {
 		t.Fatalf("Dir failed: %v", err)
 	}
 	home, _ := os.UserHomeDir()
-	want := filepath.Join(home, ".config", "gr")
+	want := filepath.Join(home, ".config", "gumroad")
 	if dir != want {
 		t.Errorf("got dir %q, want %q", dir, want)
 	}
@@ -454,7 +454,7 @@ func TestPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Path failed: %v", err)
 	}
-	want := "/tmp/test-path/gr/config.json"
+	want := "/tmp/test-path/gumroad/config.json"
 	if p != want {
 		t.Errorf("got %q, want %q", p, want)
 	}
@@ -468,7 +468,7 @@ func TestDirPermissions(t *testing.T) {
 		t.Fatalf("Save failed: %v", err)
 	}
 
-	info, err := os.Stat(filepath.Join(tmp, "gr"))
+	info, err := os.Stat(filepath.Join(tmp, "gumroad"))
 	if err != nil {
 		t.Fatalf("Stat failed: %v", err)
 	}
@@ -482,7 +482,7 @@ func TestSave_UnwritableDir(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)
 
-	dir := filepath.Join(tmp, "gr")
+	dir := filepath.Join(tmp, "gumroad")
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		t.Fatalf("MkdirAll failed: %v", err)
 	}
@@ -510,7 +510,7 @@ func TestSave_MkdirAllError(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", tmp)
 
 	// Create a file where the directory should be, blocking MkdirAll
-	blocker := filepath.Join(tmp, "gr")
+	blocker := filepath.Join(tmp, "gumroad")
 	if err := os.WriteFile(blocker, []byte("not a dir"), 0600); err != nil {
 		t.Fatalf("WriteFile failed: %v", err)
 	}
@@ -594,7 +594,7 @@ func TestDelete_PermissionDenied(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)
 
-	dir := filepath.Join(tmp, "gr")
+	dir := filepath.Join(tmp, "gumroad")
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		t.Fatalf("MkdirAll failed: %v", err)
 	}

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -82,7 +82,7 @@ func WriteJSONStreamTo(w io.Writer, key string, writeItems func(func(any) error)
 }
 
 // PrintJSONStreamWithJQ stages user-visible output before copying it to the
-// final writer. This is intentional: `gr ... --all --jq ...` must fail
+// final writer. This is intentional: `gumroad ... --all --jq ...` must fail
 // atomically so late pagination/jq errors never leave partial machine-readable
 // output on stdout. Do not switch this back to direct stdout streaming unless
 // the CLI contract changes.
@@ -91,7 +91,7 @@ func PrintJSONStreamWithJQ(w io.Writer, key, jqExpr string, writeItems func(func
 		return PrintJSONStream(w, key, writeItems)
 	}
 
-	return stageOutput(w, "gr-jq-stream-*", func(stage io.Writer) error {
+	return stageOutput(w, "gumroad-jq-stream-*", func(stage io.Writer) error {
 		return streamJSONWithJQ(stage, key, jqExpr, writeItems)
 	})
 }
@@ -99,7 +99,7 @@ func PrintJSONStreamWithJQ(w io.Writer, key, jqExpr string, writeItems func(func
 // PrintJSONStream keeps the same atomic-output contract as
 // PrintJSONStreamWithJQ for user-visible `--all --json` flows.
 func PrintJSONStream(w io.Writer, key string, writeItems func(func(any) error) error) error {
-	return stageOutput(w, "gr-json-stream-*", func(stage io.Writer) error {
+	return stageOutput(w, "gumroad-json-stream-*", func(stage io.Writer) error {
 		return StreamJSONArrayEnvelope(stage, key, writeItems)
 	})
 }

--- a/internal/prompt/input.go
+++ b/internal/prompt/input.go
@@ -55,5 +55,5 @@ func SecretInput(promptLabel, noun string, in io.Reader, out io.Writer, noInput 
 }
 
 func TokenInput(in io.Reader, out io.Writer, noInput bool) (string, error) {
-	return SecretInput("your Gumroad API token", "token", in, out, noInput, "Pipe your token via stdin: echo $TOKEN | gr auth login")
+	return SecretInput("your Gumroad API token", "token", in, out, noInput, "Pipe your token via stdin: echo $TOKEN | gumroad auth login")
 }

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -12,8 +12,8 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/antiwork/gr/internal/cmdutil"
-	"github.com/antiwork/gr/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -23,7 +23,7 @@ func Setup(t *testing.T, handler http.HandlerFunc) *httptest.Server {
 	t.Helper()
 
 	cfgDir := t.TempDir()
-	configDir := filepath.Join(cfgDir, "gr")
+	configDir := filepath.Join(cfgDir, "gumroad")
 	configPath := filepath.Join(configDir, "config.json")
 	if err := os.MkdirAll(configDir, 0700); err != nil {
 		t.Fatalf("MkdirAll failed: %v", err)
@@ -34,7 +34,7 @@ func Setup(t *testing.T, handler http.HandlerFunc) *httptest.Server {
 	t.Setenv("XDG_CONFIG_HOME", cfgDir)
 
 	srv := httptest.NewServer(handler)
-	t.Setenv("GR_API_BASE_URL", srv.URL)
+	t.Setenv("GUMROAD_API_BASE_URL", srv.URL)
 	t.Cleanup(srv.Close)
 	return srv
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -22,13 +22,13 @@ var (
 func buildBinary(t *testing.T) string {
 	t.Helper()
 	buildBinaryOnce.Do(func() {
-		dir, err := os.MkdirTemp("", "gr-test-bin-*")
+		dir, err := os.MkdirTemp("", "gumroad-test-bin-*")
 		if err != nil {
 			buildBinaryErr = err
 			return
 		}
-		buildBinaryPath = filepath.Join(dir, "gr")
-		cmd := exec.Command("go", "build", "-o", buildBinaryPath, "./cmd/gr")
+		buildBinaryPath = filepath.Join(dir, "gumroad")
+		cmd := exec.Command("go", "build", "-o", buildBinaryPath, "./cmd/gumroad")
 		cmd.Dir = getRootDir(t)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
@@ -62,7 +62,7 @@ func getRootDir(t *testing.T) string {
 func setupConfig(t *testing.T) string {
 	t.Helper()
 	cfgDir := t.TempDir()
-	cfgPath := filepath.Join(cfgDir, "gr", "config.json")
+	cfgPath := filepath.Join(cfgDir, "gumroad", "config.json")
 	if err := os.MkdirAll(filepath.Dir(cfgPath), 0700); err != nil {
 		t.Fatalf("MkdirAll failed: %v", err)
 	}
@@ -150,7 +150,7 @@ func TestVersion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("version failed: %v\n%s", err, out)
 	}
-	if !strings.Contains(out, "gr version") {
+	if !strings.Contains(out, "gumroad version") {
 		t.Errorf("expected version string, got %q", out)
 	}
 }
@@ -185,7 +185,7 @@ func TestTopLevelSKUsCommandIsUnavailable(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected top-level skus command to be unavailable")
 	}
-	if !strings.Contains(out, "unknown command \"skus\" for \"gr\"") {
+	if !strings.Contains(out, "unknown command \"skus\" for \"gumroad\"") {
 		t.Fatalf("unexpected output: %q", out)
 	}
 }
@@ -199,9 +199,9 @@ func TestProductsViewMissingIDShowsUsage(t *testing.T) {
 	for _, want := range []string{
 		"missing required argument: <id>",
 		"Usage:",
-		"gr products view <id>",
+		"gumroad products view <id>",
 		"Examples:",
-		"Run \"gr products view --help\" for more information.",
+		"Run \"gumroad products view --help\" for more information.",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("missing %q in %q", want, out)
@@ -218,10 +218,10 @@ func TestWebhooksListMissingResourceShowsUsage(t *testing.T) {
 	for _, want := range []string{
 		"missing required flag: --resource",
 		"Usage:",
-		"gr webhooks list",
+		"gumroad webhooks list",
 		"Examples:",
-		"gr webhooks list --resource sale",
-		"Run \"gr webhooks list --help\" for more information.",
+		"gumroad webhooks list --resource sale",
+		"Run \"gumroad webhooks list --help\" for more information.",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("missing %q in %q", want, out)
@@ -237,15 +237,15 @@ func TestLeafHelpIncludesExamples(t *testing.T) {
 	}
 	for _, want := range []string{
 		"Examples:",
-		"gr products view <id>",
+		"gumroad products view <id>",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("missing %q in %q", want, out)
 		}
 	}
 	for _, unwanted := range []string{
-		"gr products list",
-		"gr products delete <id>",
+		"gumroad products list",
+		"gumroad products delete <id>",
 	} {
 		if strings.Contains(out, unwanted) {
 			t.Fatalf("unexpected sibling example %q in %q", unwanted, out)
@@ -262,10 +262,10 @@ func TestNoArgCommandRejectsUnexpectedArgument(t *testing.T) {
 	for _, want := range []string{
 		"unexpected argument: extra",
 		"Usage:",
-		"gr auth status",
+		"gumroad auth status",
 		"Examples:",
-		"gr auth status",
-		"Run \"gr auth status --help\" for more information.",
+		"gumroad auth status",
+		"Run \"gumroad auth status --help\" for more information.",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("missing %q in %q", want, out)
@@ -355,7 +355,7 @@ func TestUserJSON(t *testing.T) {
 
 	bin := buildBinary(t)
 	cfgDir := setupConfig(t)
-	env := []string{"XDG_CONFIG_HOME=" + cfgDir, "GR_API_BASE_URL=" + srv.URL}
+	env := []string{"XDG_CONFIG_HOME=" + cfgDir, "GUMROAD_API_BASE_URL=" + srv.URL}
 
 	out, err := runGR(t, bin, env, "user", "--json")
 	if err != nil {
@@ -387,7 +387,7 @@ func TestUserJQ(t *testing.T) {
 
 	bin := buildBinary(t)
 	cfgDir := setupConfig(t)
-	env := []string{"XDG_CONFIG_HOME=" + cfgDir, "GR_API_BASE_URL=" + srv.URL}
+	env := []string{"XDG_CONFIG_HOME=" + cfgDir, "GUMROAD_API_BASE_URL=" + srv.URL}
 
 	out, err := runGR(t, bin, env, "user", "--jq", ".user.email")
 	if err != nil {
@@ -421,7 +421,7 @@ func TestProductsList(t *testing.T) {
 
 	bin := buildBinary(t)
 	cfgDir := setupConfig(t)
-	env := []string{"XDG_CONFIG_HOME=" + cfgDir, "GR_API_BASE_URL=" + srv.URL}
+	env := []string{"XDG_CONFIG_HOME=" + cfgDir, "GUMROAD_API_BASE_URL=" + srv.URL}
 
 	// JSON mode
 	out, err := runGR(t, bin, env, "products", "list", "--json")
@@ -464,7 +464,7 @@ func TestSalesListWithFilters(t *testing.T) {
 
 	bin := buildBinary(t)
 	cfgDir := setupConfig(t)
-	env := []string{"XDG_CONFIG_HOME=" + cfgDir, "GR_API_BASE_URL=" + srv.URL}
+	env := []string{"XDG_CONFIG_HOME=" + cfgDir, "GUMROAD_API_BASE_URL=" + srv.URL}
 
 	out, err := runGR(t, bin, env, "sales", "list", "--product", "p1", "--after", "2024-01-01", "--json")
 	if err != nil {
@@ -485,7 +485,7 @@ func TestSalesListAllJSONFailureDoesNotLeakPartialOutput(t *testing.T) {
 
 	bin := buildBinary(t)
 	cfgDir := setupConfig(t)
-	env := []string{"XDG_CONFIG_HOME=" + cfgDir, "GR_API_BASE_URL=" + srv.URL}
+	env := []string{"XDG_CONFIG_HOME=" + cfgDir, "GUMROAD_API_BASE_URL=" + srv.URL}
 
 	out, err := runGR(t, bin, env, "sales", "list", "--all", "--json")
 	if err == nil {
@@ -510,7 +510,7 @@ func TestSalesListAllJQFailureDoesNotLeakPartialOutput(t *testing.T) {
 
 	bin := buildBinary(t)
 	cfgDir := setupConfig(t)
-	env := []string{"XDG_CONFIG_HOME=" + cfgDir, "GR_API_BASE_URL=" + srv.URL}
+	env := []string{"XDG_CONFIG_HOME=" + cfgDir, "GUMROAD_API_BASE_URL=" + srv.URL}
 
 	out, err := runGR(t, bin, env, "sales", "list", "--all", "--jq", ".sales[] | .email")
 	if err == nil {
@@ -543,7 +543,7 @@ func TestInvalidJQReturnsStructuredJSONError(t *testing.T) {
 
 	bin := buildBinary(t)
 	cfgDir := setupConfig(t)
-	env := []string{"XDG_CONFIG_HOME=" + cfgDir, "GR_API_BASE_URL=" + srv.URL}
+	env := []string{"XDG_CONFIG_HOME=" + cfgDir, "GUMROAD_API_BASE_URL=" + srv.URL}
 
 	out, err := runGR(t, bin, env, "user", "--jq", ".user[")
 	if err == nil {
@@ -586,7 +586,7 @@ func TestLicenseVerifyUsesTopLevel(t *testing.T) {
 
 	bin := buildBinary(t)
 	cfgDir := setupConfig(t)
-	env := []string{"XDG_CONFIG_HOME=" + cfgDir, "GR_API_BASE_URL=" + srv.URL}
+	env := []string{"XDG_CONFIG_HOME=" + cfgDir, "GUMROAD_API_BASE_URL=" + srv.URL}
 
 	// Test formatted output shows correct use count
 	out, err := runGR(t, bin, env, "licenses", "verify", "--product", "prod1", "--key", "ABC-123", "--no-increment", "--no-color")
@@ -623,7 +623,7 @@ func TestLoginDistinguishesAuthVsTransportErrors(t *testing.T) {
 
 	bin := buildBinary(t)
 	cfgDir := t.TempDir()
-	env := []string{"XDG_CONFIG_HOME=" + cfgDir, "GR_API_BASE_URL=" + srv.URL}
+	env := []string{"XDG_CONFIG_HOME=" + cfgDir, "GUMROAD_API_BASE_URL=" + srv.URL}
 
 	// Pipe a token via stdin
 	cmd := exec.Command(bin, "auth", "login", "--no-color")
@@ -654,7 +654,7 @@ func TestLoginReportsInvalidToken(t *testing.T) {
 
 	bin := buildBinary(t)
 	cfgDir := t.TempDir()
-	env := []string{"XDG_CONFIG_HOME=" + cfgDir, "GR_API_BASE_URL=" + srv.URL}
+	env := []string{"XDG_CONFIG_HOME=" + cfgDir, "GUMROAD_API_BASE_URL=" + srv.URL}
 
 	cmd := exec.Command(bin, "auth", "login", "--no-color")
 	cmd.Env = append(os.Environ(), env...)
@@ -783,13 +783,13 @@ func TestDebugEnv(t *testing.T) {
 	cfgDir := setupConfig(t)
 	env := []string{
 		"XDG_CONFIG_HOME=" + cfgDir,
-		"GR_API_BASE_URL=" + srv.URL,
-		"GR_DEBUG=1",
+		"GUMROAD_API_BASE_URL=" + srv.URL,
+		"GUMROAD_DEBUG=1",
 	}
 
 	out, err := runGR(t, bin, env, "user")
 	if err != nil {
-		t.Fatalf("user with GR_DEBUG failed: %v\n%s", err, out)
+		t.Fatalf("user with GUMROAD_DEBUG failed: %v\n%s", err, out)
 	}
 	if !strings.Contains(out, "DEBUG request method=GET") || !strings.Contains(out, "status=200") {
 		t.Fatalf("expected debug output in combined streams, got: %q", out)

--- a/test/smoke_test.go
+++ b/test/smoke_test.go
@@ -8,29 +8,29 @@ import (
 )
 
 func TestSmoke_UserAndAuthStatus(t *testing.T) {
-	if os.Getenv("GR_SMOKE") != "1" {
-		t.Skip("set GR_SMOKE=1 and GR_ACCESS_TOKEN to run live Gumroad smoke tests")
+	if os.Getenv("GUMROAD_SMOKE") != "1" {
+		t.Skip("set GUMROAD_SMOKE=1 and GUMROAD_ACCESS_TOKEN to run live Gumroad smoke tests")
 	}
 
-	token := os.Getenv("GR_ACCESS_TOKEN")
+	token := os.Getenv("GUMROAD_ACCESS_TOKEN")
 	if token == "" {
-		t.Fatal("GR_ACCESS_TOKEN is required when GR_SMOKE=1")
+		t.Fatal("GUMROAD_ACCESS_TOKEN is required when GUMROAD_SMOKE=1")
 	}
 
 	bin := buildBinary(t)
 	cfgDir := t.TempDir()
 	env := []string{"XDG_CONFIG_HOME=" + cfgDir}
-	if baseURL := os.Getenv("GR_API_BASE_URL"); baseURL != "" {
-		env = append(env, "GR_API_BASE_URL="+baseURL)
+	if baseURL := os.Getenv("GUMROAD_API_BASE_URL"); baseURL != "" {
+		env = append(env, "GUMROAD_API_BASE_URL="+baseURL)
 	}
 
 	loginOut, err := runGRWithInput(t, bin, env, token+"\n", "auth", "login", "--json")
 	if err != nil {
-		t.Fatalf("gr auth login --json failed: %v\n%s", err, loginOut)
+		t.Fatalf("gumroad auth login --json failed: %v\n%s", err, loginOut)
 	}
 	var loginPayload map[string]json.RawMessage
 	if err := json.Unmarshal([]byte(loginOut), &loginPayload); err != nil {
-		t.Fatalf("gr auth login --json output is not valid JSON: %v\n%s", err, loginOut)
+		t.Fatalf("gumroad auth login --json output is not valid JSON: %v\n%s", err, loginOut)
 	}
 	var loginResp struct {
 		Authenticated bool `json:"authenticated"`
@@ -125,7 +125,7 @@ func TestSmoke_UserAndAuthStatus(t *testing.T) {
 func assertSmokeJSON(t *testing.T, bin string, env []string, args []string, assert func(map[string]json.RawMessage)) map[string]json.RawMessage {
 	t.Helper()
 
-	command := "gr " + strings.Join(args, " ")
+	command := "gumroad " + strings.Join(args, " ")
 	out, err := runGR(t, bin, env, args...)
 	if err != nil {
 		t.Fatalf("%s failed: %v\n%s", command, err, out)
@@ -151,7 +151,7 @@ func assertSmokeJSONWithKeys(t *testing.T, bin string, env []string, args []stri
 func assertSmokeJSONValue[T any](t *testing.T, bin string, env []string, args []string) T {
 	t.Helper()
 
-	command := "gr " + strings.Join(args, " ")
+	command := "gumroad " + strings.Join(args, " ")
 	out, err := runGR(t, bin, env, args...)
 	if err != nil {
 		t.Fatalf("%s failed: %v\n%s", command, err, out)
@@ -167,7 +167,7 @@ func assertSmokeJSONValue[T any](t *testing.T, bin string, env []string, args []
 func assertSmokePlainNonEmpty(t *testing.T, bin string, env []string, args []string) string {
 	t.Helper()
 
-	command := "gr " + strings.Join(args, " ")
+	command := "gumroad " + strings.Join(args, " ")
 	out, err := runGR(t, bin, env, args...)
 	if err != nil {
 		t.Fatalf("%s failed: %v\n%s", command, err, out)


### PR DESCRIPTION
## What

Renames the project from `gr` to `gumroad-cli` and the CLI binary from `gr` to `gumroad`. Updates the Go module path, command name, config directory, environment variables, and all references across 114 files.

| | Before | After |
|---|---|---|
| Project / module | `github.com/antiwork/gr` | `github.com/antiwork/gumroad-cli` |
| Binary | `gr` | `gumroad` |
| Config dir | `~/.config/gr/` | `~/.config/gumroad/` |
| Env vars | `GR_ACCESS_TOKEN`, `GR_DEBUG`, etc. | `GUMROAD_ACCESS_TOKEN`, `GUMROAD_DEBUG`, etc. |
| Install | `go install .../gr/cmd/gr@latest` | `go install .../gumroad-cli/cmd/gumroad@latest` |

## Why

`gr` conflicts with the Oh My Zsh `gr` alias (for `git remote`), which is enabled by default for most zsh users. Renaming to `gumroad` avoids the collision and is a cleaner, more discoverable command name.

---

This PR was implemented with AI assistance using Claude Opus 4.6.