### PR TITLE
Preserve unknown JSON fields in payouts --no-upcoming filter

### DIFF
--- a/internal/cmd/payouts/list.go
+++ b/internal/cmd/payouts/list.go
@@ -107,17 +107,52 @@ func fetchPayoutsListData(client *api.Client, params url.Values, noUpcoming bool
 		return data, nil
 	}
 
-	resp, err := cmdutil.DecodeJSON[payoutsListResponse](data)
-	if err != nil {
-		return nil, err
-	}
-	resp.Payouts = filterPayouts(resp.Payouts, noUpcoming)
+	return filterPayoutsRaw(data)
+}
 
-	data, err = json.Marshal(resp)
+// filterPayoutsRaw removes upcoming payouts from raw JSON without losing
+// unknown fields. It works with map[string]json.RawMessage so that
+// top-level and per-item fields the CLI doesn't know about are preserved.
+func filterPayoutsRaw(data json.RawMessage) (json.RawMessage, error) {
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return nil, fmt.Errorf("could not parse response: %w", err)
+	}
+
+	raw, ok := envelope["payouts"]
+	if !ok || string(raw) == "null" {
+		return data, nil
+	}
+
+	var items []json.RawMessage
+	if err := json.Unmarshal(raw, &items); err != nil {
+		return nil, fmt.Errorf("could not parse payouts array: %w", err)
+	}
+
+	filtered := make([]json.RawMessage, 0, len(items))
+	for _, item := range items {
+		var fields struct {
+			IsUpcoming bool `json:"is_upcoming"`
+		}
+		if err := json.Unmarshal(item, &fields); err != nil {
+			return nil, fmt.Errorf("could not parse payout item: %w", err)
+		}
+		if !fields.IsUpcoming {
+			filtered = append(filtered, item)
+		}
+	}
+
+	rawFiltered, err := json.Marshal(filtered)
+	if err != nil {
+		return nil, fmt.Errorf("could not encode filtered payouts: %w", err)
+	}
+	envelope["payouts"] = rawFiltered
+
+	result, err := json.Marshal(envelope)
 	if err != nil {
 		return nil, fmt.Errorf("could not encode response: %w", err)
 	}
-	return data, nil
+	return result, nil
 }
 
 func streamPayoutsListAll(opts cmdutil.Options, params url.Values, noUpcoming bool) error {

--- a/internal/cmd/payouts/payouts_test.go
+++ b/internal/cmd/payouts/payouts_test.go
@@ -628,6 +628,72 @@ func TestList_NoUpcomingEmptyPageStillShowsPaginationHint(t *testing.T) {
 	}
 }
 
+func TestList_NoUpcoming_JSON_PreservesUnknownFields(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.RawJSON(t, w, `{
+			"success": true,
+			"payouts": [
+				{"id": "pay1", "display_payout_period": "Jan 2024", "formatted_amount": "$100", "is_upcoming": false, "extra_field": "preserved"},
+				{"id": "pay2", "display_payout_period": "Feb 2024", "formatted_amount": "$50", "is_upcoming": true, "extra_field": "filtered"}
+			],
+			"unknown_top_level": "should survive"
+		}`)
+	})
+
+	cmd := testutil.Command(newListCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--no-upcoming"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+
+	// Unknown top-level field must survive
+	if resp["unknown_top_level"] != "should survive" {
+		t.Fatalf("unknown top-level field lost: %s", out)
+	}
+
+	// Only non-upcoming payout should remain
+	payouts := resp["payouts"].([]any)
+	if len(payouts) != 1 {
+		t.Fatalf("got %d payouts, want 1", len(payouts))
+	}
+
+	payout := payouts[0].(map[string]any)
+	if payout["id"] != "pay1" {
+		t.Fatalf("wrong payout survived filter: %v", payout["id"])
+	}
+
+	// Unknown per-item field must survive
+	if payout["extra_field"] != "preserved" {
+		t.Fatalf("unknown per-item field lost: %s", out)
+	}
+}
+
+func TestList_NoUpcoming_JSON_PreservesSuccessField(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.RawJSON(t, w, `{
+			"success": true,
+			"payouts": [
+				{"id": "pay1", "is_upcoming": false}
+			]
+		}`)
+	})
+
+	cmd := testutil.Command(newListCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--no-upcoming"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if resp["success"] != true {
+		t.Fatalf("success field not preserved: got %v", resp["success"])
+	}
+}
+
 func TestList_PaginationHintPreservesFilters(t *testing.T) {
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
 		testutil.JSON(t, w, map[string]any{


### PR DESCRIPTION
## What

When you run `payouts list --json --no-upcoming`, the CLI filters out upcoming payouts before printing the JSON. The old code would parse the API response, filter it, then rebuild the JSON from scratch — but only included the fields the CLI knew about. Any extra fields the API returned were quietly lost. It could also output `"success": false` even when the API said `true`.

Now the filter works directly on the raw JSON. It removes upcoming payout entries without touching anything else, so every field from the API comes through exactly as-is.

## Why

`--json` output should match what the API returns. People pipe it into `jq` or other tools and may rely on fields the CLI doesn't display in its table view. Dropping fields silently breaks that expectation.

---

This PR was implemented with AI assistance using Claude Opus 4.6 and gpt‑5.4 xhigh