### PR TITLE
Replace cents flags with user-friendly money flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ gumroad sales list --all
 gumroad sales view abc123 --json --jq '.sale.email'
 
 # Preview a refund without executing it
-gumroad sales refund abc123 --amount-cents 500 --dry-run
+gumroad sales refund abc123 --amount 5.00 --dry-run
 ```
 
 ## Commands

--- a/internal/cmd/offercodes/create.go
+++ b/internal/cmd/offercodes/create.go
@@ -9,7 +9,7 @@ import (
 )
 
 func newCreateCmd() *cobra.Command {
-	var product, name string
+	var product, name, amount string
 	var amountCents, percentOff, maxPurchaseCount int
 	var universal bool
 
@@ -19,7 +19,7 @@ func newCreateCmd() *cobra.Command {
 		Args:  cmdutil.ExactArgs(0),
 		Long: `Create an offer code for a product.
 
-Use either --amount-cents (flat discount) or --percent-off (percentage discount), not both.`,
+Use either --amount (flat discount) or --percent-off (percentage discount), not both.`,
 		RunE: func(c *cobra.Command, args []string) error {
 			if err := cmdutil.RequirePositiveIntFlag(c, "amount-cents", amountCents); err != nil {
 				return err
@@ -37,21 +37,31 @@ Use either --amount-cents (flat discount) or --percent-off (percentage discount)
 				return cmdutil.MissingFlagError(c, "--name")
 			}
 
-			flags := c.Flags()
-			hasAmountOff := flags.Changed("amount-cents")
-			hasPercentOff := flags.Changed("percent-off")
-			hasMaxPurchaseCount := flags.Changed("max-purchase-count")
+			cents, hasAmountOff, err := cmdutil.ResolveMoneyFlag(c, "amount", "amount-cents", "amount", "", amountCents, amount, false)
+			if err != nil {
+				return err
+			}
+			if hasAmountOff && cents == 0 {
+				return cmdutil.UsageErrorf(c, "--amount must be greater than 0")
+			}
+
+			hasPercentOff := c.Flags().Changed("percent-off")
+			hasMaxPurchaseCount := c.Flags().Changed("max-purchase-count")
 			if hasAmountOff && hasPercentOff {
-				return cmdutil.UsageErrorf(c, "flags --amount-cents and --percent-off cannot be used together")
+				amountFlag := "--amount"
+				if c.Flags().Changed("amount-cents") {
+					amountFlag = "--amount-cents"
+				}
+				return cmdutil.UsageErrorf(c, "flags %s and --percent-off cannot be used together", amountFlag)
 			}
 			if !hasAmountOff && !hasPercentOff {
-				return cmdutil.UsageErrorf(c, "one of --amount-cents or --percent-off is required")
+				return cmdutil.UsageErrorf(c, "one of --amount or --percent-off is required")
 			}
 
 			params := url.Values{}
 			params.Set("name", name)
 			if hasAmountOff {
-				params.Set("amount_off", strconv.Itoa(amountCents))
+				params.Set("amount_off", strconv.Itoa(cents))
 			}
 			if hasPercentOff {
 				params.Set("percent_off", strconv.Itoa(percentOff))
@@ -70,7 +80,9 @@ Use either --amount-cents (flat discount) or --percent-off (percentage discount)
 
 	cmd.Flags().StringVar(&product, "product", "", "Product ID (required)")
 	cmd.Flags().StringVar(&name, "name", "", "Offer code name (required)")
-	cmd.Flags().IntVar(&amountCents, "amount-cents", 0, "Flat discount in cents")
+	cmd.Flags().StringVar(&amount, "amount", "", "Flat discount amount (e.g. 5, 5.00)")
+	cmd.Flags().IntVar(&amountCents, "amount-cents", 0, "Flat discount in cents (deprecated, use --amount)")
+	_ = cmd.Flags().MarkHidden("amount-cents")
 	cmd.Flags().IntVar(&percentOff, "percent-off", 0, "Percentage discount")
 	cmd.Flags().IntVar(&maxPurchaseCount, "max-purchase-count", 0, "Maximum number of uses")
 	cmd.Flags().BoolVar(&universal, "universal", false, "Universal offer code")

--- a/internal/cmd/offercodes/create.go
+++ b/internal/cmd/offercodes/create.go
@@ -10,7 +10,7 @@ import (
 
 func newCreateCmd() *cobra.Command {
 	var product, name, amount string
-	var amountCents, percentOff, maxPurchaseCount int
+	var percentOff, maxPurchaseCount int
 	var universal bool
 
 	cmd := &cobra.Command{
@@ -21,9 +21,6 @@ func newCreateCmd() *cobra.Command {
 
 Use either --amount (flat discount) or --percent-off (percentage discount), not both.`,
 		RunE: func(c *cobra.Command, args []string) error {
-			if err := cmdutil.RequirePositiveIntFlag(c, "amount-cents", amountCents); err != nil {
-				return err
-			}
 			if err := cmdutil.RequirePercentFlag(c, "percent-off", percentOff); err != nil {
 				return err
 			}
@@ -37,30 +34,28 @@ Use either --amount (flat discount) or --percent-off (percentage discount), not 
 				return cmdutil.MissingFlagError(c, "--name")
 			}
 
-			cents, hasAmountOff, err := cmdutil.ResolveMoneyFlag(c, "amount", "amount-cents", "amount", "", amountCents, amount, false)
-			if err != nil {
-				return err
-			}
-			if hasAmountOff && cents == 0 {
-				return cmdutil.UsageErrorf(c, "--amount must be greater than 0")
-			}
+			flags := c.Flags()
+			hasAmount := flags.Changed("amount")
+			hasPercentOff := flags.Changed("percent-off")
+			hasMaxPurchaseCount := flags.Changed("max-purchase-count")
 
-			hasPercentOff := c.Flags().Changed("percent-off")
-			hasMaxPurchaseCount := c.Flags().Changed("max-purchase-count")
-			if hasAmountOff && hasPercentOff {
-				amountFlag := "--amount"
-				if c.Flags().Changed("amount-cents") {
-					amountFlag = "--amount-cents"
-				}
-				return cmdutil.UsageErrorf(c, "flags %s and --percent-off cannot be used together", amountFlag)
+			if hasAmount && hasPercentOff {
+				return cmdutil.UsageErrorf(c, "flags --amount and --percent-off cannot be used together")
 			}
-			if !hasAmountOff && !hasPercentOff {
+			if !hasAmount && !hasPercentOff {
 				return cmdutil.UsageErrorf(c, "one of --amount or --percent-off is required")
 			}
 
 			params := url.Values{}
 			params.Set("name", name)
-			if hasAmountOff {
+			if hasAmount {
+				cents, err := cmdutil.ParseMoney("amount", amount, "amount", "")
+				if err != nil {
+					return cmdutil.UsageErrorf(c, "%s", err.Error())
+				}
+				if cents <= 0 {
+					return cmdutil.UsageErrorf(c, "--amount must be greater than 0")
+				}
 				params.Set("amount_off", strconv.Itoa(cents))
 			}
 			if hasPercentOff {
@@ -81,8 +76,6 @@ Use either --amount (flat discount) or --percent-off (percentage discount), not 
 	cmd.Flags().StringVar(&product, "product", "", "Product ID (required)")
 	cmd.Flags().StringVar(&name, "name", "", "Offer code name (required)")
 	cmd.Flags().StringVar(&amount, "amount", "", "Flat discount amount (e.g. 5, 5.00)")
-	cmd.Flags().IntVar(&amountCents, "amount-cents", 0, "Flat discount in cents (deprecated, use --amount)")
-	_ = cmd.Flags().MarkHidden("amount-cents")
 	cmd.Flags().IntVar(&percentOff, "percent-off", 0, "Percentage discount")
 	cmd.Flags().IntVar(&maxPurchaseCount, "max-purchase-count", 0, "Maximum number of uses")
 	cmd.Flags().BoolVar(&universal, "universal", false, "Universal offer code")

--- a/internal/cmd/offercodes/offercodes_test.go
+++ b/internal/cmd/offercodes/offercodes_test.go
@@ -2,10 +2,12 @@ package offercodes
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 	"testing"
 
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/testutil"
 )
 
@@ -448,6 +450,108 @@ func TestCreate_PercentOff(t *testing.T) {
 	}
 	if gotAmountOff != "" {
 		t.Errorf("amount_off should be empty, got %q", gotAmountOff)
+	}
+}
+
+func TestCreate_Amount(t *testing.T) {
+	var gotAmountOff string
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm failed: %v", err)
+		}
+		gotAmountOff = r.PostForm.Get("amount_off")
+		testutil.JSON(t, w, map[string]any{})
+	})
+
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--product", "p1", "--name", "FLAT5", "--amount", "5.00"})
+	testutil.CaptureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute failed: %v", err)
+		}
+	})
+
+	if gotAmountOff != "500" {
+		t.Errorf("got amount_off=%q, want 500", gotAmountOff)
+	}
+}
+
+func TestCreate_AmountWholeNumber(t *testing.T) {
+	var gotAmountOff string
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm failed: %v", err)
+		}
+		gotAmountOff = r.PostForm.Get("amount_off")
+		testutil.JSON(t, w, map[string]any{})
+	})
+
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--product", "p1", "--name", "FLAT5", "--amount", "5"})
+	testutil.CaptureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute failed: %v", err)
+		}
+	})
+
+	if gotAmountOff != "500" {
+		t.Errorf("got amount_off=%q, want 500", gotAmountOff)
+	}
+}
+
+func TestCreate_AmountAndAmountCentsConflict(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API")
+	})
+
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--product", "p1", "--name", "X", "--amount", "5", "--amount-cents", "500"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "use --amount or --amount-cents, not both") {
+		t.Fatalf("expected conflict error, got: %v", err)
+	}
+}
+
+func TestCreate_AmountAndPercentOffConflict(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API")
+	})
+
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--product", "p1", "--name", "X", "--amount", "5", "--percent-off", "10"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "cannot be used together") {
+		t.Fatalf("expected mutual exclusion error, got: %v", err)
+	}
+}
+
+func TestCreate_AmountInvalidInput(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API")
+	})
+
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--product", "p1", "--name", "X", "--amount", "abc"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "not a valid amount") {
+		t.Fatalf("expected validation error, got: %v", err)
+	}
+	var usageErr *cmdutil.UsageError
+	if !errors.As(err, &usageErr) {
+		t.Fatalf("expected *cmdutil.UsageError, got %T", err)
+	}
+}
+
+func TestCreate_AmountZeroRejected(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API")
+	})
+
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--product", "p1", "--name", "X", "--amount", "0"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--amount must be greater than 0") {
+		t.Fatalf("expected amount validation error, got: %v", err)
 	}
 }
 

--- a/internal/cmd/offercodes/offercodes_test.go
+++ b/internal/cmd/offercodes/offercodes_test.go
@@ -325,7 +325,7 @@ func TestCreate_MutualExclusion(t *testing.T) {
 	})
 
 	cmd := newCreateCmd()
-	cmd.SetArgs([]string{"--product", "p1", "--name", "X", "--amount-cents", "500", "--percent-off", "10"})
+	cmd.SetArgs([]string{"--product", "p1", "--name", "X", "--amount", "5", "--percent-off", "10"})
 	err := cmd.Execute()
 	if err == nil || !strings.Contains(err.Error(), "cannot be used together") {
 		t.Fatalf("expected mutual exclusion error, got: %v", err)
@@ -348,18 +348,6 @@ func TestCreate_RequiresDiscount(t *testing.T) {
 	}
 }
 
-func TestCreate_RejectsNegativeAmountCents(t *testing.T) {
-	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
-		t.Error("should not reach API")
-	})
-
-	cmd := newCreateCmd()
-	cmd.SetArgs([]string{"--product", "p1", "--name", "X", "--amount-cents", "-5"})
-	err := cmd.Execute()
-	if err == nil || !strings.Contains(err.Error(), "--amount-cents must be greater than 0") {
-		t.Fatalf("expected amount validation error, got: %v", err)
-	}
-}
 
 func TestCreate_RejectsNegativePercentOff(t *testing.T) {
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
@@ -499,19 +487,6 @@ func TestCreate_AmountWholeNumber(t *testing.T) {
 	}
 }
 
-func TestCreate_AmountAndAmountCentsConflict(t *testing.T) {
-	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
-		t.Error("should not reach API")
-	})
-
-	cmd := newCreateCmd()
-	cmd.SetArgs([]string{"--product", "p1", "--name", "X", "--amount", "5", "--amount-cents", "500"})
-	err := cmd.Execute()
-	if err == nil || !strings.Contains(err.Error(), "use --amount or --amount-cents, not both") {
-		t.Fatalf("expected conflict error, got: %v", err)
-	}
-}
-
 func TestCreate_AmountAndPercentOffConflict(t *testing.T) {
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
 		t.Error("should not reach API")
@@ -552,29 +527,6 @@ func TestCreate_AmountZeroRejected(t *testing.T) {
 	err := cmd.Execute()
 	if err == nil || !strings.Contains(err.Error(), "--amount must be greater than 0") {
 		t.Fatalf("expected amount validation error, got: %v", err)
-	}
-}
-
-func TestCreate_AmountCents(t *testing.T) {
-	var gotAmountOff string
-	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
-		if err := r.ParseForm(); err != nil {
-			t.Fatalf("ParseForm failed: %v", err)
-		}
-		gotAmountOff = r.PostForm.Get("amount_off")
-		testutil.JSON(t, w, map[string]any{})
-	})
-
-	cmd := newCreateCmd()
-	cmd.SetArgs([]string{"--product", "p1", "--name", "FLAT5", "--amount-cents", "500"})
-	testutil.CaptureStdout(func() {
-		if err := cmd.Execute(); err != nil {
-			t.Fatalf("Execute failed: %v", err)
-		}
-	})
-
-	if gotAmountOff != "500" {
-		t.Errorf("got amount_off=%q, want 500", gotAmountOff)
 	}
 }
 

--- a/internal/cmd/sales/refund.go
+++ b/internal/cmd/sales/refund.go
@@ -11,7 +11,6 @@ import (
 
 func newRefundCmd() *cobra.Command {
 	var amount string
-	var amountCents int
 
 	cmd := &cobra.Command{
 		Use:   "refund <id>",
@@ -20,23 +19,24 @@ func newRefundCmd() *cobra.Command {
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
 
-			if err := cmdutil.RequirePositiveIntFlag(c, "amount-cents", amountCents); err != nil {
-				return err
+			var cents int
+			hasAmount := c.Flags().Changed("amount")
+			if hasAmount {
+				parsed, err := cmdutil.ParseMoney("amount", amount, "amount", "")
+				if err != nil {
+					return cmdutil.UsageErrorf(c, "%s", err.Error())
+				}
+				if parsed <= 0 {
+					return cmdutil.UsageErrorf(c, "--amount must be greater than 0")
+				}
+				cents = parsed
 			}
 
-			cents, hasAmount, err := cmdutil.ResolveMoneyFlag(c, "amount", "amount-cents", "amount", "", amountCents, amount, false)
-			if err != nil {
-				return err
-			}
-			if hasAmount && cents == 0 {
-				return cmdutil.UsageErrorf(c, "--amount must be greater than 0")
-			}
-
-			// Build the human-readable amount description used in prompts and messages.
-			amountDesc := refundAmountDesc(cents, c.Flags().Changed("amount"))
+			isPartial := cents > 0
+			amountDesc := cmdutil.FormatMoney(cents, "")
 
 			msg := "Refund sale " + args[0] + "?"
-			if cents > 0 {
+			if isPartial {
 				msg = fmt.Sprintf("Refund %s on sale %s?", amountDesc, args[0])
 			}
 
@@ -46,7 +46,7 @@ func newRefundCmd() *cobra.Command {
 			}
 			if !ok {
 				action := "refund sale " + args[0]
-				if cents > 0 {
+				if isPartial {
 					action = fmt.Sprintf("refund %s on sale %s", amountDesc, args[0])
 				}
 				return cmdutil.PrintCancelledAction(opts, action)
@@ -54,7 +54,7 @@ func newRefundCmd() *cobra.Command {
 
 			params := url.Values{}
 			successMessage := "Sale " + args[0] + " refunded."
-			if cents > 0 {
+			if isPartial {
 				params.Set("amount_cents", strconv.Itoa(cents))
 				successMessage = fmt.Sprintf("Refunded %s on sale %s.", amountDesc, args[0])
 			}
@@ -64,18 +64,6 @@ func newRefundCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&amount, "amount", "", "Partial refund amount (e.g. 5, 5.00)")
-	cmd.Flags().IntVar(&amountCents, "amount-cents", 0, "Partial refund amount in cents (deprecated, use --amount)")
-	_ = cmd.Flags().MarkHidden("amount-cents")
 
 	return cmd
-}
-
-// refundAmountDesc returns a human-readable description of the refund amount.
-// When the new --amount flag was used, it normalizes to "N.NN" format.
-// When the deprecated --amount-cents flag was used, it shows "N cents".
-func refundAmountDesc(cents int, usedNewFlag bool) string {
-	if usedNewFlag {
-		return cmdutil.FormatMoney(cents, "")
-	}
-	return fmt.Sprintf("%d cents", cents)
 }

--- a/internal/cmd/sales/refund.go
+++ b/internal/cmd/sales/refund.go
@@ -10,6 +10,7 @@ import (
 )
 
 func newRefundCmd() *cobra.Command {
+	var amount string
 	var amountCents int
 
 	cmd := &cobra.Command{
@@ -18,13 +19,25 @@ func newRefundCmd() *cobra.Command {
 		Args:  cmdutil.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
+
 			if err := cmdutil.RequirePositiveIntFlag(c, "amount-cents", amountCents); err != nil {
 				return err
 			}
 
+			cents, hasAmount, err := cmdutil.ResolveMoneyFlag(c, "amount", "amount-cents", "amount", "", amountCents, amount, false)
+			if err != nil {
+				return err
+			}
+			if hasAmount && cents == 0 {
+				return cmdutil.UsageErrorf(c, "--amount must be greater than 0")
+			}
+
+			// Build the human-readable amount description used in prompts and messages.
+			amountDesc := refundAmountDesc(cents, c.Flags().Changed("amount"))
+
 			msg := "Refund sale " + args[0] + "?"
-			if amountCents > 0 {
-				msg = fmt.Sprintf("Refund %d cents on sale %s?", amountCents, args[0])
+			if cents > 0 {
+				msg = fmt.Sprintf("Refund %s on sale %s?", amountDesc, args[0])
 			}
 
 			ok, err := cmdutil.ConfirmAction(opts, msg)
@@ -33,24 +46,36 @@ func newRefundCmd() *cobra.Command {
 			}
 			if !ok {
 				action := "refund sale " + args[0]
-				if amountCents > 0 {
-					action = fmt.Sprintf("refund %d cents on sale %s", amountCents, args[0])
+				if cents > 0 {
+					action = fmt.Sprintf("refund %s on sale %s", amountDesc, args[0])
 				}
 				return cmdutil.PrintCancelledAction(opts, action)
 			}
 
 			params := url.Values{}
 			successMessage := "Sale " + args[0] + " refunded."
-			if amountCents > 0 {
-				params.Set("amount_cents", strconv.Itoa(amountCents))
-				successMessage = fmt.Sprintf("Refunded %d cents on sale %s.", amountCents, args[0])
+			if cents > 0 {
+				params.Set("amount_cents", strconv.Itoa(cents))
+				successMessage = fmt.Sprintf("Refunded %s on sale %s.", amountDesc, args[0])
 			}
 
 			return cmdutil.RunRequestWithSuccess(opts, "Refunding sale...", "PUT", cmdutil.JoinPath("sales", args[0], "refund"), params, successMessage)
 		},
 	}
 
-	cmd.Flags().IntVar(&amountCents, "amount-cents", 0, "Partial refund amount in cents")
+	cmd.Flags().StringVar(&amount, "amount", "", "Partial refund amount (e.g. 5, 5.00)")
+	cmd.Flags().IntVar(&amountCents, "amount-cents", 0, "Partial refund amount in cents (deprecated, use --amount)")
+	_ = cmd.Flags().MarkHidden("amount-cents")
 
 	return cmd
+}
+
+// refundAmountDesc returns a human-readable description of the refund amount.
+// When the new --amount flag was used, it normalizes to "N.NN" format.
+// When the deprecated --amount-cents flag was used, it shows "N cents".
+func refundAmountDesc(cents int, usedNewFlag bool) string {
+	if usedNewFlag {
+		return cmdutil.FormatMoney(cents, "")
+	}
+	return fmt.Sprintf("%d cents", cents)
 }

--- a/internal/cmd/sales/sales_test.go
+++ b/internal/cmd/sales/sales_test.go
@@ -353,7 +353,7 @@ func TestRefund_DryRunSkipsConfirmationAndNetwork(t *testing.T) {
 	})
 
 	cmd := testutil.Command(newRefundCmd(), testutil.DryRun(true), testutil.NoInput(true))
-	cmd.SetArgs([]string{"s1", "--amount-cents", "500"})
+	cmd.SetArgs([]string{"s1", "--amount", "5.00"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
 	for _, want := range []string{"Dry run", "PUT /sales/s1/refund", "amount_cents: 500"} {
@@ -399,47 +399,13 @@ func TestRefund_Partial(t *testing.T) {
 	})
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true), testutil.Quiet(false))
-	cmd.SetArgs([]string{"s1", "--amount-cents", "500"})
-	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
-	if gotAmountCents != "500" {
-		t.Errorf("got amount_cents=%q, want 500", gotAmountCents)
-	}
-	if !strings.Contains(out, "Refunded 500 cents on sale s1.") {
-		t.Errorf("expected partial refund message, got %q", out)
-	}
-}
-
-func TestRefund_PartialWithAmount(t *testing.T) {
-	var gotAmountCents string
-	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
-		if err := r.ParseForm(); err != nil {
-			t.Fatalf("ParseForm failed: %v", err)
-		}
-		gotAmountCents = r.PostForm.Get("amount_cents")
-		testutil.JSON(t, w, map[string]any{})
-	})
-
-	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true), testutil.Quiet(false))
 	cmd.SetArgs([]string{"s1", "--amount", "5.00"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 	if gotAmountCents != "500" {
 		t.Errorf("got amount_cents=%q, want 500", gotAmountCents)
 	}
 	if !strings.Contains(out, "Refunded 5.00 on sale s1.") {
-		t.Errorf("expected user-friendly refund message, got %q", out)
-	}
-}
-
-func TestRefund_AmountAndAmountCentsConflict(t *testing.T) {
-	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
-		t.Error("should not reach API")
-	})
-
-	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
-	cmd.SetArgs([]string{"s1", "--amount", "5", "--amount-cents", "500"})
-	err := cmd.Execute()
-	if err == nil || !strings.Contains(err.Error(), "use --amount or --amount-cents, not both") {
-		t.Fatalf("expected conflict error, got: %v", err)
+		t.Errorf("expected partial refund message, got %q", out)
 	}
 }
 
@@ -503,34 +469,18 @@ func TestRefund_AmountZeroRejected(t *testing.T) {
 	}
 }
 
-func TestRefund_DryRunWithAmount(t *testing.T) {
-	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
-		t.Error("dry-run should not reach API")
-	})
-
-	cmd := testutil.Command(newRefundCmd(), testutil.DryRun(true), testutil.NoInput(true))
-	cmd.SetArgs([]string{"s1", "--amount", "5.00"})
-	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
-
-	for _, want := range []string{"Dry run", "PUT /sales/s1/refund", "amount_cents: 500"} {
-		if !strings.Contains(out, want) {
-			t.Fatalf("missing %q in %q", want, out)
-		}
-	}
-}
-
 func TestRefund_InvalidPartialAmount(t *testing.T) {
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
 		t.Error("should not reach API with invalid amount")
 	})
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
-	cmd.SetArgs([]string{"s1", "--amount-cents", "-1"})
+	cmd.SetArgs([]string{"s1", "--amount", "-1"})
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected validation error")
 	}
-	if !strings.Contains(err.Error(), "--amount-cents must be greater than 0") {
+	if !strings.Contains(err.Error(), "--amount cannot be negative") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	for _, want := range []string{"Usage:", "refund <id>"} {

--- a/internal/cmd/sales/sales_test.go
+++ b/internal/cmd/sales/sales_test.go
@@ -2,10 +2,12 @@ package sales
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 	"testing"
 
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/testutil"
 )
 
@@ -404,6 +406,116 @@ func TestRefund_Partial(t *testing.T) {
 	}
 	if !strings.Contains(out, "Refunded 500 cents on sale s1.") {
 		t.Errorf("expected partial refund message, got %q", out)
+	}
+}
+
+func TestRefund_PartialWithAmount(t *testing.T) {
+	var gotAmountCents string
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm failed: %v", err)
+		}
+		gotAmountCents = r.PostForm.Get("amount_cents")
+		testutil.JSON(t, w, map[string]any{})
+	})
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true), testutil.Quiet(false))
+	cmd.SetArgs([]string{"s1", "--amount", "5.00"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if gotAmountCents != "500" {
+		t.Errorf("got amount_cents=%q, want 500", gotAmountCents)
+	}
+	if !strings.Contains(out, "Refunded 5.00 on sale s1.") {
+		t.Errorf("expected user-friendly refund message, got %q", out)
+	}
+}
+
+func TestRefund_AmountAndAmountCentsConflict(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API")
+	})
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"s1", "--amount", "5", "--amount-cents", "500"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "use --amount or --amount-cents, not both") {
+		t.Fatalf("expected conflict error, got: %v", err)
+	}
+}
+
+func TestRefund_AmountInvalidInput(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API")
+	})
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"s1", "--amount", "abc"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "not a valid amount") {
+		t.Fatalf("expected validation error, got: %v", err)
+	}
+	var usageErr *cmdutil.UsageError
+	if !errors.As(err, &usageErr) {
+		t.Fatalf("expected *cmdutil.UsageError, got %T", err)
+	}
+}
+
+func TestRefund_AmountWholeNumberMessage(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{})
+	})
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true), testutil.Quiet(false))
+	cmd.SetArgs([]string{"s1", "--amount", "5"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if !strings.Contains(out, "Refunded 5.00 on sale s1.") {
+		t.Errorf("expected normalized refund message, got %q", out)
+	}
+}
+
+func TestRefund_AmountNoInputShowsNormalized(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API without confirmation")
+	})
+
+	cmd := testutil.Command(newRefundCmd(), testutil.NoInput(true))
+	cmd.SetArgs([]string{"s1", "--amount", "5"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error without confirmation")
+	}
+	// The error message should mention --yes (confirmation required), not raw "5"
+	if !strings.Contains(err.Error(), "--yes") {
+		t.Fatalf("expected confirmation error mentioning --yes, got: %v", err)
+	}
+}
+
+func TestRefund_AmountZeroRejected(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API")
+	})
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"s1", "--amount", "0"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--amount must be greater than 0") {
+		t.Fatalf("expected amount validation error, got: %v", err)
+	}
+}
+
+func TestRefund_DryRunWithAmount(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("dry-run should not reach API")
+	})
+
+	cmd := testutil.Command(newRefundCmd(), testutil.DryRun(true), testutil.NoInput(true))
+	cmd.SetArgs([]string{"s1", "--amount", "5.00"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	for _, want := range []string{"Dry run", "PUT /sales/s1/refund", "amount_cents: 500"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in %q", want, out)
+		}
 	}
 }
 

--- a/internal/cmd/variants/create.go
+++ b/internal/cmd/variants/create.go
@@ -9,7 +9,7 @@ import (
 )
 
 func newCreateCmd() *cobra.Command {
-	var product, category, name, description string
+	var product, category, name, description, priceDifference string
 	var priceDifferenceCents, maxPurchaseCount int
 
 	cmd := &cobra.Command{
@@ -17,7 +17,6 @@ func newCreateCmd() *cobra.Command {
 		Short: "Create a variant",
 		Args:  cmdutil.ExactArgs(0),
 		RunE: func(c *cobra.Command, args []string) error {
-			opts := cmdutil.OptionsFrom(c)
 			if err := cmdutil.RequireNonNegativeIntFlag(c, "max-purchase-count", maxPurchaseCount); err != nil {
 				return err
 			}
@@ -31,9 +30,12 @@ func newCreateCmd() *cobra.Command {
 				return cmdutil.MissingFlagError(c, "--name")
 			}
 
-			flags := c.Flags()
-			hasPriceDifference := flags.Changed("price-difference-cents")
-			hasMaxPurchaseCount := flags.Changed("max-purchase-count")
+			priceDiffCents, hasPriceDifference, err := cmdutil.ResolveMoneyFlag(c, "price-difference", "price-difference-cents", "price", "", priceDifferenceCents, priceDifference, true)
+			if err != nil {
+				return err
+			}
+
+			hasMaxPurchaseCount := c.Flags().Changed("max-purchase-count")
 
 			params := url.Values{}
 			params.Set("name", name)
@@ -41,14 +43,14 @@ func newCreateCmd() *cobra.Command {
 				params.Set("description", description)
 			}
 			if hasPriceDifference {
-				params.Set("price_difference_cents", strconv.Itoa(priceDifferenceCents))
+				params.Set("price_difference_cents", strconv.Itoa(priceDiffCents))
 			}
 			if hasMaxPurchaseCount {
 				params.Set("max_purchase_count", strconv.Itoa(maxPurchaseCount))
 			}
 
 			path := cmdutil.JoinPath("products", product, "variant_categories", category, "variants")
-			return cmdutil.RunRequestWithSuccess(opts, "Creating variant...", "POST", path, params, "Variant created.")
+			return cmdutil.RunRequestWithSuccess(cmdutil.OptionsFrom(c), "Creating variant...", "POST", path, params, "Variant created.")
 		},
 	}
 
@@ -56,7 +58,9 @@ func newCreateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&category, "category", "", "Variant category ID (required)")
 	cmd.Flags().StringVar(&name, "name", "", "Variant name (required)")
 	cmd.Flags().StringVar(&description, "description", "", "Variant description")
-	cmd.Flags().IntVar(&priceDifferenceCents, "price-difference-cents", 0, "Price difference in cents")
+	cmd.Flags().StringVar(&priceDifference, "price-difference", "", "Price difference (e.g. 5.00, -1.50)")
+	cmd.Flags().IntVar(&priceDifferenceCents, "price-difference-cents", 0, "Price difference in cents (deprecated, use --price-difference)")
+	_ = cmd.Flags().MarkHidden("price-difference-cents")
 	cmd.Flags().IntVar(&maxPurchaseCount, "max-purchase-count", 0, "Maximum number of purchases")
 
 	return cmd

--- a/internal/cmd/variants/create.go
+++ b/internal/cmd/variants/create.go
@@ -10,7 +10,7 @@ import (
 
 func newCreateCmd() *cobra.Command {
 	var product, category, name, description, priceDifference string
-	var priceDifferenceCents, maxPurchaseCount int
+	var maxPurchaseCount int
 
 	cmd := &cobra.Command{
 		Use:   "create",
@@ -30,12 +30,9 @@ func newCreateCmd() *cobra.Command {
 				return cmdutil.MissingFlagError(c, "--name")
 			}
 
-			priceDiffCents, hasPriceDifference, err := cmdutil.ResolveMoneyFlag(c, "price-difference", "price-difference-cents", "price", "", priceDifferenceCents, priceDifference, true)
-			if err != nil {
-				return err
-			}
-
-			hasMaxPurchaseCount := c.Flags().Changed("max-purchase-count")
+			flags := c.Flags()
+			hasPriceDifference := flags.Changed("price-difference")
+			hasMaxPurchaseCount := flags.Changed("max-purchase-count")
 
 			params := url.Values{}
 			params.Set("name", name)
@@ -43,7 +40,11 @@ func newCreateCmd() *cobra.Command {
 				params.Set("description", description)
 			}
 			if hasPriceDifference {
-				params.Set("price_difference_cents", strconv.Itoa(priceDiffCents))
+				cents, err := cmdutil.ParseSignedMoney("price-difference", priceDifference, "price", "")
+				if err != nil {
+					return cmdutil.UsageErrorf(c, "%s", err.Error())
+				}
+				params.Set("price_difference_cents", strconv.Itoa(cents))
 			}
 			if hasMaxPurchaseCount {
 				params.Set("max_purchase_count", strconv.Itoa(maxPurchaseCount))
@@ -59,8 +60,6 @@ func newCreateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&name, "name", "", "Variant name (required)")
 	cmd.Flags().StringVar(&description, "description", "", "Variant description")
 	cmd.Flags().StringVar(&priceDifference, "price-difference", "", "Price difference (e.g. 5.00, -1.50)")
-	cmd.Flags().IntVar(&priceDifferenceCents, "price-difference-cents", 0, "Price difference in cents (deprecated, use --price-difference)")
-	_ = cmd.Flags().MarkHidden("price-difference-cents")
 	cmd.Flags().IntVar(&maxPurchaseCount, "max-purchase-count", 0, "Maximum number of purchases")
 
 	return cmd

--- a/internal/cmd/variants/update.go
+++ b/internal/cmd/variants/update.go
@@ -9,7 +9,7 @@ import (
 )
 
 func newUpdateCmd() *cobra.Command {
-	var product, category, name, description string
+	var product, category, name, description, priceDifference string
 	var priceDifferenceCents, maxPurchaseCount int
 
 	cmd := &cobra.Command{
@@ -17,7 +17,6 @@ func newUpdateCmd() *cobra.Command {
 		Short: "Update a variant",
 		Args:  cmdutil.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
-			opts := cmdutil.OptionsFrom(c)
 			if err := cmdutil.RequireNonNegativeIntFlag(c, "max-purchase-count", maxPurchaseCount); err != nil {
 				return err
 			}
@@ -27,29 +26,35 @@ func newUpdateCmd() *cobra.Command {
 			if category == "" {
 				return cmdutil.MissingFlagError(c, "--category")
 			}
-			if err := cmdutil.RequireAnyFlagChanged(c, "name", "description", "price-difference-cents", "max-purchase-count"); err != nil {
+			if err := cmdutil.RequireAnyFlagChanged(c, "name", "description", "price-difference", "price-difference-cents", "max-purchase-count"); err != nil {
 				return err
 			}
 
+			priceDiffCents, hasPriceDiff, err := cmdutil.ResolveMoneyFlag(c, "price-difference", "price-difference-cents", "price", "", priceDifferenceCents, priceDifference, true)
+			if err != nil {
+				return err
+			}
+
+			flags := c.Flags()
 			params := url.Values{}
-			if c.Flags().Changed("name") {
+			if flags.Changed("name") {
 				if name == "" {
 					return cmdutil.UsageErrorf(c, "--name cannot be empty")
 				}
 				params.Set("name", name)
 			}
-			if c.Flags().Changed("description") {
+			if flags.Changed("description") {
 				params.Set("description", description)
 			}
-			if c.Flags().Changed("price-difference-cents") {
-				params.Set("price_difference_cents", strconv.Itoa(priceDifferenceCents))
+			if hasPriceDiff {
+				params.Set("price_difference_cents", strconv.Itoa(priceDiffCents))
 			}
-			if c.Flags().Changed("max-purchase-count") {
+			if flags.Changed("max-purchase-count") {
 				params.Set("max_purchase_count", strconv.Itoa(maxPurchaseCount))
 			}
 
 			path := cmdutil.JoinPath("products", product, "variant_categories", category, "variants", args[0])
-			return cmdutil.RunRequestWithSuccess(opts, "Updating variant...", "PUT", path, params, "Variant updated.")
+			return cmdutil.RunRequestWithSuccess(cmdutil.OptionsFrom(c), "Updating variant...", "PUT", path, params, "Variant updated.")
 		},
 	}
 
@@ -57,7 +62,9 @@ func newUpdateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&category, "category", "", "Variant category ID (required)")
 	cmd.Flags().StringVar(&name, "name", "", "New name")
 	cmd.Flags().StringVar(&description, "description", "", "New description")
-	cmd.Flags().IntVar(&priceDifferenceCents, "price-difference-cents", 0, "New price difference in cents")
+	cmd.Flags().StringVar(&priceDifference, "price-difference", "", "New price difference (e.g. 5.00, -1.50)")
+	cmd.Flags().IntVar(&priceDifferenceCents, "price-difference-cents", 0, "New price difference in cents (deprecated, use --price-difference)")
+	_ = cmd.Flags().MarkHidden("price-difference-cents")
 	cmd.Flags().IntVar(&maxPurchaseCount, "max-purchase-count", 0, "New max purchase count")
 
 	return cmd

--- a/internal/cmd/variants/update.go
+++ b/internal/cmd/variants/update.go
@@ -10,7 +10,7 @@ import (
 
 func newUpdateCmd() *cobra.Command {
 	var product, category, name, description, priceDifference string
-	var priceDifferenceCents, maxPurchaseCount int
+	var maxPurchaseCount int
 
 	cmd := &cobra.Command{
 		Use:   "update <variant_id>",
@@ -26,12 +26,7 @@ func newUpdateCmd() *cobra.Command {
 			if category == "" {
 				return cmdutil.MissingFlagError(c, "--category")
 			}
-			if err := cmdutil.RequireAnyFlagChanged(c, "name", "description", "price-difference", "price-difference-cents", "max-purchase-count"); err != nil {
-				return err
-			}
-
-			priceDiffCents, hasPriceDiff, err := cmdutil.ResolveMoneyFlag(c, "price-difference", "price-difference-cents", "price", "", priceDifferenceCents, priceDifference, true)
-			if err != nil {
+			if err := cmdutil.RequireAnyFlagChanged(c, "name", "description", "price-difference", "max-purchase-count"); err != nil {
 				return err
 			}
 
@@ -46,8 +41,12 @@ func newUpdateCmd() *cobra.Command {
 			if flags.Changed("description") {
 				params.Set("description", description)
 			}
-			if hasPriceDiff {
-				params.Set("price_difference_cents", strconv.Itoa(priceDiffCents))
+			if flags.Changed("price-difference") {
+				cents, err := cmdutil.ParseSignedMoney("price-difference", priceDifference, "price", "")
+				if err != nil {
+					return cmdutil.UsageErrorf(c, "%s", err.Error())
+				}
+				params.Set("price_difference_cents", strconv.Itoa(cents))
 			}
 			if flags.Changed("max-purchase-count") {
 				params.Set("max_purchase_count", strconv.Itoa(maxPurchaseCount))
@@ -63,8 +62,6 @@ func newUpdateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&name, "name", "", "New name")
 	cmd.Flags().StringVar(&description, "description", "", "New description")
 	cmd.Flags().StringVar(&priceDifference, "price-difference", "", "New price difference (e.g. 5.00, -1.50)")
-	cmd.Flags().IntVar(&priceDifferenceCents, "price-difference-cents", 0, "New price difference in cents (deprecated, use --price-difference)")
-	_ = cmd.Flags().MarkHidden("price-difference-cents")
 	cmd.Flags().IntVar(&maxPurchaseCount, "max-purchase-count", 0, "New max purchase count")
 
 	return cmd

--- a/internal/cmd/variants/variants_test.go
+++ b/internal/cmd/variants/variants_test.go
@@ -313,7 +313,7 @@ func TestCreate_Flags(t *testing.T) {
 	})
 
 	cmd := newCreateCmd()
-	cmd.SetArgs([]string{"--product", "p1", "--category", "vc1", "--name", "XL", "--description", "Extra large", "--price-difference-cents", "300"})
+	cmd.SetArgs([]string{"--product", "p1", "--category", "vc1", "--name", "XL", "--description", "Extra large", "--price-difference", "3.00"})
 	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
 	if gotName != "XL" {
@@ -379,19 +379,6 @@ func TestCreate_PriceDifferenceInvalidInput(t *testing.T) {
 	var usageErr *cmdutil.UsageError
 	if !errors.As(err, &usageErr) {
 		t.Fatalf("expected *cmdutil.UsageError, got %T", err)
-	}
-}
-
-func TestCreate_PriceDifferenceAndCentsConflict(t *testing.T) {
-	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
-		t.Error("should not reach API")
-	})
-
-	cmd := newCreateCmd()
-	cmd.SetArgs([]string{"--product", "p1", "--category", "vc1", "--name", "XL", "--price-difference", "5", "--price-difference-cents", "500"})
-	err := cmd.Execute()
-	if err == nil || !strings.Contains(err.Error(), "use --price-difference or --price-difference-cents, not both") {
-		t.Fatalf("expected conflict error, got: %v", err)
 	}
 }
 
@@ -528,7 +515,7 @@ func TestUpdate_Flags(t *testing.T) {
 	})
 
 	cmd := newUpdateCmd()
-	cmd.SetArgs([]string{"v1", "--product", "p1", "--category", "vc1", "--name", "XXL", "--price-difference-cents", "700"})
+	cmd.SetArgs([]string{"v1", "--product", "p1", "--category", "vc1", "--name", "XXL", "--price-difference", "7.00"})
 	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
 	if gotName != "XXL" {
@@ -591,19 +578,6 @@ func TestUpdate_PriceDifferenceInvalidInput(t *testing.T) {
 	var usageErr *cmdutil.UsageError
 	if !errors.As(err, &usageErr) {
 		t.Fatalf("expected *cmdutil.UsageError, got %T", err)
-	}
-}
-
-func TestUpdate_PriceDifferenceAndCentsConflict(t *testing.T) {
-	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
-		t.Error("should not reach API")
-	})
-
-	cmd := newUpdateCmd()
-	cmd.SetArgs([]string{"v1", "--product", "p1", "--category", "vc1", "--price-difference", "5", "--price-difference-cents", "500"})
-	err := cmd.Execute()
-	if err == nil || !strings.Contains(err.Error(), "use --price-difference or --price-difference-cents, not both") {
-		t.Fatalf("expected conflict error, got: %v", err)
 	}
 }
 

--- a/internal/cmd/variants/variants_test.go
+++ b/internal/cmd/variants/variants_test.go
@@ -2,10 +2,12 @@ package variants
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 	"testing"
 
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/testutil"
 )
 
@@ -325,6 +327,74 @@ func TestCreate_Flags(t *testing.T) {
 	}
 }
 
+func TestCreate_PriceDifference(t *testing.T) {
+	var gotPriceDiff string
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm failed: %v", err)
+		}
+		gotPriceDiff = r.PostForm.Get("price_difference_cents")
+		testutil.JSON(t, w, map[string]any{})
+	})
+
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--product", "p1", "--category", "vc1", "--name", "XL", "--price-difference", "5.00"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotPriceDiff != "500" {
+		t.Errorf("got price_difference_cents=%q, want 500", gotPriceDiff)
+	}
+}
+
+func TestCreate_PriceDifferenceNegative(t *testing.T) {
+	var gotPriceDiff string
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm failed: %v", err)
+		}
+		gotPriceDiff = r.PostForm.Get("price_difference_cents")
+		testutil.JSON(t, w, map[string]any{})
+	})
+
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--product", "p1", "--category", "vc1", "--name", "SM", "--price-difference", "-1.50"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotPriceDiff != "-150" {
+		t.Errorf("got price_difference_cents=%q, want -150", gotPriceDiff)
+	}
+}
+
+func TestCreate_PriceDifferenceInvalidInput(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API")
+	})
+
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--product", "p1", "--category", "vc1", "--name", "XL", "--price-difference", "abc"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "not a valid price") {
+		t.Fatalf("expected validation error, got: %v", err)
+	}
+	var usageErr *cmdutil.UsageError
+	if !errors.As(err, &usageErr) {
+		t.Fatalf("expected *cmdutil.UsageError, got %T", err)
+	}
+}
+
+func TestCreate_PriceDifferenceAndCentsConflict(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API")
+	})
+
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--product", "p1", "--category", "vc1", "--name", "XL", "--price-difference", "5", "--price-difference-cents", "500"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "use --price-difference or --price-difference-cents, not both") {
+		t.Fatalf("expected conflict error, got: %v", err)
+	}
+}
+
 func TestCreate_NameRequired(t *testing.T) {
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
 		t.Error("should not reach API")
@@ -467,6 +537,84 @@ func TestUpdate_Flags(t *testing.T) {
 	if gotPriceDiff != "700" {
 		t.Errorf("got price_difference_cents=%q, want 700", gotPriceDiff)
 	}
+}
+
+func TestUpdate_PriceDifference(t *testing.T) {
+	var gotPriceDiff string
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm failed: %v", err)
+		}
+		gotPriceDiff = r.PostForm.Get("price_difference_cents")
+		testutil.JSON(t, w, map[string]any{})
+	})
+
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{"v1", "--product", "p1", "--category", "vc1", "--price-difference", "7.00"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotPriceDiff != "700" {
+		t.Errorf("got price_difference_cents=%q, want 700", gotPriceDiff)
+	}
+}
+
+func TestUpdate_PriceDifferenceNegative(t *testing.T) {
+	var gotPriceDiff string
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm failed: %v", err)
+		}
+		gotPriceDiff = r.PostForm.Get("price_difference_cents")
+		testutil.JSON(t, w, map[string]any{})
+	})
+
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{"v1", "--product", "p1", "--category", "vc1", "--price-difference", "-2.50"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotPriceDiff != "-250" {
+		t.Errorf("got price_difference_cents=%q, want -250", gotPriceDiff)
+	}
+}
+
+func TestUpdate_PriceDifferenceInvalidInput(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API")
+	})
+
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{"v1", "--product", "p1", "--category", "vc1", "--price-difference", "$5"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "not a valid price") {
+		t.Fatalf("expected validation error, got: %v", err)
+	}
+	var usageErr *cmdutil.UsageError
+	if !errors.As(err, &usageErr) {
+		t.Fatalf("expected *cmdutil.UsageError, got %T", err)
+	}
+}
+
+func TestUpdate_PriceDifferenceAndCentsConflict(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API")
+	})
+
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{"v1", "--product", "p1", "--category", "vc1", "--price-difference", "5", "--price-difference-cents", "500"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "use --price-difference or --price-difference-cents, not both") {
+		t.Fatalf("expected conflict error, got: %v", err)
+	}
+}
+
+func TestUpdate_PriceDifferenceSatisfiesRequireAnyFlag(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{})
+	})
+
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{"v1", "--product", "p1", "--category", "vc1", "--price-difference", "3.00"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 }
 
 func TestUpdate_ProductRequired(t *testing.T) {

--- a/internal/cmdutil/money.go
+++ b/internal/cmdutil/money.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-
-	"github.com/spf13/cobra"
 )
 
 // singleUnitCurrencies are currencies where 1 unit = 1 minor unit (no cents).
@@ -51,37 +49,6 @@ func ParseSignedMoney(flag, value, noun, currency string) (int, error) {
 	return parseMoney(flag, value, noun, currency)
 }
 
-// ResolveMoneyFlag resolves a new string-based money flag and its deprecated
-// int-based cents counterpart. It returns the resolved cents value, whether
-// either flag was set, and any error. If both flags are set, it returns an error.
-func ResolveMoneyFlag(c *cobra.Command, newFlag, oldFlag, noun, currency string, oldValue int, newValue string, signed bool) (int, bool, error) {
-	flags := c.Flags()
-	newSet := flags.Changed(newFlag)
-	oldSet := flags.Changed(oldFlag)
-
-	if newSet && oldSet {
-		return 0, false, UsageErrorf(c, "use --%s or --%s, not both", newFlag, oldFlag)
-	}
-	if !newSet && !oldSet {
-		return 0, false, nil
-	}
-
-	if newSet {
-		var cents int
-		var err error
-		if signed {
-			cents, err = ParseSignedMoney(newFlag, newValue, noun, currency)
-		} else {
-			cents, err = ParseMoney(newFlag, newValue, noun, currency)
-		}
-		if err != nil {
-			return 0, false, UsageErrorf(c, "%s", err.Error())
-		}
-		return cents, true, nil
-	}
-
-	return oldValue, true, nil
-}
 
 // FormatMoney converts a minor-unit amount back to a user-friendly string
 // (e.g. 1099 → "10.99", 1000 → "10.00", -150 → "-1.50").

--- a/internal/cmdutil/money.go
+++ b/internal/cmdutil/money.go
@@ -1,0 +1,194 @@
+package cmdutil
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// singleUnitCurrencies are currencies where 1 unit = 1 minor unit (no cents).
+// Source: config/currencies.json in the Gumroad codebase.
+var singleUnitCurrencies = map[string]bool{
+	"jpy": true,
+}
+
+// IsSingleUnitCurrency reports whether the given currency code has no
+// minor unit (e.g. JPY where ¥1 = 1 minor unit).
+func IsSingleUnitCurrency(currency string) bool {
+	return singleUnitCurrencies[strings.ToLower(currency)]
+}
+
+// scalingFactor returns the multiplier to convert user-facing amounts to
+// API minor units: 1 for single-unit currencies, 100 otherwise.
+func scalingFactor(currency string) int {
+	if IsSingleUnitCurrency(currency) {
+		return 1
+	}
+	return 100
+}
+
+// ParseMoney converts a user-friendly price string to minor units using
+// integer math (no floats). The scaling factor depends on the currency:
+// ×100 for most currencies, ×1 for single-unit currencies like JPY.
+//
+// If currency is empty, defaults to ×100 (standard behavior).
+// Rejects negative values — use ParseSignedMoney for those.
+func ParseMoney(flag, value, noun, currency string) (int, error) {
+	cents, err := parseMoney(flag, value, noun, currency)
+	if err != nil {
+		return 0, err
+	}
+	if cents < 0 {
+		return 0, fmt.Errorf("--%s cannot be negative", flag)
+	}
+	return cents, nil
+}
+
+// ParseSignedMoney is like ParseMoney but allows negative values.
+func ParseSignedMoney(flag, value, noun, currency string) (int, error) {
+	return parseMoney(flag, value, noun, currency)
+}
+
+// ResolveMoneyFlag resolves a new string-based money flag and its deprecated
+// int-based cents counterpart. It returns the resolved cents value, whether
+// either flag was set, and any error. If both flags are set, it returns an error.
+func ResolveMoneyFlag(c *cobra.Command, newFlag, oldFlag, noun, currency string, oldValue int, newValue string, signed bool) (int, bool, error) {
+	flags := c.Flags()
+	newSet := flags.Changed(newFlag)
+	oldSet := flags.Changed(oldFlag)
+
+	if newSet && oldSet {
+		return 0, false, UsageErrorf(c, "use --%s or --%s, not both", newFlag, oldFlag)
+	}
+	if !newSet && !oldSet {
+		return 0, false, nil
+	}
+
+	if newSet {
+		var cents int
+		var err error
+		if signed {
+			cents, err = ParseSignedMoney(newFlag, newValue, noun, currency)
+		} else {
+			cents, err = ParseMoney(newFlag, newValue, noun, currency)
+		}
+		if err != nil {
+			return 0, false, UsageErrorf(c, "%s", err.Error())
+		}
+		return cents, true, nil
+	}
+
+	return oldValue, true, nil
+}
+
+// FormatMoney converts a minor-unit amount back to a user-friendly string
+// (e.g. 1099 → "10.99", 1000 → "10.00", -150 → "-1.50").
+// For single-unit currencies like JPY, returns the amount as-is (e.g. 1000 → "1000").
+func FormatMoney(cents int, currency string) string {
+	if IsSingleUnitCurrency(currency) {
+		return strconv.Itoa(cents)
+	}
+	negative := cents < 0
+	if negative {
+		cents = -cents
+	}
+	s := fmt.Sprintf("%d.%02d", cents/100, cents%100)
+	if negative {
+		return "-" + s
+	}
+	return s
+}
+
+func parseMoney(flag, value, noun, currency string) (int, error) {
+	if value == "" {
+		return 0, fmt.Errorf("--%s cannot be empty", flag)
+	}
+
+	negative := false
+	s := value
+	if strings.HasPrefix(s, "-") {
+		negative = true
+		s = s[1:]
+	}
+
+	factor := scalingFactor(currency)
+	singleUnit := factor == 1
+
+	parts := strings.SplitN(s, ".", 2)
+
+	// Reject unreasonably large values that could overflow int arithmetic.
+	// Count only digits, excluding the decimal point.
+	const maxDigits = 12
+	digitCount := len(parts[0])
+	if len(parts) == 2 {
+		digitCount += len(parts[1])
+	}
+	if digitCount > maxDigits {
+		return 0, fmt.Errorf("--%s value is too large", flag)
+	}
+	if len(parts) == 1 {
+		whole, ok := parseDigits(parts[0])
+		if !ok {
+			return 0, fmt.Errorf("%q is not a valid %s", value, noun)
+		}
+		result := whole * factor
+		if negative {
+			result = -result
+		}
+		return result, nil
+	}
+
+	if singleUnit {
+		return 0, fmt.Errorf("JPY prices cannot have decimal places")
+	}
+
+	wholePart := parts[0]
+	fracPart := parts[1]
+
+	if len(fracPart) > 2 {
+		return 0, fmt.Errorf("--%s has too many decimal places (max 2)", flag)
+	}
+	if len(fracPart) == 0 {
+		return 0, fmt.Errorf("%q is not a valid %s", value, noun)
+	}
+
+	whole, ok := parseDigits(wholePart)
+	if !ok {
+		if wholePart != "" {
+			return 0, fmt.Errorf("%q is not a valid %s", value, noun)
+		}
+	}
+
+	frac, ok := parseDigits(fracPart)
+	if !ok {
+		return 0, fmt.Errorf("%q is not a valid %s", value, noun)
+	}
+
+	if len(fracPart) == 1 {
+		frac *= 10
+	}
+
+	result := whole*100 + frac
+	if negative {
+		result = -result
+	}
+	return result, nil
+}
+
+// parseDigits parses a string of digits into a non-negative integer.
+// Returns false for empty strings or non-digit input.
+func parseDigits(s string) (int, bool) {
+	if s == "" {
+		return 0, false
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, false
+	}
+	if n < 0 {
+		return 0, false
+	}
+	return n, true
+}

--- a/internal/cmdutil/money_test.go
+++ b/internal/cmdutil/money_test.go
@@ -1,0 +1,164 @@
+package cmdutil
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseMoney(t *testing.T) {
+	tests := []struct {
+		name     string
+		flag     string
+		value    string
+		noun     string
+		currency string
+		want     int
+		wantErr  string
+	}{
+		{name: "whole number", flag: "price", value: "10", noun: "price", want: 1000},
+		{name: "two decimals", flag: "price", value: "10.00", noun: "price", want: 1000},
+		{name: "cents", flag: "price", value: "9.99", noun: "price", want: 999},
+		{name: "one decimal", flag: "price", value: "5.5", noun: "price", want: 550},
+		{name: "zero", flag: "price", value: "0", noun: "price", want: 0},
+		{name: "zero decimal", flag: "price", value: "0.00", noun: "price", want: 0},
+		{name: "large", flag: "price", value: "999.99", noun: "price", want: 99999},
+		{name: "negative", flag: "price", value: "-10", noun: "price", wantErr: "cannot be negative"},
+		{name: "three decimals", flag: "price", value: "10.999", noun: "price", wantErr: "too many decimal places"},
+		{name: "letters", flag: "price", value: "abc", noun: "price", wantErr: "not a valid price"},
+		{name: "empty", flag: "price", value: "", noun: "price", wantErr: "cannot be empty"},
+		{name: "dollar sign", flag: "price", value: "$10", noun: "price", wantErr: "not a valid price"},
+		{name: "comma", flag: "price", value: "1,000", noun: "price", wantErr: "not a valid price"},
+		{name: "just dot", flag: "price", value: "10.", noun: "price", wantErr: "not a valid price"},
+
+		// Currency-aware tests
+		{name: "usd explicit", flag: "price", value: "10", noun: "price", currency: "usd", want: 1000},
+		{name: "eur with cents", flag: "price", value: "10.99", noun: "price", currency: "eur", want: 1099},
+		{name: "jpy whole", flag: "price", value: "1000", noun: "price", currency: "jpy", want: 1000},
+		{name: "jpy uppercase", flag: "price", value: "1000", noun: "price", currency: "JPY", want: 1000},
+		{name: "jpy rejects decimals", flag: "price", value: "10.99", noun: "price", currency: "jpy", wantErr: "JPY prices cannot have decimal places"},
+		{name: "jpy rejects single decimal", flag: "price", value: "10.5", noun: "price", currency: "jpy", wantErr: "JPY prices cannot have decimal places"},
+		{name: "empty currency defaults x100", flag: "price", value: "10", noun: "price", currency: "", want: 1000},
+
+		// Overflow protection
+		{name: "very large value", flag: "price", value: "99999999999999", noun: "price", wantErr: "too large"},
+
+		// Noun in error messages
+		{name: "noun in error", flag: "amount", value: "abc", noun: "amount", wantErr: "not a valid amount"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseMoney(tt.flag, tt.value, tt.noun, tt.currency)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseSignedMoney(t *testing.T) {
+	tests := []struct {
+		name     string
+		flag     string
+		value    string
+		noun     string
+		currency string
+		want     int
+		wantErr  string
+	}{
+		{name: "positive whole", flag: "price-difference", value: "10", noun: "price", want: 1000},
+		{name: "positive decimal", flag: "price-difference", value: "5.50", noun: "price", want: 550},
+		{name: "negative whole", flag: "price-difference", value: "-10", noun: "price", want: -1000},
+		{name: "negative decimal", flag: "price-difference", value: "-1.50", noun: "price", want: -150},
+		{name: "negative zero", flag: "price-difference", value: "-0", noun: "price", want: 0},
+		{name: "zero", flag: "price-difference", value: "0", noun: "price", want: 0},
+		{name: "letters", flag: "price-difference", value: "abc", noun: "price", wantErr: "not a valid price"},
+		{name: "three decimals", flag: "price-difference", value: "-10.999", noun: "price", wantErr: "too many decimal places"},
+
+		// JPY signed
+		{name: "jpy positive", flag: "price-difference", value: "500", noun: "price", currency: "jpy", want: 500},
+		{name: "jpy negative", flag: "price-difference", value: "-500", noun: "price", currency: "jpy", want: -500},
+		{name: "jpy rejects decimals", flag: "price-difference", value: "-10.5", noun: "price", currency: "jpy", wantErr: "JPY prices cannot have decimal places"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseSignedMoney(tt.flag, tt.value, tt.noun, tt.currency)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatMoney(t *testing.T) {
+	tests := []struct {
+		name     string
+		cents    int
+		currency string
+		want     string
+	}{
+		{name: "whole dollars", cents: 1000, want: "10.00"},
+		{name: "with cents", cents: 1099, want: "10.99"},
+		{name: "zero", cents: 0, want: "0.00"},
+		{name: "sub-dollar", cents: 50, want: "0.50"},
+		{name: "negative", cents: -150, want: "-1.50"},
+		{name: "jpy", cents: 1000, currency: "jpy", want: "1000"},
+		{name: "jpy negative", cents: -500, currency: "jpy", want: "-500"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatMoney(tt.cents, tt.currency)
+			if got != tt.want {
+				t.Fatalf("FormatMoney(%d, %q) = %q, want %q", tt.cents, tt.currency, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsSingleUnitCurrency(t *testing.T) {
+	tests := []struct {
+		currency string
+		want     bool
+	}{
+		{"jpy", true},
+		{"JPY", true},
+		{"Jpy", true},
+		{"usd", false},
+		{"eur", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.currency, func(t *testing.T) {
+			if got := IsSingleUnitCurrency(tt.currency); got != tt.want {
+				t.Fatalf("IsSingleUnitCurrency(%q) = %v, want %v", tt.currency, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Replaces the internal-facing `--amount-cents` and `--price-difference-cents` flags with user-friendly `--amount` and `--price-difference` flags that accept dollar amounts (e.g. `--amount 5.00` instead of `--amount-cents 500`). The deprecated flags remain as hidden aliases for backward compatibility.

Commands updated:
- `offer-codes create`: `--amount` replaces `--amount-cents`
- `sales refund`: `--amount` replaces `--amount-cents`, with normalized display in confirmation/success messages (e.g. "Refunded 5.00 on sale X" instead of "Refunded 500 cents on sale X")
- `variants create`: `--price-difference` replaces `--price-difference-cents`, supports negative values
- `variants update`: `--price-difference` replaces `--price-difference-cents`, supports negative values

A shared `ParseMoney`/`ParseSignedMoney` parser in `internal/cmdutil/money.go` handles string-to-cents conversion using integer math only (no floats). It supports currency-aware scaling (x100 for most currencies, x1 for JPY) for future use by commands that have currency info available.

## Why

Typing `--amount-cents 500` to mean "$5.00" is error-prone and unintuitive. The `products create` command already uses `--price 10.00` — this brings the remaining money flags in line with that pattern.

The old `--amount-cents` and `--price-difference-cents` flags are removed entirely since there are no existing users.

---

This PR was implemented with AI assistance using Claude Opus 4.6 and gpt‑5.4 xhigh