### PR TITLE
Fix GoReleaser deprecation warnings

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,7 +39,26 @@ homebrew_casks:
       branch: main
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     directory: Casks
+    url:
+      verified: github.com/antiwork/gumroad-cli/
     homepage: https://gumroad.com
     description: CLI for the Gumroad API
     binaries:
       - gumroad
+    manpages:
+      - man/*.1
+    generate_completions_from_executable:
+      args:
+        - completion
+      shell_parameter_format: cobra
+    caveats: |
+      `gumroad` is currently distributed as an unsigned, non-notarized binary.
+      On macOS, this cask removes the quarantine bit after install.
+      If Gatekeeper still blocks execution, run:
+        xattr -dr com.apple.quarantine "$(brew --prefix)/bin/gumroad"
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/gumroad"]
+          end

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,31 +20,26 @@ builds:
       - arm64
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
     files:
       - man/*.1
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 
 checksum:
   name_template: "checksums.txt"
 
-brews:
+homebrew_casks:
   - name: gumroad
     repository:
       owner: antiwork
       name: homebrew-cli
       branch: main
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
-    directory: Formula
+    directory: Casks
     homepage: https://gumroad.com
     description: CLI for the Gumroad API
-    license: MIT
-    install: |
-      bin.install "gumroad"
-      man1.install Dir["man/*.1"]
-      generate_completions_from_executable(bin/"gumroad", "completion")
-    test: |
-      system bin/"gumroad", "--version"
+    binaries:
+      - gumroad

--- a/README.md
+++ b/README.md
@@ -18,11 +18,13 @@ $ gumroad sales list --json --jq '.sales[0].email'
 
 ## Install
 
-**Homebrew** (macOS and Linux):
+**Homebrew**:
 
 ```sh
 brew install --cask antiwork/cli/gumroad
 ```
+
+On macOS, this installs the binary, man pages, and shell completions. Linux Homebrew support for casks depends on the Homebrew version and cask support available on your system; if `brew install --cask` is unavailable, use the shell script below.
 
 **Shell script** (macOS, Linux, and Windows via Git Bash):
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ gumroad sales list --json --jq '.sales[0].email'
 **Homebrew** (macOS and Linux):
 
 ```sh
-brew install antiwork/cli/gumroad
+brew install --cask antiwork/cli/gumroad
 ```
 
 **Shell script** (macOS, Linux, and Windows via Git Bash):


### PR DESCRIPTION
## What

Fixes the GoReleaser v2 deprecations in this release config:

- `archives.format` -> `archives.formats`
- `archives.format_overrides.format` -> `archives.format_overrides.formats`
- `brews` -> `homebrew_casks`

Also updates the Homebrew cask path so it does not regress user-facing install behavior:

- restore Homebrew-installed man pages via `manpages`
- restore shell completions via `generate_completions_from_executable`
- add `url.verified` for the GitHub download domain
- update README install docs to use `brew install --cask`
- avoid overpromising blanket Linux Homebrew support in the README

## Why

GoReleaser v2 deprecates the old archive keys and the legacy `brews` publisher.

Moving from a formula to a cask initially dropped two features that existed in the old formula install block: man page installation and generated shell completions. This PR restores both on the cask path.

Homebrew added Linux cask support in Homebrew 4.5.0 on April 29, 2025, but support still depends on the user's Homebrew install/version, so the README now avoids promising `brew install --cask` as a universal Linux path.

## Temporary macOS workaround

The generated cask currently ships an unsigned, non-notarized binary.

To keep `brew install --cask antiwork/cli/gumroad` usable on macOS without blocking this PR on Apple Developer certificate / notarization setup, the cask includes a temporary `postflight` workaround that removes the quarantine bit with `xattr -dr com.apple.quarantine`.

This is intentionally temporary. Proper `Developer ID` signing and notarization should replace this once the required Apple access and credentials are available.

## Verification

- `goreleaser v2.15.2 release --snapshot --clean --verbose`
- confirmed the generated cask includes Linux targets, `manpage` entries, `generate_completions_from_executable`, and the temporary macOS `postflight` / `caveats` stanzas

---

This PR was implemented with AI assistance using Claude Opus 4.6 and GPT-5.
