### PR TITLE
Expand skill docs and add auto-refresh on version change

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -71,6 +71,7 @@ func NewRootCmd() *cobra.Command {
 			if err := cmdutil.RequireNonNegativeDurationFlag(cmd, "page-delay", opts.PageDelay); err != nil {
 				return err
 			}
+			skill.AutoRefresh(Version)
 			return nil
 		},
 		Version: Version,

--- a/internal/cmd/skill/refresh.go
+++ b/internal/cmd/skill/refresh.go
@@ -44,10 +44,8 @@ func AutoRefresh(version string) {
 	_ = os.WriteFile(sentinelPath, []byte(version), 0600)
 }
 
-// refreshExistingInstalls overwrites existing skill files with new content.
-// Uses os.Stat (follows symlinks) so symlinked files get their targets refreshed.
-// Skips project-relative paths since there's no reliable project root at startup.
-// Returns true if all writes succeeded (or no files needed updating).
+// refreshExistingInstalls uses os.Stat (follows symlinks) so symlinked targets
+// get refreshed. Skips project-relative paths — no reliable project root at startup.
 func refreshExistingInstalls(content []byte) bool {
 	ok := true
 	for _, loc := range skillLocations {

--- a/internal/cmd/skill/refresh.go
+++ b/internal/cmd/skill/refresh.go
@@ -1,0 +1,69 @@
+package skill
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/antiwork/gumroad-cli/internal/config"
+	"github.com/antiwork/gumroad-cli/skills"
+)
+
+const sentinelFile = ".last-skill-version"
+
+var configDir = config.Dir
+
+// AutoRefresh silently refreshes installed skill files when the CLI version changes.
+// It only overwrites files that already exist — it never creates new installs.
+func AutoRefresh(version string) {
+	if version == "" || version == "dev" {
+		return
+	}
+
+	dir, err := configDir()
+	if err != nil {
+		return
+	}
+
+	sentinelPath := filepath.Join(dir, sentinelFile)
+	stored, _ := os.ReadFile(sentinelPath)
+	if strings.TrimSpace(string(stored)) == version {
+		return
+	}
+
+	content, err := skills.SkillMarkdown()
+	if err != nil {
+		return
+	}
+
+	if !refreshExistingInstalls(content) {
+		return
+	}
+
+	_ = os.MkdirAll(dir, 0700)
+	_ = os.WriteFile(sentinelPath, []byte(version), 0600)
+}
+
+// refreshExistingInstalls overwrites existing skill files with new content.
+// Uses os.Stat (follows symlinks) so symlinked files get their targets refreshed.
+// Skips project-relative paths since there's no reliable project root at startup.
+// Returns true if all writes succeeded (or no files needed updating).
+func refreshExistingInstalls(content []byte) bool {
+	ok := true
+	for _, loc := range skillLocations {
+		// Skip project-relative paths
+		if !strings.HasPrefix(loc.Path, "~/") && !filepath.IsAbs(loc.Path) {
+			continue
+		}
+
+		p := expandPath(loc.Path)
+		if _, err := os.Stat(p); err != nil {
+			continue
+		}
+
+		if err := os.WriteFile(p, content, 0644); err != nil { //nolint:gosec // G306: skill files are not secrets
+			ok = false
+		}
+	}
+	return ok
+}

--- a/internal/cmd/skill/refresh_test.go
+++ b/internal/cmd/skill/refresh_test.go
@@ -1,0 +1,189 @@
+package skill
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func overrideConfigDir(t *testing.T, dir string) {
+	t.Helper()
+	orig := configDir
+	configDir = func() (string, error) { return dir, nil }
+	t.Cleanup(func() { configDir = orig })
+}
+
+func TestAutoRefresh_SkipsDevVersion(t *testing.T) {
+	dir := t.TempDir()
+	overrideConfigDir(t, dir)
+
+	AutoRefresh("dev")
+
+	sentinel := filepath.Join(dir, sentinelFile)
+	if _, err := os.Stat(sentinel); err == nil {
+		t.Error("expected no sentinel for dev version")
+	}
+}
+
+func TestAutoRefresh_SkipsEmptyVersion(t *testing.T) {
+	dir := t.TempDir()
+	overrideConfigDir(t, dir)
+
+	AutoRefresh("")
+
+	sentinel := filepath.Join(dir, sentinelFile)
+	if _, err := os.Stat(sentinel); err == nil {
+		t.Error("expected no sentinel for empty version")
+	}
+}
+
+func TestAutoRefresh_WritesSentinel(t *testing.T) {
+	dir := t.TempDir()
+	overrideConfigDir(t, dir)
+	overrideHomeDir(t, dir)
+
+	AutoRefresh("1.0.0")
+
+	data, err := os.ReadFile(filepath.Join(dir, sentinelFile))
+	if err != nil {
+		t.Fatalf("expected sentinel file: %v", err)
+	}
+	if string(data) != "1.0.0" {
+		t.Errorf("expected version 1.0.0, got %q", string(data))
+	}
+}
+
+func TestAutoRefresh_SkipsWhenVersionUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	overrideConfigDir(t, dir)
+	overrideHomeDir(t, dir)
+
+	// Create a skill file to track writes
+	skillPath := filepath.Join(dir, ".agents", skillRelPath)
+	if err := os.MkdirAll(filepath.Dir(skillPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(skillPath, []byte("old"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// First run writes sentinel
+	AutoRefresh("1.0.0")
+
+	// Restore old content to detect if it gets overwritten
+	if err := os.WriteFile(skillPath, []byte("old"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second run with same version should skip
+	AutoRefresh("1.0.0")
+	data, _ := os.ReadFile(skillPath)
+	if string(data) != "old" {
+		t.Error("expected skill file to be unchanged on same version")
+	}
+}
+
+func TestAutoRefresh_RefreshesOnVersionChange(t *testing.T) {
+	dir := t.TempDir()
+	overrideConfigDir(t, dir)
+	overrideHomeDir(t, dir)
+
+	// Create an existing skill file
+	skillPath := filepath.Join(dir, ".agents", skillRelPath)
+	if err := os.MkdirAll(filepath.Dir(skillPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(skillPath, []byte("old content"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write v1 sentinel
+	if err := os.WriteFile(filepath.Join(dir, sentinelFile), []byte("1.0.0"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	AutoRefresh("2.0.0")
+
+	data, err := os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatalf("could not read skill: %v", err)
+	}
+	if string(data) == "old content" {
+		t.Error("expected skill to be updated, still has old content")
+	}
+	if !strings.Contains(string(data), "gumroad") {
+		t.Error("expected refreshed skill content")
+	}
+
+	sentinel, _ := os.ReadFile(filepath.Join(dir, sentinelFile))
+	if string(sentinel) != "2.0.0" {
+		t.Errorf("expected sentinel 2.0.0, got %q", string(sentinel))
+	}
+}
+
+func TestAutoRefresh_OnlyRefreshesExistingFiles(t *testing.T) {
+	dir := t.TempDir()
+	overrideConfigDir(t, dir)
+	overrideHomeDir(t, dir)
+
+	// Don't create any skill files — nothing should be created
+	AutoRefresh("1.0.0")
+
+	for _, d := range []string{".agents", ".claude", ".codex", ".opencode"} {
+		p := filepath.Join(dir, d, skillRelPath)
+		if _, err := os.Stat(p); err == nil {
+			t.Errorf("expected no file at %s (should not create new installs)", p)
+		}
+	}
+}
+
+func TestAutoRefresh_RefreshesSymlinkedFiles(t *testing.T) {
+	if !symlinkSupported() {
+		t.Skip("symlinks not supported")
+	}
+
+	dir := t.TempDir()
+	overrideConfigDir(t, dir)
+	overrideHomeDir(t, dir)
+
+	// Create the baseline file
+	basePath := filepath.Join(dir, ".agents", skillRelPath)
+	if err := os.MkdirAll(filepath.Dir(basePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(basePath, []byte("old"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a symlink from .claude to the baseline (directory-level)
+	claudeSkillDir := filepath.Join(dir, ".claude", skillDirName)
+	if err := os.MkdirAll(filepath.Dir(claudeSkillDir), 0755); err != nil {
+		t.Fatal(err)
+	}
+	agentsSkillDir := filepath.Join(dir, ".agents", skillDirName)
+	if err := os.Symlink(agentsSkillDir, claudeSkillDir); err != nil {
+		t.Fatal(err)
+	}
+
+	AutoRefresh("1.0.0")
+
+	// The baseline file should be refreshed (os.Stat follows symlinks)
+	data, _ := os.ReadFile(basePath)
+	if string(data) == "old" {
+		t.Error("expected baseline file to be refreshed")
+	}
+}
+
+func symlinkSupported() bool {
+	dir, err := os.MkdirTemp("", "symlink-test")
+	if err != nil {
+		return false
+	}
+	defer os.RemoveAll(dir)
+	target := filepath.Join(dir, "target")
+	if err := os.WriteFile(target, nil, 0600); err != nil {
+		return false
+	}
+	return os.Symlink(target, filepath.Join(dir, "link")) == nil
+}

--- a/internal/cmd/skill/skill.go
+++ b/internal/cmd/skill/skill.go
@@ -1,10 +1,10 @@
 package skill
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/output"
@@ -14,35 +14,48 @@ import (
 )
 
 const (
-	skillRelPath   = "skills/gumroad/SKILL.md"
+	skillDirName   = "skills/gumroad"
+	skillFileName  = "SKILL.md"
+	skillRelPath   = skillDirName + "/" + skillFileName
 	selectValPrint = "" // sentinel: user chose "Print to stdout"
 )
 
-type installTarget struct {
+// skillLocation represents a predefined install target.
+type skillLocation struct {
 	Label string
-	Path  string
+	Path  string // may contain ~ prefix
 }
 
 var userHomeDir = os.UserHomeDir
 var readSkill = skills.SkillMarkdown
 
-var defaultTargets = func() []installTarget {
-	targets := []installTarget{
-		{"Claude Code (Project)", filepath.Join(".claude", skillRelPath)},
+func codexGlobalSkillPath() string {
+	if home := strings.TrimSpace(os.Getenv("CODEX_HOME")); home != "" {
+		return filepath.Join(home, skillRelPath)
 	}
+	return "~/.codex/" + skillRelPath
+}
 
-	home, _ := userHomeDir()
-	if home == "" {
-		return targets
+// skillLocations is the canonical list of install targets.
+// Used by the interactive menu, headless install, and auto-refresh.
+var skillLocations = []skillLocation{
+	{"Agents (Shared)", "~/.agents/" + skillRelPath},
+	{"Claude Code (Global)", "~/.claude/" + skillRelPath},
+	{"Claude Code (Project)", ".claude/" + skillRelPath},
+	{"Codex (Global)", codexGlobalSkillPath()},
+	{"OpenCode (Global)", "~/.opencode/" + skillRelPath},
+}
+
+// expandPath expands a leading ~ to the user's home directory.
+func expandPath(path string) string {
+	if !strings.HasPrefix(path, "~/") {
+		return path
 	}
-
-	return append([]installTarget{
-		{"Agents (Shared)", filepath.Join(home, ".agents", skillRelPath)},
-		{"Claude Code (Global)", filepath.Join(home, ".claude", skillRelPath)},
-	}, append(targets,
-		installTarget{"Codex (Global)", filepath.Join(home, ".codex", skillRelPath)},
-		installTarget{"OpenCode (Global)", filepath.Join(home, ".opencode", skillRelPath)},
-	)...)
+	home, err := userHomeDir()
+	if err != nil {
+		return path
+	}
+	return filepath.Join(home, path[2:])
 }
 
 func NewSkillCmd() *cobra.Command {
@@ -85,12 +98,11 @@ func runSkill(opts cmdutil.Options) error {
 		return err
 	}
 
-	targets := defaultTargets()
-	selectOpts := make([]prompt.SelectOption, len(targets)+1)
-	for i, t := range targets {
-		selectOpts[i] = prompt.SelectOption{Label: t.Label + " — " + t.Path, Value: t.Path}
+	selectOpts := make([]prompt.SelectOption, len(skillLocations)+1)
+	for i, loc := range skillLocations {
+		selectOpts[i] = prompt.SelectOption{Label: loc.Label + " — " + loc.Path, Value: loc.Path}
 	}
-	selectOpts[len(targets)] = prompt.SelectOption{Label: "Print to stdout", Value: selectValPrint}
+	selectOpts[len(skillLocations)] = prompt.SelectOption{Label: "Print to stdout", Value: selectValPrint}
 
 	chosen, err := selectFunc("Install skill to:", selectOpts, opts.In(), opts.Err(), opts.NoInput)
 	if err != nil {
@@ -102,7 +114,7 @@ func runSkill(opts cmdutil.Options) error {
 		return err
 	}
 
-	return writeSkillFile(chosen, content, opts)
+	return writeSkillFile(expandPath(chosen), content, opts)
 }
 
 func newInstallCmd() *cobra.Command {
@@ -111,10 +123,11 @@ func newInstallCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "install",
 		Short: "Install the skill to default agent locations",
-		Long: `Install the embedded SKILL.md to ~/.agents/skills/gumroad/SKILL.md (shared baseline).
+		Long: `Install the embedded SKILL.md to ~/.agents/skills/gumroad/ (shared baseline).
 
-If Claude Code is detected (~/.claude exists), also creates a symlink at
-~/.claude/skills/gumroad/SKILL.md pointing to the shared location.`,
+If Claude Code is detected (~/.claude exists), creates a directory symlink at
+~/.claude/skills/gumroad pointing to the shared location. Falls back to a
+file copy if symlinks are unavailable.`,
 		Example: `  # Install to default locations
   gumroad skill install
 
@@ -146,15 +159,22 @@ func runInstall(opts cmdutil.Options, customPath string) error {
 		return fmt.Errorf("could not determine home directory: %w", err)
 	}
 
-	sharedPath := filepath.Join(home, ".agents", skillRelPath)
-	if err := writeSkillFile(sharedPath, content, opts); err != nil {
+	// Write to the shared baseline
+	sharedDir := filepath.Join(home, ".agents", skillDirName)
+	sharedFile := filepath.Join(sharedDir, skillFileName)
+	if err := writeSkillFile(sharedFile, content, opts); err != nil {
 		return err
 	}
 
+	// Symlink Claude Code to the shared baseline (directory-level, relative path)
 	claudeDir := filepath.Join(home, ".claude")
 	if info, statErr := os.Stat(claudeDir); statErr == nil && info.IsDir() {
-		claudeSkillPath := filepath.Join(home, ".claude", skillRelPath)
-		if err := symlinkSkillFile(claudeSkillPath, sharedPath, opts); err != nil {
+		if err := linkOrCopySkillDir(
+			filepath.Join(home, ".claude", skillDirName),
+			filepath.Join("..", "..", ".agents", skillDirName),
+			sharedDir,
+			opts,
+		); err != nil {
 			return err
 		}
 	}
@@ -162,29 +182,68 @@ func runInstall(opts cmdutil.Options, customPath string) error {
 	return nil
 }
 
+// writeSkillFile writes the skill content to a file path.
 func writeSkillFile(path string, content []byte, opts cmdutil.Options) error {
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0755); err != nil { //nolint:gosec // G301: skill files are not secrets
 		return fmt.Errorf("could not create directory %s: %w", dir, err)
 	}
-	if err := os.WriteFile(path, content, 0600); err != nil {
+	if err := os.WriteFile(path, content, 0644); err != nil { //nolint:gosec // G306: skill files are not secrets
 		return fmt.Errorf("could not write %s: %w", path, err)
 	}
 	return cmdutil.PrintSuccess(opts, fmt.Sprintf("Installed skill to %s", path))
 }
 
-func symlinkSkillFile(linkPath, targetPath string, opts cmdutil.Options) error {
-	dir := filepath.Dir(linkPath)
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return fmt.Errorf("could not create directory %s: %w", dir, err)
+// linkOrCopySkillDir creates a directory symlink at linkPath pointing to relTarget.
+// If symlinks fail (e.g. Windows), falls back to copying files from absTarget.
+func linkOrCopySkillDir(linkPath, relTarget, absTarget string, opts cmdutil.Options) error {
+	parent := filepath.Dir(linkPath)
+	if err := os.MkdirAll(parent, 0755); err != nil { //nolint:gosec // G301: skill files are not secrets
+		return fmt.Errorf("could not create directory %s: %w", parent, err)
 	}
 
-	if err := os.Remove(linkPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("could not remove existing %s: %w", linkPath, err)
+	// Remove existing symlink or file. If it's a populated directory,
+	// leave it alone — the user may have placed custom files there.
+	if info, err := os.Lstat(linkPath); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			_ = os.Remove(linkPath)
+		} else {
+			// It's a real directory — skip symlink, fall through to copy fallback
+			return copySkillDir(absTarget, linkPath, opts)
+		}
 	}
 
-	if err := os.Symlink(targetPath, linkPath); err != nil {
-		return fmt.Errorf("could not symlink %s → %s: %w", linkPath, targetPath, err)
+	if err := os.Symlink(relTarget, linkPath); err == nil {
+		return cmdutil.PrintSuccess(opts, fmt.Sprintf("Linked %s → %s", linkPath, relTarget))
 	}
-	return cmdutil.PrintSuccess(opts, fmt.Sprintf("Linked %s → %s", linkPath, targetPath))
+
+	// Fallback: copy files from the shared directory
+	return copySkillDir(absTarget, linkPath, opts)
+}
+
+// copySkillDir copies all files from src to dst as a fallback when symlinks fail.
+func copySkillDir(src, dst string, opts cmdutil.Options) error {
+	if err := os.MkdirAll(dst, 0755); err != nil { //nolint:gosec // G301: skill files are not secrets
+		return fmt.Errorf("could not create directory %s: %w", dst, err)
+	}
+
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return fmt.Errorf("could not read %s: %w", src, err)
+	}
+
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		data, readErr := os.ReadFile(filepath.Join(src, e.Name()))
+		if readErr != nil {
+			return fmt.Errorf("could not read %s: %w", e.Name(), readErr)
+		}
+		if writeErr := os.WriteFile(filepath.Join(dst, e.Name()), data, 0644); writeErr != nil { //nolint:gosec // G306: skill files are not secrets
+			return fmt.Errorf("could not write %s: %w", e.Name(), writeErr)
+		}
+	}
+
+	return cmdutil.PrintSuccess(opts, fmt.Sprintf("Copied skill to %s (symlink unavailable)", dst))
 }

--- a/internal/cmd/skill/skill.go
+++ b/internal/cmd/skill/skill.go
@@ -1,6 +1,7 @@
 package skill
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -198,14 +199,14 @@ func linkOrCopySkillDir(linkPath, relTarget, absTarget string, opts cmdutil.Opti
 		return fmt.Errorf("could not create directory %s: %w", parent, err)
 	}
 
-	// Remove existing symlink or file. If it's a populated directory,
-	// leave it alone — the user may have placed custom files there.
+	// If a real directory exists, preserve it (user may have custom files)
+	// and fall through to copy. For symlinks or files, remove first.
 	if info, err := os.Lstat(linkPath); err == nil {
-		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
-			_ = os.Remove(linkPath)
-		} else {
-			// It's a real directory — skip symlink, fall through to copy fallback
+		if info.IsDir() && info.Mode()&os.ModeSymlink == 0 {
 			return copySkillDir(absTarget, linkPath, opts)
+		}
+		if err := os.Remove(linkPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("could not remove existing %s: %w", linkPath, err)
 		}
 	}
 

--- a/internal/cmd/skill/skill.go
+++ b/internal/cmd/skill/skill.go
@@ -20,7 +20,6 @@ const (
 	selectValPrint = "" // sentinel: user chose "Print to stdout"
 )
 
-// skillLocation represents a predefined install target.
 type skillLocation struct {
 	Label string
 	Path  string // may contain ~ prefix
@@ -46,7 +45,6 @@ var skillLocations = []skillLocation{
 	{"OpenCode (Global)", "~/.opencode/" + skillRelPath},
 }
 
-// expandPath expands a leading ~ to the user's home directory.
 func expandPath(path string) string {
 	if !strings.HasPrefix(path, "~/") {
 		return path
@@ -159,7 +157,6 @@ func runInstall(opts cmdutil.Options, customPath string) error {
 		return fmt.Errorf("could not determine home directory: %w", err)
 	}
 
-	// Write to the shared baseline
 	sharedDir := filepath.Join(home, ".agents", skillDirName)
 	sharedFile := filepath.Join(sharedDir, skillFileName)
 	if err := writeSkillFile(sharedFile, content, opts); err != nil {
@@ -182,7 +179,6 @@ func runInstall(opts cmdutil.Options, customPath string) error {
 	return nil
 }
 
-// writeSkillFile writes the skill content to a file path.
 func writeSkillFile(path string, content []byte, opts cmdutil.Options) error {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0755); err != nil { //nolint:gosec // G301: skill files are not secrets
@@ -217,11 +213,9 @@ func linkOrCopySkillDir(linkPath, relTarget, absTarget string, opts cmdutil.Opti
 		return cmdutil.PrintSuccess(opts, fmt.Sprintf("Linked %s → %s", linkPath, relTarget))
 	}
 
-	// Fallback: copy files from the shared directory
 	return copySkillDir(absTarget, linkPath, opts)
 }
 
-// copySkillDir copies all files from src to dst as a fallback when symlinks fail.
 func copySkillDir(src, dst string, opts cmdutil.Options) error {
 	if err := os.MkdirAll(dst, 0755); err != nil { //nolint:gosec // G301: skill files are not secrets
 		return fmt.Errorf("could not create directory %s: %w", dst, err)

--- a/internal/cmd/skill/skill_test.go
+++ b/internal/cmd/skill/skill_test.go
@@ -23,6 +23,13 @@ func setInteractive(t *testing.T, interactive bool) {
 	t.Cleanup(func() { prompt.IsInteractive = orig })
 }
 
+func overrideHomeDir(t *testing.T, dir string) {
+	t.Helper()
+	orig := userHomeDir
+	userHomeDir = func() (string, error) { return dir, nil }
+	t.Cleanup(func() { userHomeDir = orig })
+}
+
 func rootWithSkill() *cobra.Command {
 	root := &cobra.Command{Use: "gumroad"}
 	root.AddCommand(NewSkillCmd())
@@ -42,7 +49,7 @@ func TestSkill_NonTTY_PrintsToStdout(t *testing.T) {
 	}
 
 	got := stdout.String()
-	if !strings.Contains(got, "name: gumroad-cli") {
+	if !strings.Contains(got, "name: gumroad") {
 		t.Errorf("expected skill content, got %q", got[:min(len(got), 200)])
 	}
 	if !strings.Contains(got, "gumroad products list") {
@@ -60,7 +67,7 @@ func TestSkill_NoInput_PrintsToStdout(t *testing.T) {
 	}
 
 	got := stdout.String()
-	if !strings.Contains(got, "name: gumroad-cli") {
+	if !strings.Contains(got, "name: gumroad") {
 		t.Errorf("expected skill content with --no-input, got %q", got[:min(len(got), 200)])
 	}
 }
@@ -69,7 +76,6 @@ func TestSkill_PipedStdin_FallsBackToStdout(t *testing.T) {
 	output.SetStdoutIsTerminalForTesting(true)
 	defer output.ResetStdoutIsTerminalForTesting()
 
-	// Simulate piped stdin (non-interactive reader)
 	r, w, err := os.Pipe()
 	if err != nil {
 		t.Fatal(err)
@@ -85,7 +91,7 @@ func TestSkill_PipedStdin_FallsBackToStdout(t *testing.T) {
 		t.Fatalf("expected fallback to stdout, got error: %v", runErr)
 	}
 
-	if !strings.Contains(stdout.String(), "name: gumroad-cli") {
+	if !strings.Contains(stdout.String(), "name: gumroad") {
 		t.Error("expected skill content on stdout when stdin is piped")
 	}
 }
@@ -97,9 +103,6 @@ func TestSkillInstall_CustomPath(t *testing.T) {
 	cmd := testutil.Command(newInstallCmd(), testutil.Quiet(false))
 	cmd.SetArgs([]string{"--path", path})
 
-	var stderr bytes.Buffer
-	cmd.SetErr(&stderr)
-
 	err := cmd.Execute()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -109,61 +112,107 @@ func TestSkillInstall_CustomPath(t *testing.T) {
 	if readErr != nil {
 		t.Fatalf("could not read installed file: %v", readErr)
 	}
-	if !strings.Contains(string(content), "name: gumroad-cli") {
+	if !strings.Contains(string(content), "name: gumroad") {
 		t.Error("installed file does not contain expected skill content")
 	}
 }
 
 func TestSkillInstall_DefaultLocations(t *testing.T) {
-	dir := t.TempDir()
-
-	// Create a fake ~/.claude dir so symlink path triggers
-	claudeDir := filepath.Join(dir, ".claude")
-	if err := os.MkdirAll(claudeDir, 0755); err != nil {
-		t.Fatalf("could not create claude dir: %v", err)
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks require elevated privileges on Windows")
 	}
 
-	// Override userHomeDir for the install command
-	origHome := userHomeDir
-	userHomeDir = func() (string, error) { return dir, nil }
-	t.Cleanup(func() { userHomeDir = origHome })
+	dir := t.TempDir()
+	overrideHomeDir(t, dir)
+
+	// Create ~/.claude so symlink triggers
+	if err := os.MkdirAll(filepath.Join(dir, ".claude"), 0755); err != nil {
+		t.Fatal(err)
+	}
 
 	cmd := testutil.Command(newInstallCmd())
-
-	var stderr bytes.Buffer
-	cmd.SetErr(&stderr)
-
 	err := cmd.RunE(cmd, []string{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Verify shared file was written
-	sharedPath := filepath.Join(dir, ".agents", skillRelPath)
-	if _, statErr := os.Stat(sharedPath); statErr != nil {
-		t.Errorf("expected shared file at %s", sharedPath)
+	// Verify shared file
+	sharedFile := filepath.Join(dir, ".agents", skillRelPath)
+	if _, statErr := os.Stat(sharedFile); statErr != nil {
+		t.Errorf("expected shared file at %s", sharedFile)
 	}
 
-	// Verify symlink was created
-	claudeSkillPath := filepath.Join(dir, ".claude", skillRelPath)
-	info, statErr := os.Lstat(claudeSkillPath)
+	// Verify directory symlink at ~/.claude/skills/gumroad
+	claudeSkillDir := filepath.Join(dir, ".claude", skillDirName)
+	info, statErr := os.Lstat(claudeSkillDir)
 	if statErr != nil {
-		t.Errorf("expected symlink at %s", claudeSkillPath)
-	} else if info.Mode()&os.ModeSymlink == 0 {
-		t.Errorf("expected symlink at %s, got regular file", claudeSkillPath)
+		t.Fatalf("expected symlink dir at %s: %v", claudeSkillDir, statErr)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("expected directory symlink at %s, got mode %v", claudeSkillDir, info.Mode())
 	}
 
-	// Verify symlink target resolves to correct content
-	content, readErr := os.ReadFile(claudeSkillPath)
+	// Verify symlink target is relative
+	target, _ := os.Readlink(claudeSkillDir)
+	if !strings.HasPrefix(target, "..") {
+		t.Errorf("expected relative symlink target, got %q", target)
+	}
+
+	// Verify content resolves through symlink
+	content, readErr := os.ReadFile(filepath.Join(claudeSkillDir, skillFileName))
 	if readErr != nil {
 		t.Fatalf("could not read through symlink: %v", readErr)
 	}
-	if !strings.Contains(string(content), "name: gumroad-cli") {
-		t.Error("symlinked file does not contain expected skill content")
+	if !strings.Contains(string(content), "name: gumroad") {
+		t.Error("symlinked file does not contain expected content")
+	}
+}
+
+func TestSkillInstall_FallbackCopyOnSymlinkFailure(t *testing.T) {
+	dir := t.TempDir()
+	overrideHomeDir(t, dir)
+
+	if err := os.MkdirAll(filepath.Join(dir, ".claude"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write shared baseline first
+	content, _ := readSkill()
+	sharedDir := filepath.Join(dir, ".agents", skillDirName)
+	if err := os.MkdirAll(sharedDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sharedDir, skillFileName), content, 0644); err != nil { //nolint:gosec // G306: test file
+		t.Fatal(err)
+	}
+
+	// Pre-create a regular file at the symlink target to block symlink creation
+	claudeSkillDir := filepath.Join(dir, ".claude", skillDirName)
+	if err := os.MkdirAll(claudeSkillDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// linkOrCopySkillDir uses RemoveAll first, so it will remove the dir and try symlink.
+	// To actually test the copy fallback, we need symlink to fail.
+	// This is hard to simulate portably. Instead, test copySkillDir directly.
+	dstDir := filepath.Join(dir, "copy-target")
+	opts := testutil.TestOptions()
+	err := copySkillDir(sharedDir, dstDir, opts)
+	if err != nil {
+		t.Fatalf("copySkillDir failed: %v", err)
+	}
+
+	copied, readErr := os.ReadFile(filepath.Join(dstDir, skillFileName))
+	if readErr != nil {
+		t.Fatalf("could not read copied file: %v", readErr)
+	}
+	if !strings.Contains(string(copied), "name: gumroad") {
+		t.Error("copied file missing expected content")
 	}
 }
 
 func TestSkillInstall_HomeError(t *testing.T) {
+	overrideHomeDir(t, "")
 	origHome := userHomeDir
 	userHomeDir = func() (string, error) { return "", fmt.Errorf("no home") }
 	t.Cleanup(func() { userHomeDir = origHome })
@@ -177,11 +226,7 @@ func TestSkillInstall_HomeError(t *testing.T) {
 
 func TestSkillInstall_NoClaudeDir(t *testing.T) {
 	dir := t.TempDir()
-	// Don't create .claude dir — symlink step should be skipped
-
-	origHome := userHomeDir
-	userHomeDir = func() (string, error) { return dir, nil }
-	t.Cleanup(func() { userHomeDir = origHome })
+	overrideHomeDir(t, dir)
 
 	cmd := testutil.Command(newInstallCmd())
 	err := cmd.RunE(cmd, []string{})
@@ -189,16 +234,14 @@ func TestSkillInstall_NoClaudeDir(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Shared file should exist
 	sharedPath := filepath.Join(dir, ".agents", skillRelPath)
 	if _, statErr := os.Stat(sharedPath); statErr != nil {
 		t.Errorf("expected shared file at %s", sharedPath)
 	}
 
-	// Claude symlink should NOT exist
-	claudeSkillPath := filepath.Join(dir, ".claude", skillRelPath)
-	if _, statErr := os.Stat(claudeSkillPath); statErr == nil {
-		t.Errorf("did not expect file at %s when ~/.claude doesn't exist", claudeSkillPath)
+	claudeSkillDir := filepath.Join(dir, ".claude", skillDirName)
+	if _, statErr := os.Stat(claudeSkillDir); statErr == nil {
+		t.Errorf("did not expect dir at %s when ~/.claude doesn't exist", claudeSkillDir)
 	}
 }
 
@@ -206,15 +249,13 @@ func TestSkillInstall_OverwritesExisting(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "SKILL.md")
 
-	// Write old content
 	if err := os.WriteFile(path, []byte("old content"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
 	cmd := testutil.Command(newInstallCmd())
 	cmd.SetArgs([]string{"--path", path})
-	err := cmd.Execute()
-	if err != nil {
+	if err := cmd.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -222,7 +263,7 @@ func TestSkillInstall_OverwritesExisting(t *testing.T) {
 	if strings.Contains(string(content), "old content") {
 		t.Error("expected old content to be overwritten")
 	}
-	if !strings.Contains(string(content), "name: gumroad-cli") {
+	if !strings.Contains(string(content), "name: gumroad") {
 		t.Error("expected new skill content")
 	}
 }
@@ -237,8 +278,7 @@ func TestSkillInstall_Quiet(t *testing.T) {
 	var stderr bytes.Buffer
 	cmd.SetErr(&stderr)
 
-	err := cmd.Execute()
-	if err != nil {
+	if err := cmd.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -255,24 +295,14 @@ func TestSkill_TTY_SelectInstallTarget(t *testing.T) {
 	dir := t.TempDir()
 	installPath := filepath.Join(dir, "SKILL.md")
 
-	origTargets := defaultTargets
-	defaultTargets = func() []installTarget {
-		return []installTarget{
-			{"Test", installPath},
-		}
-	}
-	t.Cleanup(func() { defaultTargets = origTargets })
-
 	origSelect := selectFunc
 	selectFunc = func(msg string, opts []prompt.SelectOption, in io.Reader, out io.Writer, noInput bool) (string, error) {
-		// Simulate choosing the first option (the install path)
-		return opts[0].Value, nil
+		return installPath, nil
 	}
 	t.Cleanup(func() { selectFunc = origSelect })
 
 	cmd := testutil.Command(NewSkillCmd(), testutil.NoInput(false))
-	err := cmd.RunE(cmd, []string{})
-	if err != nil {
+	if err := cmd.RunE(cmd, []string{}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -280,7 +310,7 @@ func TestSkill_TTY_SelectInstallTarget(t *testing.T) {
 	if readErr != nil {
 		t.Fatalf("expected file at %s: %v", installPath, readErr)
 	}
-	if !strings.Contains(string(content), "name: gumroad-cli") {
+	if !strings.Contains(string(content), "name: gumroad") {
 		t.Error("installed file missing expected content")
 	}
 }
@@ -290,12 +320,6 @@ func TestSkill_TTY_SelectStdout(t *testing.T) {
 	defer output.ResetStdoutIsTerminalForTesting()
 	setInteractive(t, true)
 
-	origTargets := defaultTargets
-	defaultTargets = func() []installTarget {
-		return []installTarget{{"Test", "/tmp/unused"}}
-	}
-	t.Cleanup(func() { defaultTargets = origTargets })
-
 	origSelect := selectFunc
 	selectFunc = func(msg string, opts []prompt.SelectOption, in io.Reader, out io.Writer, noInput bool) (string, error) {
 		return selectValPrint, nil
@@ -304,12 +328,11 @@ func TestSkill_TTY_SelectStdout(t *testing.T) {
 
 	var stdout bytes.Buffer
 	cmd := testutil.Command(NewSkillCmd(), testutil.NoInput(false), testutil.Stdout(&stdout))
-	err := cmd.RunE(cmd, []string{})
-	if err != nil {
+	if err := cmd.RunE(cmd, []string{}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if !strings.Contains(stdout.String(), "name: gumroad-cli") {
+	if !strings.Contains(stdout.String(), "name: gumroad") {
 		t.Error("expected skill content on stdout")
 	}
 }
@@ -318,12 +341,6 @@ func TestSkill_TTY_SelectError(t *testing.T) {
 	output.SetStdoutIsTerminalForTesting(true)
 	defer output.ResetStdoutIsTerminalForTesting()
 	setInteractive(t, true)
-
-	origTargets := defaultTargets
-	defaultTargets = func() []installTarget {
-		return []installTarget{{"Test", "/tmp/unused"}}
-	}
-	t.Cleanup(func() { defaultTargets = origTargets })
 
 	origSelect := selectFunc
 	selectFunc = func(msg string, opts []prompt.SelectOption, in io.Reader, out io.Writer, noInput bool) (string, error) {
@@ -338,136 +355,188 @@ func TestSkill_TTY_SelectError(t *testing.T) {
 	}
 }
 
-func TestDefaultTargets_NoHome(t *testing.T) {
-	origHome := userHomeDir
-	userHomeDir = func() (string, error) { return "", fmt.Errorf("no home") }
-	t.Cleanup(func() { userHomeDir = origHome })
+func TestExpandPath(t *testing.T) {
+	overrideHomeDir(t, "/fakehome")
 
-	targets := defaultTargets()
-	if len(targets) != 1 {
-		t.Fatalf("expected 1 target without HOME, got %d", len(targets))
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"~/.agents/skills", "/fakehome/.agents/skills"},
+		{".claude/skills", ".claude/skills"},
+		{"/absolute/path", "/absolute/path"},
 	}
-	if targets[0].Label != "Claude Code (Project)" {
-		t.Errorf("expected project target, got %q", targets[0].Label)
-	}
-}
-
-func TestDefaultTargets_WithHome(t *testing.T) {
-	origHome := userHomeDir
-	userHomeDir = func() (string, error) { return "/fakehome", nil }
-	t.Cleanup(func() { userHomeDir = origHome })
-
-	targets := defaultTargets()
-	if len(targets) != 5 {
-		t.Fatalf("expected 5 targets with HOME, got %d", len(targets))
+	for _, tt := range tests {
+		got := expandPath(tt.input)
+		if got != tt.want {
+			t.Errorf("expandPath(%q) = %q, want %q", tt.input, got, tt.want)
+		}
 	}
 }
 
-func TestSkillInstall_ReplacesExistingSymlink(t *testing.T) {
+func TestCodexGlobalSkillPath_Default(t *testing.T) {
+	t.Setenv("CODEX_HOME", "")
+	path := codexGlobalSkillPath()
+	if !strings.Contains(path, ".codex") {
+		t.Errorf("expected default codex path, got %q", path)
+	}
+}
+
+func TestCodexGlobalSkillPath_CustomHome(t *testing.T) {
+	t.Setenv("CODEX_HOME", "/custom/codex")
+	path := codexGlobalSkillPath()
+	if !strings.HasPrefix(path, "/custom/codex") {
+		t.Errorf("expected custom codex path, got %q", path)
+	}
+}
+
+func TestLinkOrCopySkillDir_Symlink(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlinks require elevated privileges on Windows")
 	}
 
 	dir := t.TempDir()
-	linkPath := filepath.Join(dir, "link")
-	target1 := filepath.Join(dir, "target1")
-	target2 := filepath.Join(dir, "target2")
+	srcDir := filepath.Join(dir, "src")
+	if err := os.MkdirAll(srcDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "SKILL.md"), []byte("content"), 0644); err != nil { //nolint:gosec // G306: test
+		t.Fatal(err)
+	}
 
-	if err := os.WriteFile(target1, []byte("old"), 0600); err != nil {
+	linkPath := filepath.Join(dir, "link")
+	opts := testutil.TestOptions()
+	if err := linkOrCopySkillDir(linkPath, srcDir, srcDir, opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	info, _ := os.Lstat(linkPath)
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Error("expected symlink")
+	}
+}
+
+func TestLinkOrCopySkillDir_ExistingDirFallsToCopy(t *testing.T) {
+	dir := t.TempDir()
+	srcDir := filepath.Join(dir, "src")
+	if err := os.MkdirAll(srcDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(target2, []byte("new"), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(srcDir, "SKILL.md"), []byte("skill"), 0644); err != nil { //nolint:gosec // G306: test
 		t.Fatal(err)
 	}
-	if err := os.Symlink(target1, linkPath); err != nil {
+
+	// Pre-create a real directory at the link path
+	linkPath := filepath.Join(dir, "link")
+	if err := os.MkdirAll(linkPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Put a custom file the user might have
+	if err := os.WriteFile(filepath.Join(linkPath, "custom.txt"), []byte("user data"), 0644); err != nil { //nolint:gosec // G306: test
 		t.Fatal(err)
 	}
 
 	opts := testutil.TestOptions()
-	err := symlinkSkillFile(linkPath, target2, opts)
-	if err != nil {
+	if err := linkOrCopySkillDir(linkPath, "../src", srcDir, opts); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	resolved, _ := os.Readlink(linkPath)
-	if resolved != target2 {
-		t.Errorf("expected symlink to %s, got %s", target2, resolved)
+	// SKILL.md should be copied
+	data, _ := os.ReadFile(filepath.Join(linkPath, "SKILL.md"))
+	if string(data) != "skill" {
+		t.Errorf("expected copied SKILL.md, got %q", string(data))
+	}
+
+	// User's custom file should be preserved
+	custom, _ := os.ReadFile(filepath.Join(linkPath, "custom.txt"))
+	if string(custom) != "user data" {
+		t.Error("expected user's custom.txt to be preserved")
 	}
 }
 
-func TestSymlinkSkillFile_InvalidDir(t *testing.T) {
+func TestLinkOrCopySkillDir_ReplacesExistingSymlink(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlinks require elevated privileges on Windows")
 	}
 
 	dir := t.TempDir()
-	// Use a file as parent to make MkdirAll fail (cross-platform)
+	srcDir := filepath.Join(dir, "src")
+	if err := os.MkdirAll(srcDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "SKILL.md"), []byte("new"), 0644); err != nil { //nolint:gosec // G306: test
+		t.Fatal(err)
+	}
+
+	// Create an old symlink pointing elsewhere
+	linkPath := filepath.Join(dir, "link")
+	oldTarget := filepath.Join(dir, "old")
+	if err := os.MkdirAll(oldTarget, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(oldTarget, linkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := testutil.TestOptions()
+	if err := linkOrCopySkillDir(linkPath, srcDir, srcDir, opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should be a new symlink to srcDir
+	target, _ := os.Readlink(linkPath)
+	if target != srcDir {
+		t.Errorf("expected symlink to %s, got %s", srcDir, target)
+	}
+}
+
+func TestLinkOrCopySkillDir_InvalidParent(t *testing.T) {
+	dir := t.TempDir()
 	blocker := filepath.Join(dir, "blocker")
 	if err := os.WriteFile(blocker, []byte("x"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
 	opts := testutil.TestOptions()
-	err := symlinkSkillFile(filepath.Join(blocker, "sub", "link"), filepath.Join(dir, "target"), opts)
+	err := linkOrCopySkillDir(filepath.Join(blocker, "sub", "link"), "../src", dir, opts)
 	if err == nil {
-		t.Fatal("expected error for invalid directory")
-	}
-	if !strings.Contains(err.Error(), "could not create directory") {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatal("expected error for invalid parent directory")
 	}
 }
 
-func TestSymlinkSkillFile_Success(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("symlinks require elevated privileges on Windows")
-	}
-
+func TestCopySkillDir_InvalidSrc(t *testing.T) {
 	dir := t.TempDir()
-	targetPath := filepath.Join(dir, "target")
-	if err := os.WriteFile(targetPath, []byte("content"), 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	linkPath := filepath.Join(dir, "sub", "link")
 	opts := testutil.TestOptions()
-	err := symlinkSkillFile(linkPath, targetPath, opts)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	resolved, _ := os.Readlink(linkPath)
-	if resolved != targetPath {
-		t.Errorf("expected symlink to %s, got %s", targetPath, resolved)
+	err := copySkillDir(filepath.Join(dir, "nonexistent"), filepath.Join(dir, "dst"), opts)
+	if err == nil {
+		t.Fatal("expected error for nonexistent source")
 	}
 }
 
-func TestSymlinkSkillFile_NoExistingFile(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("symlinks require elevated privileges on Windows")
-	}
-
+func TestCopySkillDir(t *testing.T) {
 	dir := t.TempDir()
-	targetPath := filepath.Join(dir, "target")
-	if err := os.WriteFile(targetPath, []byte("content"), 0600); err != nil {
+	srcDir := filepath.Join(dir, "src")
+	if err := os.MkdirAll(srcDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "SKILL.md"), []byte("skill"), 0644); err != nil { //nolint:gosec // G306: test
 		t.Fatal(err)
 	}
 
-	linkPath := filepath.Join(dir, "newlink")
+	dstDir := filepath.Join(dir, "dst")
 	opts := testutil.TestOptions()
-	err := symlinkSkillFile(linkPath, targetPath, opts)
-	if err != nil {
+	if err := copySkillDir(srcDir, dstDir, opts); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	resolved, _ := os.Readlink(linkPath)
-	if resolved != targetPath {
-		t.Errorf("expected symlink to %s, got %s", targetPath, resolved)
+	data, _ := os.ReadFile(filepath.Join(dstDir, "SKILL.md"))
+	if string(data) != "skill" {
+		t.Errorf("got %q", string(data))
 	}
 }
 
 func TestWriteSkillFile_InvalidPath(t *testing.T) {
 	dir := t.TempDir()
-	// Use a file as parent to make MkdirAll fail (cross-platform)
 	blocker := filepath.Join(dir, "blocker")
 	if err := os.WriteFile(blocker, []byte("x"), 0600); err != nil {
 		t.Fatal(err)
@@ -503,8 +572,7 @@ func TestWriteSkillFile_Success(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "nested", "SKILL.md")
 	opts := testutil.TestOptions()
-	err := writeSkillFile(path, []byte("skill content"), opts)
-	if err != nil {
+	if err := writeSkillFile(path, []byte("skill content"), opts); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	data, _ := os.ReadFile(path)
@@ -555,8 +623,7 @@ func TestSkill_Help(t *testing.T) {
 	var stdout bytes.Buffer
 	root.SetOut(&stdout)
 
-	err := root.Execute()
-	if err != nil {
+	if err := root.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -573,8 +640,7 @@ func TestSkillInstall_Help(t *testing.T) {
 	var stdout bytes.Buffer
 	root.SetOut(&stdout)
 
-	err := root.Execute()
-	if err != nil {
+	if err := root.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 

--- a/internal/cmd/skill/skill_test.go
+++ b/internal/cmd/skill/skill_test.go
@@ -362,7 +362,7 @@ func TestExpandPath(t *testing.T) {
 		input string
 		want  string
 	}{
-		{"~/.agents/skills", "/fakehome/.agents/skills"},
+		{"~/.agents/skills", filepath.Join("/fakehome", ".agents", "skills")},
 		{".claude/skills", ".claude/skills"},
 		{"/absolute/path", "/absolute/path"},
 	}
@@ -385,7 +385,7 @@ func TestCodexGlobalSkillPath_Default(t *testing.T) {
 func TestCodexGlobalSkillPath_CustomHome(t *testing.T) {
 	t.Setenv("CODEX_HOME", "/custom/codex")
 	path := codexGlobalSkillPath()
-	if !strings.HasPrefix(path, "/custom/codex") {
+	if !strings.Contains(path, "custom") || !strings.Contains(path, "codex") {
 		t.Errorf("expected custom codex path, got %q", path)
 	}
 }

--- a/skills/embed_test.go
+++ b/skills/embed_test.go
@@ -15,7 +15,7 @@ func TestSkillMarkdown_ReturnsContent(t *testing.T) {
 	}
 
 	content := string(data)
-	if !strings.Contains(content, "name: gumroad-cli") {
+	if !strings.Contains(content, "name: gumroad") {
 		t.Error("expected frontmatter with name")
 	}
 	if !strings.Contains(content, "gumroad products list") {

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -122,10 +122,6 @@ gumroad sales view <id> --json --no-input
 gumroad sales refund <id> --yes --json --no-input
 gumroad sales refund <id> --amount 5.00 --yes --json --no-input
 
-# Mark as shipped
-gumroad sales ship <id> --json --no-input
-gumroad sales ship <id> --tracking-url https://track.example.com/123 --json --no-input
-
 # Resend receipt
 gumroad sales resend-receipt <id> --json --no-input
 ```

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -1,78 +1,258 @@
 ---
-name: gumroad-cli
-description: Use the `gumroad` CLI to look up and manage Gumroad data from the terminal. Trigger when the user asks about Gumroad products, sales, subscribers, licenses, payouts, offer codes, webhooks, or any Gumroad data lookup. Also trigger on "check my Gumroad", "look up a sale", "verify a license", "list my products", or any request to query or act on Gumroad data. Do NOT trigger for Gumroad web UI, Rails, or codebase questions.
+name: gumroad
+description: >
+  Use the `gumroad` CLI to look up and manage Gumroad data from the terminal.
+  Trigger when the user asks about Gumroad products, sales, subscribers,
+  licenses, payouts, offer codes, webhooks, or any Gumroad data lookup.
+  Also trigger on "check my Gumroad", "look up a sale", "verify a license",
+  "list my products", "how much have I made", "who bought", "recent sales",
+  "refund a sale", "create a product", "manage webhooks", "check my earnings",
+  "see my revenue", "who subscribed", "manage my store", "discount code",
+  "coupon", "shipping status", "payout schedule", or any request to query
+  or act on Gumroad data — even if the user doesn't say "Gumroad" explicitly
+  but is clearly referring to their creator store or digital product sales.
+  Do NOT trigger for Gumroad web UI, Rails, or codebase questions.
 ---
 
 # gumroad CLI
 
-Use `gumroad` (Gumroad CLI) to query and manage Gumroad data. Always use `--json` for programmatic access and `--no-input` to prevent interactive prompts from hanging.
+Use `gumroad` (Gumroad CLI) to query and manage Gumroad data.
 
-## Key flags
+## Agent invariants
 
-```
---json          Structured JSON output (always use this)
---jq <expr>     Filter JSON (avoids parsing full response)
---no-input      Fail instead of prompting (prevents hangs)
---yes           Auto-confirm destructive ops (delete, refund)
---quiet         Suppress spinners and status messages
-```
+Always follow these rules:
 
-## Common patterns
+- **Always** pass `--no-input` to prevent interactive prompts from blocking.
+- **Always** pass `--json` for programmatic access.
+- Use `--json --jq <expr>` together to extract exactly what you need.
+- For destructive operations (delete, refund), add `--yes` to skip confirmation.
+- Pass `--quiet` to suppress spinners and status messages.
+- Pass `--dry-run` to preview mutating requests without executing them.
+- Use `--page-delay 200ms` with `--all` to avoid rate limits on large datasets.
+- Prices are in whole currency units (e.g. `--price 10.00` for $10), not cents. The CLI converts internally. Use `--currency eur` to change currency.
+- Products are created as drafts — use `gumroad products publish <id>` to make them live.
+- If a command fails with an auth error, tell the user to run `gumroad auth login` interactively — agents cannot do this step.
+
+## Response shapes
+
+Responses are wrapped in `{"success": true, ...}` with resource-specific keys:
+
+- `user` → `.user`
+- `products list` → `.products[]`
+- `products view` → `.product`
+- `sales list` → `.sales[]`
+- `sales view` → `.sale`
+- `payouts list` → `.payouts[]`, `payouts view/upcoming` → `.payout`
+- `subscribers list` → `.subscribers[]`, `subscribers view` → `.subscriber`
+- `licenses verify` → `.purchase`
+- `offer-codes list` → `.offer_codes[]`
+- `variant-categories list` → `.variant_categories[]`
+- `variants list` → `.variants[]`
+- `webhooks list` → `.resource_subscriptions[]`
+
+## Commands
+
+### auth — Manage authentication
 
 ```sh
-# Check auth status
+# Check auth (do this first if unsure)
 gumroad auth status --no-input
 
+# Login requires interactive input — tell the user to run it themselves
+# gumroad auth login
+
+# Logout
+gumroad auth logout --no-input
+```
+
+### user — Account info
+
+```sh
+gumroad user --json --no-input
+gumroad user --json --jq '.user.email' --no-input
+```
+
+### products — Manage products
+
+```sh
 # List all products
 gumroad products list --json --no-input
 
+# View a product
+gumroad products view <id> --json --no-input
+
 # Create a product (created as draft)
 gumroad products create --name "Art Pack" --price 10.00 --json --no-input
+gumroad products create --name "Newsletter" --type membership --subscription-duration monthly --json --no-input
+gumroad products create --name "E-Book" --type ebook --price 5 --tag art --tag digital --json --no-input
 
-# Get a specific product
-gumroad products view <id> --json --no-input
+# Update a product
+gumroad products update <id> --name "New Name" --json --no-input
+gumroad products update <id> --price 15.00 --currency eur --json --no-input
+
+# Publish / unpublish
+gumroad products publish <id> --json --no-input
+gumroad products unpublish <id> --json --no-input
+
+# Delete (destructive — needs --yes)
+gumroad products delete <id> --yes --json --no-input
+
+# List SKUs for a product
+gumroad products skus <id> --json --no-input
+```
+
+**Create flags:** `--name` (required), `--price`, `--type` (digital|course|ebook|membership|bundle|coffee|call|commission), `--currency`, `--pay-what-you-want`, `--suggested-price`, `--description`, `--custom-summary`, `--custom-permalink`, `--custom-receipt`, `--max-purchase-count`, `--taxonomy-id`, `--tag` (repeatable).
+
+### sales — Manage sales
+
+```sh
+# List sales (paginated)
+gumroad sales list --json --no-input
+gumroad sales list --product <id> --after 2024-01-01 --json --no-input
+gumroad sales list --email user@example.com --json --no-input
+gumroad sales list --all --json --no-input
 
 # Find a sale by email
 gumroad sales list --json --jq '.sales[] | select(.email == "user@example.com")' --no-input
 
-# Get recent sales for a product
-gumroad sales list --product <id> --after 2026-01-01 --json --no-input
+# View a sale
+gumroad sales view <id> --json --no-input
 
-# Extract a single field
-gumroad user --json --jq '.user.email' --no-input
+# Refund (destructive — needs --yes)
+gumroad sales refund <id> --yes --json --no-input
+gumroad sales refund <id> --amount 5.00 --yes --json --no-input
 
-# Verify a license key
-gumroad licenses verify --product <id> --key <key> --no-increment --json --no-input
+# Mark as shipped
+gumroad sales ship <id> --json --no-input
+gumroad sales ship <id> --tracking-url https://track.example.com/123 --json --no-input
 
-# List subscribers
-gumroad subscribers list --product <id> --json --no-input
+# Resend receipt
+gumroad sales resend-receipt <id> --json --no-input
+```
 
-# Check upcoming payouts
+**List filters:** `--product`, `--order`, `--email`, `--after` (YYYY-MM-DD), `--before` (YYYY-MM-DD), `--all`, `--page-key`.
+
+### payouts — View payouts
+
+```sh
+# List payouts
+gumroad payouts list --json --no-input
+gumroad payouts list --after 2024-01-01 --before 2024-12-31 --json --no-input
+gumroad payouts list --all --json --no-input
+
+# View a payout
+gumroad payouts view <id> --json --no-input
+gumroad payouts view <id> --include-transactions --json --no-input
+
+# Upcoming payout
 gumroad payouts upcoming --json --no-input
 ```
 
-## Available commands
+**List filters:** `--after`, `--before`, `--all`, `--page-key`, `--no-upcoming`.
+**View flags:** `--include-transactions`, `--no-sales`.
 
-```
-auth           login, status, logout
-user           Account info
-products       create, update, list, view, delete, publish, unpublish, skus
-sales          list, view, refund, ship, resend-receipt
-payouts        list, view, upcoming
-subscribers    list, view
-licenses       verify, enable, disable, decrement, rotate
-offer-codes    list, view, create, update, delete
-variant-categories  list, view, create, update, delete
-variants       list, view, create, update, delete
-custom-fields  list, create, update, delete
-webhooks       list, create, delete
+### subscribers — View subscribers
+
+```sh
+gumroad subscribers list --product <id> --json --no-input
+gumroad subscribers list --product <id> --email user@example.com --json --no-input
+gumroad subscribers list --product <id> --all --json --no-input
+gumroad subscribers view <id> --json --no-input
 ```
 
-## Important notes
+**List flags:** `--product` (required), `--email`, `--all`, `--page-key`.
 
-- Always include `--no-input` to prevent the CLI from blocking on interactive prompts.
-- Use `--json --jq` together to extract exactly what you need without parsing.
-- Products are created as drafts — use `gumroad products publish <id>` to publish.
-- If `gumroad auth status` fails, the user needs to run `gumroad auth login` interactively.
-- For destructive operations (delete, refund), add `--yes` to skip confirmation.
-- Run `gumroad <command> --help` for flag details on any specific command.
+### licenses — Manage license keys
+
+License keys are passed via stdin. Never pass keys as command-line arguments.
+
+```sh
+# Verify without incrementing use count
+echo "$LICENSE_KEY" | gumroad licenses verify --product <id> --no-increment --json --no-input
+
+# Verify (increments use count)
+echo "$LICENSE_KEY" | gumroad licenses verify --product <id> --json --no-input
+
+# Enable / disable
+echo "$LICENSE_KEY" | gumroad licenses enable --product <id> --json --no-input
+echo "$LICENSE_KEY" | gumroad licenses disable --product <id> --json --no-input
+
+# Decrement use count
+echo "$LICENSE_KEY" | gumroad licenses decrement --product <id> --json --no-input
+
+# Rotate (regenerate) key
+echo "$LICENSE_KEY" | gumroad licenses rotate --product <id> --json --no-input
+```
+
+**All subcommands require** `--product <id>`. Key comes from stdin.
+
+### offer-codes — Manage discount codes
+
+```sh
+# List offer codes for a product
+gumroad offer-codes list --product <id> --json --no-input
+
+# Create (percent or flat, not both)
+gumroad offer-codes create --product <id> --name SAVE10 --percent-off 10 --json --no-input
+gumroad offer-codes create --product <id> --name FLAT5 --amount 5.00 --json --no-input
+
+# View / update / delete
+gumroad offer-codes view <code_id> --product <id> --json --no-input
+gumroad offer-codes update <code_id> --product <id> --max-purchase-count 100 --json --no-input
+gumroad offer-codes delete <code_id> --product <id> --yes --json --no-input
+```
+
+**Create flags:** `--product` (required), `--name` (required), `--percent-off` OR `--amount`, `--max-purchase-count`, `--universal`.
+
+### variant-categories — Manage variant categories
+
+```sh
+gumroad variant-categories list --product <id> --json --no-input
+gumroad variant-categories create --product <id> --title "Size" --json --no-input
+gumroad variant-categories view <cat_id> --product <id> --json --no-input
+gumroad variant-categories update <cat_id> --product <id> --title "Color" --json --no-input
+gumroad variant-categories delete <cat_id> --product <id> --yes --json --no-input
+```
+
+### variants — Manage variants within a category
+
+```sh
+gumroad variants list --product <id> --category <cat_id> --json --no-input
+gumroad variants create --product <id> --category <cat_id> --name "Large" --json --no-input
+gumroad variants create --product <id> --category <cat_id> --name "XL" --price-difference 5.00 --json --no-input
+gumroad variants view <var_id> --product <id> --category <cat_id> --json --no-input
+gumroad variants update <var_id> --product <id> --category <cat_id> --name "Medium" --json --no-input
+gumroad variants delete <var_id> --product <id> --category <cat_id> --yes --json --no-input
+```
+
+**All subcommands require** `--product` and `--category`.
+
+### custom-fields — Manage product custom fields
+
+Custom fields are keyed by name, not ID.
+
+```sh
+gumroad custom-fields list --product <id> --json --no-input
+gumroad custom-fields create --product <id> --name "Company" --required --json --no-input
+gumroad custom-fields update --product <id> --name "Company" --required --json --no-input
+gumroad custom-fields delete --product <id> --name "Company" --yes --json --no-input
+```
+
+### webhooks — Manage webhook subscriptions
+
+```sh
+# List (--resource is required)
+gumroad webhooks list --resource sale --json --no-input
+
+# Create
+gumroad webhooks create --resource sale --url https://example.com/hook --json --no-input
+
+# Delete
+gumroad webhooks delete <id> --yes --json --no-input
+```
+
+## Tips
+
+- Use `--all` with `sales list`, `subscribers list`, `payouts list` to fetch every page automatically.
+- Use `--plain` for tab-separated output suitable for `cut`, `awk`, and other Unix tools.
+- Run `gumroad <command> --help` for full flag details on any command.


### PR DESCRIPTION
Fixes antiwork/gumroad#4408

## What

Completes the remaining checklist items from #4408 (PR 1 shipped the infrastructure in #22):

**Expanded SKILL.md** — documents every subcommand with examples, flags, and agent-specific notes. Adds trigger patterns for natural language, agent invariants (`--no-input`, `--json`, `--yes` for destructive ops), response shape reference for jq filters, price format clarification (whole currency units, not cents), and auth error recovery guidance.

**Auto-refresh on version change** — on every CLI invocation, `AutoRefresh` checks a `.last-skill-version` sentinel in the config directory. When the CLI version changes, it silently refreshes all installed skill files that already exist. It never creates new installs. The sentinel only advances when all writes succeed.

**Improved install mechanism**:
- Directory-level relative symlinks for Claude Code (`~/.claude/skills/gumroad → ../../.agents/skills/gumroad`)
- Falls back to file copy when symlinks are unavailable (Windows)
- Protects user data — Lstat guard prevents `RemoveAll` on user-populated directories
- `CODEX_HOME` env var support for custom Codex install paths
- `0644` permissions for skill files
- `os.Stat` for refresh so symlinked files get their targets updated

## Why

The first PR embedded the skill and added the `gumroad skill` command, but the SKILL.md content was minimal and there was no mechanism to keep installed skills in sync with CLI upgrades. This PR ensures agents have complete command documentation, and that upgrading the CLI automatically refreshes the skill everywhere it's installed.

---

This PR was implemented with AI assistance using Claude Opus 4.6 and gpt‑5.4 xhigh