### PR TITLE
Fix percent-off offer codes sending wrong API params

### DIFF
--- a/internal/cmd/offercodes/create.go
+++ b/internal/cmd/offercodes/create.go
@@ -67,7 +67,8 @@ Use either --amount (flat discount) or --percent-off (percentage discount), not 
 				params.Set("amount_off", strconv.Itoa(cents))
 			}
 			if hasPercentOff {
-				params.Set("percent_off", strconv.Itoa(percentOff))
+				params.Set("amount_off", strconv.Itoa(percentOff))
+				params.Set("offer_type", "percent")
 			}
 			if hasMaxPurchaseCount {
 				params.Set("max_purchase_count", strconv.Itoa(maxPurchaseCount))

--- a/internal/cmd/offercodes/offercodes_test.go
+++ b/internal/cmd/offercodes/offercodes_test.go
@@ -431,13 +431,13 @@ func TestCreate_NameRequired(t *testing.T) {
 }
 
 func TestCreate_PercentOff(t *testing.T) {
-	var gotPercentOff, gotAmountOff string
+	var gotAmountOff, gotOfferType string
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseForm(); err != nil {
 			t.Fatalf("ParseForm failed: %v", err)
 		}
-		gotPercentOff = r.PostForm.Get("percent_off")
 		gotAmountOff = r.PostForm.Get("amount_off")
+		gotOfferType = r.PostForm.Get("offer_type")
 		testutil.JSON(t, w, map[string]any{"offer_code": map[string]any{"id": "oc1", "name": r.PostForm.Get("name")}})
 	})
 
@@ -449,21 +449,22 @@ func TestCreate_PercentOff(t *testing.T) {
 		}
 	})
 
-	if gotPercentOff != "20" {
-		t.Errorf("got percent_off=%q, want 20", gotPercentOff)
+	if gotAmountOff != "20" {
+		t.Errorf("got amount_off=%q, want 20", gotAmountOff)
 	}
-	if gotAmountOff != "" {
-		t.Errorf("amount_off should be empty, got %q", gotAmountOff)
+	if gotOfferType != "percent" {
+		t.Errorf("got offer_type=%q, want percent", gotOfferType)
 	}
 }
 
 func TestCreate_Amount(t *testing.T) {
-	var gotAmountOff string
+	var gotAmountOff, gotOfferType string
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseForm(); err != nil {
 			t.Fatalf("ParseForm failed: %v", err)
 		}
 		gotAmountOff = r.PostForm.Get("amount_off")
+		gotOfferType = r.PostForm.Get("offer_type")
 		testutil.JSON(t, w, map[string]any{"offer_code": map[string]any{"id": "oc1", "name": "FLAT5"}})
 	})
 
@@ -477,6 +478,9 @@ func TestCreate_Amount(t *testing.T) {
 
 	if gotAmountOff != "500" {
 		t.Errorf("got amount_off=%q, want 500", gotAmountOff)
+	}
+	if gotOfferType != "" {
+		t.Errorf("offer_type should be empty for flat discount, got %q", gotOfferType)
 	}
 }
 


### PR DESCRIPTION
## What

`gumroad offer-codes create --percent-off 10` was sending `percent_off=10` to the Gumroad API, which the API doesn't recognize. The API's `check_offer_code_params` validation only accepts `amount_off` or `amount_cents` — requests without either are rejected with "You are missing required offer code parameters."

The fix sends `amount_off` with the percentage value and adds `offer_type=percent` to distinguish it from flat-amount discounts. Tests updated to verify both the percent and flat-amount paths send the correct params.

## Why

The Gumroad API uses `amount_off` for both discount types, differentiated by `offer_type`. The `percent_off` parameter name exists only in API responses, not as an accepted request parameter.

---

This PR was implemented with AI assistance using Claude Opus 4.6 and gpt‑5.4 xhigh