### PR TITLE
Add structured error hints to CLI output

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -196,7 +196,8 @@ func (c *Client) do(method, path string, params url.Values) (json.RawMessage, er
 		}
 		if err := json.Unmarshal(data, &envelope); err == nil {
 			if envelope.Success != nil && !*envelope.Success {
-				err := &APIError{StatusCode: resp.StatusCode, Message: rewriteError(resp.StatusCode, envelope.Message)}
+				msg, hint := rewriteError(resp.StatusCode, envelope.Message)
+				err := &APIError{StatusCode: resp.StatusCode, Message: msg, Hint: hint}
 				logResponse(resp.StatusCode, len(data), err, start)
 				return nil, err
 			}

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -652,8 +652,11 @@ func TestClient_HTTP401Error(t *testing.T) {
 	if apiErr.StatusCode != 401 {
 		t.Errorf("got status %d, want 401", apiErr.StatusCode)
 	}
-	if apiErr.Message != "Not authenticated. Run `gumroad auth login` or set `GUMROAD_ACCESS_TOKEN`." {
+	if apiErr.Message != "Not authenticated." {
 		t.Errorf("got message %q", apiErr.Message)
+	}
+	if apiErr.Hint != HintRunAuthLogin {
+		t.Errorf("got hint %q", apiErr.Hint)
 	}
 }
 

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -6,19 +6,35 @@ import (
 	"fmt"
 )
 
+const HintRunAuthLogin = "Run: gumroad auth login — or set GUMROAD_ACCESS_TOKEN"
+
 var (
 	ErrNotAuthenticated = errors.New("not authenticated")
 	ErrAccessDenied     = errors.New("access denied")
 	ErrResourceNotFound = errors.New("resource not found")
 )
 
+// HintedError is implemented by errors that carry an actionable recovery suggestion.
+type HintedError interface {
+	error
+	GetHint() string
+}
+
 type APIError struct {
 	StatusCode int
 	Message    string
+	Hint       string
 }
 
 func (e *APIError) Error() string {
 	return e.Message
+}
+
+func (e *APIError) GetHint() string {
+	if e == nil {
+		return ""
+	}
+	return e.Hint
 }
 
 func (e *APIError) Is(target error) bool {
@@ -44,30 +60,37 @@ func parseAPIError(statusCode int, body []byte) error {
 		Message string `json:"message"`
 	}
 	if err := json.Unmarshal(body, &resp); err == nil && resp.Message != "" {
-		return &APIError{StatusCode: statusCode, Message: rewriteError(statusCode, resp.Message)}
+		msg, hint := rewriteError(statusCode, resp.Message)
+		return &APIError{StatusCode: statusCode, Message: msg, Hint: hint}
 	}
 
-	return &APIError{StatusCode: statusCode, Message: rewriteError(statusCode, "")}
+	msg, hint := rewriteError(statusCode, "")
+	return &APIError{StatusCode: statusCode, Message: msg, Hint: hint}
 }
 
-func rewriteError(statusCode int, msg string) string {
+func rewriteError(statusCode int, msg string) (message, hint string) {
 	switch statusCode {
 	case 401:
-		return "Not authenticated. Run `gumroad auth login` or set `GUMROAD_ACCESS_TOKEN`."
+		return "Not authenticated.", HintRunAuthLogin
 	case 403:
 		if msg != "" {
-			return fmt.Sprintf("Access denied: %s", msg)
+			return fmt.Sprintf("Access denied: %s", msg), "Check that your token has the required scope."
 		}
-		return "Access denied. Your token may not have the required scope."
+		return "Access denied.", "Check that your token has the required scope."
 	case 404:
 		if msg != "" {
-			return msg
+			return msg, "Check the resource ID and try again."
 		}
-		return "Resource not found."
+		return "Resource not found.", "Check the resource ID and try again."
+	case 429:
+		if msg != "" {
+			return msg, "Wait a moment and retry."
+		}
+		return "Rate limited.", "Wait a moment and retry."
 	default:
 		if msg != "" {
-			return msg
+			return msg, ""
 		}
-		return fmt.Sprintf("API error (HTTP %d)", statusCode)
+		return fmt.Sprintf("API error (HTTP %d)", statusCode), ""
 	}
 }

--- a/internal/api/errors_test.go
+++ b/internal/api/errors_test.go
@@ -37,7 +37,7 @@ func TestParseAPIError_401(t *testing.T) {
 	body := []byte(`{"success":false}`)
 	err := parseAPIError(401, body)
 	apiErr := mustAPIError(t, err)
-	if apiErr.Message != "Not authenticated. Run `gumroad auth login` or set `GUMROAD_ACCESS_TOKEN`." {
+	if apiErr.Message != "Not authenticated." {
 		t.Errorf("got message %q", apiErr.Message)
 	}
 	if !errors.Is(err, ErrNotAuthenticated) {
@@ -60,7 +60,7 @@ func TestParseAPIError_403_WithMessage(t *testing.T) {
 func TestParseAPIError_403_NoMessage(t *testing.T) {
 	body := []byte(`{"success":false}`)
 	apiErr := mustAPIError(t, parseAPIError(403, body))
-	if apiErr.Message != "Access denied. Your token may not have the required scope." {
+	if apiErr.Message != "Access denied." {
 		t.Errorf("got message %q", apiErr.Message)
 	}
 }
@@ -141,5 +141,47 @@ func TestAPIErrorIs(t *testing.T) {
 	}
 	if err401.Is(nil) {
 		t.Fatal("did not expect nil target to match")
+	}
+}
+
+func TestAPIError_Hints(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantHint   string
+	}{
+		{"401", 401, `{"success":false}`, HintRunAuthLogin},
+		{"403", 403, `{"success":false}`, "Check that your token has the required scope."},
+		{"404", 404, `{"success":false}`, "Check the resource ID and try again."},
+		{"429", 429, `{"success":false,"message":"Rate limited"}`, "Wait a moment and retry."},
+		{"500", 500, `{"success":false}`, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			apiErr := mustAPIError(t, parseAPIError(tt.statusCode, []byte(tt.body)))
+			if apiErr.Hint != tt.wantHint {
+				t.Errorf("got hint %q, want %q", apiErr.Hint, tt.wantHint)
+			}
+		})
+	}
+}
+
+func TestHintedErrorInterface(t *testing.T) {
+	err := &APIError{StatusCode: 401, Message: "Not authenticated.", Hint: HintRunAuthLogin}
+	var hinted HintedError
+	if !errors.As(err, &hinted) {
+		t.Fatal("expected APIError to satisfy HintedError")
+	}
+	if hinted.GetHint() != HintRunAuthLogin {
+		t.Errorf("got hint %q", hinted.GetHint())
+	}
+}
+
+func TestAPIError_GetHint_Nil(t *testing.T) {
+	var err *APIError
+	if err.GetHint() != "" {
+		t.Errorf("expected empty hint from nil receiver")
 	}
 }

--- a/internal/cmd/errors.go
+++ b/internal/cmd/errors.go
@@ -27,6 +27,7 @@ type commandErrorDetail struct {
 	Type       string `json:"type"`
 	Code       string `json:"code,omitempty"`
 	Message    string `json:"message"`
+	Hint       string `json:"hint,omitempty"`
 	StatusCode int    `json:"status_code,omitempty"`
 }
 
@@ -63,13 +64,19 @@ func classifyCommandError(err error) commandErrorDetail {
 			Type:       "api_error",
 			Code:       apiErrorCode(apiErr.StatusCode),
 			Message:    apiErr.Error(),
+			Hint:       apiErr.GetHint(),
 			StatusCode: apiErr.StatusCode,
 		}
 	case errors.Is(err, config.ErrNotAuthenticated), errors.Is(err, api.ErrNotAuthenticated):
+		hint := api.HintRunAuthLogin
+		if strings.Contains(err.Error(), "gumroad auth login") {
+			hint = ""
+		}
 		return commandErrorDetail{
 			Type:    "auth_error",
 			Code:    "not_authenticated",
 			Message: err.Error(),
+			Hint:    hint,
 		}
 	case errors.Is(err, prompt.ErrConfirmationNoInput), errors.Is(err, prompt.ErrConfirmationNonInteractive):
 		return invalidInputErrorDetail(err.Error())

--- a/internal/cmd/errors_test.go
+++ b/internal/cmd/errors_test.go
@@ -35,6 +35,70 @@ func TestPrintStructuredCommandError(t *testing.T) {
 	}
 }
 
+func TestPrintStructuredCommandError_WithHint(t *testing.T) {
+	var buf bytes.Buffer
+	err := printStructuredCommandError(&buf, &api.APIError{StatusCode: 401, Message: "Not authenticated.", Hint: api.HintRunAuthLogin})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var payload commandErrorEnvelope
+	if err := json.Unmarshal(buf.Bytes(), &payload); err != nil {
+		t.Fatalf("expected JSON output, got %v with %q", err, buf.String())
+	}
+	if payload.Error.Hint != api.HintRunAuthLogin {
+		t.Errorf("got hint %q, want %q", payload.Error.Hint, api.HintRunAuthLogin)
+	}
+}
+
+func TestClassifyCommandError_APIWithHint(t *testing.T) {
+	detail := classifyCommandError(&api.APIError{StatusCode: 404, Message: "Resource not found.", Hint: "Check the resource ID and try again."})
+	if detail.Hint != "Check the resource ID and try again." {
+		t.Errorf("got hint %q", detail.Hint)
+	}
+}
+
+func TestClassifyCommandError_AuthHint(t *testing.T) {
+	detail := classifyCommandError(config.ErrNotAuthenticated)
+	if detail.Hint != api.HintRunAuthLogin {
+		t.Errorf("got hint %q, want %q", detail.Hint, api.HintRunAuthLogin)
+	}
+}
+
+func TestClassifyCommandError_WrappedAPIError(t *testing.T) {
+	wrapped := fmt.Errorf("invalid token: %w", &api.APIError{StatusCode: 401, Message: "Not authenticated.", Hint: api.HintRunAuthLogin})
+	detail := classifyCommandError(wrapped)
+	if detail.Type != "api_error" || detail.Code != "not_authenticated" {
+		t.Fatalf("unexpected detail: %+v", detail)
+	}
+	if detail.Hint != api.HintRunAuthLogin {
+		t.Errorf("got hint %q, want %q", detail.Hint, api.HintRunAuthLogin)
+	}
+}
+
+func TestClassifyCommandError_WrappedConfigAuth(t *testing.T) {
+	wrapped := fmt.Errorf("setup failed: %w", config.ErrNotAuthenticated)
+	detail := classifyCommandError(wrapped)
+	if detail.Type != "auth_error" || detail.Code != "not_authenticated" {
+		t.Fatalf("unexpected detail: %+v", detail)
+	}
+	if detail.Hint != api.HintRunAuthLogin {
+		t.Errorf("got hint %q, want %q", detail.Hint, api.HintRunAuthLogin)
+	}
+}
+
+func TestClassifyCommandError_ConfigAuthWithRemediationInMessage(t *testing.T) {
+	// Simulates the real error from config.ResolveToken which already embeds remediation.
+	wrapped := fmt.Errorf("%w. Run `gumroad auth login` first or set `GUMROAD_ACCESS_TOKEN`", config.ErrNotAuthenticated)
+	detail := classifyCommandError(wrapped)
+	if detail.Type != "auth_error" || detail.Code != "not_authenticated" {
+		t.Fatalf("unexpected detail: %+v", detail)
+	}
+	if detail.Hint != "" {
+		t.Errorf("expected empty hint when message already contains remediation, got %q", detail.Hint)
+	}
+}
+
 func TestClassifyCommandError_Nil(t *testing.T) {
 	detail := classifyCommandError(nil)
 	if detail.Type != "internal_error" || detail.Code != "unknown_error" {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -2,12 +2,14 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"strconv"
 	"strings"
 
+	"github.com/antiwork/gumroad-cli/internal/api"
 	"github.com/antiwork/gumroad-cli/internal/cmd/auth"
 	"github.com/antiwork/gumroad-cli/internal/cmd/categories"
 	"github.com/antiwork/gumroad-cli/internal/cmd/completion"
@@ -22,6 +24,7 @@ import (
 	"github.com/antiwork/gumroad-cli/internal/cmd/variants"
 	"github.com/antiwork/gumroad-cli/internal/cmd/webhooks"
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/config"
 	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -196,8 +199,28 @@ func exitCodeForCommandError(cmd *cobra.Command, err error) int {
 }
 
 func printHumanCommandError(cmd *cobra.Command, err error) {
-	style := output.NewStylerForWriter(cmd.ErrOrStderr(), noColorRequested(cmd))
-	fmt.Fprintln(cmd.ErrOrStderr(), style.Red("Error: "+err.Error()))
+	w := cmd.ErrOrStderr()
+	style := output.NewStylerForWriter(w, noColorRequested(cmd))
+	fmt.Fprintln(w, style.Red("Error: "+err.Error()))
+
+	if hint := hintFromError(err); hint != "" {
+		fmt.Fprintln(w, style.Dim("Hint: "+hint))
+	}
+}
+
+func hintFromError(err error) string {
+	var hinted api.HintedError
+	if errors.As(err, &hinted) {
+		return hinted.GetHint()
+	}
+	if errors.Is(err, config.ErrNotAuthenticated) || errors.Is(err, api.ErrNotAuthenticated) {
+		// config.ResolveToken already embeds remediation in the error message;
+		// only add the hint when it would not duplicate.
+		if !strings.Contains(err.Error(), "gumroad auth login") {
+			return api.HintRunAuthLogin
+		}
+	}
+	return ""
 }
 
 func noColorRequested(cmd *cobra.Command) bool {

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -10,7 +10,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/antiwork/gumroad-cli/internal/api"
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/config"
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -521,5 +524,65 @@ func TestCommandContext_PrefersCommandContext(t *testing.T) {
 
 	if got := commandContext(cmd).Value(contextKey("trace")); got != "abc123" {
 		t.Fatalf("got context value %v, want abc123", got)
+	}
+}
+
+func TestHintFromError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"api_error_with_hint", &api.APIError{StatusCode: 401, Message: "Not authenticated.", Hint: api.HintRunAuthLogin}, api.HintRunAuthLogin},
+		{"api_error_no_hint", &api.APIError{StatusCode: 500, Message: "Server error"}, ""},
+		{"config_not_authenticated", config.ErrNotAuthenticated, api.HintRunAuthLogin},
+		{"wrapped_api_error", fmt.Errorf("invalid token: %w", &api.APIError{StatusCode: 401, Message: "Not authenticated.", Hint: api.HintRunAuthLogin}), api.HintRunAuthLogin},
+		{"wrapped_config_error", fmt.Errorf("setup failed: %w", config.ErrNotAuthenticated), api.HintRunAuthLogin},
+		{"wrapped_api_not_authenticated", fmt.Errorf("check failed: %w", api.ErrNotAuthenticated), api.HintRunAuthLogin},
+		{"config_auth_with_remediation", fmt.Errorf("%w. Run `gumroad auth login` first or set `GUMROAD_ACCESS_TOKEN`", config.ErrNotAuthenticated), ""},
+		{"plain_error", errors.New("boom"), ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hintFromError(tt.err); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrintHumanCommandError_ShowsHint(t *testing.T) {
+	output.SetColorEnabledForTesting(false)
+	defer output.ResetColorEnabledForTesting()
+
+	cmd := &cobra.Command{Use: "test"}
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+
+	printHumanCommandError(cmd, &api.APIError{StatusCode: 401, Message: "Not authenticated.", Hint: api.HintRunAuthLogin})
+
+	got := stderr.String()
+	if !strings.Contains(got, "Error: Not authenticated.") {
+		t.Errorf("expected error message, got %q", got)
+	}
+	if !strings.Contains(got, "Hint: Run: gumroad auth login") {
+		t.Errorf("expected hint line, got %q", got)
+	}
+}
+
+func TestPrintHumanCommandError_NoHint(t *testing.T) {
+	output.SetColorEnabledForTesting(false)
+	defer output.ResetColorEnabledForTesting()
+
+	cmd := &cobra.Command{Use: "test"}
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+
+	printHumanCommandError(cmd, errors.New("something broke"))
+
+	got := stderr.String()
+	if strings.Contains(got, "Hint:") {
+		t.Errorf("expected no hint line, got %q", got)
 	}
 }


### PR DESCRIPTION
Fixes antiwork/gumroad#4407

## What

Adds a `Hint` field to `APIError` and a `HintedError` interface so any error can carry an actionable recovery suggestion. Common API failures now produce structured hints:

- **401** → `Run: gumroad auth login — or set GUMROAD_ACCESS_TOKEN`
- **403** → `Check that your token has the required scope.`
- **404** → `Check the resource ID and try again.`
- **429** → `Wait a moment and retry.`

In human mode, the hint prints as a dimmed line below the error. In `--json` mode, a `"hint"` field appears in the error envelope (omitted when empty). When the error message already contains remediation text (e.g. from `config.ResolveToken`), the hint is suppressed to avoid duplication.

## Why

Per [clig.dev](https://clig.dev/): "Catch expected errors and rewrite them for humans — suggest the next step." A 401 used to print a message with baked-in guidance. Now the error message is clean (`Not authenticated.`) and the hint is a separate, structured field — usable by both humans and machines. This improves the first-run experience and makes error recovery scriptable via `--json`.

The previous approach embedded hints directly in `err.Error()` strings, which made them invisible to `--json` consumers and impossible to style differently in human output. Separating message from hint fixes both.

---

This PR was implemented with AI assistance using Claude Opus 4.6 and gpt‑5.4 high