### PR TITLE
Require confirmation for licenses rotate and decrement

### DIFF
--- a/internal/cmd/licenses/decrement.go
+++ b/internal/cmd/licenses/decrement.go
@@ -13,7 +13,10 @@ func newDecrementCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "decrement",
 		Short: "Decrement the use count of a license key",
-		Args:  cmdutil.ExactArgs(0),
+		Long: `Decrement the use count of a license key. This cannot be undone.
+
+Requires confirmation. Use --yes to skip when piping the key via stdin.`,
+		Args: cmdutil.ExactArgs(0),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
 			if product == "" {
@@ -29,7 +32,7 @@ func newDecrementCmd() *cobra.Command {
 				return err
 			}
 			if !ok {
-				return cmdutil.PrintCancelledAction(opts, "decrement license use count", product)
+				return cmdutil.PrintCancelledAction(opts, "decrement license use count for product "+product, product)
 			}
 
 			params := url.Values{}

--- a/internal/cmd/licenses/decrement.go
+++ b/internal/cmd/licenses/decrement.go
@@ -24,6 +24,14 @@ func newDecrementCmd() *cobra.Command {
 				return err
 			}
 
+			ok, err := cmdutil.ConfirmAction(opts, "Decrement license use count for product "+product+"?")
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return cmdutil.PrintCancelledAction(opts, "decrement license use count", product)
+			}
+
 			params := url.Values{}
 			params.Set("product_id", product)
 			params.Set("license_key", key)

--- a/internal/cmd/licenses/licenses_test.go
+++ b/internal/cmd/licenses/licenses_test.go
@@ -352,7 +352,7 @@ func TestDecrement_CorrectEndpoint(t *testing.T) {
 		testutil.JSON(t, w, map[string]any{})
 	})
 
-	cmd := newDecrementCmd()
+	cmd := testutil.Command(newDecrementCmd(), testutil.Yes(true))
 	cmd.SetArgs([]string{"--product", "p1", "--key", "K1"})
 	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
@@ -368,7 +368,7 @@ func TestRotate_ReturnsNewKey(t *testing.T) {
 		})
 	})
 
-	cmd := testutil.Command(newRotateCmd(), testutil.Quiet(false))
+	cmd := testutil.Command(newRotateCmd(), testutil.Yes(true), testutil.Quiet(false))
 	cmd.SetArgs([]string{"--product", "p1", "--key", "OLD-KEY"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
@@ -408,7 +408,7 @@ func TestDecrement_Output(t *testing.T) {
 		testutil.JSON(t, w, map[string]any{})
 	})
 
-	cmd := testutil.Command(newDecrementCmd(), testutil.Quiet(false))
+	cmd := testutil.Command(newDecrementCmd(), testutil.Yes(true), testutil.Quiet(false))
 	cmd.SetArgs([]string{"--product", "p1", "--key", "K1"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 	if !strings.Contains(out, "decremented") {
@@ -423,7 +423,7 @@ func TestRotate_JSON(t *testing.T) {
 		})
 	})
 
-	cmd := testutil.Command(newRotateCmd(), testutil.JSONOutput())
+	cmd := testutil.Command(newRotateCmd(), testutil.Yes(true), testutil.JSONOutput())
 	cmd.SetArgs([]string{"--product", "p1", "--key", "K1"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 	var resp struct {
@@ -460,7 +460,7 @@ func TestRotate_Plain(t *testing.T) {
 		})
 	})
 
-	cmd := testutil.Command(newRotateCmd(), testutil.PlainOutput())
+	cmd := testutil.Command(newRotateCmd(), testutil.Yes(true), testutil.PlainOutput())
 	cmd.SetArgs([]string{"--product", "p1", "--key", "K1"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 	if !strings.Contains(out, "NEW-PLAIN") {
@@ -475,7 +475,7 @@ func TestRotate_QuietStillPrintsNewKey(t *testing.T) {
 		})
 	})
 
-	cmd := testutil.Command(newRotateCmd(), testutil.Quiet(true))
+	cmd := testutil.Command(newRotateCmd(), testutil.Yes(true), testutil.Quiet(true))
 	cmd.SetArgs([]string{"--product", "p1", "--key", "K1"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 	if strings.TrimSpace(out) != "NEW-QUIET" {
@@ -534,7 +534,7 @@ func TestDecrement_JSON(t *testing.T) {
 		testutil.JSON(t, w, map[string]any{})
 	})
 
-	cmd := testutil.Command(newDecrementCmd(), testutil.JSONOutput())
+	cmd := testutil.Command(newDecrementCmd(), testutil.Yes(true), testutil.JSONOutput())
 	cmd.SetArgs([]string{"--product", "p1", "--key", "SECRET-KEY"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 	var resp struct {
@@ -586,7 +586,7 @@ func TestDecrement_APIError(t *testing.T) {
 		testutil.JSON(t, w, map[string]any{"message": "Error"})
 	})
 
-	cmd := newDecrementCmd()
+	cmd := testutil.Command(newDecrementCmd(), testutil.Yes(true))
 	cmd.SetArgs([]string{"--product", "p1", "--key", "K1"})
 	err := cmd.Execute()
 	if err == nil {
@@ -600,7 +600,7 @@ func TestRotate_APIError(t *testing.T) {
 		testutil.JSON(t, w, map[string]any{"message": "Error"})
 	})
 
-	cmd := newRotateCmd()
+	cmd := testutil.Command(newRotateCmd(), testutil.Yes(true))
 	cmd.SetArgs([]string{"--product", "p1", "--key", "K1"})
 	err := cmd.Execute()
 	if err == nil {
@@ -660,5 +660,37 @@ func TestRotate_FlagValidation(t *testing.T) {
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected error without --key")
+	}
+}
+
+func TestRotate_NoInputRequiresYes(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API")
+	})
+
+	cmd := testutil.Command(newRotateCmd(), testutil.NoInput(true))
+	cmd.SetArgs([]string{"--product", "p1", "--key", "K1"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error without confirmation")
+	}
+	if !strings.Contains(err.Error(), "--yes") {
+		t.Errorf("error should mention --yes: %v", err)
+	}
+}
+
+func TestDecrement_NoInputRequiresYes(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API")
+	})
+
+	cmd := testutil.Command(newDecrementCmd(), testutil.NoInput(true))
+	cmd.SetArgs([]string{"--product", "p1", "--key", "K1"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error without confirmation")
+	}
+	if !strings.Contains(err.Error(), "--yes") {
+		t.Errorf("error should mention --yes: %v", err)
 	}
 }

--- a/internal/cmd/licenses/rotate.go
+++ b/internal/cmd/licenses/rotate.go
@@ -16,7 +16,10 @@ func newRotateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "rotate",
 		Short: "Rotate (regenerate) a license key",
-		Args:  cmdutil.ExactArgs(0),
+		Long: `Rotate (regenerate) a license key. The old key is permanently invalidated.
+
+Requires confirmation. Use --yes to skip when piping the key via stdin.`,
+		Args: cmdutil.ExactArgs(0),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
 			if product == "" {
@@ -32,7 +35,7 @@ func newRotateCmd() *cobra.Command {
 				return err
 			}
 			if !ok {
-				return cmdutil.PrintCancelledAction(opts, "rotate license key", product)
+				return cmdutil.PrintCancelledAction(opts, "rotate license key for product "+product, product)
 			}
 
 			params := url.Values{}

--- a/internal/cmd/licenses/rotate.go
+++ b/internal/cmd/licenses/rotate.go
@@ -27,6 +27,14 @@ func newRotateCmd() *cobra.Command {
 				return err
 			}
 
+			ok, err := cmdutil.ConfirmAction(opts, "Rotate license key for product "+product+"?")
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return cmdutil.PrintCancelledAction(opts, "rotate license key", product)
+			}
+
 			params := url.Values{}
 			params.Set("product_id", product)
 			params.Set("license_key", key)


### PR DESCRIPTION
## What

Adds confirmation prompts to `licenses rotate` and `licenses decrement`. These are irreversible operations that previously executed without asking.

- `licenses rotate` regenerates the license key, permanently invalidating the old one
- `licenses decrement` reduces the use count, which can't be undone (there's no increment counterpart)

Both now prompt before executing, consistent with every other destructive command (delete, refund, logout). Skippable with `--yes`, fails with `--no-input` unless `--yes` is also set.

## Why

These two commands were the only irreversible mutations without confirmation. `enable`/`disable` are reversible toggles and don't need it. `verify` increments uses by default but that's reversible via `decrement`.

---

Built with Claude Opus 4.6 and gpt‑5.4 xhigh