### PR TITLE
Clear env access token in test setup helpers

### DIFF
--- a/internal/cmdutil/misc_test.go
+++ b/internal/cmdutil/misc_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/config"
 	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -478,6 +479,7 @@ func setupAuthedAPI(t *testing.T, handler http.HandlerFunc) {
 		t.Fatalf("write config: %v", err)
 	}
 	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+	t.Setenv(config.EnvAccessToken, "")
 
 	srv := httptest.NewServer(handler)
 	t.Setenv("GUMROAD_API_BASE_URL", srv.URL)

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/config"
 	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -32,6 +33,7 @@ func Setup(t *testing.T, handler http.HandlerFunc) *httptest.Server {
 		t.Fatalf("WriteFile failed: %v", err)
 	}
 	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+	t.Setenv(config.EnvAccessToken, "")
 
 	srv := httptest.NewServer(handler)
 	t.Setenv("GUMROAD_API_BASE_URL", srv.URL)

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -1,0 +1,30 @@
+package testutil
+
+import (
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/config"
+)
+
+func TestSetup_ClearsEnvAccessToken(t *testing.T) {
+	t.Setenv(config.EnvAccessToken, "should-be-cleared")
+
+	Setup(t, func(w http.ResponseWriter, r *http.Request) {})
+
+	if got := os.Getenv(config.EnvAccessToken); got != "" {
+		t.Fatalf("Setup should clear %s, got %q", config.EnvAccessToken, got)
+	}
+
+	info, err := config.ResolveToken()
+	if err != nil {
+		t.Fatalf("ResolveToken failed: %v", err)
+	}
+	if info.Value != "test-token" {
+		t.Fatalf("expected config-file token, got %q", info.Value)
+	}
+	if info.Source != config.TokenSourceConfig {
+		t.Fatalf("expected source %q, got %q", config.TokenSourceConfig, info.Source)
+	}
+}


### PR DESCRIPTION
## What

`testutil.Setup` and `cmdutil.setupAuthedAPI` create a config file with `test-token` and point `XDG_CONFIG_HOME` at a temp directory, but neither cleared `GUMROAD_ACCESS_TOKEN`. Since `ResolveToken()` checks the env var first, a developer with a real token exported would have tests silently use it instead of the fixture token, potentially causing tests to pass or fail for the wrong reasons.

Both helpers now clear `GUMROAD_ACCESS_TOKEN` via `t.Setenv`, which automatically restores the original value after the test. A regression test proves the config-file token path is forced.

## Why

Better test isolation. The mock server URL is already overridden so requests don't reach production, but tests checking auth behavior, token values, or token source could produce incorrect results when the env token leaks through.

---

This PR was implemented with AI assistance using Claude Opus 4.6 and gpt‑5.4 xhigh
