### PR TITLE
Fix logout plain output to use fixed columns with source

### DIFF
--- a/internal/cmd/auth/auth_test.go
+++ b/internal/cmd/auth/auth_test.go
@@ -880,8 +880,32 @@ func TestLogout_PlainOutput(t *testing.T) {
 	if err := cmd.RunE(cmd, []string{}); err != nil {
 		t.Fatalf("RunE failed: %v", err)
 	}
-	if strings.TrimSpace(out.String()) != "false\ttrue" {
-		t.Fatalf("unexpected plain output: %q", out.String())
+	if got := strings.TrimRight(out.String(), "\n"); got != "false\ttrue\t" {
+		t.Fatalf("unexpected plain output: %q", got)
+	}
+}
+
+func TestLogout_PlainOutput_WithEnvToken(t *testing.T) {
+	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("logout should not reach API")
+	})
+	cfgDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cfgDir, "gumroad"), 0700); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "gumroad", "config.json"), []byte(`{"access_token":"tok"}`), 0600); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+	withEnvAccessToken(t, "env-token")
+
+	var out bytes.Buffer
+	cmd := testutil.Command(newLogoutCmd(), testutil.Yes(true), testutil.PlainOutput(), testutil.Stdout(&out))
+	if err := cmd.RunE(cmd, []string{}); err != nil {
+		t.Fatalf("RunE failed: %v", err)
+	}
+	if strings.TrimSpace(out.String()) != "false\ttrue\tenv" {
+		t.Fatalf("unexpected plain output: %q, want %q", out.String(), "false\ttrue\tenv")
 	}
 }
 

--- a/internal/cmd/auth/logout.go
+++ b/internal/cmd/auth/logout.go
@@ -56,7 +56,7 @@ func newLogoutCmd() *cobra.Command {
 			}
 			if opts.PlainOutput {
 				return output.PrintPlain(opts.Out(), [][]string{
-					{strconv.FormatBool(status.Authenticated), "true"},
+					{strconv.FormatBool(status.Authenticated), strconv.FormatBool(status.LoggedOut), string(status.Source)},
 				})
 			}
 			if opts.Quiet {


### PR DESCRIPTION
## What

`auth logout --plain` used to output two columns (`authenticated` and a hardcoded `"true"` for `logged_out`). When `GUMROAD_ACCESS_TOKEN` was set in the environment, the plain output gave no indication that a token was still active — the JSON and human-readable outputs mentioned it, but plain output dropped that information entirely.

Now plain output always emits three fixed columns: `authenticated`, `logged_out`, and `source`. When an env token is present after logout, the source column shows `env`. When there's no env token, the column is empty. The `logged_out` column also now uses the actual field value instead of a hardcoded `"true"`.

## Why

Plain output is meant for scripting. Scripts parsing `auth logout --plain` had no way to detect that an environment token was still active after config deletion. The fix also makes the column count stable — it was previously 2 columns, now always 3, which is easier to parse reliably.

---

This PR was implemented with AI assistance using Claude Opus 4.6 and gpt‑5.4 xhigh