### PR TITLE
Standardize help text descriptions

### DIFF
--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -31,9 +31,9 @@ func newLoginCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "login",
-		Short: "Authenticate with Gumroad",
+		Short: "Log in to Gumroad",
 		Args:  cmdutil.ExactArgs(0),
-		Long: `Authenticate with Gumroad via browser-based OAuth or a manual API token.
+		Long: `Log in to Gumroad via browser-based OAuth or a manual API token.
 
 By default, opens your browser for OAuth authorization.
 When stdin is piped (e.g. echo $TOKEN | gumroad auth login), reads a token directly.`,

--- a/internal/cmd/auth/logout.go
+++ b/internal/cmd/auth/logout.go
@@ -19,7 +19,7 @@ type logoutStatus struct {
 func newLogoutCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     "logout",
-		Short:   "Remove stored authentication token",
+		Short:   "Log out of Gumroad",
 		Args:    cmdutil.ExactArgs(0),
 		Example: "  gumroad auth logout",
 		RunE: func(c *cobra.Command, args []string) error {

--- a/internal/cmd/auth/status.go
+++ b/internal/cmd/auth/status.go
@@ -36,7 +36,7 @@ type authUser struct {
 func newStatusCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     "status",
-		Short:   "Show current authentication status",
+		Short:   "Show authentication status",
 		Args:    cmdutil.ExactArgs(0),
 		Example: "  gumroad auth status",
 		RunE: func(c *cobra.Command, args []string) error {

--- a/internal/cmd/categories/categories.go
+++ b/internal/cmd/categories/categories.go
@@ -8,7 +8,7 @@ func NewCategoriesCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "variant-categories",
 		Aliases: []string{"vc"},
-		Short:   "Manage product variant categories",
+		Short:   "Manage variant categories",
 		Example: `  gumroad variant-categories list --product <id>
   gumroad variant-categories create --product <id> --title "Size"`,
 	}

--- a/internal/cmd/customfields/customfields.go
+++ b/internal/cmd/customfields/customfields.go
@@ -8,7 +8,7 @@ func NewCustomFieldsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "custom-fields",
 		Aliases: []string{"cf"},
-		Short:   "Manage product custom fields",
+		Short:   "Manage custom fields",
 		Long:    "Manage custom fields for a product. Update and delete key by name, not ID.",
 		Example: `  gumroad custom-fields list --product <id>
   gumroad custom-fields create --product <id> --name "Company" --required`,

--- a/internal/cmd/customfields/delete.go
+++ b/internal/cmd/customfields/delete.go
@@ -10,7 +10,7 @@ func newDeleteCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "delete",
-		Short: "Delete a custom field (keyed by name)",
+		Short: "Delete a custom field",
 		Args:  cmdutil.ExactArgs(0),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)

--- a/internal/cmd/customfields/update.go
+++ b/internal/cmd/customfields/update.go
@@ -13,7 +13,7 @@ func newUpdateCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "update",
-		Short: "Update a custom field (keyed by name)",
+		Short: "Update a custom field",
 		Args:  cmdutil.ExactArgs(0),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)

--- a/internal/cmd/licenses/decrement.go
+++ b/internal/cmd/licenses/decrement.go
@@ -12,8 +12,8 @@ func newDecrementCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "decrement",
-		Short: "Decrement the use count of a license key",
-		Long: `Decrement the use count of a license key. This cannot be undone.
+		Short: "Decrement a license use count",
+		Long: `Decrement a license use count. This cannot be undone.
 
 Requires confirmation. Use --yes to skip when piping the key via stdin.`,
 		Args: cmdutil.ExactArgs(0),

--- a/internal/cmd/licenses/licenses.go
+++ b/internal/cmd/licenses/licenses.go
@@ -7,7 +7,7 @@ import (
 func NewLicensesCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "licenses",
-		Short: "Manage product licenses",
+		Short: "Manage licenses",
 		Example: `  echo "$LICENSE_KEY" | gumroad licenses verify --product <id> --no-increment
   echo "$LICENSE_KEY" | gumroad licenses enable --product <id>
   echo "$LICENSE_KEY" | gumroad licenses disable --product <id>`,

--- a/internal/cmd/licenses/rotate.go
+++ b/internal/cmd/licenses/rotate.go
@@ -15,8 +15,8 @@ func newRotateCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "rotate",
-		Short: "Rotate (regenerate) a license key",
-		Long: `Rotate (regenerate) a license key. The old key is permanently invalidated.
+		Short: "Rotate a license key",
+		Long: `Rotate a license key. The old key is permanently invalidated.
 
 Requires confirmation. Use --yes to skip when piping the key via stdin.`,
 		Args: cmdutil.ExactArgs(0),

--- a/internal/cmd/offercodes/offercodes.go
+++ b/internal/cmd/offercodes/offercodes.go
@@ -8,7 +8,7 @@ func NewOfferCodesCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "offer-codes",
 		Aliases: []string{"oc"},
-		Short:   "Manage product offer codes",
+		Short:   "Manage offer codes",
 		Example: `  gumroad offer-codes list --product <id>
   gumroad offer-codes create --product <id> --name SAVE10 --percent-off 10`,
 	}

--- a/internal/cmd/payouts/list.go
+++ b/internal/cmd/payouts/list.go
@@ -34,7 +34,7 @@ func newListCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List your payouts",
+		Short: "List payouts",
 		Args:  cmdutil.ExactArgs(0),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)

--- a/internal/cmd/payouts/payouts.go
+++ b/internal/cmd/payouts/payouts.go
@@ -7,7 +7,7 @@ import (
 func NewPayoutsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "payouts",
-		Short: "View your payouts",
+		Short: "View payouts",
 		Example: `  gumroad payouts list
   gumroad payouts view <id>
   gumroad payouts upcoming`,

--- a/internal/cmd/products/list.go
+++ b/internal/cmd/products/list.go
@@ -26,7 +26,7 @@ type productsListResponse struct {
 func newListCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     "list",
-		Short:   "List your products",
+		Short:   "List products",
 		Args:    cmdutil.ExactArgs(0),
 		Example: `  gumroad products list`,
 		RunE: func(c *cobra.Command, args []string) error {

--- a/internal/cmd/products/products.go
+++ b/internal/cmd/products/products.go
@@ -8,8 +8,8 @@ import (
 func NewProductsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "products",
-		Short: "Manage your Gumroad products",
-		Long: "Manage your Gumroad products.\n\n" +
+		Short: "Manage products",
+		Long: "Manage products.\n\n" +
 			"Create, update, list, view, delete, publish, and unpublish products. " +
 			"New products are created as drafts; use `gumroad products publish <id>` to publish.",
 		Example: `  gumroad products list

--- a/internal/cmd/sales/list.go
+++ b/internal/cmd/sales/list.go
@@ -32,7 +32,7 @@ func newListCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List your sales",
+		Short: "List sales",
 		Args:  cmdutil.ExactArgs(0),
 		Example: `  gumroad sales list
   gumroad sales list --product <id> --after 2024-01-01

--- a/internal/cmd/sales/resend_receipt.go
+++ b/internal/cmd/sales/resend_receipt.go
@@ -10,7 +10,7 @@ import (
 func newResendReceiptCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "resend-receipt <id>",
-		Short: "Resend the receipt for a sale",
+		Short: "Resend a receipt",
 		Args:  cmdutil.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)

--- a/internal/cmd/sales/sales.go
+++ b/internal/cmd/sales/sales.go
@@ -7,7 +7,7 @@ import (
 func NewSalesCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sales",
-		Short: "Manage your sales",
+		Short: "Manage sales",
 		Example: `  gumroad sales list
   gumroad sales view <id>
   gumroad sales refund <id>`,

--- a/internal/cmd/subscribers/subscribers.go
+++ b/internal/cmd/subscribers/subscribers.go
@@ -7,7 +7,7 @@ import (
 func NewSubscribersCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "subscribers",
-		Short: "Manage product subscribers",
+		Short: "View subscribers",
 		Example: `  gumroad subscribers list --product <id>
   gumroad subscribers view <id>`,
 	}

--- a/internal/cmd/user/user.go
+++ b/internal/cmd/user/user.go
@@ -23,7 +23,7 @@ type userResponse struct {
 func NewUserCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "user",
-		Short: "Show your Gumroad account info",
+		Short: "Show account info",
 		Args:  cmdutil.ExactArgs(0),
 		Example: `  gumroad user
   gumroad user --json

--- a/internal/cmd/variants/variants.go
+++ b/internal/cmd/variants/variants.go
@@ -7,7 +7,7 @@ import (
 func NewVariantsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "variants",
-		Short: "Manage product variants",
+		Short: "Manage variants",
 		Example: `  gumroad variants list --product <id> --category <cat_id>
   gumroad variants create --product <id> --category <cat_id> --name "Large"`,
 	}

--- a/internal/cmd/webhooks/create.go
+++ b/internal/cmd/webhooks/create.go
@@ -21,7 +21,7 @@ func newCreateCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create a webhook subscription",
+		Short: "Create a webhook",
 		Args:  cmdutil.ExactArgs(0),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)

--- a/internal/cmd/webhooks/delete.go
+++ b/internal/cmd/webhooks/delete.go
@@ -10,8 +10,8 @@ import (
 func newDeleteCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "delete <id>",
-		Short: "Delete a webhook subscription",
-		Long: `Delete a webhook subscription.
+		Short: "Delete a webhook",
+		Long: `Delete a webhook.
 
 Note: This only succeeds when the token's OAuth app matches the subscription's app.`,
 		Args: cmdutil.ExactArgs(1),

--- a/internal/cmd/webhooks/list.go
+++ b/internal/cmd/webhooks/list.go
@@ -24,9 +24,9 @@ func newListCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List webhook subscriptions",
+		Short: "List webhooks",
 		Args:  cmdutil.ExactArgs(0),
-		Long:  "List webhook subscriptions. --resource is required (no 'list all' endpoint).",
+		Long:  "List webhooks. --resource is required (no 'list all' endpoint).",
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
 			if resource == "" {

--- a/internal/cmd/webhooks/webhooks.go
+++ b/internal/cmd/webhooks/webhooks.go
@@ -7,8 +7,8 @@ import (
 func NewWebhooksCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "webhooks",
-		Short: "Manage resource subscriptions (webhooks)",
-		Long: `Manage webhook subscriptions for resource events.
+		Short: "Manage webhooks",
+		Long: `Manage webhooks for resource events.
 
 Note: delete only succeeds when the token's OAuth app matches the subscription's app.`,
 		Example: `  gumroad webhooks list --resource sale

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -223,7 +223,7 @@ gumroad variants delete <var_id> --product <id> --category <cat_id> --yes --json
 
 **All subcommands require** `--product` and `--category`.
 
-### custom-fields — Manage product custom fields
+### custom-fields — Manage custom fields
 
 Custom fields are keyed by name, not ID.
 
@@ -234,7 +234,7 @@ gumroad custom-fields update --product <id> --name "Company" --required --json -
 gumroad custom-fields delete --product <id> --name "Company" --yes --json --no-input
 ```
 
-### webhooks — Manage webhook subscriptions
+### webhooks — Manage webhooks
 
 ```sh
 # List (--resource is required)


### PR DESCRIPTION
## What

Standardizes `Short` (and matching `Long`) descriptions across all commands to a consistent pattern.

## Why

Help text used inconsistent patterns. Mixed possessives ("your"), brand mentions ("Gumroad"), qualifiers ("product", "subscription"), and verbs ("Manage" for read-only groups). This makes the CLI harder to scan and creates noise for agents parsing help output.

---

Built with Claude Opus 4.6 and gpt‑5.4 xhigh