### PR TITLE
Retry GET requests on transient body-read failures

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -11,6 +12,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -160,6 +162,14 @@ func (c *Client) do(method, path string, params url.Values) (json.RawMessage, er
 		data, readErr := readResponseBody(resp.Body)
 		resp.Body.Close()
 		if readErr != nil {
+			if isRetryableReadError(readErr) && shouldRetry(method, attempt, 0) {
+				delay := retryDelay(attempt, "")
+				c.debugf("retry method=%s url=%s attempt=%d wait=%s reason=%q", method, logURL, attempt+1, delay, readErr)
+				if err := c.snooze(delay); err != nil {
+					return nil, fmt.Errorf("request failed: %w", err)
+				}
+				continue
+			}
 			c.debugf("response method=%s url=%s status=%d phase=read dur=%s err=%q", method, logURL, resp.StatusCode, time.Since(start).Round(time.Millisecond), readErr)
 			return nil, fmt.Errorf("could not read response: %w", readErr)
 		}
@@ -242,6 +252,23 @@ func sleepContext(ctx context.Context, delay time.Duration) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+}
+
+func isRetryableReadError(err error) bool {
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	// Check for connection reset. On Unix this is syscall.ECONNRESET (errno 54).
+	// On Windows the real error is WSAECONNRESET (errno 10054), which has a
+	// different value than the POSIX compatibility alias, so we check both.
+	if errors.Is(err, syscall.ECONNRESET) {
+		return true
+	}
+	var errno syscall.Errno
+	if errors.As(err, &errno) && errno == 10054 {
+		return true
+	}
+	return false
 }
 
 func shouldRetry(method string, attempt int, statusCode int) bool {

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -393,6 +393,115 @@ func TestClient_GetRetryCanceledDuringBackoff(t *testing.T) {
 	}
 }
 
+func TestClient_GetRetriesBodyReadFailure(t *testing.T) {
+	attempts := 0
+	c := &Client{
+		token:   "test-token",
+		baseURL: "http://localhost",
+		version: "test",
+		httpClient: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				attempts++
+				if attempts == 1 {
+					return &http.Response{
+						StatusCode: 200,
+						Body:       io.NopCloser(errReader{err: io.ErrUnexpectedEOF}),
+					}, nil
+				}
+				body := `{"success":true,"value":"ok"}`
+				return &http.Response{
+					StatusCode: 200,
+					Header:     http.Header{},
+					Body:       io.NopCloser(strings.NewReader(body)),
+				}, nil
+			}),
+		},
+	}
+	var slept []time.Duration
+	c.sleep = func(_ context.Context, d time.Duration) error {
+		slept = append(slept, d)
+		return nil
+	}
+
+	data, err := c.Get("/test", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("got %d attempts, want 2", attempts)
+	}
+	if len(slept) != 1 {
+		t.Fatalf("got %d sleeps, want 1", len(slept))
+	}
+	if !strings.Contains(string(data), "ok") {
+		t.Fatalf("unexpected response: %s", data)
+	}
+}
+
+func TestClient_PostDoesNotRetryBodyReadFailure(t *testing.T) {
+	attempts := 0
+	c := &Client{
+		token:   "test-token",
+		baseURL: "http://localhost",
+		version: "test",
+		httpClient: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				attempts++
+				return &http.Response{
+					StatusCode: 200,
+					Body:       io.NopCloser(errReader{err: io.ErrUnexpectedEOF}),
+				}, nil
+			}),
+		},
+	}
+	c.sleep = func(context.Context, time.Duration) error {
+		t.Fatal("unexpected retry sleep for POST")
+		return nil
+	}
+
+	_, err := c.Post("/test", nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if attempts != 1 {
+		t.Fatalf("got %d attempts, want 1", attempts)
+	}
+}
+
+func TestClient_GetDoesNotRetryOversizedBody(t *testing.T) {
+	attempts := 0
+	oversized := strings.Repeat("x", maxResponseBodySize+1)
+	c := &Client{
+		token:   "test-token",
+		baseURL: "http://localhost",
+		version: "test",
+		httpClient: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				attempts++
+				return &http.Response{
+					StatusCode: 200,
+					Body:       io.NopCloser(strings.NewReader(oversized)),
+				}, nil
+			}),
+		},
+	}
+	c.sleep = func(context.Context, time.Duration) error {
+		t.Fatal("unexpected retry sleep for oversized body")
+		return nil
+	}
+
+	_, err := c.Get("/test", nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "response too large") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("got %d attempts, want 1", attempts)
+	}
+}
+
 func TestParseRetryAfter_Seconds(t *testing.T) {
 	delay, ok := parseRetryAfter("2")
 	if !ok {


### PR DESCRIPTION
## What

The API client already retries GET requests on transport errors (connection refused, DNS failure) and retryable HTTP status codes (503, 429, etc.). But if the HTTP response started successfully and the connection dropped during body read, the error was not retried. The partial failure surfaced immediately.

Now transient body-read errors (`io.ErrUnexpectedEOF`, connection reset) on GET requests trigger the same retry logic with exponential backoff. Non-transient errors like "response too large" are not retried. POST/PUT/DELETE are never retried, matching the existing policy.

The connection reset check works cross-platform. It handles both the Unix `ECONNRESET` (errno 54) and the Windows `WSAECONNRESET` (errno 10054), which have different values in Go's syscall package.

## Why

For paginated `--all` operations, a body-read failure on page N wastes all prior work. Retrying the failed page instead of giving up immediately makes these long-running operations more resilient, especially on unstable connections.

---

This PR was implemented with AI assistance using Claude Opus 4.6 and gpt‑5.4 xhigh