### PR TITLE
Scope man page cleanup to gumroad-prefixed files

### DIFF
--- a/cmd/gen-man/main.go
+++ b/cmd/gen-man/main.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/antiwork/gumroad-cli/internal/cmd"
 	cobradoc "github.com/spf13/cobra/doc"
@@ -51,7 +52,7 @@ func removeExistingManPages(outputDir string) error {
 	}
 
 	for _, entry := range entries {
-		if entry.IsDir() || filepath.Ext(entry.Name()) != ".1" {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".1" || !strings.HasPrefix(entry.Name(), "gumroad") {
 			continue
 		}
 

--- a/cmd/gen-man/main_test.go
+++ b/cmd/gen-man/main_test.go
@@ -48,3 +48,30 @@ func TestRunRemovesStaleManPagesAndGeneratesCurrentTree(t *testing.T) {
 		t.Fatalf("expected empty stderr, got %q", stderr.String())
 	}
 }
+
+func TestRemoveExistingManPages_PreservesNonGumroadFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create gumroad man pages and an unrelated one
+	for _, name := range []string{"gumroad.1", "gumroad-products.1", "other-tool.1"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("content"), 0600); err != nil {
+			t.Fatalf("WriteFile %s: %v", name, err)
+		}
+	}
+
+	if err := removeExistingManPages(dir); err != nil {
+		t.Fatalf("removeExistingManPages failed: %v", err)
+	}
+
+	// Gumroad files should be removed
+	for _, name := range []string{"gumroad.1", "gumroad-products.1"} {
+		if _, err := os.Stat(filepath.Join(dir, name)); !os.IsNotExist(err) {
+			t.Fatalf("expected %s to be removed", name)
+		}
+	}
+
+	// Non-gumroad file should survive
+	if _, err := os.Stat(filepath.Join(dir, "other-tool.1")); err != nil {
+		t.Fatalf("expected other-tool.1 to survive: %v", err)
+	}
+}


### PR DESCRIPTION
## What

The man page generator's `removeExistingManPages` function deleted every `.1` file in the output directory before regenerating. If someone pointed it at a shared man directory (e.g., `/usr/local/share/man/man1/`), it would remove unrelated man pages from other tools.

Now it only removes `.1` files whose name starts with `gumroad`, matching the files Cobra's `GenManTree` actually generates (`gumroad.1`, `gumroad-products.1`, etc.).

## Why

The default output directory (`man/`) is project-local and safe, but the generator accepts an arbitrary path as its first argument. Deleting only the files this tool creates is the right behavior regardless of where the output lands.

---

This PR was implemented with AI assistance using Claude Opus 4.6 and gpt‑5.4 xhigh