### PR TITLE
Add OAuth browser login with PKCE

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/antiwork/gumroad-cli
 go 1.25.4
 
 require (
+	github.com/cli/browser v1.3.0
 	github.com/itchyny/gojq v0.12.18
 	github.com/mattn/go-runewidth v0.0.19
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/cli/browser v1.3.0 h1:LejqCrpWr+1pRqmEPDGnTZOjsMe7sehifLynZJuqJpo=
+github.com/cli/browser v1.3.0/go.mod h1:HH8s+fOAxjhQoBUAsKuPCbqUuxZDhQ2/aD+SzsEfBTk=
 github.com/clipperhouse/stringish v0.1.1 h1:+NSqMOr3GR6k1FdRhhnXrLfztGzuG+VuFDfatpWHKCs=
 github.com/clipperhouse/stringish v0.1.1/go.mod h1:v/WhFtE1q0ovMta2+m+UbpZ+2/HEXNWYXQgCt4hdOzA=
 github.com/clipperhouse/uax29/v2 v2.3.0 h1:SNdx9DVUqMoBuBoW3iLOj4FQv3dN5mDtuqwuhIGpJy4=

--- a/internal/cmd/auth/auth_test.go
+++ b/internal/cmd/auth/auth_test.go
@@ -1035,13 +1035,17 @@ func TestLogin_OAuth_BrowserFlow(t *testing.T) {
 	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") != "Bearer oauth-access-token-from-server" {
 			w.WriteHeader(401)
-			json.NewEncoder(w).Encode(map[string]any{"success": false})
+			if err := json.NewEncoder(w).Encode(map[string]any{"success": false}); err != nil {
+				t.Errorf("encode response: %v", err)
+			}
 			return
 		}
-		json.NewEncoder(w).Encode(map[string]any{
+		if err := json.NewEncoder(w).Encode(map[string]any{
 			"success": true,
 			"user":    map[string]any{"name": "OAuth User", "email": "oauth@test.com"},
-		})
+		}); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
 	})
 	cfgDir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", cfgDir)
@@ -1069,10 +1073,12 @@ func TestLogin_OAuth_BrowserFails_FallsBackToHeadless(t *testing.T) {
 	withMockBrowserFail(t)
 	setupOAuthTokenServer(t)
 	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		if err := json.NewEncoder(w).Encode(map[string]any{
 			"success": true,
 			"user":    map[string]any{"name": "Headless User", "email": "h@test.com"},
-		})
+		}); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
 	})
 	cfgDir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", cfgDir)
@@ -1149,7 +1155,9 @@ func TestLogin_OAuth_VerifyAndSave_401(t *testing.T) {
 	setupOAuthTokenServer(t)
 	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(401)
-		json.NewEncoder(w).Encode(map[string]any{"success": false, "message": "Unauthorized"})
+		if err := json.NewEncoder(w).Encode(map[string]any{"success": false, "message": "Unauthorized"}); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
 	})
 	cfgDir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", cfgDir)
@@ -1166,10 +1174,12 @@ func TestLogin_OAuth_JSONOutput(t *testing.T) {
 	withMockBrowser(t)
 	setupOAuthTokenServer(t)
 	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		if err := json.NewEncoder(w).Encode(map[string]any{
 			"success": true,
 			"user":    map[string]any{"name": "JSON User", "email": "json@test.com"},
-		})
+		}); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
 	})
 	cfgDir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", cfgDir)
@@ -1193,10 +1203,12 @@ func TestLogin_OAuth_PlainOutput(t *testing.T) {
 	withMockBrowser(t)
 	setupOAuthTokenServer(t)
 	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		if err := json.NewEncoder(w).Encode(map[string]any{
 			"success": true,
 			"user":    map[string]any{"name": "Plain", "email": "p@t.com"},
-		})
+		}); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
 	})
 	cfgDir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", cfgDir)
@@ -1216,10 +1228,12 @@ func TestLogin_OAuth_QuietOutput(t *testing.T) {
 	withMockBrowser(t)
 	setupOAuthTokenServer(t)
 	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		if err := json.NewEncoder(w).Encode(map[string]any{
 			"success": true,
 			"user":    map[string]any{"name": "Quiet", "email": "q@t.com"},
-		})
+		}); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
 	})
 	cfgDir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", cfgDir)
@@ -1237,10 +1251,12 @@ func TestLogin_OAuth_QuietOutput(t *testing.T) {
 func TestLogin_PipedStdin_StillWorks(t *testing.T) {
 	withTerminal(t, false)
 	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		if err := json.NewEncoder(w).Encode(map[string]any{
 			"success": true,
 			"user":    map[string]any{"name": "Piped", "email": "piped@test.com"},
-		})
+		}); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
 	})
 	cfgDir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", cfgDir)

--- a/internal/cmd/auth/auth_test.go
+++ b/internal/cmd/auth/auth_test.go
@@ -982,7 +982,7 @@ func withMockBrowser(t *testing.T) {
 		redirectURI := u.Query().Get("redirect_uri")
 		state := u.Query().Get("state")
 		callbackURL := fmt.Sprintf("%s?code=test-auth-code&state=%s", redirectURI, state)
-		resp, err := http.Get(callbackURL)
+		resp, err := http.Get(callbackURL) //nolint:gosec // G107: test-only, URL from test server
 		if err != nil {
 			return err
 		}
@@ -1008,11 +1008,13 @@ func setupOAuthTokenServer(t *testing.T) {
 	t.Helper()
 	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(oauth.TokenResponse{
+		if err := json.NewEncoder(w).Encode(oauth.TokenResponse{
 			AccessToken: "oauth-access-token-from-server",
 			TokenType:   "bearer",
 			Scope:       "edit_products view_sales",
-		})
+		}); err != nil {
+			t.Errorf("encode token response: %v", err)
+		}
 	}))
 	t.Cleanup(tokenSrv.Close)
 
@@ -1132,7 +1134,9 @@ func TestLogin_OAuth_WebFlag_NoFallback(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", cfgDir)
 
 	cmd := testutil.Command(newLoginCmd())
-	cmd.Flags().Set("web", "true")
+	if err := cmd.Flags().Set("web", "true"); err != nil {
+		t.Fatalf("set --web flag: %v", err)
+	}
 	err := cmd.RunE(cmd, []string{})
 	if err == nil || !strings.Contains(err.Error(), "browser login failed") {
 		t.Fatalf("expected browser login failed error, got: %v", err)

--- a/internal/cmd/auth/auth_test.go
+++ b/internal/cmd/auth/auth_test.go
@@ -3,16 +3,39 @@ package auth
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/antiwork/gumroad-cli/internal/config"
+	"github.com/antiwork/gumroad-cli/internal/oauth"
 	"github.com/antiwork/gumroad-cli/internal/testutil"
 )
+
+// syncBuffer is a thread-safe bytes.Buffer for concurrent test read/write.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
 
 func setupAuth(t *testing.T, handler http.HandlerFunc) {
 	t.Helper()
@@ -934,6 +957,304 @@ func TestLogout_NonInteractiveRequiresYes(t *testing.T) {
 	// Config should still exist
 	if _, statErr := os.Stat(filepath.Join(cfgDir, "gumroad", "config.json")); statErr != nil {
 		t.Error("config should not be deleted when confirmation is blocked")
+	}
+}
+
+// --- OAuth Login ---
+
+func withTerminal(t *testing.T, isTTY bool) {
+	t.Helper()
+	old := isTerminalFunc
+	isTerminalFunc = func(r interface{}) bool { return isTTY }
+	t.Cleanup(func() { isTerminalFunc = old })
+}
+
+// withMockBrowser replaces oauth.OpenBrowser with a function that simulates
+// the browser by hitting the callback endpoint directly.
+func withMockBrowser(t *testing.T) {
+	t.Helper()
+	old := oauth.OpenBrowser
+	oauth.OpenBrowser = func(authURL string) error {
+		u, err := url.Parse(authURL)
+		if err != nil {
+			return err
+		}
+		redirectURI := u.Query().Get("redirect_uri")
+		state := u.Query().Get("state")
+		callbackURL := fmt.Sprintf("%s?code=test-auth-code&state=%s", redirectURI, state)
+		resp, err := http.Get(callbackURL)
+		if err != nil {
+			return err
+		}
+		resp.Body.Close()
+		return nil
+	}
+	t.Cleanup(func() { oauth.OpenBrowser = old })
+}
+
+// withMockBrowserFail replaces oauth.OpenBrowser with one that always fails.
+func withMockBrowserFail(t *testing.T) {
+	t.Helper()
+	old := oauth.OpenBrowser
+	oauth.OpenBrowser = func(authURL string) error {
+		return fmt.Errorf("no display available")
+	}
+	t.Cleanup(func() { oauth.OpenBrowser = old })
+}
+
+// setupOAuthTokenServer creates a mock token endpoint and configures the oauth
+// package to use it. Returns the API server for /user verification.
+func setupOAuthTokenServer(t *testing.T) {
+	t.Helper()
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(oauth.TokenResponse{
+			AccessToken: "oauth-access-token-from-server",
+			TokenType:   "bearer",
+			Scope:       "edit_products view_sales",
+		})
+	}))
+	t.Cleanup(tokenSrv.Close)
+
+	// Override OAuth constants for tests.
+	oldCfg := oauth.DefaultFlowConfigFunc
+	oauth.DefaultFlowConfigFunc = func() oauth.FlowConfig {
+		cfg := oldCfg()
+		cfg.TokenURL = tokenSrv.URL + "/oauth/token"
+		return cfg
+	}
+	t.Cleanup(func() { oauth.DefaultFlowConfigFunc = oldCfg })
+}
+
+func TestLogin_OAuth_BrowserFlow(t *testing.T) {
+	withTerminal(t, true)
+	withMockBrowser(t)
+	setupOAuthTokenServer(t)
+	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer oauth-access-token-from-server" {
+			w.WriteHeader(401)
+			json.NewEncoder(w).Encode(map[string]any{"success": false})
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"success": true,
+			"user":    map[string]any{"name": "OAuth User", "email": "oauth@test.com"},
+		})
+	})
+	cfgDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+
+	var out bytes.Buffer
+	cmd := testutil.Command(newLoginCmd(), testutil.Quiet(false), testutil.Stdout(&out))
+	if err := cmd.RunE(cmd, []string{}); err != nil {
+		t.Fatalf("RunE: %v", err)
+	}
+	if !strings.Contains(out.String(), "OAuth User") {
+		t.Errorf("expected user info in output: %q", out.String())
+	}
+
+	data, err := os.ReadFile(filepath.Join(cfgDir, "gumroad", "config.json"))
+	if err != nil {
+		t.Fatalf("config not saved: %v", err)
+	}
+	if !strings.Contains(string(data), "oauth-access-token-from-server") {
+		t.Errorf("config should contain OAuth token, got: %s", data)
+	}
+}
+
+func TestLogin_OAuth_BrowserFails_FallsBackToHeadless(t *testing.T) {
+	withTerminal(t, true)
+	withMockBrowserFail(t)
+	setupOAuthTokenServer(t)
+	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"success": true,
+			"user":    map[string]any{"name": "Headless User", "email": "h@test.com"},
+		})
+	})
+	cfgDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+
+	var out bytes.Buffer
+
+	// Use a mutex-protected buffer for stderr to avoid data races
+	// between the command goroutine writing and the test goroutine reading.
+	errOut := &syncBuffer{}
+
+	pr, pw, _ := os.Pipe()
+	cmd := testutil.Command(newLoginCmd(), testutil.Quiet(false), testutil.Stdout(&out), testutil.Stderr(errOut), testutil.Stdin(pr))
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.RunE(cmd, []string{})
+	}()
+
+	// Poll stderr until the headless prompt appears.
+	var state string
+	for i := 0; i < 200; i++ {
+		time.Sleep(10 * time.Millisecond)
+		content := errOut.String()
+		if strings.Contains(content, "Paste the full URL") {
+			for _, line := range strings.Split(content, "\n") {
+				line = strings.TrimSpace(line)
+				if strings.HasPrefix(line, "http") {
+					u, _ := url.Parse(line)
+					state = u.Query().Get("state")
+					break
+				}
+			}
+			break
+		}
+	}
+
+	if state == "" {
+		pw.Close()
+		<-done
+		t.Fatalf("could not extract state from headless prompt. stderr: %q", errOut.String())
+	}
+
+	fmt.Fprintf(pw, "http://127.0.0.1/callback?code=headless-code&state=%s\n", state)
+	pw.Close()
+
+	if err := <-done; err != nil {
+		t.Fatalf("RunE: %v", err)
+	}
+}
+
+func TestLogin_OAuth_WebFlag_NoFallback(t *testing.T) {
+	withTerminal(t, true)
+	withMockBrowserFail(t)
+	setupOAuthTokenServer(t)
+	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API when --web fails")
+	})
+	cfgDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+
+	cmd := testutil.Command(newLoginCmd())
+	cmd.Flags().Set("web", "true")
+	err := cmd.RunE(cmd, []string{})
+	if err == nil || !strings.Contains(err.Error(), "browser login failed") {
+		t.Fatalf("expected browser login failed error, got: %v", err)
+	}
+}
+
+func TestLogin_OAuth_VerifyAndSave_401(t *testing.T) {
+	withTerminal(t, true)
+	withMockBrowser(t)
+	setupOAuthTokenServer(t)
+	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(401)
+		json.NewEncoder(w).Encode(map[string]any{"success": false, "message": "Unauthorized"})
+	})
+	cfgDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+
+	cmd := testutil.Command(newLoginCmd())
+	err := cmd.RunE(cmd, []string{})
+	if err == nil || !strings.Contains(err.Error(), "invalid token") {
+		t.Fatalf("expected invalid token error, got: %v", err)
+	}
+}
+
+func TestLogin_OAuth_JSONOutput(t *testing.T) {
+	withTerminal(t, true)
+	withMockBrowser(t)
+	setupOAuthTokenServer(t)
+	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"success": true,
+			"user":    map[string]any{"name": "JSON User", "email": "json@test.com"},
+		})
+	})
+	cfgDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+
+	var out bytes.Buffer
+	cmd := testutil.Command(newLoginCmd(), testutil.JSONOutput(), testutil.Stdout(&out))
+	if err := cmd.RunE(cmd, []string{}); err != nil {
+		t.Fatalf("RunE: %v", err)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(out.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out.String())
+	}
+	if resp["authenticated"] != true {
+		t.Errorf("authenticated = %v, want true", resp["authenticated"])
+	}
+}
+
+func TestLogin_OAuth_PlainOutput(t *testing.T) {
+	withTerminal(t, true)
+	withMockBrowser(t)
+	setupOAuthTokenServer(t)
+	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"success": true,
+			"user":    map[string]any{"name": "Plain", "email": "p@t.com"},
+		})
+	})
+	cfgDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+
+	var out bytes.Buffer
+	cmd := testutil.Command(newLoginCmd(), testutil.PlainOutput(), testutil.Stdout(&out))
+	if err := cmd.RunE(cmd, []string{}); err != nil {
+		t.Fatalf("RunE: %v", err)
+	}
+	if strings.TrimSpace(out.String()) != "true\tPlain\tp@t.com" {
+		t.Fatalf("unexpected plain output: %q", out.String())
+	}
+}
+
+func TestLogin_OAuth_QuietOutput(t *testing.T) {
+	withTerminal(t, true)
+	withMockBrowser(t)
+	setupOAuthTokenServer(t)
+	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"success": true,
+			"user":    map[string]any{"name": "Quiet", "email": "q@t.com"},
+		})
+	})
+	cfgDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+
+	var out bytes.Buffer
+	cmd := testutil.Command(newLoginCmd(), testutil.Quiet(true), testutil.Stdout(&out))
+	if err := cmd.RunE(cmd, []string{}); err != nil {
+		t.Fatalf("RunE: %v", err)
+	}
+	if out.String() != "" {
+		t.Errorf("quiet mode should produce no output, got: %q", out.String())
+	}
+}
+
+func TestLogin_PipedStdin_StillWorks(t *testing.T) {
+	withTerminal(t, false)
+	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"success": true,
+			"user":    map[string]any{"name": "Piped", "email": "piped@test.com"},
+		})
+	})
+	cfgDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+
+	cmd := testutil.Command(newLoginCmd(), testutil.Stdin(strings.NewReader("piped-token\n")))
+	if err := cmd.RunE(cmd, []string{}); err != nil {
+		t.Fatalf("RunE: %v", err)
+	}
+}
+
+func TestLogin_WebFlag(t *testing.T) {
+	cmd := newLoginCmd()
+	f := cmd.Flags().Lookup("web")
+	if f == nil {
+		t.Fatal("--web flag not found")
+	}
+	if f.DefValue != "false" {
+		t.Errorf("--web default = %q, want false", f.DefValue)
 	}
 }
 

--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -1,40 +1,57 @@
 package auth
 
 import (
+	"bufio"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/url"
+	"os"
 
 	"github.com/antiwork/gumroad-cli/internal/api"
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/config"
+	"github.com/antiwork/gumroad-cli/internal/oauth"
 	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/antiwork/gumroad-cli/internal/prompt"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 type authUserEnvelope struct {
 	User json.RawMessage `json:"user"`
 }
 
+// isTerminalFunc checks whether the reader is a terminal. Replaceable in tests.
+var isTerminalFunc = defaultIsTerminal
+
 func newLoginCmd() *cobra.Command {
-	return &cobra.Command{
+	var webFlag bool
+
+	cmd := &cobra.Command{
 		Use:   "login",
-		Short: "Authenticate with a Gumroad API token",
+		Short: "Authenticate with Gumroad",
 		Args:  cmdutil.ExactArgs(0),
-		Long:  "Store your Gumroad API token for future use.\nThe token is read interactively (or from stdin when piped).",
-		Example: `  # Interactive login
+		Long: `Authenticate with Gumroad via browser-based OAuth or a manual API token.
+
+By default, opens your browser for OAuth authorization.
+When stdin is piped (e.g. echo $TOKEN | gumroad auth login), reads a token directly.`,
+		Example: `  # Browser-based OAuth login (default)
   gumroad auth login
 
-  # Pipe token from stdin
+  # Explicit browser OAuth
+  gumroad auth login --web
+
+  # Pipe token from stdin (CI/scripts)
   echo "your-token" | gumroad auth login`,
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
 			if opts.DryRun {
 				return cmdutil.PrintDryRunAction(opts, "store API token")
 			}
-			token, err := prompt.TokenInput(opts.In(), opts.Err(), opts.NoInput)
+
+			token, err := resolveToken(opts, webFlag)
 			if err != nil {
 				return err
 			}
@@ -42,54 +59,125 @@ func newLoginCmd() *cobra.Command {
 				return cmdutil.UsageErrorf(c, "token cannot be empty")
 			}
 
-			sp := output.NewSpinnerTo("Verifying token...", opts.Err())
-			if cmdutil.ShouldShowSpinner(opts) {
-				sp.Start()
-			}
-			defer sp.Stop()
-
-			client := cmdutil.NewAPIClient(opts, token)
-			data, err := client.Get("/user", url.Values{})
-			if err != nil {
-				var apiErr *api.APIError
-				if errors.As(err, &apiErr) && (apiErr.StatusCode == 401 || apiErr.StatusCode == 403) {
-					return fmt.Errorf("invalid token: %w", err)
-				}
-				return fmt.Errorf("could not verify token: %w", err)
-			}
-
-			resp, err := cmdutil.DecodeJSON[authUserEnvelope](data)
-			if err != nil {
-				return err
-			}
-
-			if err := config.Save(&config.Config{AccessToken: token}); err != nil {
-				return fmt.Errorf("could not save token: %w", err)
-			}
-
-			if opts.UsesJSONOutput() {
-				return printAuthJSON(opts, statusOutput{
-					Authenticated: true,
-					User:          resp.User,
-				})
-			}
-
-			user, err := decodeAuthUser(resp.User)
-			if err != nil {
-				return err
-			}
-
-			if opts.PlainOutput {
-				return output.PrintPlain(opts.Out(), [][]string{
-					{"true", user.Name, user.Email},
-				})
-			}
-
-			if opts.Quiet {
-				return nil
-			}
-
-			return writeAuthenticatedMessage(opts.Out(), opts.Style(), user, "Logged in.")
+			return verifyAndSave(c, opts, token)
 		},
 	}
+
+	cmd.Flags().BoolVar(&webFlag, "web", false, "Force browser-based OAuth login")
+
+	return cmd
+}
+
+func resolveToken(opts cmdutil.Options, webFlag bool) (string, error) {
+	if !isTerminalFunc(opts.In()) {
+		return prompt.TokenInput(opts.In(), opts.Err(), opts.NoInput)
+	}
+	return oauthLogin(opts, webFlag)
+}
+
+func defaultIsTerminal(r interface{}) bool {
+	if f, ok := r.(*os.File); ok {
+		return term.IsTerminal(int(f.Fd()))
+	}
+	return false
+}
+
+func oauthLogin(opts cmdutil.Options, webFlag bool) (string, error) {
+	cfg := oauth.DefaultFlowConfig()
+
+	token, browserErr := tryBrowserFlow(opts, cfg)
+	if browserErr == nil {
+		return token, nil
+	}
+
+	if webFlag {
+		return "", fmt.Errorf("browser login failed: %w", browserErr)
+	}
+
+	// Fall back to headless flow.
+	fmt.Fprintln(opts.Err(), "Could not open browser. Falling back to manual flow.")
+	fmt.Fprintln(opts.Err())
+
+	return oauth.HeadlessFlow(opts.Context, cfg, opts.Err(), stdinReader(opts.In()))
+}
+
+func tryBrowserFlow(opts cmdutil.Options, cfg oauth.FlowConfig) (string, error) {
+	sp := output.NewSpinnerTo("Opening browser for authorization...", opts.Err())
+	if cmdutil.ShouldShowSpinner(opts) {
+		sp.Start()
+	}
+	defer sp.Stop()
+
+	return oauth.BrowserFlow(opts.Context, cfg, func(authURL string) error {
+		sp.Stop()
+		if err := oauth.OpenBrowser(authURL); err != nil {
+			return err
+		}
+		fmt.Fprintln(opts.Err(), "Waiting for authorization in browser...")
+		return nil
+	})
+}
+
+func stdinReader(in io.Reader) func() (string, error) {
+	return func() (string, error) {
+		scanner := bufio.NewScanner(in)
+		if !scanner.Scan() {
+			if err := scanner.Err(); err != nil {
+				return "", err
+			}
+			return "", fmt.Errorf("no input received")
+		}
+		return scanner.Text(), nil
+	}
+}
+
+func verifyAndSave(c *cobra.Command, opts cmdutil.Options, token string) error {
+	sp := output.NewSpinnerTo("Verifying token...", opts.Err())
+	if cmdutil.ShouldShowSpinner(opts) {
+		sp.Start()
+	}
+	defer sp.Stop()
+
+	client := cmdutil.NewAPIClient(opts, token)
+	data, err := client.Get("/user", url.Values{})
+	if err != nil {
+		var apiErr *api.APIError
+		if errors.As(err, &apiErr) && (apiErr.StatusCode == 401 || apiErr.StatusCode == 403) {
+			return fmt.Errorf("invalid token: %w", err)
+		}
+		return fmt.Errorf("could not verify token: %w", err)
+	}
+
+	resp, err := cmdutil.DecodeJSON[authUserEnvelope](data)
+	if err != nil {
+		return err
+	}
+
+	if err := config.Save(&config.Config{AccessToken: token}); err != nil {
+		return fmt.Errorf("could not save token: %w", err)
+	}
+
+	if opts.UsesJSONOutput() {
+		return printAuthJSON(opts, statusOutput{
+			Authenticated: true,
+			User:          resp.User,
+		})
+	}
+
+	user, err := decodeAuthUser(resp.User)
+	if err != nil {
+		return err
+	}
+
+	if opts.PlainOutput {
+		return output.PrintPlain(opts.Out(), [][]string{
+			{"true", user.Name, user.Email},
+		})
+	}
+
+	if opts.Quiet {
+		return nil
+	}
+
+	return writeAuthenticatedMessage(opts.Out(), opts.Style(), user, "Logged in.")
 }

--- a/internal/oauth/browser.go
+++ b/internal/oauth/browser.go
@@ -1,0 +1,6 @@
+package oauth
+
+import "github.com/cli/browser"
+
+// OpenBrowser opens the specified URL in the user's default browser.
+var OpenBrowser = browser.OpenURL

--- a/internal/oauth/flow.go
+++ b/internal/oauth/flow.go
@@ -100,7 +100,7 @@ func BrowserFlow(ctx context.Context, cfg FlowConfig, openBrowser func(string) e
 	resultCh := make(chan callbackResult, 1)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/callback", callbackHandler(state, resultCh))
-	server := &http.Server{Handler: mux}
+	server := &http.Server{Handler: mux, ReadHeaderTimeout: 10 * time.Second}
 
 	serverDone := make(chan struct{})
 	go func() {
@@ -127,7 +127,22 @@ func BrowserFlow(ctx context.Context, cfg FlowConfig, openBrowser func(string) e
 	select {
 	case result = <-resultCh:
 	case <-ctx.Done():
-		return "", fmt.Errorf("authorization timed out after %s", cfg.Timeout)
+		if ctx.Err() != context.DeadlineExceeded {
+			return "", fmt.Errorf("authorization cancelled")
+		}
+		// Drain resultCh in case the callback arrived at the exact deadline.
+		select {
+		case result = <-resultCh:
+			if result.Err != nil {
+				return "", result.Err
+			}
+			// Original ctx expired; give the token exchange its own deadline.
+			xctx, xcancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer xcancel()
+			return exchangeCode(xctx, cfg, result.Code, redirectURI, verifier)
+		default:
+			return "", fmt.Errorf("authorization timed out after %s", cfg.Timeout)
+		}
 	}
 	if result.Err != nil {
 		return "", result.Err
@@ -167,9 +182,25 @@ func HeadlessFlow(ctx context.Context, cfg FlowConfig, out io.Writer, readLine f
 	fmt.Fprintf(out, "(it may show an error page — that's expected).\n\n")
 	fmt.Fprintf(out, "Paste the full URL from your browser's address bar: ")
 
-	line, err := readLine()
-	if err != nil {
-		return "", fmt.Errorf("could not read URL: %w", err)
+	type lineResult struct {
+		line string
+		err  error
+	}
+	lineCh := make(chan lineResult, 1)
+	go func() {
+		l, e := readLine()
+		lineCh <- lineResult{l, e}
+	}()
+
+	var line string
+	select {
+	case res := <-lineCh:
+		if res.err != nil {
+			return "", fmt.Errorf("could not read URL: %w", res.err)
+		}
+		line = res.line
+	case <-ctx.Done():
+		return "", fmt.Errorf("authorization timed out after %s", cfg.Timeout)
 	}
 
 	code, err := parseCallbackURL(strings.TrimSpace(line), state)

--- a/internal/oauth/flow.go
+++ b/internal/oauth/flow.go
@@ -1,0 +1,321 @@
+package oauth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"html"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// TokenResponse is the JSON body returned by the OAuth token endpoint.
+type TokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	Scope       string `json:"scope"`
+}
+
+// FlowConfig holds the parameters for an OAuth authorization code flow.
+type FlowConfig struct {
+	ClientID     string
+	AuthorizeURL string
+	TokenURL     string
+	Scopes       string
+	Timeout      time.Duration
+	HTTPClient   *http.Client // optional; defaults to http.DefaultClient
+}
+
+// DefaultFlowConfigFunc returns a FlowConfig using the built-in constants.
+// Replaceable in tests.
+var DefaultFlowConfigFunc = defaultFlowConfig
+
+// DefaultFlowConfig returns a FlowConfig using the built-in constants.
+func DefaultFlowConfig() FlowConfig {
+	return DefaultFlowConfigFunc()
+}
+
+func defaultFlowConfig() FlowConfig {
+	return FlowConfig{
+		ClientID:     ClientID,
+		AuthorizeURL: AuthorizeURL,
+		TokenURL:     TokenURL,
+		Scopes:       Scopes,
+		Timeout:      DefaultTimeout,
+	}
+}
+
+// callbackResult carries the authorization code or error from the callback handler.
+type callbackResult struct {
+	Code string
+	Err  error
+}
+
+// BrowserFlow runs the full OAuth authorization code flow with PKCE.
+// It binds a local listener, opens the authorize URL via openBrowser,
+// waits for the callback, and exchanges the code for an access token.
+func BrowserFlow(ctx context.Context, cfg FlowConfig, openBrowser func(string) error) (string, error) {
+	if cfg.HTTPClient == nil {
+		cfg.HTTPClient = http.DefaultClient
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, cfg.Timeout)
+	defer cancel()
+
+	// Bind ephemeral port.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", fmt.Errorf("could not bind local listener: %w", err)
+	}
+
+	port := listener.Addr().(*net.TCPAddr).Port
+	redirectURI := fmt.Sprintf("http://127.0.0.1:%d/callback", port)
+
+	// Generate PKCE verifier + challenge.
+	verifier, err := GenerateVerifier()
+	if err != nil {
+		_ = listener.Close()
+		return "", fmt.Errorf("could not generate PKCE verifier: %w", err)
+	}
+	challenge := ChallengeFromVerifier(verifier)
+
+	// Generate state for CSRF protection.
+	state, err := generateState()
+	if err != nil {
+		_ = listener.Close()
+		return "", fmt.Errorf("could not generate state: %w", err)
+	}
+
+	// Build authorize URL.
+	authURL := buildAuthorizeURL(cfg, redirectURI, challenge, state)
+
+	// Start callback server.
+	resultCh := make(chan callbackResult, 1)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/callback", callbackHandler(state, resultCh))
+	server := &http.Server{Handler: mux}
+
+	serverDone := make(chan struct{})
+	go func() {
+		defer close(serverDone)
+		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
+			resultCh <- callbackResult{Err: fmt.Errorf("callback server error: %w", err)}
+		}
+	}()
+
+	defer func() {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+		_ = server.Shutdown(shutdownCtx)
+		<-serverDone
+	}()
+
+	// Open browser.
+	if err := openBrowser(authURL); err != nil {
+		return "", fmt.Errorf("could not open browser: %w", err)
+	}
+
+	// Wait for callback or timeout.
+	var result callbackResult
+	select {
+	case result = <-resultCh:
+	case <-ctx.Done():
+		return "", fmt.Errorf("authorization timed out after %s", cfg.Timeout)
+	}
+	if result.Err != nil {
+		return "", result.Err
+	}
+
+	// Exchange code for token.
+	return exchangeCode(ctx, cfg, result.Code, redirectURI, verifier)
+}
+
+// HeadlessFlow runs the OAuth flow without a browser: prints the authorize URL
+// and prompts the user to paste the redirect URL.
+func HeadlessFlow(ctx context.Context, cfg FlowConfig, out io.Writer, readLine func() (string, error)) (string, error) {
+	if cfg.HTTPClient == nil {
+		cfg.HTTPClient = http.DefaultClient
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, cfg.Timeout)
+	defer cancel()
+
+	verifier, err := GenerateVerifier()
+	if err != nil {
+		return "", fmt.Errorf("could not generate PKCE verifier: %w", err)
+	}
+	challenge := ChallengeFromVerifier(verifier)
+
+	state, err := generateState()
+	if err != nil {
+		return "", fmt.Errorf("could not generate state: %w", err)
+	}
+
+	// Use a placeholder redirect URI — user will paste the URL from their browser.
+	redirectURI := "http://127.0.0.1/callback"
+	authURL := buildAuthorizeURL(cfg, redirectURI, challenge, state)
+
+	fmt.Fprintf(out, "Open this URL in your browser:\n  %s\n\n", authURL)
+	fmt.Fprintf(out, "After authorizing, your browser will redirect to a localhost URL\n")
+	fmt.Fprintf(out, "(it may show an error page — that's expected).\n\n")
+	fmt.Fprintf(out, "Paste the full URL from your browser's address bar: ")
+
+	line, err := readLine()
+	if err != nil {
+		return "", fmt.Errorf("could not read URL: %w", err)
+	}
+
+	code, err := parseCallbackURL(strings.TrimSpace(line), state)
+	if err != nil {
+		return "", err
+	}
+
+	return exchangeCode(ctx, cfg, code, redirectURI, verifier)
+}
+
+func generateState() (string, error) {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+func buildAuthorizeURL(cfg FlowConfig, redirectURI, challenge, state string) string {
+	v := url.Values{
+		"response_type":         {"code"},
+		"client_id":             {cfg.ClientID},
+		"redirect_uri":          {redirectURI},
+		"scope":                 {cfg.Scopes},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"state":                 {state},
+	}
+	return cfg.AuthorizeURL + "?" + v.Encode()
+}
+
+func callbackHandler(expectedState string, resultCh chan<- callbackResult) http.HandlerFunc {
+	var once sync.Once
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+
+		q := r.URL.Query()
+
+		// Validate state first to reject forged requests from local attackers.
+		// Requests with wrong/missing state are silently ignored so the flow
+		// keeps waiting for the real callback.
+		if q.Get("state") != expectedState {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, htmlPage("Error", "Invalid request. Please try again."))
+			return
+		}
+
+		// State matches — this is the real callback. Extract the result once.
+		code, err := extractCode(q, expectedState)
+		once.Do(func() {
+			if err != nil {
+				resultCh <- callbackResult{Err: err}
+			} else {
+				resultCh <- callbackResult{Code: code}
+			}
+		})
+
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, htmlPage("Error", "Authorization failed. You can close this tab."))
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, htmlPage("Success", "Authorization complete! You can close this tab."))
+	}
+}
+
+func parseCallbackURL(rawURL, expectedState string) (string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid URL: %w", err)
+	}
+	return extractCode(u.Query(), expectedState)
+}
+
+// extractCode validates the OAuth callback parameters and returns the authorization code.
+// State is checked first to reject forged responses before trusting any other parameters.
+func extractCode(q url.Values, expectedState string) (string, error) {
+	if q.Get("state") != expectedState {
+		return "", fmt.Errorf("state mismatch: possible CSRF attack")
+	}
+
+	if errParam := q.Get("error"); errParam != "" {
+		desc := q.Get("error_description")
+		if desc == "" {
+			desc = errParam
+		}
+		return "", fmt.Errorf("authorization denied: %s", desc)
+	}
+
+	code := q.Get("code")
+	if code == "" {
+		return "", fmt.Errorf("no authorization code received")
+	}
+	return code, nil
+}
+
+func exchangeCode(ctx context.Context, cfg FlowConfig, code, redirectURI, verifier string) (string, error) {
+	data := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"redirect_uri":  {redirectURI},
+		"client_id":     {cfg.ClientID},
+		"code_verifier": {verifier},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", cfg.TokenURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("could not build token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := cfg.HTTPClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("token exchange failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", fmt.Errorf("could not read token response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("token exchange failed (HTTP %d)", resp.StatusCode)
+	}
+
+	var tokenResp TokenResponse
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return "", fmt.Errorf("could not parse token response: %w", err)
+	}
+
+	if tokenResp.AccessToken == "" {
+		return "", fmt.Errorf("token response did not contain an access token")
+	}
+
+	return tokenResp.AccessToken, nil
+}
+
+func htmlPage(title, message string) string {
+	t := html.EscapeString(title)
+	m := html.EscapeString(message)
+	return fmt.Sprintf(`<!DOCTYPE html>
+<html><head><title>%s — Gumroad CLI</title>
+<style>body{font-family:system-ui,sans-serif;display:flex;justify-content:center;align-items:center;height:100vh;margin:0;background:#f9f9f9}
+.card{text-align:center;padding:2rem;border-radius:8px;background:white;box-shadow:0 1px 3px rgba(0,0,0,0.12)}</style>
+</head><body><div class="card"><h1>%s</h1><p>%s</p></div></body></html>`, t, t, m)
+}

--- a/internal/oauth/flow_test.go
+++ b/internal/oauth/flow_test.go
@@ -13,6 +13,22 @@ import (
 	"time"
 )
 
+func mustEncode(t *testing.T, w http.ResponseWriter, v any) {
+	t.Helper()
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		t.Fatalf("encode JSON: %v", err)
+	}
+}
+
+func mustGet(t *testing.T, url string) *http.Response {
+	t.Helper()
+	resp, err := http.Get(url) //nolint:gosec // G107: test-only, URL is constructed from test server
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	return resp
+}
+
 func testConfig(tokenServer *httptest.Server) FlowConfig {
 	return FlowConfig{
 		ClientID:     "test-client-id",
@@ -48,7 +64,7 @@ func tokenHandler(t *testing.T, wantVerifier bool) http.HandlerFunc {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(TokenResponse{
+		mustEncode(t, w, TokenResponse{
 			AccessToken: "test-access-token",
 			TokenType:   "bearer",
 			Scope:       "edit_products view_sales",
@@ -72,10 +88,7 @@ func TestBrowserFlow_HappyPath(t *testing.T) {
 
 		// Hit the callback endpoint.
 		callbackURL := fmt.Sprintf("%s?code=test-auth-code&state=%s", redirectURI, state)
-		resp, err := http.Get(callbackURL)
-		if err != nil {
-			t.Fatalf("callback request failed: %v", err)
-		}
+		resp := mustGet(t, callbackURL)
 		resp.Body.Close()
 		return nil
 	})
@@ -99,10 +112,7 @@ func TestBrowserFlow_StateMismatch(t *testing.T) {
 
 		// Send a callback with wrong state — should be silently ignored.
 		callbackURL := fmt.Sprintf("%s?code=test-auth-code&state=wrong-state", redirectURI)
-		resp, err := http.Get(callbackURL)
-		if err != nil {
-			t.Fatalf("callback request failed: %v", err)
-		}
+		resp := mustGet(t, callbackURL)
 		resp.Body.Close()
 		if resp.StatusCode != http.StatusBadRequest {
 			t.Errorf("expected 400 for wrong state, got %d", resp.StatusCode)
@@ -126,10 +136,7 @@ func TestBrowserFlow_UserDenied(t *testing.T) {
 		state := u.Query().Get("state")
 
 		callbackURL := fmt.Sprintf("%s?error=access_denied&error_description=User+denied&state=%s", redirectURI, state)
-		resp, err := http.Get(callbackURL)
-		if err != nil {
-			t.Fatalf("callback request failed: %v", err)
-		}
+		resp := mustGet(t, callbackURL)
 		resp.Body.Close()
 		return nil
 	})
@@ -179,7 +186,7 @@ func TestBrowserFlow_TokenExchangeFailure(t *testing.T) {
 		redirectURI := u.Query().Get("redirect_uri")
 		state := u.Query().Get("state")
 		callbackURL := fmt.Sprintf("%s?code=bad-code&state=%s", redirectURI, state)
-		resp, _ := http.Get(callbackURL)
+		resp := mustGet(t, callbackURL)
 		resp.Body.Close()
 		return nil
 	})
@@ -196,7 +203,7 @@ func TestBrowserFlow_PKCEParamsInTokenExchange(t *testing.T) {
 		capturedVerifier = vals.Get("code_verifier")
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(TokenResponse{AccessToken: "tok", TokenType: "bearer"})
+		mustEncode(t, w, TokenResponse{AccessToken: "tok", TokenType: "bearer"})
 	}))
 	defer tokenSrv.Close()
 	cfg := testConfig(tokenSrv)
@@ -215,7 +222,7 @@ func TestBrowserFlow_PKCEParamsInTokenExchange(t *testing.T) {
 		}
 
 		callbackURL := fmt.Sprintf("%s?code=auth-code&state=%s", redirectURI, state)
-		resp, _ := http.Get(callbackURL)
+		resp := mustGet(t, callbackURL)
 		resp.Body.Close()
 		return nil
 	})
@@ -365,7 +372,7 @@ func TestBrowserFlow_NoCode(t *testing.T) {
 		state := u.Query().Get("state")
 
 		callbackURL := fmt.Sprintf("%s?state=%s", redirectURI, state)
-		resp, _ := http.Get(callbackURL)
+		resp := mustGet(t, callbackURL)
 		resp.Body.Close()
 		return nil
 	})
@@ -387,7 +394,7 @@ func TestBrowserFlow_TokenResponseEmpty(t *testing.T) {
 		redirectURI := u.Query().Get("redirect_uri")
 		state := u.Query().Get("state")
 		callbackURL := fmt.Sprintf("%s?code=c&state=%s", redirectURI, state)
-		resp, _ := http.Get(callbackURL)
+		resp := mustGet(t, callbackURL)
 		resp.Body.Close()
 		return nil
 	})
@@ -408,7 +415,7 @@ func TestBrowserFlow_TokenResponseInvalidJSON(t *testing.T) {
 		redirectURI := u.Query().Get("redirect_uri")
 		state := u.Query().Get("state")
 		callbackURL := fmt.Sprintf("%s?code=c&state=%s", redirectURI, state)
-		resp, _ := http.Get(callbackURL)
+		resp := mustGet(t, callbackURL)
 		resp.Body.Close()
 		return nil
 	})
@@ -446,7 +453,7 @@ func TestBrowserFlow_ErrorParamWithoutDescription(t *testing.T) {
 		redirectURI := u.Query().Get("redirect_uri")
 		state := u.Query().Get("state")
 		callbackURL := fmt.Sprintf("%s?error=server_error&state=%s", redirectURI, state)
-		resp, _ := http.Get(callbackURL)
+		resp := mustGet(t, callbackURL)
 		resp.Body.Close()
 		return nil
 	})

--- a/internal/oauth/flow_test.go
+++ b/internal/oauth/flow_test.go
@@ -1,0 +1,456 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func testConfig(tokenServer *httptest.Server) FlowConfig {
+	return FlowConfig{
+		ClientID:     "test-client-id",
+		AuthorizeURL: "http://unused/oauth/authorize",
+		TokenURL:     tokenServer.URL + "/oauth/token",
+		Scopes:       "edit_products view_sales",
+		Timeout:      5 * time.Second,
+		HTTPClient:   tokenServer.Client(),
+	}
+}
+
+func tokenHandler(t *testing.T, wantVerifier bool) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		t.Helper()
+		if r.Method != "POST" {
+			t.Errorf("token request method = %s, want POST", r.Method)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/x-www-form-urlencoded" {
+			t.Errorf("Content-Type = %s, want application/x-www-form-urlencoded", ct)
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		vals, _ := url.ParseQuery(string(body))
+
+		if vals.Get("grant_type") != "authorization_code" {
+			t.Errorf("grant_type = %q, want authorization_code", vals.Get("grant_type"))
+		}
+		if vals.Get("client_id") != "test-client-id" {
+			t.Errorf("client_id = %q, want test-client-id", vals.Get("client_id"))
+		}
+		if wantVerifier && vals.Get("code_verifier") == "" {
+			t.Error("code_verifier is missing from token request")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(TokenResponse{
+			AccessToken: "test-access-token",
+			TokenType:   "bearer",
+			Scope:       "edit_products view_sales",
+		})
+	}
+}
+
+func TestBrowserFlow_HappyPath(t *testing.T) {
+	tokenSrv := httptest.NewServer(tokenHandler(t, true))
+	defer tokenSrv.Close()
+	cfg := testConfig(tokenSrv)
+
+	token, err := BrowserFlow(context.Background(), cfg, func(authURL string) error {
+		// Simulate browser: parse the authorize URL, extract state, hit the callback.
+		u, _ := url.Parse(authURL)
+		state := u.Query().Get("state")
+		redirectURI := u.Query().Get("redirect_uri")
+		if state == "" {
+			t.Fatal("state missing from authorize URL")
+		}
+
+		// Hit the callback endpoint.
+		callbackURL := fmt.Sprintf("%s?code=test-auth-code&state=%s", redirectURI, state)
+		resp, err := http.Get(callbackURL)
+		if err != nil {
+			t.Fatalf("callback request failed: %v", err)
+		}
+		resp.Body.Close()
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("BrowserFlow: %v", err)
+	}
+	if token != "test-access-token" {
+		t.Fatalf("token = %q, want test-access-token", token)
+	}
+}
+
+func TestBrowserFlow_StateMismatch(t *testing.T) {
+	tokenSrv := httptest.NewServer(tokenHandler(t, false))
+	defer tokenSrv.Close()
+	cfg := testConfig(tokenSrv)
+	cfg.Timeout = 200 * time.Millisecond
+
+	_, err := BrowserFlow(context.Background(), cfg, func(authURL string) error {
+		u, _ := url.Parse(authURL)
+		redirectURI := u.Query().Get("redirect_uri")
+
+		// Send a callback with wrong state — should be silently ignored.
+		callbackURL := fmt.Sprintf("%s?code=test-auth-code&state=wrong-state", redirectURI)
+		resp, err := http.Get(callbackURL)
+		if err != nil {
+			t.Fatalf("callback request failed: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("expected 400 for wrong state, got %d", resp.StatusCode)
+		}
+		return nil
+	})
+	// Flow should time out since the wrong-state callback is ignored.
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("expected timeout error (invalid callback ignored), got: %v", err)
+	}
+}
+
+func TestBrowserFlow_UserDenied(t *testing.T) {
+	tokenSrv := httptest.NewServer(tokenHandler(t, false))
+	defer tokenSrv.Close()
+	cfg := testConfig(tokenSrv)
+
+	_, err := BrowserFlow(context.Background(), cfg, func(authURL string) error {
+		u, _ := url.Parse(authURL)
+		redirectURI := u.Query().Get("redirect_uri")
+		state := u.Query().Get("state")
+
+		callbackURL := fmt.Sprintf("%s?error=access_denied&error_description=User+denied&state=%s", redirectURI, state)
+		resp, err := http.Get(callbackURL)
+		if err != nil {
+			t.Fatalf("callback request failed: %v", err)
+		}
+		resp.Body.Close()
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "authorization denied") {
+		t.Fatalf("expected authorization denied error, got: %v", err)
+	}
+}
+
+func TestBrowserFlow_Timeout(t *testing.T) {
+	tokenSrv := httptest.NewServer(tokenHandler(t, false))
+	defer tokenSrv.Close()
+	cfg := testConfig(tokenSrv)
+	cfg.Timeout = 100 * time.Millisecond
+
+	_, err := BrowserFlow(context.Background(), cfg, func(authURL string) error {
+		// Don't hit the callback — let it time out.
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("expected timeout error, got: %v", err)
+	}
+}
+
+func TestBrowserFlow_BrowserOpenFails(t *testing.T) {
+	tokenSrv := httptest.NewServer(tokenHandler(t, false))
+	defer tokenSrv.Close()
+	cfg := testConfig(tokenSrv)
+
+	_, err := BrowserFlow(context.Background(), cfg, func(authURL string) error {
+		return fmt.Errorf("no display available")
+	})
+	if err == nil || !strings.Contains(err.Error(), "could not open browser") {
+		t.Fatalf("expected browser open error, got: %v", err)
+	}
+}
+
+func TestBrowserFlow_TokenExchangeFailure(t *testing.T) {
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(400)
+		fmt.Fprint(w, `{"error":"invalid_grant"}`)
+	}))
+	defer tokenSrv.Close()
+	cfg := testConfig(tokenSrv)
+
+	_, err := BrowserFlow(context.Background(), cfg, func(authURL string) error {
+		u, _ := url.Parse(authURL)
+		redirectURI := u.Query().Get("redirect_uri")
+		state := u.Query().Get("state")
+		callbackURL := fmt.Sprintf("%s?code=bad-code&state=%s", redirectURI, state)
+		resp, _ := http.Get(callbackURL)
+		resp.Body.Close()
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "token exchange failed (HTTP 400)") {
+		t.Fatalf("expected token exchange error, got: %v", err)
+	}
+}
+
+func TestBrowserFlow_PKCEParamsInTokenExchange(t *testing.T) {
+	var capturedVerifier string
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		vals, _ := url.ParseQuery(string(body))
+		capturedVerifier = vals.Get("code_verifier")
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(TokenResponse{AccessToken: "tok", TokenType: "bearer"})
+	}))
+	defer tokenSrv.Close()
+	cfg := testConfig(tokenSrv)
+
+	_, err := BrowserFlow(context.Background(), cfg, func(authURL string) error {
+		u, _ := url.Parse(authURL)
+		redirectURI := u.Query().Get("redirect_uri")
+		state := u.Query().Get("state")
+
+		// Verify PKCE params in authorize URL.
+		if u.Query().Get("code_challenge") == "" {
+			t.Error("code_challenge missing from authorize URL")
+		}
+		if u.Query().Get("code_challenge_method") != "S256" {
+			t.Errorf("code_challenge_method = %q, want S256", u.Query().Get("code_challenge_method"))
+		}
+
+		callbackURL := fmt.Sprintf("%s?code=auth-code&state=%s", redirectURI, state)
+		resp, _ := http.Get(callbackURL)
+		resp.Body.Close()
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("BrowserFlow: %v", err)
+	}
+	if capturedVerifier == "" {
+		t.Error("code_verifier was not sent in token exchange")
+	}
+	if len(capturedVerifier) != 43 {
+		t.Errorf("code_verifier length = %d, want 43", len(capturedVerifier))
+	}
+}
+
+// --- Headless flow tests ---
+
+func TestHeadlessFlow_HappyPath(t *testing.T) {
+	tokenSrv := httptest.NewServer(tokenHandler(t, true))
+	defer tokenSrv.Close()
+	cfg := testConfig(tokenSrv)
+
+	var output strings.Builder
+	var capturedState string
+
+	token, err := HeadlessFlow(context.Background(), cfg, &output, func() (string, error) {
+		// Parse the printed URL to get the state.
+		lines := strings.Split(output.String(), "\n")
+		for _, line := range lines {
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(line, "http") {
+				u, _ := url.Parse(line)
+				capturedState = u.Query().Get("state")
+				break
+			}
+		}
+		if capturedState == "" {
+			t.Fatal("could not find state in output")
+		}
+		return fmt.Sprintf("http://127.0.0.1/callback?code=headless-code&state=%s", capturedState), nil
+	})
+	if err != nil {
+		t.Fatalf("HeadlessFlow: %v", err)
+	}
+	if token != "test-access-token" {
+		t.Fatalf("token = %q, want test-access-token", token)
+	}
+}
+
+func TestHeadlessFlow_StateMismatch(t *testing.T) {
+	tokenSrv := httptest.NewServer(tokenHandler(t, false))
+	defer tokenSrv.Close()
+	cfg := testConfig(tokenSrv)
+
+	var output strings.Builder
+	_, err := HeadlessFlow(context.Background(), cfg, &output, func() (string, error) {
+		return "http://127.0.0.1/callback?code=c&state=wrong", nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "state mismatch") {
+		t.Fatalf("expected state mismatch error, got: %v", err)
+	}
+}
+
+func TestHeadlessFlow_UserDenied(t *testing.T) {
+	tokenSrv := httptest.NewServer(tokenHandler(t, false))
+	defer tokenSrv.Close()
+	cfg := testConfig(tokenSrv)
+
+	var output strings.Builder
+	var capturedState string
+
+	_, err := HeadlessFlow(context.Background(), cfg, &output, func() (string, error) {
+		lines := strings.Split(output.String(), "\n")
+		for _, line := range lines {
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(line, "http") {
+				u, _ := url.Parse(line)
+				capturedState = u.Query().Get("state")
+				break
+			}
+		}
+		return fmt.Sprintf("http://127.0.0.1/callback?error=access_denied&state=%s", capturedState), nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "authorization denied") {
+		t.Fatalf("expected denied error, got: %v", err)
+	}
+}
+
+func TestHeadlessFlow_ReadError(t *testing.T) {
+	tokenSrv := httptest.NewServer(tokenHandler(t, false))
+	defer tokenSrv.Close()
+	cfg := testConfig(tokenSrv)
+
+	var output strings.Builder
+	_, err := HeadlessFlow(context.Background(), cfg, &output, func() (string, error) {
+		return "", fmt.Errorf("connection closed")
+	})
+	if err == nil || !strings.Contains(err.Error(), "could not read URL") {
+		t.Fatalf("expected read error, got: %v", err)
+	}
+}
+
+func TestHeadlessFlow_InvalidURL(t *testing.T) {
+	tokenSrv := httptest.NewServer(tokenHandler(t, false))
+	defer tokenSrv.Close()
+	cfg := testConfig(tokenSrv)
+
+	var output strings.Builder
+	_, err := HeadlessFlow(context.Background(), cfg, &output, func() (string, error) {
+		return "://bad-url", nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid URL") {
+		t.Fatalf("expected invalid URL error, got: %v", err)
+	}
+}
+
+func TestHeadlessFlow_NoCode(t *testing.T) {
+	tokenSrv := httptest.NewServer(tokenHandler(t, false))
+	defer tokenSrv.Close()
+	cfg := testConfig(tokenSrv)
+
+	var output strings.Builder
+	_, err := HeadlessFlow(context.Background(), cfg, &output, func() (string, error) {
+		lines := strings.Split(output.String(), "\n")
+		for _, line := range lines {
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(line, "http") {
+				u, _ := url.Parse(line)
+				state := u.Query().Get("state")
+				return fmt.Sprintf("http://127.0.0.1/callback?state=%s", state), nil
+			}
+		}
+		return "http://127.0.0.1/callback", nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "no authorization code") {
+		t.Fatalf("expected no code error, got: %v", err)
+	}
+}
+
+func TestBrowserFlow_NoCode(t *testing.T) {
+	tokenSrv := httptest.NewServer(tokenHandler(t, false))
+	defer tokenSrv.Close()
+	cfg := testConfig(tokenSrv)
+
+	_, err := BrowserFlow(context.Background(), cfg, func(authURL string) error {
+		u, _ := url.Parse(authURL)
+		redirectURI := u.Query().Get("redirect_uri")
+		state := u.Query().Get("state")
+
+		callbackURL := fmt.Sprintf("%s?state=%s", redirectURI, state)
+		resp, _ := http.Get(callbackURL)
+		resp.Body.Close()
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "no authorization code") {
+		t.Fatalf("expected no code error, got: %v", err)
+	}
+}
+
+func TestBrowserFlow_TokenResponseEmpty(t *testing.T) {
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"access_token":"","token_type":"bearer"}`)
+	}))
+	defer tokenSrv.Close()
+	cfg := testConfig(tokenSrv)
+
+	_, err := BrowserFlow(context.Background(), cfg, func(authURL string) error {
+		u, _ := url.Parse(authURL)
+		redirectURI := u.Query().Get("redirect_uri")
+		state := u.Query().Get("state")
+		callbackURL := fmt.Sprintf("%s?code=c&state=%s", redirectURI, state)
+		resp, _ := http.Get(callbackURL)
+		resp.Body.Close()
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "did not contain an access token") {
+		t.Fatalf("expected empty token error, got: %v", err)
+	}
+}
+
+func TestBrowserFlow_TokenResponseInvalidJSON(t *testing.T) {
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `not json`)
+	}))
+	defer tokenSrv.Close()
+	cfg := testConfig(tokenSrv)
+
+	_, err := BrowserFlow(context.Background(), cfg, func(authURL string) error {
+		u, _ := url.Parse(authURL)
+		redirectURI := u.Query().Get("redirect_uri")
+		state := u.Query().Get("state")
+		callbackURL := fmt.Sprintf("%s?code=c&state=%s", redirectURI, state)
+		resp, _ := http.Get(callbackURL)
+		resp.Body.Close()
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "could not parse token response") {
+		t.Fatalf("expected parse error, got: %v", err)
+	}
+}
+
+func TestDefaultFlowConfig(t *testing.T) {
+	cfg := DefaultFlowConfig()
+	if cfg.ClientID != ClientID {
+		t.Errorf("ClientID = %q, want %q", cfg.ClientID, ClientID)
+	}
+	if cfg.AuthorizeURL != AuthorizeURL {
+		t.Errorf("AuthorizeURL = %q, want %q", cfg.AuthorizeURL, AuthorizeURL)
+	}
+	if cfg.TokenURL != TokenURL {
+		t.Errorf("TokenURL = %q, want %q", cfg.TokenURL, TokenURL)
+	}
+	if cfg.Scopes != Scopes {
+		t.Errorf("Scopes = %q, want %q", cfg.Scopes, Scopes)
+	}
+	if cfg.Timeout != DefaultTimeout {
+		t.Errorf("Timeout = %v, want %v", cfg.Timeout, DefaultTimeout)
+	}
+}
+
+func TestBrowserFlow_ErrorParamWithoutDescription(t *testing.T) {
+	tokenSrv := httptest.NewServer(tokenHandler(t, false))
+	defer tokenSrv.Close()
+	cfg := testConfig(tokenSrv)
+
+	_, err := BrowserFlow(context.Background(), cfg, func(authURL string) error {
+		u, _ := url.Parse(authURL)
+		redirectURI := u.Query().Get("redirect_uri")
+		state := u.Query().Get("state")
+		callbackURL := fmt.Sprintf("%s?error=server_error&state=%s", redirectURI, state)
+		resp, _ := http.Get(callbackURL)
+		resp.Body.Close()
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "server_error") {
+		t.Fatalf("expected server_error in message, got: %v", err)
+	}
+}

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -5,7 +5,7 @@ import "time"
 const (
 	// ClientID is the public OAuth application UID for the Gumroad CLI.
 	// This is a public client (confidential: false) — the client ID is not secret.
-	ClientID = "PLACEHOLDER_REPLACE_BEFORE_RELEASE"
+	ClientID = "oljO5HmcOWvCZ5wbitpXPXk3u0LjAb5GdAEBBU5hwKA"
 
 	AuthorizeURL = "https://app.gumroad.com/oauth/authorize"
 	TokenURL     = "https://app.gumroad.com/oauth/token" //nolint:gosec // G101: not a credential

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -8,7 +8,7 @@ const (
 	ClientID = "PLACEHOLDER_REPLACE_BEFORE_RELEASE"
 
 	AuthorizeURL = "https://app.gumroad.com/oauth/authorize"
-	TokenURL = "https://app.gumroad.com/oauth/token" //nolint:gosec // G101: not a credential
+	TokenURL     = "https://app.gumroad.com/oauth/token" //nolint:gosec // G101: not a credential
 
 	Scopes = "edit_products view_sales mark_sales_as_shipped edit_sales view_payouts view_profile account"
 

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -1,0 +1,16 @@
+package oauth
+
+import "time"
+
+const (
+	// ClientID is the public OAuth application UID for the Gumroad CLI.
+	// This is a public client (confidential: false) — the client ID is not secret.
+	ClientID = "PLACEHOLDER_REPLACE_BEFORE_RELEASE"
+
+	AuthorizeURL = "https://app.gumroad.com/oauth/authorize"
+	TokenURL     = "https://app.gumroad.com/oauth/token"
+
+	Scopes = "edit_products view_sales mark_sales_as_shipped edit_sales view_payouts view_profile account"
+
+	DefaultTimeout = 2 * time.Minute
+)

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -8,7 +8,7 @@ const (
 	ClientID = "PLACEHOLDER_REPLACE_BEFORE_RELEASE"
 
 	AuthorizeURL = "https://app.gumroad.com/oauth/authorize"
-	TokenURL     = "https://app.gumroad.com/oauth/token"
+	TokenURL = "https://app.gumroad.com/oauth/token" //nolint:gosec // G101: not a credential
 
 	Scopes = "edit_products view_sales mark_sales_as_shipped edit_sales view_payouts view_profile account"
 

--- a/internal/oauth/pkce.go
+++ b/internal/oauth/pkce.go
@@ -1,0 +1,22 @@
+package oauth
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+)
+
+// GenerateVerifier creates a PKCE code verifier: 32 random bytes, base64url-encoded (43 chars).
+func GenerateVerifier() (string, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+// ChallengeFromVerifier computes the S256 PKCE code challenge for a given verifier.
+func ChallengeFromVerifier(verifier string) string {
+	h := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(h[:])
+}

--- a/internal/oauth/pkce_test.go
+++ b/internal/oauth/pkce_test.go
@@ -1,0 +1,46 @@
+package oauth
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"testing"
+)
+
+func TestGenerateVerifier_Length(t *testing.T) {
+	v, err := GenerateVerifier()
+	if err != nil {
+		t.Fatalf("GenerateVerifier: %v", err)
+	}
+	if len(v) != 43 {
+		t.Fatalf("verifier length = %d, want 43", len(v))
+	}
+}
+
+func TestGenerateVerifier_Unique(t *testing.T) {
+	v1, _ := GenerateVerifier()
+	v2, _ := GenerateVerifier()
+	if v1 == v2 {
+		t.Fatal("two verifiers should not be identical")
+	}
+}
+
+func TestChallengeFromVerifier_KnownVector(t *testing.T) {
+	// RFC 7636 Appendix B test vector
+	verifier := "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	h := sha256.Sum256([]byte(verifier))
+	want := base64.RawURLEncoding.EncodeToString(h[:])
+
+	got := ChallengeFromVerifier(verifier)
+	if got != want {
+		t.Fatalf("challenge = %q, want %q", got, want)
+	}
+}
+
+func TestChallengeFromVerifier_Deterministic(t *testing.T) {
+	v, _ := GenerateVerifier()
+	c1 := ChallengeFromVerifier(v)
+	c2 := ChallengeFromVerifier(v)
+	if c1 != c2 {
+		t.Fatal("same verifier should produce same challenge")
+	}
+}

--- a/internal/output/spinner.go
+++ b/internal/output/spinner.go
@@ -17,6 +17,7 @@ type Spinner struct {
 	writer  io.Writer
 	done    chan struct{}
 	mu      sync.Mutex
+	wg      sync.WaitGroup
 	active  bool
 }
 
@@ -46,7 +47,9 @@ func (s *Spinner) Start() {
 	s.mu.Unlock()
 
 	frames := []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+	s.wg.Add(1)
 	go func() {
+		defer s.wg.Done()
 		i := 0
 		for {
 			select {
@@ -64,9 +67,13 @@ func (s *Spinner) Start() {
 
 func (s *Spinner) Stop() {
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	wasActive := s.active
 	if s.active {
 		close(s.done)
 		s.active = false
+	}
+	s.mu.Unlock()
+	if wasActive {
+		s.wg.Wait()
 	}
 }


### PR DESCRIPTION
Ref: antiwork/gumroad/issues/4406

## What

Replaces the manual API token prompt with browser-based OAuth as the default login flow. When a user runs `gumroad auth login` in a terminal, the CLI:

1. Binds an ephemeral localhost port and opens the Gumroad OAuth authorize page in their browser
2. User logs in and sees a consent screen listing requested scopes
3. Browser redirects to the local callback server with an authorization code
4. CLI exchanges the code for an access token using PKCE (S256), verifies it against `/user`, and saves it

If the browser can't open (SSH, headless server), the CLI falls back to a manual flow: prints the authorize URL and asks the user to paste the redirect URL from their browser's address bar.

Piped stdin (`echo $TOKEN | gumroad auth login`) continues to work exactly as before for CI/scripts.

New `--web` flag forces browser OAuth and skips the headless fallback.

## Why

The current login requires users to manually navigate to gumroad.com, find their API token in settings, copy it, and paste it into the terminal. This is the #1 friction point for new CLI users. Browser-based OAuth matches the standard CLI auth UX (like `gh auth login`). One command, one browser click, done.

PKCE is used because the CLI is a public client (the client ID is embedded in an open-source binary, so there's no client secret). PKCE binds the authorization code to the specific CLI instance that initiated the flow, preventing interception attacks.

### Security hardening

The implementation was adversarially reviewed and hardened:

- **State-first validation** — callback checks `state` before trusting `error`/`error_description` to prevent forged error injection from local attackers
- **Single-use callback** — `sync.Once` ensures only one result is processed; invalid-state requests are silently ignored (prevents DoS via channel blocking)
- **XSS defense** — HTML responses use `html.EscapeString()` on all interpolated values
- **No raw bodies in errors** — token exchange failures show HTTP status only, not server response body
- **Response size cap** — `io.LimitReader` limits token response to 1MB

### Dependency

This PR depends on the Gumroad-side PR that adds PKCE support (`doorkeeper-pkce` gem) and creates the production OAuth application. The `ClientID` constant in `internal/oauth/oauth.go` is a placeholder (`PLACEHOLDER_REPLACE_BEFORE_RELEASE`) that must be replaced with the real production OAuth application UID before release.

---

This PR was implemented with AI assistance using Claude Opus 4.6 and gpt‑5.4 xhigh