### PR TITLE
Add products create command

### DIFF
--- a/.claude/skills/gumroad-cli/SKILL.md
+++ b/.claude/skills/gumroad-cli/SKILL.md
@@ -26,6 +26,9 @@ gumroad auth status --no-input
 # List all products
 gumroad products list --json --no-input
 
+# Create a product (created as draft)
+gumroad products create --name "Art Pack" --price 10.00 --json --no-input
+
 # Get a specific product
 gumroad products view <id> --json --no-input
 
@@ -53,7 +56,7 @@ gumroad payouts upcoming --json --no-input
 ```
 auth           login, status, logout
 user           Account info
-products       list, view, delete, enable, disable, skus
+products       create, list, view, delete, enable, disable, skus
 sales          list, view, refund, ship, resend-receipt
 payouts        list, view, upcoming
 subscribers    list, view
@@ -69,7 +72,7 @@ webhooks       list, create, delete
 
 - Always include `--no-input` to prevent the CLI from blocking on interactive prompts.
 - Use `--json --jq` together to extract exactly what you need without parsing.
-- The API does not support product create/update — only list, view, delete, enable, disable.
+- Products are created as drafts — use `gumroad products enable <id>` to publish.
 - If `gumroad auth status` fails, the user needs to run `gumroad auth login` interactively.
 - For destructive operations (delete, refund), add `--yes` to skip confirmation.
 - Run `gumroad <command> --help` for flag details on any specific command.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,5 +72,4 @@ These are non-obvious behaviors in the Gumroad API v2 that directly affect how y
 - **200 OK with `success: false`** — the API returns HTTP 200 for many errors. Always check the `success` field in the response body, not just the status code. `internal/api/errors.go` handles this.
 - **Inconsistent numeric types** — some fields like `sales_usd_cents` arrive as `0` (int) or `0.0` (float) depending on state. Use `json.Number` or handle both when parsing.
 - **Null vs missing fields** — optional fields may be `null`, empty string, or omitted entirely.
-- **Products create/update return 404** — the routes exist but the actions are stubbed out. Only list, view, delete, enable, disable work.
 - **Deprecated `page` param on sales** — use cursor-based `page_key` instead.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ gumroad sales refund abc123 --amount 5.00 --dry-run
 ```
 gumroad auth          login, status, logout
 gumroad user          View your account info
-gumroad products      list, view, delete, enable, disable, skus
+gumroad products      create, list, view, delete, enable, disable, skus
 gumroad sales         list, view, refund, ship, resend-receipt
 gumroad payouts       list, view, upcoming
 gumroad subscribers   list, view
@@ -132,7 +132,7 @@ If you decline a confirmation prompt, mutating commands still emit JSON in machi
 
 `gumroad` maps 1:1 to the [Gumroad API v2](https://app.gumroad.com/api). The CLI exposes everything the API supports today — but the API has some gaps worth knowing about:
 
-- **No product create/update** — the API routes exist but are not implemented. Products must be created and edited through the web UI. The CLI supports delete, enable, and disable which do work.
+- **No product update** — the update API endpoint is not yet supported by the CLI. Products can be created via `gumroad products create` (as drafts) and published via `gumroad products enable`.
 - **No analytics or audience data** — no API endpoints exist for dashboard stats, traffic, or email lists.
 - **No bulk operations** — all actions are one resource at a time.
 - **Limited filtering** — `gumroad sales list` supports date/email/product filters, but `gumroad products list` returns everything with no filtering.
@@ -162,7 +162,7 @@ cmd/gumroad/main.go    Entry point
 internal/
   cmd/                 Command implementations (cobra)
     auth/              Authentication (login, status, logout)
-    products/          gumroad products list|view|delete|enable|disable
+    products/          gumroad products create|list|view|delete|enable|disable
     sales/             gumroad sales list|view|refund|ship|resend-receipt
     ...                One package per noun
   api/                 HTTP client for Gumroad API v2

--- a/internal/cmd/products/create.go
+++ b/internal/cmd/products/create.go
@@ -109,7 +109,7 @@ func newCreateCmd() *cobra.Command {
 				params.Set("customizable_price", strconv.FormatBool(payWhatYouWant))
 			}
 			if flags.Changed("suggested-price") {
-				cents, err := cmdutil.ParseMoney("suggested-price", suggestedPrice, "price", currency)
+				cents, err := cmdutil.ParseMoney("suggested-price", suggestedPrice, "suggested price", currency)
 				if err != nil {
 					return cmdutil.UsageErrorf(c, "%s", err.Error())
 				}
@@ -164,7 +164,7 @@ func newCreateCmd() *cobra.Command {
 	cmd.Flags().IntVar(&maxPurchaseCount, "max-purchase-count", 0, "Maximum number of purchases (inventory limit)")
 	cmd.Flags().StringVar(&taxonomyID, "taxonomy-id", "", "Taxonomy/category ID")
 	cmd.Flags().StringVar(&subscriptionDuration, "subscription-duration", "", "Subscription duration (membership only: monthly, quarterly, biannually, yearly, every_two_years)")
-	cmd.Flags().StringSliceVar(&tags, "tag", nil, "Tag (repeatable)")
+	cmd.Flags().StringArrayVar(&tags, "tag", nil, "Tag (repeatable)")
 
 	return cmd
 }

--- a/internal/cmd/products/create.go
+++ b/internal/cmd/products/create.go
@@ -1,0 +1,170 @@
+package products
+
+import (
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+func sortedKeys(m map[string]bool) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return strings.Join(keys, ", ")
+}
+
+type createProductResponse struct {
+	Product struct {
+		ID             string `json:"id"`
+		Name           string `json:"name"`
+		FormattedPrice string `json:"formatted_price"`
+	} `json:"product"`
+}
+
+var validProductTypes = map[string]bool{
+	"digital": true, "course": true, "ebook": true,
+	"membership": true, "bundle": true, "coffee": true,
+	"call": true, "commission": true,
+}
+
+var validSubscriptionDurations = map[string]bool{
+	"monthly": true, "quarterly": true, "biannually": true,
+	"yearly": true, "every_two_years": true,
+}
+
+func newCreateCmd() *cobra.Command {
+	var name, nativeType, currency, description, customPermalink string
+	var customSummary, customReceipt, subscriptionDuration, taxonomyID string
+	var price, suggestedPrice string
+	var maxPurchaseCount int
+	var payWhatYouWant bool
+	var tags []string
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new product (as draft)",
+		Example: `  gumroad products create --name "Art Pack" --price 10.00
+  gumroad products create --name "Newsletter" --type membership --subscription-duration monthly
+  gumroad products create --name "E-Book" --type ebook --price 5 --tag art --tag digital`,
+		Args: cmdutil.ExactArgs(0),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			flags := c.Flags()
+
+			if name == "" {
+				return cmdutil.MissingFlagError(c, "--name")
+			}
+
+			if !validProductTypes[nativeType] {
+				return cmdutil.UsageErrorf(c, "invalid --type %q; must be one of: %s", nativeType, sortedKeys(validProductTypes))
+			}
+
+			if flags.Changed("subscription-duration") {
+				if nativeType != "membership" {
+					return cmdutil.UsageErrorf(c, "--subscription-duration can only be used with --type membership")
+				}
+				if !validSubscriptionDurations[subscriptionDuration] {
+					return cmdutil.UsageErrorf(c, "invalid --subscription-duration %q; must be one of: %s", subscriptionDuration, sortedKeys(validSubscriptionDurations))
+				}
+			}
+
+			if err := cmdutil.RequireNonNegativeIntFlag(c, "max-purchase-count", maxPurchaseCount); err != nil {
+				return err
+			}
+
+			params := url.Values{}
+			params.Set("name", name)
+			params.Set("native_type", nativeType)
+			currency = strings.ToLower(currency)
+			if flags.Changed("price") {
+				cents, err := cmdutil.ParseMoney("price", price, "price", currency)
+				if err != nil {
+					return cmdutil.UsageErrorf(c, "%s", err.Error())
+				}
+				params.Set("price", strconv.Itoa(cents))
+			}
+			if flags.Changed("currency") {
+				params.Set("price_currency_type", currency)
+			}
+			if flags.Changed("description") {
+				params.Set("description", description)
+			}
+			if flags.Changed("custom-permalink") {
+				params.Set("custom_permalink", customPermalink)
+			}
+			if flags.Changed("custom-summary") {
+				params.Set("custom_summary", customSummary)
+			}
+			if flags.Changed("custom-receipt") {
+				params.Set("custom_receipt", customReceipt)
+			}
+			if flags.Changed("pay-what-you-want") {
+				params.Set("customizable_price", strconv.FormatBool(payWhatYouWant))
+			}
+			if flags.Changed("suggested-price") {
+				cents, err := cmdutil.ParseMoney("suggested-price", suggestedPrice, "price", currency)
+				if err != nil {
+					return cmdutil.UsageErrorf(c, "%s", err.Error())
+				}
+				params.Set("suggested_price_cents", strconv.Itoa(cents))
+			}
+			if flags.Changed("max-purchase-count") {
+				params.Set("max_purchase_count", strconv.Itoa(maxPurchaseCount))
+			}
+			if flags.Changed("taxonomy-id") {
+				params.Set("taxonomy_id", taxonomyID)
+			}
+			if flags.Changed("subscription-duration") {
+				params.Set("subscription_duration", subscriptionDuration)
+			}
+			for _, t := range tags {
+				params.Add("tags[]", t)
+			}
+
+			return cmdutil.RunRequestDecoded[createProductResponse](opts,
+				"Creating product...", "POST", "/products", params,
+				func(resp createProductResponse) error {
+					p := resp.Product
+					if opts.PlainOutput {
+						return output.PrintPlain(opts.Out(), [][]string{
+							{p.ID, p.Name, p.FormattedPrice},
+						})
+					}
+					if opts.Quiet {
+						return nil
+					}
+					s := opts.Style()
+					if err := output.Writef(opts.Out(), "%s %s (%s)\n",
+						s.Bold("Created draft product:"), p.Name, s.Dim(p.ID)); err != nil {
+						return err
+					}
+					return output.Writef(opts.Out(), "\n%s gumroad products enable %s\n",
+						s.Dim("Publish with:"), p.ID)
+				})
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Product name (required)")
+	cmd.Flags().StringVar(&nativeType, "type", "digital", "Product type (digital, course, ebook, membership, bundle, coffee, call, commission)")
+	cmd.Flags().StringVar(&price, "price", "", "Price (e.g. 10, 10.00, 9.99)")
+	cmd.Flags().StringVar(&currency, "currency", "", "Price currency (e.g. usd, eur)")
+	cmd.Flags().StringVar(&description, "description", "", "HTML description")
+	cmd.Flags().StringVar(&customPermalink, "custom-permalink", "", "Custom URL slug")
+	cmd.Flags().StringVar(&customSummary, "custom-summary", "", "Short summary")
+	cmd.Flags().StringVar(&customReceipt, "custom-receipt", "", "Custom receipt text")
+	cmd.Flags().BoolVar(&payWhatYouWant, "pay-what-you-want", false, "Enable pay-what-you-want pricing")
+	cmd.Flags().StringVar(&suggestedPrice, "suggested-price", "", "Suggested price for pay-what-you-want (e.g. 5, 5.00)")
+	cmd.Flags().IntVar(&maxPurchaseCount, "max-purchase-count", 0, "Maximum number of purchases (inventory limit)")
+	cmd.Flags().StringVar(&taxonomyID, "taxonomy-id", "", "Taxonomy/category ID")
+	cmd.Flags().StringVar(&subscriptionDuration, "subscription-duration", "", "Subscription duration (membership only: monthly, quarterly, biannually, yearly, every_two_years)")
+	cmd.Flags().StringSliceVar(&tags, "tag", nil, "Tag (repeatable)")
+
+	return cmd
+}

--- a/internal/cmd/products/products.go
+++ b/internal/cmd/products/products.go
@@ -10,14 +10,16 @@ func NewProductsCmd() *cobra.Command {
 		Use:   "products",
 		Short: "Manage your Gumroad products",
 		Long: "Manage your Gumroad products.\n\n" +
-			"Gumroad's API does not support creating or updating products. " +
-			"Use the web UI to create or edit products; `gumroad` supports listing, viewing, deleting, enabling, and disabling them.",
+			"Create, list, view, delete, enable, and disable products. " +
+			"New products are created as drafts; use `gumroad products enable <id>` to publish.",
 		Example: `  gumroad products list
+  gumroad products create --name "Art Pack" --price 10.00
   gumroad products view <id>
   gumroad products delete <id>
   gumroad products skus <id>`,
 	}
 
+	cmd.AddCommand(newCreateCmd())
 	cmd.AddCommand(newListCmd())
 	cmd.AddCommand(newViewCmd())
 	cmd.AddCommand(newDeleteCmd())

--- a/internal/cmd/products/products_test.go
+++ b/internal/cmd/products/products_test.go
@@ -8,6 +8,7 @@ import (
 	"image/png"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -258,10 +259,10 @@ func TestDelete_RequiresConfirmation(t *testing.T) {
 	}
 }
 
-func TestNewProductsCmd_HelpMentionsCreateUpdateLimitation(t *testing.T) {
+func TestNewProductsCmd_HelpMentionsDraftWorkflow(t *testing.T) {
 	cmd := NewProductsCmd()
-	if !strings.Contains(cmd.Long, "does not support creating or updating products") {
-		t.Fatalf("expected products help to mention create/update limitation, got %q", cmd.Long)
+	if !strings.Contains(cmd.Long, "created as drafts") {
+		t.Fatalf("expected products help to mention draft workflow, got %q", cmd.Long)
 	}
 }
 
@@ -319,6 +320,343 @@ func TestDisable_CorrectEndpoint(t *testing.T) {
 	}
 	if gotPath != "/products/p1/disable" {
 		t.Errorf("got path %q, want /products/p1/disable", gotPath)
+	}
+}
+
+func TestCreate_Success(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotForm url.Values
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		_ = r.ParseForm()
+		gotForm = r.PostForm
+		testutil.JSON(t, w, map[string]any{
+			"product": map[string]any{
+				"id": "newprod1", "name": "Art Pack",
+				"formatted_price": "$10", "sales_count": 0,
+			},
+		})
+	})
+
+	cmd := testutil.Command(newCreateCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--name", "Art Pack", "--price", "10.00", "--tag", "art", "--tag", "digital"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if gotMethod != "POST" {
+		t.Errorf("got method %q, want POST", gotMethod)
+	}
+	if gotPath != "/products" {
+		t.Errorf("got path %q, want /products", gotPath)
+	}
+	if gotForm.Get("name") != "Art Pack" {
+		t.Errorf("got name=%q, want Art Pack", gotForm.Get("name"))
+	}
+	if gotForm.Get("native_type") != "digital" {
+		t.Errorf("got native_type=%q, want digital", gotForm.Get("native_type"))
+	}
+	if gotForm.Get("price") != "1000" {
+		t.Errorf("got price=%q, want 1000", gotForm.Get("price"))
+	}
+	tags := gotForm["tags[]"]
+	if len(tags) != 2 || tags[0] != "art" || tags[1] != "digital" {
+		t.Errorf("got tags=%v, want [art digital]", tags)
+	}
+	if !strings.Contains(out, "Created draft product:") || !strings.Contains(out, "newprod1") {
+		t.Errorf("expected create confirmation, got: %q", out)
+	}
+	if !strings.Contains(out, "Publish with:") {
+		t.Errorf("expected publish tip, got: %q", out)
+	}
+}
+
+func TestCreate_MinimalFlags(t *testing.T) {
+	var gotForm url.Values
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotForm = r.PostForm
+		testutil.JSON(t, w, map[string]any{
+			"product": map[string]any{
+				"id": "p1", "name": "Simple",
+				"formatted_price": "$0", "sales_count": 0,
+			},
+		})
+	})
+
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--name", "Simple"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if gotForm.Get("name") != "Simple" {
+		t.Errorf("got name=%q, want Simple", gotForm.Get("name"))
+	}
+	if gotForm.Get("native_type") != "digital" {
+		t.Errorf("got native_type=%q, want digital", gotForm.Get("native_type"))
+	}
+	if gotForm.Get("price") != "" {
+		t.Errorf("price should not be sent when not set, got %q", gotForm.Get("price"))
+	}
+}
+
+func TestCreate_AllOptionalFlags(t *testing.T) {
+	var gotForm url.Values
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotForm = r.PostForm
+		testutil.JSON(t, w, map[string]any{
+			"product": map[string]any{
+				"id": "p1", "name": "Full", "formatted_price": "$10",
+			},
+		})
+	})
+
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{
+		"--name", "Full",
+		"--type", "membership",
+		"--price", "10.00",
+		"--currency", "eur",
+		"--description", "<p>Hello</p>",
+		"--custom-permalink", "my-product",
+		"--custom-summary", "A summary",
+		"--custom-receipt", "Thanks!",
+		"--pay-what-you-want",
+		"--suggested-price", "5.00",
+		"--max-purchase-count", "100",
+		"--taxonomy-id", "tax123",
+		"--subscription-duration", "monthly",
+	})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	checks := map[string]string{
+		"name":                  "Full",
+		"native_type":           "membership",
+		"price":                 "1000",
+		"price_currency_type":   "eur",
+		"description":           "<p>Hello</p>",
+		"custom_permalink":      "my-product",
+		"custom_summary":        "A summary",
+		"custom_receipt":        "Thanks!",
+		"customizable_price":    "true",
+		"suggested_price_cents": "500",
+		"max_purchase_count":    "100",
+		"taxonomy_id":           "tax123",
+		"subscription_duration": "monthly",
+	}
+	for param, want := range checks {
+		if got := gotForm.Get(param); got != want {
+			t.Errorf("param %s: got %q, want %q", param, got, want)
+		}
+	}
+}
+
+func TestCreate_MissingName(t *testing.T) {
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--price", "1.00"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--name") {
+		t.Errorf("expected missing --name error, got: %v", err)
+	}
+}
+
+func TestCreate_InvalidType(t *testing.T) {
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--name", "X", "--type", "physical"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "invalid --type") {
+		t.Errorf("expected invalid type error, got: %v", err)
+	}
+}
+
+func TestCreate_SubscriptionDurationNonMembership(t *testing.T) {
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--name", "X", "--type", "digital", "--subscription-duration", "monthly"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--subscription-duration can only be used with --type membership") {
+		t.Errorf("expected subscription-duration error, got: %v", err)
+	}
+}
+
+func TestCreate_InvalidSubscriptionDuration(t *testing.T) {
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--name", "X", "--type", "membership", "--subscription-duration", "weekly"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "invalid --subscription-duration") {
+		t.Errorf("expected invalid subscription-duration error, got: %v", err)
+	}
+}
+
+func TestCreate_NegativePrice(t *testing.T) {
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--name", "X", "--price", "-10.00"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--price cannot be negative") {
+		t.Errorf("expected negative price error, got: %v", err)
+	}
+}
+
+func TestCreate_InvalidPrice(t *testing.T) {
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--name", "X", "--price", "abc"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "not a valid price") {
+		t.Errorf("expected invalid price error, got: %v", err)
+	}
+}
+
+func TestCreate_TooManyDecimals(t *testing.T) {
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--name", "X", "--price", "10.999"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "too many decimal places") {
+		t.Errorf("expected too many decimals error, got: %v", err)
+	}
+}
+
+func TestCreate_NegativeSuggestedPrice(t *testing.T) {
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--name", "X", "--suggested-price", "-5.00"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--suggested-price cannot be negative") {
+		t.Errorf("expected negative suggested-price error, got: %v", err)
+	}
+}
+
+func TestCreate_JPYRejectsDecimals(t *testing.T) {
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--name", "X", "--price", "10.99", "--currency", "jpy"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "JPY prices cannot have decimal places") {
+		t.Errorf("expected JPY decimal error, got: %v", err)
+	}
+}
+
+func TestCreate_JPYWholeNumber(t *testing.T) {
+	var gotForm url.Values
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotForm = r.PostForm
+		testutil.JSON(t, w, map[string]any{
+			"product": map[string]any{
+				"id": "p1", "name": "X", "formatted_price": "¥1000",
+			},
+		})
+	})
+
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--name", "X", "--price", "1000", "--currency", "jpy"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if gotForm.Get("price") != "1000" {
+		t.Errorf("expected price=1000 for JPY (×1 scaling), got %q", gotForm.Get("price"))
+	}
+}
+
+func TestCreate_NegativeMaxPurchaseCount(t *testing.T) {
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--name", "X", "--max-purchase-count", "-1"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--max-purchase-count") {
+		t.Errorf("expected negative max-purchase-count error, got: %v", err)
+	}
+}
+
+func TestCreate_MaxPurchaseCountZero(t *testing.T) {
+	var gotForm url.Values
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotForm = r.PostForm
+		testutil.JSON(t, w, map[string]any{
+			"product": map[string]any{
+				"id": "p1", "name": "X", "formatted_price": "$0", "sales_count": 0,
+			},
+		})
+	})
+
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--name", "X", "--max-purchase-count", "0"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if gotForm.Get("max_purchase_count") != "0" {
+		t.Errorf("expected max_purchase_count=0, got %q", gotForm.Get("max_purchase_count"))
+	}
+}
+
+func TestCreate_JSON(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"product": map[string]any{
+				"id": "p1", "name": "Art", "formatted_price": "$10", "sales_count": 0,
+			},
+		})
+	})
+
+	cmd := testutil.Command(newCreateCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--name", "Art"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+}
+
+func TestCreate_Plain(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"product": map[string]any{
+				"id": "p1", "name": "Art", "formatted_price": "$10", "sales_count": 0,
+			},
+		})
+	})
+
+	cmd := testutil.Command(newCreateCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{"--name", "Art"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if !strings.Contains(out, "p1\tArt\t$10") {
+		t.Errorf("expected plain tab-separated output, got: %q", out)
+	}
+}
+
+func TestCreate_WholeNumberPrice(t *testing.T) {
+	var gotForm url.Values
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotForm = r.PostForm
+		testutil.JSON(t, w, map[string]any{
+			"product": map[string]any{
+				"id": "p1", "name": "X", "formatted_price": "$10",
+			},
+		})
+	})
+
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--name", "X", "--price", "10"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if gotForm.Get("price") != "1000" {
+		t.Errorf("expected price=1000 (10 dollars), got %q", gotForm.Get("price"))
+	}
+}
+
+func TestCreate_DryRun(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API in dry-run mode")
+	})
+
+	cmd := testutil.Command(newCreateCmd(), testutil.DryRun(true))
+	cmd.SetArgs([]string{"--name", "Art", "--price", "10.00"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if !strings.Contains(out, "POST") || !strings.Contains(out, "/products") {
+		t.Errorf("expected dry-run output with method and path, got: %q", out)
+	}
+}
+
+func TestCreate_APIError(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(422)
+		testutil.JSON(t, w, map[string]any{"message": "Name is required"})
+	})
+
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--name", "X"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error from API")
 	}
 }
 
@@ -511,7 +849,7 @@ func TestNewProductsCmd(t *testing.T) {
 	for _, c := range cmd.Commands() {
 		subs[c.Use] = true
 	}
-	for _, name := range []string{"list", "view <id>", "delete <id>", "enable <id>", "disable <id>", "skus <id>"} {
+	for _, name := range []string{"create", "list", "view <id>", "delete <id>", "enable <id>", "disable <id>", "skus <id>"} {
 		if !subs[name] {
 			t.Errorf("missing subcommand %q", name)
 		}

--- a/internal/cmd/products/products_test.go
+++ b/internal/cmd/products/products_test.go
@@ -520,11 +520,41 @@ func TestCreate_NegativeSuggestedPrice(t *testing.T) {
 	}
 }
 
+func TestCreate_InvalidSuggestedPrice(t *testing.T) {
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--name", "X", "--suggested-price", "abc"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "not a valid suggested price") {
+		t.Errorf("expected invalid suggested-price error, got: %v", err)
+	}
+}
+
+func TestCreate_CommaInTag(t *testing.T) {
+	var gotForm url.Values
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotForm = r.PostForm
+		testutil.JSON(t, w, map[string]any{
+			"product": map[string]any{
+				"id": "p1", "name": "X", "formatted_price": "$0",
+			},
+		})
+	})
+
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--name", "X", "--tag", "art,digital"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	tags := gotForm["tags[]"]
+	if len(tags) != 1 || tags[0] != "art,digital" {
+		t.Errorf("expected single tag \"art,digital\", got %v", tags)
+	}
+}
+
 func TestCreate_JPYRejectsDecimals(t *testing.T) {
 	cmd := newCreateCmd()
 	cmd.SetArgs([]string{"--name", "X", "--price", "10.99", "--currency", "jpy"})
 	err := cmd.Execute()
-	if err == nil || !strings.Contains(err.Error(), "JPY prices cannot have decimal places") {
+	if err == nil || !strings.Contains(err.Error(), "JPY amounts cannot have decimal places") {
 		t.Errorf("expected JPY decimal error, got: %v", err)
 	}
 }

--- a/internal/cmdutil/money.go
+++ b/internal/cmdutil/money.go
@@ -108,7 +108,7 @@ func parseMoney(flag, value, noun, currency string) (int, error) {
 	}
 
 	if singleUnit {
-		return 0, fmt.Errorf("JPY prices cannot have decimal places")
+		return 0, fmt.Errorf("--%s: JPY amounts cannot have decimal places", flag)
 	}
 
 	wholePart := parts[0]

--- a/internal/cmdutil/money_test.go
+++ b/internal/cmdutil/money_test.go
@@ -35,8 +35,8 @@ func TestParseMoney(t *testing.T) {
 		{name: "eur with cents", flag: "price", value: "10.99", noun: "price", currency: "eur", want: 1099},
 		{name: "jpy whole", flag: "price", value: "1000", noun: "price", currency: "jpy", want: 1000},
 		{name: "jpy uppercase", flag: "price", value: "1000", noun: "price", currency: "JPY", want: 1000},
-		{name: "jpy rejects decimals", flag: "price", value: "10.99", noun: "price", currency: "jpy", wantErr: "JPY prices cannot have decimal places"},
-		{name: "jpy rejects single decimal", flag: "price", value: "10.5", noun: "price", currency: "jpy", wantErr: "JPY prices cannot have decimal places"},
+		{name: "jpy rejects decimals", flag: "price", value: "10.99", noun: "price", currency: "jpy", wantErr: "JPY amounts cannot have decimal places"},
+		{name: "jpy rejects single decimal", flag: "price", value: "10.5", noun: "price", currency: "jpy", wantErr: "JPY amounts cannot have decimal places"},
 		{name: "empty currency defaults x100", flag: "price", value: "10", noun: "price", currency: "", want: 1000},
 
 		// Overflow protection
@@ -90,7 +90,7 @@ func TestParseSignedMoney(t *testing.T) {
 		// JPY signed
 		{name: "jpy positive", flag: "price-difference", value: "500", noun: "price", currency: "jpy", want: 500},
 		{name: "jpy negative", flag: "price-difference", value: "-500", noun: "price", currency: "jpy", want: -500},
-		{name: "jpy rejects decimals", flag: "price-difference", value: "-10.5", noun: "price", currency: "jpy", wantErr: "JPY prices cannot have decimal places"},
+		{name: "jpy rejects decimals", flag: "price-difference", value: "-10.5", noun: "price", currency: "jpy", wantErr: "JPY amounts cannot have decimal places"},
 	}
 
 	for _, tt := range tests {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -168,14 +168,14 @@ func TestHelp(t *testing.T) {
 	}
 }
 
-func TestProductsHelpMentionsCreateUpdateLimitation(t *testing.T) {
+func TestProductsHelpMentionsDraftWorkflow(t *testing.T) {
 	bin := buildBinary(t)
 	out, err := runGR(t, bin, nil, "products", "--help")
 	if err != nil {
 		t.Fatalf("products --help failed: %v\n%s", err, out)
 	}
-	if !strings.Contains(out, "does not support creating or updating products") {
-		t.Fatalf("products help should mention API limitation, got %q", out)
+	if !strings.Contains(out, "created as drafts") {
+		t.Fatalf("products help should mention draft workflow, got %q", out)
 	}
 }
 


### PR DESCRIPTION
Ref antiwork/gumroad/issues/4363

## What

Adds `gumroad products create`. Creators can now create products from the CLI. Products are created as drafts; publishing uses the existing `gumroad products enable <id>` command.

Supports 14 flags: `--name` (required), `--type`, `--price`, `--currency`, `--description`, `--custom-permalink`, `--custom-summary`, `--custom-receipt`, `--pay-what-you-want`, `--suggested-price`, `--max-purchase-count`, `--taxonomy-id`, `--subscription-duration`, and `--tag` (repeatable). Price flags accept user-friendly amounts (`--price 10.00`) and use the shared `cmdutil.ParseMoney` for currency-aware conversion (JPY ×1, everything else ×100).

Client-side validation covers: required name, product type allow-list, subscription duration allow-list + membership-only check, non-negative prices, and JPY decimal rejection.

## Why

The API endpoints (`POST /v2/products`) shipped but the CLI had no way to use them. This is the first of two PRs (create now, update next) to close that gap.

The `--price 10.00` UX (vs the old `--price-cents 1000` pattern) was chosen to avoid leaking the API's internal cents representation.

---

This PR was implemented with AI assistance using Claude Opus 4.6 and gpt‑5.4 xhigh