### PR TITLE
Reject leading plus in money parser, add negative amount test

### DIFF
--- a/internal/cmd/offercodes/offercodes_test.go
+++ b/internal/cmd/offercodes/offercodes_test.go
@@ -348,6 +348,22 @@ func TestCreate_RequiresDiscount(t *testing.T) {
 	}
 }
 
+func TestCreate_AmountNegativeRejected(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API")
+	})
+
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--product", "p1", "--name", "X", "--amount", "-1"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--amount cannot be negative") {
+		t.Fatalf("expected negative amount error, got: %v", err)
+	}
+	var usageErr *cmdutil.UsageError
+	if !errors.As(err, &usageErr) {
+		t.Fatalf("expected *cmdutil.UsageError, got %T", err)
+	}
+}
 
 func TestCreate_RejectsNegativePercentOff(t *testing.T) {
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {

--- a/internal/cmdutil/money.go
+++ b/internal/cmdutil/money.go
@@ -150,11 +150,13 @@ func parseDigits(s string) (int, bool) {
 	if s == "" {
 		return 0, false
 	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return 0, false
+		}
+	}
 	n, err := strconv.Atoi(s)
 	if err != nil {
-		return 0, false
-	}
-	if n < 0 {
 		return 0, false
 	}
 	return n, true

--- a/internal/cmdutil/money_test.go
+++ b/internal/cmdutil/money_test.go
@@ -29,6 +29,8 @@ func TestParseMoney(t *testing.T) {
 		{name: "dollar sign", flag: "price", value: "$10", noun: "price", wantErr: "not a valid price"},
 		{name: "comma", flag: "price", value: "1,000", noun: "price", wantErr: "not a valid price"},
 		{name: "just dot", flag: "price", value: "10.", noun: "price", wantErr: "not a valid price"},
+		{name: "leading plus", flag: "price", value: "+5.00", noun: "price", wantErr: "not a valid price"},
+		{name: "leading plus whole", flag: "price", value: "+5", noun: "price", wantErr: "not a valid price"},
 
 		// Currency-aware tests
 		{name: "usd explicit", flag: "price", value: "10", noun: "price", currency: "usd", want: 1000},


### PR DESCRIPTION
Address PR #10 review feedback

## What

Two fixes from the [PR #10 review](https://github.com/antiwork/gumroad-cli/pull/10):

1. **`parseDigits` now rejects leading `+` signs.** `strconv.Atoi` silently accepts `+5` as valid, so `--amount +5.00` was parsed as 500 cents without error. A digit-only validation loop now runs before `Atoi`, rejecting any character outside `0`–`9`.

2. **Added `TestCreate_AmountNegativeRejected` integration test.** PR #10 deleted the old `TestCreate_RejectsNegativeAmountCents` without adding an equivalent for the new `--amount` flag. This adds a command-level test that `offer-codes create --amount -1` is rejected, matching the pattern in `sales/refund_test.go`. Includes both error message and `*cmdutil.UsageError` type assertion.

## Why

The leading `+` acceptance was inconsistent — `$10` and `1,000` were correctly rejected, but `+5.00` slipped through because `strconv.Atoi` treats `+` as a valid sign prefix. The test gap meant a future change from `ParseMoney` to `ParseSignedMoney` in offer-codes could silently allow negative amounts without any test catching it.

---

This PR was implemented with AI assistance using Claude Opus 4.6 and gpt‑5.4 xhigh