### PR TITLE
Return resource IDs in mutation command output

### DIFF
--- a/internal/cmd/categories/categories_test.go
+++ b/internal/cmd/categories/categories_test.go
@@ -246,7 +246,7 @@ func TestCreate_SendsTitle(t *testing.T) {
 			t.Fatalf("ParseForm failed: %v", err)
 		}
 		gotTitle = r.PostForm.Get("title")
-		testutil.JSON(t, w, map[string]any{})
+		testutil.JSON(t, w, map[string]any{"variant_category": map[string]any{"id": "vc1", "title": "Size"}})
 	})
 
 	cmd := newCreateCmd()
@@ -300,6 +300,38 @@ func TestCreate_JSON(t *testing.T) {
 	var resp map[string]any
 	if err := json.Unmarshal([]byte(out), &resp); err != nil {
 		t.Fatalf("not valid JSON: %v", err)
+	}
+}
+
+func TestCreate_Output(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{"variant_category": map[string]any{"id": "vc1", "title": "Size"}})
+	})
+
+	cmd := testutil.Command(newCreateCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--product", "p1", "--title", "Size"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if !strings.Contains(out, "Created variant category:") {
+		t.Errorf("expected created message, got: %q", out)
+	}
+	if !strings.Contains(out, "vc1") {
+		t.Errorf("expected category ID in output, got: %q", out)
+	}
+	if !strings.Contains(out, "Size") {
+		t.Errorf("expected category title in output, got: %q", out)
+	}
+}
+
+func TestCreate_Plain(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{"variant_category": map[string]any{"id": "vc1", "title": "Size"}})
+	})
+
+	cmd := testutil.Command(newCreateCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{"--product", "p1", "--title", "Size"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if !strings.Contains(out, "vc1\tSize") {
+		t.Errorf("expected plain tab-separated output, got: %q", out)
 	}
 }
 

--- a/internal/cmd/categories/create.go
+++ b/internal/cmd/categories/create.go
@@ -4,8 +4,16 @@ import (
 	"net/url"
 
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
+
+type createCategoryResponse struct {
+	VariantCategory struct {
+		ID    string `json:"id"`
+		Title string `json:"title"`
+	} `json:"variant_category"`
+}
 
 func newCreateCmd() *cobra.Command {
 	var product, title string
@@ -26,7 +34,20 @@ func newCreateCmd() *cobra.Command {
 			params.Set("title", title)
 
 			opts := cmdutil.OptionsFrom(c)
-			return cmdutil.RunRequestWithSuccess(opts, "Creating variant category...", "POST", cmdutil.JoinPath("products", product, "variant_categories"), params, "Variant category created.")
+			return cmdutil.RunRequestDecoded[createCategoryResponse](opts,
+				"Creating variant category...", "POST", cmdutil.JoinPath("products", product, "variant_categories"), params,
+				func(resp createCategoryResponse) error {
+					vc := resp.VariantCategory
+					if opts.PlainOutput {
+						return output.PrintPlain(opts.Out(), [][]string{{vc.ID, vc.Title}})
+					}
+					if opts.Quiet {
+						return nil
+					}
+					s := opts.Style()
+					return output.Writef(opts.Out(), "%s %s (%s)\n",
+						s.Bold("Created variant category:"), vc.Title, s.Dim(vc.ID))
+				})
 		},
 	}
 

--- a/internal/cmd/categories/delete.go
+++ b/internal/cmd/categories/delete.go
@@ -28,7 +28,7 @@ func newDeleteCmd() *cobra.Command {
 				return cmdutil.PrintCancelledAction(opts, "delete variant category "+args[0])
 			}
 
-			return cmdutil.RunRequestWithSuccess(opts, "Deleting variant category...", "DELETE", cmdutil.JoinPath("products", product, "variant_categories", args[0]), url.Values{}, "Variant category deleted.")
+			return cmdutil.RunRequestWithSuccess(opts, "Deleting variant category...", "DELETE", cmdutil.JoinPath("products", product, "variant_categories", args[0]), url.Values{}, "Variant category "+args[0]+" deleted.")
 		},
 	}
 

--- a/internal/cmd/categories/update.go
+++ b/internal/cmd/categories/update.go
@@ -31,7 +31,7 @@ func newUpdateCmd() *cobra.Command {
 				params.Set("title", title)
 			}
 
-			return cmdutil.RunRequestWithSuccess(opts, "Updating variant category...", "PUT", cmdutil.JoinPath("products", product, "variant_categories", args[0]), params, "Variant category updated.")
+			return cmdutil.RunRequestWithSuccess(opts, "Updating variant category...", "PUT", cmdutil.JoinPath("products", product, "variant_categories", args[0]), params, "Variant category "+args[0]+" updated.")
 		},
 	}
 

--- a/internal/cmd/customfields/create.go
+++ b/internal/cmd/customfields/create.go
@@ -39,7 +39,7 @@ func newCreateCmd() *cobra.Command {
 			}
 			params.Set("type", normalizedType)
 
-			return cmdutil.RunRequestWithSuccess(opts, "Creating custom field...", "POST", cmdutil.JoinPath("products", product, "custom_fields"), params, "Custom field created.")
+			return cmdutil.RunRequestWithSuccess(opts, "Creating custom field...", "POST", cmdutil.JoinPath("products", product, "custom_fields"), params, "Custom field "+name+" created.")
 		},
 	}
 

--- a/internal/cmd/customfields/delete.go
+++ b/internal/cmd/customfields/delete.go
@@ -29,7 +29,7 @@ func newDeleteCmd() *cobra.Command {
 				return cmdutil.PrintCancelledAction(opts, "delete custom field \""+name+"\"")
 			}
 
-			return cmdutil.RunRequestWithSuccess(opts, "Deleting custom field...", "DELETE", cmdutil.JoinPath("products", product, "custom_fields", name), nil, "Custom field deleted.")
+			return cmdutil.RunRequestWithSuccess(opts, "Deleting custom field...", "DELETE", cmdutil.JoinPath("products", product, "custom_fields", name), nil, "Custom field "+name+" deleted.")
 		},
 	}
 

--- a/internal/cmd/customfields/update.go
+++ b/internal/cmd/customfields/update.go
@@ -36,7 +36,7 @@ func newUpdateCmd() *cobra.Command {
 				}
 			}
 
-			return cmdutil.RunRequestWithSuccess(opts, "Updating custom field...", "PUT", cmdutil.JoinPath("products", product, "custom_fields", name), params, "Custom field updated.")
+			return cmdutil.RunRequestWithSuccess(opts, "Updating custom field...", "PUT", cmdutil.JoinPath("products", product, "custom_fields", name), params, "Custom field "+name+" updated.")
 		},
 	}
 

--- a/internal/cmd/licenses/decrement.go
+++ b/internal/cmd/licenses/decrement.go
@@ -28,7 +28,7 @@ func newDecrementCmd() *cobra.Command {
 			params.Set("product_id", product)
 			params.Set("license_key", key)
 
-			return cmdutil.RunRequestWithSuccess(opts, "Decrementing license uses...", "PUT", "/licenses/decrement_uses_count", params, "License use count decremented.")
+			return cmdutil.RunRequestWithSuccess(opts, "Decrementing license uses...", "PUT", "/licenses/decrement_uses_count", params, "License use count decremented for product "+product+".")
 		},
 	}
 

--- a/internal/cmd/licenses/disable.go
+++ b/internal/cmd/licenses/disable.go
@@ -28,7 +28,7 @@ func newDisableCmd() *cobra.Command {
 			params.Set("product_id", product)
 			params.Set("license_key", key)
 
-			return cmdutil.RunRequestWithSuccess(opts, "Disabling license...", "PUT", "/licenses/disable", params, "License disabled.")
+			return cmdutil.RunRequestWithSuccess(opts, "Disabling license...", "PUT", "/licenses/disable", params, "License disabled for product "+product+".")
 		},
 	}
 

--- a/internal/cmd/licenses/enable.go
+++ b/internal/cmd/licenses/enable.go
@@ -28,7 +28,7 @@ func newEnableCmd() *cobra.Command {
 			params.Set("product_id", product)
 			params.Set("license_key", key)
 
-			return cmdutil.RunRequestWithSuccess(opts, "Enabling license...", "PUT", "/licenses/enable", params, "License enabled.")
+			return cmdutil.RunRequestWithSuccess(opts, "Enabling license...", "PUT", "/licenses/enable", params, "License enabled for product "+product+".")
 		},
 	}
 

--- a/internal/cmd/offercodes/create.go
+++ b/internal/cmd/offercodes/create.go
@@ -5,8 +5,16 @@ import (
 	"strconv"
 
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
+
+type createOfferCodeResponse struct {
+	OfferCode struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"offer_code"`
+}
 
 func newCreateCmd() *cobra.Command {
 	var product, name, amount string
@@ -69,7 +77,20 @@ Use either --amount (flat discount) or --percent-off (percentage discount), not 
 			}
 
 			opts := cmdutil.OptionsFrom(c)
-			return cmdutil.RunRequestWithSuccess(opts, "Creating offer code...", "POST", cmdutil.JoinPath("products", product, "offer_codes"), params, "Offer code "+name+" created.")
+			return cmdutil.RunRequestDecoded[createOfferCodeResponse](opts,
+				"Creating offer code...", "POST", cmdutil.JoinPath("products", product, "offer_codes"), params,
+				func(resp createOfferCodeResponse) error {
+					oc := resp.OfferCode
+					if opts.PlainOutput {
+						return output.PrintPlain(opts.Out(), [][]string{{oc.ID, oc.Name}})
+					}
+					if opts.Quiet {
+						return nil
+					}
+					s := opts.Style()
+					return output.Writef(opts.Out(), "%s %s (%s)\n",
+						s.Bold("Created offer code:"), oc.Name, s.Dim(oc.ID))
+				})
 		},
 	}
 

--- a/internal/cmd/offercodes/delete.go
+++ b/internal/cmd/offercodes/delete.go
@@ -28,7 +28,7 @@ func newDeleteCmd() *cobra.Command {
 				return cmdutil.PrintCancelledAction(opts, "delete offer code "+args[0])
 			}
 
-			return cmdutil.RunRequestWithSuccess(opts, "Deleting offer code...", "DELETE", cmdutil.JoinPath("products", product, "offer_codes", args[0]), url.Values{}, "Offer code deleted.")
+			return cmdutil.RunRequestWithSuccess(opts, "Deleting offer code...", "DELETE", cmdutil.JoinPath("products", product, "offer_codes", args[0]), url.Values{}, "Offer code "+args[0]+" deleted.")
 		},
 	}
 

--- a/internal/cmd/offercodes/offercodes_test.go
+++ b/internal/cmd/offercodes/offercodes_test.go
@@ -438,7 +438,7 @@ func TestCreate_PercentOff(t *testing.T) {
 		}
 		gotPercentOff = r.PostForm.Get("percent_off")
 		gotAmountOff = r.PostForm.Get("amount_off")
-		testutil.JSON(t, w, map[string]any{})
+		testutil.JSON(t, w, map[string]any{"offer_code": map[string]any{"id": "oc1", "name": r.PostForm.Get("name")}})
 	})
 
 	cmd := newCreateCmd()
@@ -464,7 +464,7 @@ func TestCreate_Amount(t *testing.T) {
 			t.Fatalf("ParseForm failed: %v", err)
 		}
 		gotAmountOff = r.PostForm.Get("amount_off")
-		testutil.JSON(t, w, map[string]any{})
+		testutil.JSON(t, w, map[string]any{"offer_code": map[string]any{"id": "oc1", "name": "FLAT5"}})
 	})
 
 	cmd := newCreateCmd()
@@ -487,7 +487,7 @@ func TestCreate_AmountWholeNumber(t *testing.T) {
 			t.Fatalf("ParseForm failed: %v", err)
 		}
 		gotAmountOff = r.PostForm.Get("amount_off")
-		testutil.JSON(t, w, map[string]any{})
+		testutil.JSON(t, w, map[string]any{"offer_code": map[string]any{"id": "oc1", "name": "FLAT5"}})
 	})
 
 	cmd := newCreateCmd()
@@ -554,7 +554,7 @@ func TestCreate_Universal(t *testing.T) {
 		}
 		gotUniversal = r.PostForm.Get("universal")
 		gotMaxPurchase = r.PostForm.Get("max_purchase_count")
-		testutil.JSON(t, w, map[string]any{})
+		testutil.JSON(t, w, map[string]any{"offer_code": map[string]any{"id": "oc1", "name": "UNI"}})
 	})
 
 	cmd := newCreateCmd()
@@ -576,7 +576,7 @@ func TestCreate_MaxPurchaseCountZero(t *testing.T) {
 			t.Fatalf("ParseForm failed: %v", err)
 		}
 		gotMaxPurchase = r.PostForm.Get("max_purchase_count")
-		testutil.JSON(t, w, map[string]any{})
+		testutil.JSON(t, w, map[string]any{"offer_code": map[string]any{"id": "oc1", "name": "ZERO"}})
 	})
 
 	cmd := newCreateCmd()
@@ -600,6 +600,38 @@ func TestCreate_JSON(t *testing.T) {
 	var resp map[string]any
 	if err := json.Unmarshal([]byte(out), &resp); err != nil {
 		t.Fatalf("not valid JSON: %v", err)
+	}
+}
+
+func TestCreate_Output(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{"offer_code": map[string]any{"id": "oc1", "name": "SAVE10"}})
+	})
+
+	cmd := testutil.Command(newCreateCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--product", "p1", "--name", "SAVE10", "--percent-off", "10"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if !strings.Contains(out, "Created offer code:") {
+		t.Errorf("expected created message, got: %q", out)
+	}
+	if !strings.Contains(out, "oc1") {
+		t.Errorf("expected offer code ID in output, got: %q", out)
+	}
+	if !strings.Contains(out, "SAVE10") {
+		t.Errorf("expected offer code name in output, got: %q", out)
+	}
+}
+
+func TestCreate_Plain(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{"offer_code": map[string]any{"id": "oc1", "name": "SAVE10"}})
+	})
+
+	cmd := testutil.Command(newCreateCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{"--product", "p1", "--name", "SAVE10", "--percent-off", "10"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if !strings.Contains(out, "oc1\tSAVE10") {
+		t.Errorf("expected plain tab-separated output, got: %q", out)
 	}
 }
 

--- a/internal/cmd/offercodes/update.go
+++ b/internal/cmd/offercodes/update.go
@@ -33,7 +33,7 @@ func newUpdateCmd() *cobra.Command {
 				params.Set("max_purchase_count", strconv.Itoa(maxPurchaseCount))
 			}
 
-			return cmdutil.RunRequestWithSuccess(opts, "Updating offer code...", "PUT", cmdutil.JoinPath("products", product, "offer_codes", args[0]), params, "Offer code updated.")
+			return cmdutil.RunRequestWithSuccess(opts, "Updating offer code...", "PUT", cmdutil.JoinPath("products", product, "offer_codes", args[0]), params, "Offer code "+args[0]+" updated.")
 		},
 	}
 

--- a/internal/cmd/products/update.go
+++ b/internal/cmd/products/update.go
@@ -94,7 +94,7 @@ func newUpdateCmd() *cobra.Command {
 			path := cmdutil.JoinPath("products", args[0])
 			return cmdutil.RunRequestWithSuccess(opts,
 				"Updating product...", "PUT", path, params,
-				"Product updated.")
+				"Product "+args[0]+" updated.")
 		},
 	}
 

--- a/internal/cmd/variants/create.go
+++ b/internal/cmd/variants/create.go
@@ -5,8 +5,16 @@ import (
 	"strconv"
 
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
+
+type createVariantResponse struct {
+	Variant struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"variant"`
+}
 
 func newCreateCmd() *cobra.Command {
 	var product, category, name, description, priceDifference string
@@ -50,8 +58,22 @@ func newCreateCmd() *cobra.Command {
 				params.Set("max_purchase_count", strconv.Itoa(maxPurchaseCount))
 			}
 
+			opts := cmdutil.OptionsFrom(c)
 			path := cmdutil.JoinPath("products", product, "variant_categories", category, "variants")
-			return cmdutil.RunRequestWithSuccess(cmdutil.OptionsFrom(c), "Creating variant...", "POST", path, params, "Variant created.")
+			return cmdutil.RunRequestDecoded[createVariantResponse](opts,
+				"Creating variant...", "POST", path, params,
+				func(resp createVariantResponse) error {
+					v := resp.Variant
+					if opts.PlainOutput {
+						return output.PrintPlain(opts.Out(), [][]string{{v.ID, v.Name}})
+					}
+					if opts.Quiet {
+						return nil
+					}
+					s := opts.Style()
+					return output.Writef(opts.Out(), "%s %s (%s)\n",
+						s.Bold("Created variant:"), v.Name, s.Dim(v.ID))
+				})
 		},
 	}
 

--- a/internal/cmd/variants/delete.go
+++ b/internal/cmd/variants/delete.go
@@ -32,7 +32,7 @@ func newDeleteCmd() *cobra.Command {
 			}
 
 			path := cmdutil.JoinPath("products", product, "variant_categories", category, "variants", args[0])
-			return cmdutil.RunRequestWithSuccess(opts, "Deleting variant...", "DELETE", path, url.Values{}, "Variant deleted.")
+			return cmdutil.RunRequestWithSuccess(opts, "Deleting variant...", "DELETE", path, url.Values{}, "Variant "+args[0]+" deleted.")
 		},
 	}
 

--- a/internal/cmd/variants/update.go
+++ b/internal/cmd/variants/update.go
@@ -53,7 +53,7 @@ func newUpdateCmd() *cobra.Command {
 			}
 
 			path := cmdutil.JoinPath("products", product, "variant_categories", category, "variants", args[0])
-			return cmdutil.RunRequestWithSuccess(cmdutil.OptionsFrom(c), "Updating variant...", "PUT", path, params, "Variant updated.")
+			return cmdutil.RunRequestWithSuccess(cmdutil.OptionsFrom(c), "Updating variant...", "PUT", path, params, "Variant "+args[0]+" updated.")
 		},
 	}
 

--- a/internal/cmd/variants/variants_test.go
+++ b/internal/cmd/variants/variants_test.go
@@ -309,7 +309,7 @@ func TestCreate_Flags(t *testing.T) {
 		gotName = r.PostForm.Get("name")
 		gotDesc = r.PostForm.Get("description")
 		gotPriceDiff = r.PostForm.Get("price_difference_cents")
-		testutil.JSON(t, w, map[string]any{})
+		testutil.JSON(t, w, map[string]any{"variant": map[string]any{"id": "v1", "name": r.PostForm.Get("name")}})
 	})
 
 	cmd := newCreateCmd()
@@ -334,7 +334,7 @@ func TestCreate_PriceDifference(t *testing.T) {
 			t.Fatalf("ParseForm failed: %v", err)
 		}
 		gotPriceDiff = r.PostForm.Get("price_difference_cents")
-		testutil.JSON(t, w, map[string]any{})
+		testutil.JSON(t, w, map[string]any{"variant": map[string]any{"id": "v1", "name": "XL"}})
 	})
 
 	cmd := newCreateCmd()
@@ -353,7 +353,7 @@ func TestCreate_PriceDifferenceNegative(t *testing.T) {
 			t.Fatalf("ParseForm failed: %v", err)
 		}
 		gotPriceDiff = r.PostForm.Get("price_difference_cents")
-		testutil.JSON(t, w, map[string]any{})
+		testutil.JSON(t, w, map[string]any{"variant": map[string]any{"id": "v1", "name": "SM"}})
 	})
 
 	cmd := newCreateCmd()
@@ -433,6 +433,38 @@ func TestCreate_JSON(t *testing.T) {
 	var resp map[string]any
 	if err := json.Unmarshal([]byte(out), &resp); err != nil {
 		t.Fatalf("not valid JSON: %v", err)
+	}
+}
+
+func TestCreate_Output(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{"variant": map[string]any{"id": "v1", "name": "XL"}})
+	})
+
+	cmd := testutil.Command(newCreateCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--product", "p1", "--category", "vc1", "--name", "XL"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if !strings.Contains(out, "Created variant:") {
+		t.Errorf("expected created message, got: %q", out)
+	}
+	if !strings.Contains(out, "v1") {
+		t.Errorf("expected variant ID in output, got: %q", out)
+	}
+	if !strings.Contains(out, "XL") {
+		t.Errorf("expected variant name in output, got: %q", out)
+	}
+}
+
+func TestCreate_Plain(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{"variant": map[string]any{"id": "v1", "name": "XL"}})
+	})
+
+	cmd := testutil.Command(newCreateCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{"--product", "p1", "--category", "vc1", "--name", "XL"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if !strings.Contains(out, "v1\tXL") {
+		t.Errorf("expected plain tab-separated output, got: %q", out)
 	}
 }
 

--- a/internal/cmd/variants/variants_test.go
+++ b/internal/cmd/variants/variants_test.go
@@ -488,7 +488,7 @@ func TestCreate_MaxPurchaseCount(t *testing.T) {
 			t.Fatalf("ParseForm failed: %v", err)
 		}
 		gotParam = r.PostForm.Get("max_purchase_count")
-		testutil.JSON(t, w, map[string]any{})
+		testutil.JSON(t, w, map[string]any{"variant": map[string]any{"id": "v1", "name": "XL"}})
 	})
 
 	cmd := newCreateCmd()
@@ -507,7 +507,7 @@ func TestCreate_MaxPurchaseCountZero(t *testing.T) {
 			t.Fatalf("ParseForm failed: %v", err)
 		}
 		gotParam = r.PostForm.Get("max_purchase_count")
-		testutil.JSON(t, w, map[string]any{})
+		testutil.JSON(t, w, map[string]any{"variant": map[string]any{"id": "v1", "name": "XL"}})
 	})
 
 	cmd := newCreateCmd()

--- a/internal/cmd/webhooks/create.go
+++ b/internal/cmd/webhooks/create.go
@@ -4,8 +4,17 @@ import (
 	"net/url"
 
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
+
+type createWebhookResponse struct {
+	ResourceSubscription struct {
+		ID           string `json:"id"`
+		ResourceName string `json:"resource_name"`
+		PostURL      string `json:"post_url"`
+	} `json:"resource_subscription"`
+}
 
 func newCreateCmd() *cobra.Command {
 	var resource, postURL string
@@ -30,7 +39,20 @@ func newCreateCmd() *cobra.Command {
 			params.Set("resource_name", resource)
 			params.Set("post_url", postURL)
 
-			return cmdutil.RunRequestWithSuccess(opts, "Creating webhook...", "PUT", "/resource_subscriptions", params, "Webhook created for "+resource+".")
+			return cmdutil.RunRequestDecoded[createWebhookResponse](opts,
+				"Creating webhook...", "PUT", "/resource_subscriptions", params,
+				func(resp createWebhookResponse) error {
+					ws := resp.ResourceSubscription
+					if opts.PlainOutput {
+						return output.PrintPlain(opts.Out(), [][]string{{ws.ID, ws.ResourceName, ws.PostURL}})
+					}
+					if opts.Quiet {
+						return nil
+					}
+					s := opts.Style()
+					return output.Writef(opts.Out(), "%s %s → %s (%s)\n",
+						s.Bold("Created webhook:"), ws.ResourceName, ws.PostURL, s.Dim(ws.ID))
+				})
 		},
 	}
 

--- a/internal/cmd/webhooks/delete.go
+++ b/internal/cmd/webhooks/delete.go
@@ -25,7 +25,7 @@ Note: This only succeeds when the token's OAuth app matches the subscription's a
 				return cmdutil.PrintCancelledAction(opts, "delete webhook "+args[0])
 			}
 
-			return cmdutil.RunRequestWithSuccess(opts, "Deleting webhook...", "DELETE", cmdutil.JoinPath("resource_subscriptions", args[0]), url.Values{}, "Webhook deleted.")
+			return cmdutil.RunRequestWithSuccess(opts, "Deleting webhook...", "DELETE", cmdutil.JoinPath("resource_subscriptions", args[0]), url.Values{}, "Webhook "+args[0]+" deleted.")
 		},
 	}
 }

--- a/internal/cmd/webhooks/webhooks_test.go
+++ b/internal/cmd/webhooks/webhooks_test.go
@@ -83,7 +83,13 @@ func TestCreate_Params(t *testing.T) {
 		}
 		gotResource = r.PostForm.Get("resource_name")
 		gotURL = r.PostForm.Get("post_url")
-		testutil.JSON(t, w, map[string]any{})
+		testutil.JSON(t, w, map[string]any{
+			"resource_subscription": map[string]any{
+				"id":            "rs1",
+				"resource_name": r.PostForm.Get("resource_name"),
+				"post_url":      r.PostForm.Get("post_url"),
+			},
+		})
 	})
 
 	cmd := newCreateCmd()

--- a/internal/cmd/webhooks/webhooks_test.go
+++ b/internal/cmd/webhooks/webhooks_test.go
@@ -273,14 +273,48 @@ func TestList_APIError(t *testing.T) {
 
 func TestCreate_Output(t *testing.T) {
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
-		testutil.JSON(t, w, map[string]any{})
+		testutil.JSON(t, w, map[string]any{
+			"resource_subscription": map[string]any{
+				"id":            "rs1",
+				"resource_name": "sale",
+				"post_url":      "https://example.com",
+			},
+		})
 	})
 
 	cmd := testutil.Command(newCreateCmd(), testutil.Quiet(false))
 	cmd.SetArgs([]string{"--resource", "sale", "--url", "https://example.com"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
-	if !strings.Contains(out, "Webhook created") {
+	if !strings.Contains(out, "Created webhook:") {
 		t.Errorf("expected created message, got: %q", out)
+	}
+	if !strings.Contains(out, "rs1") {
+		t.Errorf("expected webhook ID in output, got: %q", out)
+	}
+	if !strings.Contains(out, "sale") {
+		t.Errorf("expected resource name in output, got: %q", out)
+	}
+	if !strings.Contains(out, "https://example.com") {
+		t.Errorf("expected post URL in output, got: %q", out)
+	}
+}
+
+func TestCreate_Plain(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"resource_subscription": map[string]any{
+				"id":            "rs1",
+				"resource_name": "sale",
+				"post_url":      "https://example.com",
+			},
+		})
+	})
+
+	cmd := testutil.Command(newCreateCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{"--resource", "sale", "--url", "https://example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if !strings.Contains(out, "rs1\tsale\thttps://example.com") {
+		t.Errorf("expected plain tab-separated output, got: %q", out)
 	}
 }
 


### PR DESCRIPTION
## What

All mutation commands (create, update, delete, enable, disable, decrement) now include resource identifiers in their success output.

**Create commands** (variants, categories, offer codes, webhooks) decode the API response to extract and display the server-generated ID alongside the resource name. This uses `RunRequestDecoded` with a render callback, matching the existing pattern in `products create`.

**Update/delete commands** echo back the resource ID that was passed as an argument (e.g., "Product abc123 updated." instead of "Product updated.").

**License commands** include the product ID in their success message (e.g., "License enabled for product abc123.").

All output modes are supported: styled (default), `--plain` (tab-separated ID and name), `--json` (raw API response), and `--quiet` (suppressed).

## Why

Automation consumers (agents, scripts, CI pipelines) need resource identifiers in command output to chain operations. Previously, most mutation commands printed generic messages like "Variant created." with no way to extract the server-generated ID without `--json` + `--jq`. This is the most impactful gap identified from an audit of agent-friendly CLI patterns against our existing design.

The approach follows the precedent set by `products create`, which already used `RunRequestDecoded` to show the created product's ID, name, and price.

---

This PR was implemented with AI assistance using Claude Opus 4.6 and gpt‑5.4 xhigh