### PR TITLE
Add products update command

### DIFF
--- a/.claude/skills/gumroad-cli/SKILL.md
+++ b/.claude/skills/gumroad-cli/SKILL.md
@@ -56,7 +56,7 @@ gumroad payouts upcoming --json --no-input
 ```
 auth           login, status, logout
 user           Account info
-products       create, list, view, delete, publish, unpublish, skus
+products       create, update, list, view, delete, publish, unpublish, skus
 sales          list, view, refund, ship, resend-receipt
 payouts        list, view, upcoming
 subscribers    list, view

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ gumroad sales refund abc123 --amount 5.00 --dry-run
 ```
 gumroad auth          login, status, logout
 gumroad user          View your account info
-gumroad products      create, list, view, delete, publish, unpublish, skus
+gumroad products      create, update, list, view, delete, publish, unpublish, skus
 gumroad sales         list, view, refund, ship, resend-receipt
 gumroad payouts       list, view, upcoming
 gumroad subscribers   list, view
@@ -132,7 +132,7 @@ If you decline a confirmation prompt, mutating commands still emit JSON in machi
 
 `gumroad` maps 1:1 to the [Gumroad API v2](https://app.gumroad.com/api). The CLI exposes everything the API supports today — but the API has some gaps worth knowing about:
 
-- **No product update** — the update API endpoint is not yet supported by the CLI. Products can be created via `gumroad products create` (as drafts) and published via `gumroad products publish`.
+- **No rich content or file upload** — product create/update supports basic fields but not rich content pages or file attachments. Use the web UI for those.
 - **No analytics or audience data** — no API endpoints exist for dashboard stats, traffic, or email lists.
 - **No bulk operations** — all actions are one resource at a time.
 - **Limited filtering** — `gumroad sales list` supports date/email/product filters, but `gumroad products list` returns everything with no filtering.
@@ -162,7 +162,7 @@ cmd/gumroad/main.go    Entry point
 internal/
   cmd/                 Command implementations (cobra)
     auth/              Authentication (login, status, logout)
-    products/          gumroad products create|list|view|delete|publish|unpublish
+    products/          gumroad products create|update|list|view|delete|publish|unpublish
     sales/             gumroad sales list|view|refund|ship|resend-receipt
     ...                One package per noun
   api/                 HTTP client for Gumroad API v2

--- a/internal/cmd/products/products.go
+++ b/internal/cmd/products/products.go
@@ -10,10 +10,11 @@ func NewProductsCmd() *cobra.Command {
 		Use:   "products",
 		Short: "Manage your Gumroad products",
 		Long: "Manage your Gumroad products.\n\n" +
-			"Create, list, view, delete, publish, and unpublish products. " +
+			"Create, update, list, view, delete, publish, and unpublish products. " +
 			"New products are created as drafts; use `gumroad products publish <id>` to publish.",
 		Example: `  gumroad products list
   gumroad products create --name "Art Pack" --price 10.00
+  gumroad products update <product_id> --name "New Name"
   gumroad products view <id>
   gumroad products publish <id>
   gumroad products unpublish <id>
@@ -22,6 +23,7 @@ func NewProductsCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(newCreateCmd())
+	cmd.AddCommand(newUpdateCmd())
 	cmd.AddCommand(newListCmd())
 	cmd.AddCommand(newViewCmd())
 	cmd.AddCommand(newDeleteCmd())

--- a/internal/cmd/products/products_test.go
+++ b/internal/cmd/products/products_test.go
@@ -693,6 +693,238 @@ func TestCreate_APIError(t *testing.T) {
 	}
 }
 
+func TestUpdate_SingleFlag(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotForm url.Values
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		_ = r.ParseForm()
+		gotForm = r.PostForm
+		testutil.JSON(t, w, map[string]any{})
+	})
+
+	cmd := testutil.Command(newUpdateCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"prod1", "--name", "New Name"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if gotMethod != "PUT" {
+		t.Errorf("got method %q, want PUT", gotMethod)
+	}
+	if gotPath != "/products/prod1" {
+		t.Errorf("got path %q, want /products/prod1", gotPath)
+	}
+	if gotForm.Get("name") != "New Name" {
+		t.Errorf("got name=%q, want New Name", gotForm.Get("name"))
+	}
+	if gotForm.Get("price") != "" {
+		t.Errorf("price should not be sent, got %q", gotForm.Get("price"))
+	}
+	if !strings.Contains(out, "updated") {
+		t.Errorf("expected updated message, got: %q", out)
+	}
+}
+
+func TestUpdate_MultipleFlags(t *testing.T) {
+	var gotForm url.Values
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotForm = r.PostForm
+		testutil.JSON(t, w, map[string]any{})
+	})
+
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{"prod1",
+		"--name", "Updated",
+		"--price", "20.00",
+		"--currency", "eur",
+		"--description", "<p>New</p>",
+		"--custom-permalink", "updated-slug",
+		"--custom-summary", "New summary",
+		"--custom-receipt", "Thanks!",
+		"--pay-what-you-want",
+		"--suggested-price", "10.00",
+		"--max-purchase-count", "50",
+		"--taxonomy-id", "tax1",
+	})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	checks := map[string]string{
+		"name":                  "Updated",
+		"price":                 "2000",
+		"price_currency_type":   "eur",
+		"description":           "<p>New</p>",
+		"custom_permalink":      "updated-slug",
+		"custom_summary":        "New summary",
+		"custom_receipt":        "Thanks!",
+		"customizable_price":    "true",
+		"suggested_price_cents": "1000",
+		"max_purchase_count":    "50",
+		"taxonomy_id":           "tax1",
+	}
+	for param, want := range checks {
+		if got := gotForm.Get(param); got != want {
+			t.Errorf("param %s: got %q, want %q", param, got, want)
+		}
+	}
+}
+
+func TestUpdate_NoFlags(t *testing.T) {
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{"prod1"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "at least one") {
+		t.Errorf("expected 'at least one' error, got: %v", err)
+	}
+}
+
+func TestUpdate_EmptyName(t *testing.T) {
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{"prod1", "--name", ""})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--name cannot be empty") {
+		t.Errorf("expected empty name error, got: %v", err)
+	}
+}
+
+func TestUpdate_NegativePrice(t *testing.T) {
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{"prod1", "--price", "-10.00"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--price cannot be negative") {
+		t.Errorf("expected negative price error, got: %v", err)
+	}
+}
+
+func TestUpdate_NegativeSuggestedPrice(t *testing.T) {
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{"prod1", "--suggested-price", "-5.00"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--suggested-price cannot be negative") {
+		t.Errorf("expected negative suggested-price error, got: %v", err)
+	}
+}
+
+func TestUpdate_NegativeMaxPurchaseCount(t *testing.T) {
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{"prod1", "--max-purchase-count", "-1"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--max-purchase-count") {
+		t.Errorf("expected negative max-purchase-count error, got: %v", err)
+	}
+}
+
+func TestUpdate_InvalidPrice(t *testing.T) {
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{"prod1", "--price", "abc"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "not a valid price") {
+		t.Errorf("expected invalid price error, got: %v", err)
+	}
+}
+
+func TestUpdate_TooManyDecimals(t *testing.T) {
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{"prod1", "--price", "10.999"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "too many decimal places") {
+		t.Errorf("expected too many decimals error, got: %v", err)
+	}
+}
+
+func TestUpdate_InvalidSuggestedPrice(t *testing.T) {
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{"prod1", "--suggested-price", "abc"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "not a valid suggested price") {
+		t.Errorf("expected invalid suggested-price error, got: %v", err)
+	}
+}
+
+func TestUpdate_JPYRejectsDecimals(t *testing.T) {
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{"prod1", "--price", "10.99", "--currency", "jpy"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "JPY amounts cannot have decimal places") {
+		t.Errorf("expected JPY decimal error, got: %v", err)
+	}
+}
+
+func TestUpdate_JSON(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{})
+	})
+
+	cmd := testutil.Command(newUpdateCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"prod1", "--name", "X"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if !strings.Contains(out, "true") {
+		t.Errorf("expected JSON with success, got: %q", out)
+	}
+}
+
+func TestUpdate_DryRun(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API in dry-run mode")
+	})
+
+	cmd := testutil.Command(newUpdateCmd(), testutil.DryRun(true))
+	cmd.SetArgs([]string{"prod1", "--name", "X"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if !strings.Contains(out, "PUT") || !strings.Contains(out, "/products/prod1") {
+		t.Errorf("expected dry-run output, got: %q", out)
+	}
+}
+
+func TestUpdate_Tags(t *testing.T) {
+	var gotForm url.Values
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotForm = r.PostForm
+		testutil.JSON(t, w, map[string]any{})
+	})
+
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{"prod1", "--tag", "ruby", "--tag", "rails"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	tags := gotForm["tags[]"]
+	if len(tags) != 2 || tags[0] != "ruby" || tags[1] != "rails" {
+		t.Errorf("got tags=%v, want [ruby rails]", tags)
+	}
+}
+
+func TestUpdate_NameOnlyDoesNotTouchTags(t *testing.T) {
+	var gotForm url.Values
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotForm = r.PostForm
+		testutil.JSON(t, w, map[string]any{})
+	})
+
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{"prod1", "--name", "New Name"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if gotForm.Get("name") != "New Name" {
+		t.Errorf("got name=%q, want New Name", gotForm.Get("name"))
+	}
+	if _, ok := gotForm["tags[]"]; ok {
+		t.Errorf("tags should not be sent when --tag not provided, got %v", gotForm["tags[]"])
+	}
+}
+
+func TestUpdate_APIError(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(422)
+		testutil.JSON(t, w, map[string]any{"message": "Price cannot be updated for tiered membership"})
+	})
+
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{"prod1", "--price", "10.00"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error from API")
+	}
+}
+
 func TestView_Plain(t *testing.T) {
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
 		testutil.JSON(t, w, map[string]any{
@@ -885,7 +1117,7 @@ func TestNewProductsCmd(t *testing.T) {
 	for _, c := range cmd.Commands() {
 		subs[c.Use] = true
 	}
-	for _, name := range []string{"create", "list", "view <id>", "delete <id>", "publish <id>", "unpublish <id>", "skus <id>"} {
+	for _, name := range []string{"create", "update <product_id>", "list", "view <id>", "delete <id>", "publish <id>", "unpublish <id>", "skus <id>"} {
 		if !subs[name] {
 			t.Errorf("missing subcommand %q", name)
 		}

--- a/internal/cmd/products/update.go
+++ b/internal/cmd/products/update.go
@@ -1,0 +1,115 @@
+package products
+
+import (
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+func newUpdateCmd() *cobra.Command {
+	var name, currency, description, customPermalink string
+	var customSummary, customReceipt, taxonomyID string
+	var price, suggestedPrice string
+	var maxPurchaseCount int
+	var payWhatYouWant bool
+	var tags []string
+
+	cmd := &cobra.Command{
+		Use:   "update <product_id>",
+		Short: "Update a product",
+		Example: `  gumroad products update <id> --name "New Name"
+  gumroad products update <id> --price 15.00 --currency eur
+  gumroad products update <id> --tag art --tag digital`,
+		Args: cmdutil.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			flags := c.Flags()
+
+			if err := cmdutil.RequireAnyFlagChanged(c,
+				"name", "price", "currency", "description",
+				"custom-permalink", "custom-summary", "custom-receipt",
+				"pay-what-you-want", "suggested-price", "max-purchase-count",
+				"taxonomy-id", "tag",
+			); err != nil {
+				return err
+			}
+
+			if flags.Changed("name") && name == "" {
+				return cmdutil.UsageErrorf(c, "--name cannot be empty")
+			}
+			if err := cmdutil.RequireNonNegativeIntFlag(c, "max-purchase-count", maxPurchaseCount); err != nil {
+				return err
+			}
+
+			currency = strings.ToLower(currency)
+			params := url.Values{}
+			if flags.Changed("name") {
+				params.Set("name", name)
+			}
+			if flags.Changed("price") {
+				cents, err := cmdutil.ParseMoney("price", price, "price", currency)
+				if err != nil {
+					return cmdutil.UsageErrorf(c, "%s", err.Error())
+				}
+				params.Set("price", strconv.Itoa(cents))
+			}
+			if flags.Changed("currency") {
+				params.Set("price_currency_type", currency)
+			}
+			if flags.Changed("description") {
+				params.Set("description", description)
+			}
+			if flags.Changed("custom-permalink") {
+				params.Set("custom_permalink", customPermalink)
+			}
+			if flags.Changed("custom-summary") {
+				params.Set("custom_summary", customSummary)
+			}
+			if flags.Changed("custom-receipt") {
+				params.Set("custom_receipt", customReceipt)
+			}
+			if flags.Changed("pay-what-you-want") {
+				params.Set("customizable_price", strconv.FormatBool(payWhatYouWant))
+			}
+			if flags.Changed("suggested-price") {
+				cents, err := cmdutil.ParseMoney("suggested-price", suggestedPrice, "suggested price", currency)
+				if err != nil {
+					return cmdutil.UsageErrorf(c, "%s", err.Error())
+				}
+				params.Set("suggested_price_cents", strconv.Itoa(cents))
+			}
+			if flags.Changed("max-purchase-count") {
+				params.Set("max_purchase_count", strconv.Itoa(maxPurchaseCount))
+			}
+			if flags.Changed("taxonomy-id") {
+				params.Set("taxonomy_id", taxonomyID)
+			}
+			for _, t := range tags {
+				params.Add("tags[]", t)
+			}
+
+			path := cmdutil.JoinPath("products", args[0])
+			return cmdutil.RunRequestWithSuccess(opts,
+				"Updating product...", "PUT", path, params,
+				"Product updated.")
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "New product name")
+	cmd.Flags().StringVar(&price, "price", "", "New price (e.g. 10, 10.00, 9.99)")
+	cmd.Flags().StringVar(&currency, "currency", "", "New price currency (e.g. usd, eur)")
+	cmd.Flags().StringVar(&description, "description", "", "New HTML description")
+	cmd.Flags().StringVar(&customPermalink, "custom-permalink", "", "New custom URL slug")
+	cmd.Flags().StringVar(&customSummary, "custom-summary", "", "New short summary")
+	cmd.Flags().StringVar(&customReceipt, "custom-receipt", "", "New custom receipt text")
+	cmd.Flags().BoolVar(&payWhatYouWant, "pay-what-you-want", false, "Enable pay-what-you-want pricing")
+	cmd.Flags().StringVar(&suggestedPrice, "suggested-price", "", "New suggested price for pay-what-you-want (e.g. 5, 5.00)")
+	cmd.Flags().IntVar(&maxPurchaseCount, "max-purchase-count", 0, "New maximum number of purchases")
+	cmd.Flags().StringVar(&taxonomyID, "taxonomy-id", "", "New taxonomy/category ID")
+	cmd.Flags().StringArrayVar(&tags, "tag", nil, "Tag (repeatable, replaces all existing tags)")
+
+	return cmd
+}


### PR DESCRIPTION
Ref antiwork/gumroad/issues/4363

## What

Adds `gumroad products update <product_id>`. Creators can now update existing products from the CLI. Supports partial updates: only explicitly provided flags are sent to the API.

12 flags: `--name`, `--price`, `--currency`, `--description`, `--custom-permalink`, `--custom-summary`, `--custom-receipt`, `--pay-what-you-want`, `--suggested-price`, `--max-purchase-count`, `--taxonomy-id`, and `--tag` (repeatable, replaces all existing tags). At least one flag must be provided.

Uses the same currency-aware price parsing as `products create` — `--price 10.00` sends cents to the API, with correct JPY scaling.

## Why

Second of two PRs implementing antiwork/gumroad#4363 (first was `products create` in #11). The `PUT /v2/products/:id` API endpoint (PR #4272) is merged and this exposes it in the CLI.

Uses `RunRequestWithSuccess` (not `RunRequestDecoded`) since the update response only needs a success message, matching the pattern used by `variants update`, `offer-codes update`, and other mutation commands.

---

This PR was implemented with AI assistance using Claude Opus 4.6 and gpt‑5.4 xhigh