### PR TITLE
Add Homebrew tap, install script, and man pages in releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -28,3 +32,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,11 @@
 version: 2
 
+project_name: gumroad-cli
+
+before:
+  hooks:
+    - go run ./cmd/gen-man
+
 builds:
   - main: ./cmd/gumroad
     binary: gumroad
@@ -16,6 +22,8 @@ builds:
 archives:
   - format: tar.gz
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - man/*.1
     format_overrides:
       - goos: windows
         format: zip
@@ -23,10 +31,20 @@ archives:
 checksum:
   name_template: "checksums.txt"
 
-# Brew tap — inactive until packaging is set up
-# brews:
-#   - repository:
-#       owner: antiwork
-#       name: homebrew-tap
-#     homepage: https://gumroad.com
-#     description: CLI for the Gumroad API
+brews:
+  - name: gumroad
+    repository:
+      owner: antiwork
+      name: homebrew-cli
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Formula
+    homepage: https://gumroad.com
+    description: CLI for the Gumroad API
+    license: MIT
+    install: |
+      bin.install "gumroad"
+      man1.install Dir["man/*.1"]
+      generate_completions_from_executable(bin/"gumroad", "completion")
+    test: |
+      system bin/"gumroad", "--version"

--- a/README.md
+++ b/README.md
@@ -18,13 +18,27 @@ $ gumroad sales list --json --jq '.sales[0].email'
 
 ## Install
 
+**Homebrew** (macOS and Linux):
+
+```sh
+brew install antiwork/cli/gumroad
+```
+
+**Shell script** (macOS, Linux, and Windows via Git Bash):
+
+```sh
+curl -fsSL https://gumroad.com/install-cli | bash
+```
+
+> Homebrew and the install script require a published release. Until the first release is tagged, use `go install` or build from source.
+
 **Go**:
 
 ```sh
 go install github.com/antiwork/gumroad-cli/cmd/gumroad@latest
 ```
 
-**Local install with man pages and completions**:
+**From source** with man pages and completions:
 
 ```sh
 make install
@@ -34,10 +48,6 @@ make install PREFIX="$HOME/.local"
 ```
 
 Under the selected `PREFIX`, `make install` places the binary in `bin/`, man pages in `share/man/man1/`, and shell completions under `share/`.
-
-**Binary releases**: Not published yet. For now, install with `go install` or build locally with `make build`.
-
-Homebrew packaging is not active yet.
 
 ## Quick start
 

--- a/cmd/gen-man/main.go
+++ b/cmd/gen-man/main.go
@@ -32,7 +32,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 	root.DisableAutoGenTag = true
 
 	if err := cobradoc.GenManTree(root, &cobradoc.GenManHeader{
-		Title:   "GR",
+		Title:   "GUMROAD",
 		Section: "1",
 		Source:  "Gumroad",
 		Manual:  "Gumroad CLI",

--- a/script/install.sh
+++ b/script/install.sh
@@ -62,7 +62,7 @@ check_requirements() {
 
     if [[ "$OS" == "windows" ]]; then
         if ! command -v unzip &>/dev/null; then
-            echo "Error: unzip is required on Windows but not found. Install it with: pacman -S unzip" >&2
+            echo "Error: unzip is required on Windows but not found. Install it via your package manager (pacman -S unzip for MSYS2/Git Bash, or Cygwin setup for Cygwin)." >&2
             exit 1
         fi
     else
@@ -99,9 +99,15 @@ detect_platform() {
 }
 
 resolve_version() {
-    local url version
+    local url version curl_exit=0
     url=$(curl -fsS -o /dev/null -w '%{redirect_url}' --max-redirs 0 \
-        "https://github.com/${REPO}/releases/latest" 2>/dev/null) || true
+        "https://github.com/${REPO}/releases/latest" 2>/dev/null) || curl_exit=$?
+
+    if [[ "$curl_exit" -ne 0 ]]; then
+        echo "Error: failed to reach GitHub (curl exit ${curl_exit}). Check your network connection." >&2
+        exit 1
+    fi
+
     version="${url##*/}"
 
     if [[ ! $version =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
@@ -171,9 +177,15 @@ install_binary() {
     fi
 
     if [[ -d "${WORK_DIR}/man" ]] && [[ "$OS" != "windows" ]]; then
-        local man_dir="${HOME}/.local/share/man/man1"
-        mkdir -p "$man_dir"
-        cp "${WORK_DIR}"/man/*.1 "$man_dir/" 2>/dev/null || true
+        local man_dir man_files
+        man_dir="$(dirname "$BIN_DIR")/share/man/man1"
+        shopt -s nullglob
+        man_files=("${WORK_DIR}"/man/*.1)
+        shopt -u nullglob
+        if [[ ${#man_files[@]} -gt 0 ]]; then
+            mkdir -p "$man_dir"
+            cp "${man_files[@]}" "$man_dir/"
+        fi
     fi
 }
 
@@ -209,7 +221,11 @@ setup_path() {
         *)      shell_rc="$HOME/.profile" ;;
     esac
 
-    if [[ -f "$shell_rc" ]] && grep -qF "$BIN_DIR" "$shell_rc" 2>/dev/null; then
+    local guard_pattern="export PATH=\"$BIN_DIR:\$PATH\""
+    if [[ "${SHELL:-}" == */fish ]]; then
+        guard_pattern="fish_add_path -- \"$BIN_DIR\""
+    fi
+    if [[ -f "$shell_rc" ]] && grep -qxF "$guard_pattern" "$shell_rc" 2>/dev/null; then
         return 0
     fi
 

--- a/script/install.sh
+++ b/script/install.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install script for the Gumroad CLI.
+# Usage:
+#   curl -fsSL https://gumroad.com/install-cli | bash
+#   GUMROAD_BIN_DIR=~/.bin bash install.sh
+
+REPO="antiwork/gumroad-cli"
+
+if [[ -z "${HOME:-}" ]]; then
+    echo "Error: HOME is not set." >&2
+    exit 1
+fi
+
+BIN_DIR="${GUMROAD_BIN_DIR:-$HOME/.local/bin}"
+
+if command -v cygpath &>/dev/null; then
+    BIN_DIR=$(cygpath -u "$BIN_DIR")
+fi
+
+SHA_CMD=""
+WORK_DIR=""
+
+binary_name() {
+    if [[ "$OS" == "windows" ]]; then
+        echo "gumroad.exe"
+    else
+        echo "gumroad"
+    fi
+}
+
+main() {
+    detect_platform
+    check_requirements
+    resolve_version
+
+    WORK_DIR=$(mktemp -d)
+    trap 'rm -rf "$WORK_DIR"' EXIT
+
+    download_and_verify
+    install_binary
+    setup_path
+
+    echo "gumroad ${VERSION} installed to ${BIN_DIR}/$(binary_name)"
+}
+
+check_requirements() {
+    if ! command -v curl &>/dev/null; then
+        echo "Error: curl is required but not found." >&2
+        exit 1
+    fi
+
+    if command -v sha256sum &>/dev/null; then
+        SHA_CMD="sha256sum"
+    elif command -v shasum &>/dev/null; then
+        SHA_CMD="shasum -a 256"
+    else
+        echo "Error: sha256sum or shasum is required but neither was found." >&2
+        exit 1
+    fi
+
+    if [[ "$OS" == "windows" ]]; then
+        if ! command -v unzip &>/dev/null; then
+            echo "Error: unzip is required on Windows but not found. Install it with: pacman -S unzip" >&2
+            exit 1
+        fi
+    else
+        if ! command -v tar &>/dev/null; then
+            echo "Error: tar is required but not found." >&2
+            exit 1
+        fi
+    fi
+}
+
+detect_platform() {
+    local os arch
+
+    os=$(uname -s | tr '[:upper:]' '[:lower:]')
+    case "$os" in
+        darwin)               OS="darwin" ;;
+        linux)                OS="linux" ;;
+        mingw*|msys*|cygwin*) OS="windows" ;;
+        *)
+            echo "Error: unsupported OS: $os. Supported: macOS, Linux, Windows (Git Bash/MSYS2)." >&2
+            exit 1
+            ;;
+    esac
+
+    arch=$(uname -m)
+    case "$arch" in
+        x86_64|amd64)   ARCH="amd64" ;;
+        aarch64|arm64)  ARCH="arm64" ;;
+        *)
+            echo "Error: unsupported architecture: $arch. Supported: x86_64, arm64." >&2
+            exit 1
+            ;;
+    esac
+}
+
+resolve_version() {
+    local url version
+    url=$(curl -fsS -o /dev/null -w '%{redirect_url}' --max-redirs 0 \
+        "https://github.com/${REPO}/releases/latest" 2>/dev/null) || true
+    version="${url##*/}"
+
+    if [[ ! $version =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+        echo "Error: no published release found. Check https://github.com/${REPO}/releases" >&2
+        exit 1
+    fi
+
+    VERSION="$version"
+}
+
+download_and_verify() {
+    local ext="tar.gz"
+    if [[ "$OS" == "windows" ]]; then
+        ext="zip"
+    fi
+
+    local archive="gumroad-cli_${OS}_${ARCH}.${ext}"
+    local base_url="https://github.com/${REPO}/releases/download/${VERSION}"
+
+    echo "Downloading gumroad ${VERSION} for ${OS}/${ARCH}..."
+
+    local pid_archive pid_checksums
+    curl -fsSL "${base_url}/${archive}" -o "${WORK_DIR}/${archive}" &
+    pid_archive=$!
+    curl -fsSL "${base_url}/checksums.txt" -o "${WORK_DIR}/checksums.txt" &
+    pid_checksums=$!
+
+    if ! wait "$pid_archive"; then
+        echo "Error: failed to download ${archive}" >&2
+        exit 1
+    fi
+    if ! wait "$pid_checksums"; then
+        echo "Error: failed to download checksums.txt" >&2
+        exit 1
+    fi
+
+    local expected actual
+    expected=$(awk -v f="$archive" '$2 == f || $2 == ("*" f) {print $1; exit}' "${WORK_DIR}/checksums.txt")
+    if [[ -z "$expected" ]]; then
+        echo "Error: archive ${archive} not found in checksums.txt" >&2
+        exit 1
+    fi
+
+    actual=$(cd "$WORK_DIR" && $SHA_CMD "$archive" | awk '{print $1}')
+    if [[ "$expected" != "$actual" ]]; then
+        echo "Error: checksum mismatch for ${archive}" >&2
+        echo "  expected: ${expected}" >&2
+        echo "  got:      ${actual}" >&2
+        exit 1
+    fi
+
+    if [[ "$ext" == "zip" ]]; then
+        unzip -q "${WORK_DIR}/${archive}" -d "$WORK_DIR"
+    else
+        tar -xzf "${WORK_DIR}/${archive}" -C "$WORK_DIR"
+    fi
+}
+
+install_binary() {
+    local name
+    name=$(binary_name)
+
+    mkdir -p "$BIN_DIR"
+    cp "${WORK_DIR}/${name}" "${BIN_DIR}/${name}"
+    if [[ "$OS" != "windows" ]]; then
+        chmod +x "${BIN_DIR}/${name}"
+    fi
+
+    if [[ -d "${WORK_DIR}/man" ]] && [[ "$OS" != "windows" ]]; then
+        local man_dir="${HOME}/.local/share/man/man1"
+        mkdir -p "$man_dir"
+        cp "${WORK_DIR}"/man/*.1 "$man_dir/" 2>/dev/null || true
+    fi
+}
+
+setup_path() {
+    if [[ ":$PATH:" == *":$BIN_DIR:"* ]]; then
+        return 0
+    fi
+
+    local shell_rc=""
+    case "${SHELL:-}" in
+        */zsh)  shell_rc="$HOME/.zshrc" ;;
+        */bash)
+            if [[ "$OS" == "windows" ]]; then
+                # Git Bash opens login shells that read these in order
+                if [[ -f "$HOME/.bash_profile" ]]; then
+                    shell_rc="$HOME/.bash_profile"
+                elif [[ -f "$HOME/.bash_login" ]]; then
+                    shell_rc="$HOME/.bash_login"
+                else
+                    shell_rc="$HOME/.profile"
+                fi
+            elif [[ -f "$HOME/.bashrc" ]]; then
+                shell_rc="$HOME/.bashrc"
+            elif [[ -f "$HOME/.bash_profile" ]]; then
+                shell_rc="$HOME/.bash_profile"
+            elif [[ -f "$HOME/.bash_login" ]]; then
+                shell_rc="$HOME/.bash_login"
+            else
+                shell_rc="$HOME/.profile"
+            fi
+            ;;
+        */fish) shell_rc="$HOME/.config/fish/config.fish" ;;
+        *)      shell_rc="$HOME/.profile" ;;
+    esac
+
+    if [[ -f "$shell_rc" ]] && grep -qF "$BIN_DIR" "$shell_rc" 2>/dev/null; then
+        return 0
+    fi
+
+    mkdir -p "$(dirname "$shell_rc")"
+
+    if [[ "${SHELL:-}" == */fish ]]; then
+        echo "" >> "$shell_rc"
+        echo "# Added by gumroad installer" >> "$shell_rc"
+        echo "fish_add_path -- \"$BIN_DIR\"" >> "$shell_rc"
+    else
+        echo "" >> "$shell_rc"
+        echo "# Added by gumroad installer" >> "$shell_rc"
+        echo "export PATH=\"$BIN_DIR:\$PATH\"" >> "$shell_rc"
+    fi
+
+    echo "Added ${BIN_DIR} to PATH in ${shell_rc}"
+    echo "Run: source ${shell_rc}"
+}
+
+main


### PR DESCRIPTION
Rev antiwork/gumroad#4405

## What

Three new install methods so users don't need Go installed:

**Homebrew** — activated the `brews:` section in `.goreleaser.yml` targeting `antiwork/homebrew-cli`. On each tagged release, GoReleaser auto-publishes a formula with the binary, man pages, and shell completions (bash, zsh, fish).

**Curl installer** — `script/install.sh`, a bash script that detects OS/arch (macOS, Linux, Windows via Git Bash), downloads the latest release from GitHub, verifies SHA256 checksums, and installs to `~/.local/bin`. Auto-patches shell rc files if `~/.local/bin` isn't in PATH.

**Man pages in releases** — GoReleaser now generates man pages via a `before` hook and includes them in every release archive. The install script copies them to `~/.local/share/man/man1/`.

Also updated the release workflow with a `HOMEBREW_TAP_TOKEN` env var (needed for cross-repo formula push) and a concurrency guard.

## Why

`go install` requires a Go toolchain — a high barrier for non-developers. Homebrew and `curl | bash` are the two most common CLI distribution patterns. The `antiwork/homebrew-cli` tap repo was created (empty) ahead of this PR; GoReleaser will populate it on the first release.

The install script defaults to `~/.local/bin` (no sudo needed), parallel downloads, checksum verification, and automatic PATH setup.

### Prerequisites before first release

1. Create a fine-grained PAT scoped to `antiwork/homebrew-cli` with `Contents: write`
2. Add it as `HOMEBREW_TAP_TOKEN` secret in `gumroad-cli` repo settings
3. Set up `gumroad.com/install-cli` redirect → `https://raw.githubusercontent.com/antiwork/gumroad-cli/main/script/install.sh`

---

This PR was implemented with AI assistance using Claude Opus 4.6 and gpt‑5.4 xhigh