### PR TITLE
Reject --all and --page-key used together

### DIFF
--- a/internal/cmd/payouts/list.go
+++ b/internal/cmd/payouts/list.go
@@ -72,6 +72,7 @@ func newListCmd() *cobra.Command {
 	cmd.Flags().StringVar(&pageKey, "page-key", "", "Pagination cursor")
 	cmd.Flags().BoolVar(&noUpcoming, "no-upcoming", false, "Exclude upcoming payouts")
 	cmd.Flags().BoolVar(&all, "all", false, "Fetch all pages")
+	cmd.MarkFlagsMutuallyExclusive("all", "page-key")
 
 	return cmd
 }

--- a/internal/cmd/payouts/payouts_test.go
+++ b/internal/cmd/payouts/payouts_test.go
@@ -713,3 +713,19 @@ func TestList_PaginationHintPreservesFilters(t *testing.T) {
 		t.Fatalf("expected replayable pagination hint %q in %q", want, out)
 	}
 }
+
+func TestList_AllAndPageKeyConflict(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API with conflicting flags")
+	})
+
+	cmd := newListCmd()
+	cmd.SetArgs([]string{"--all", "--page-key", "cursor123"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for --all and --page-key together")
+	}
+	if !strings.Contains(err.Error(), "none of the others can be") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/cmd/sales/list.go
+++ b/internal/cmd/sales/list.go
@@ -83,6 +83,7 @@ func newListCmd() *cobra.Command {
 	cmd.Flags().StringVar(&after, "after", "", "Filter sales after date (YYYY-MM-DD)")
 	cmd.Flags().StringVar(&pageKey, "page-key", "", "Pagination cursor")
 	cmd.Flags().BoolVar(&all, "all", false, "Fetch all pages")
+	cmd.MarkFlagsMutuallyExclusive("all", "page-key")
 
 	return cmd
 }

--- a/internal/cmd/sales/sales_test.go
+++ b/internal/cmd/sales/sales_test.go
@@ -741,3 +741,19 @@ func TestView_InvalidJSON(t *testing.T) {
 		t.Fatalf("expected parse error, got: %v", err)
 	}
 }
+
+func TestList_AllAndPageKeyConflict(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API with conflicting flags")
+	})
+
+	cmd := newListCmd()
+	cmd.SetArgs([]string{"--all", "--page-key", "cursor123"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for --all and --page-key together")
+	}
+	if !strings.Contains(err.Error(), "none of the others can be") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/cmd/subscribers/list.go
+++ b/internal/cmd/subscribers/list.go
@@ -62,6 +62,7 @@ func newListCmd() *cobra.Command {
 	cmd.Flags().StringVar(&email, "email", "", "Filter by email")
 	cmd.Flags().StringVar(&pageKey, "page-key", "", "Pagination cursor")
 	cmd.Flags().BoolVar(&all, "all", false, "Fetch all pages")
+	cmd.MarkFlagsMutuallyExclusive("all", "page-key")
 
 	return cmd
 }

--- a/internal/cmd/subscribers/subscribers_test.go
+++ b/internal/cmd/subscribers/subscribers_test.go
@@ -604,3 +604,19 @@ func TestView_InvalidJSON(t *testing.T) {
 		t.Fatalf("expected parse error, got: %v", err)
 	}
 }
+
+func TestList_AllAndPageKeyConflict(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API with conflicting flags")
+	})
+
+	cmd := newListCmd()
+	cmd.SetArgs([]string{"--product", "p1", "--all", "--page-key", "cursor123"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for --all and --page-key together")
+	}
+	if !strings.Contains(err.Error(), "none of the others can be") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## What

`payouts list`, `sales list`, and `subscribers list` all accepted `--all` and `--page-key` simultaneously without error. When both were set, `--all` silently used the page key as a starting cursor and paginated forward from there — undocumented behavior that could confuse users expecting `--all` to fetch everything from the beginning.

Now the three commands mark these flags as mutually exclusive via Cobra's built-in `MarkFlagsMutuallyExclusive`. Using both together produces a clear error before the command runs.

## Why

`--all` means "fetch every page." `--page-key` means "fetch one page starting from this cursor." Accepting both silently is confusing. The user gets a hybrid behavior they didn't ask for. Rejecting the combination early with a clear error is better than guessing what they meant.

---

This PR was implemented with AI assistance using Claude Opus 4.6 and gpt‑5.4 xhigh