### PR TITLE
Handle IDs starting with - in positional args

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -114,6 +114,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(completion.NewCompletionCmd())
 	cmd.AddCommand(skill.NewSkillCmd())
 	cmdutil.PropagateExamples(cmd)
+	cmdutil.AllowDashIDs(cmd)
 
 	return cmd
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -204,14 +204,16 @@ func executeCommand(cmd *cobra.Command, stdout, stderr io.Writer) int {
 }
 
 // isUnknownShorthandError checks if the error is from cobra/pflag rejecting
-// a dash-prefixed argument as an unknown shorthand flag.
+// a dash-prefixed argument as an unknown shorthand flag. This relies on
+// pflag's error format: "unknown shorthand flag: 'X' in -XYZ".
 func isUnknownShorthandError(err error) bool {
 	return strings.Contains(err.Error(), "unknown shorthand flag")
 }
 
 // insertDoubleDashBeforeArg finds the arg that caused an "unknown shorthand flag"
 // error and inserts "--" before it so cobra treats it as a positional arg.
-// Returns nil if the offending arg cannot be identified.
+// Returns nil if the offending arg cannot be identified or doesn't look like
+// an encoded ID (to avoid retrying real flag typos like "-z").
 func insertDoubleDashBeforeArg(args []string, err error) []string {
 	// Error format: "unknown shorthand flag: 'c' in -cGksPcArAUU8j_XTYsrnQ=="
 	// The error may include usage text after newlines, so only look at the first line.
@@ -224,6 +226,13 @@ func insertDoubleDashBeforeArg(args []string, err error) []string {
 		return nil
 	}
 	offending := firstLine[inIdx+4:]
+
+	// Only retry if the offending arg looks like an encoded ID, not a flag typo.
+	// Gumroad IDs are base64-encoded and contain digits, '=', '_', '+', or '/'.
+	// Flag typos like "-z" or "-json" are purely alphabetic (plus the leading dash).
+	if !looksLikeEncodedID(offending) {
+		return nil
+	}
 
 	// Move the offending arg to the end, preceded by "--", so all flags
 	// remain before "--" and are parsed normally.
@@ -241,6 +250,23 @@ func insertDoubleDashBeforeArg(args []string, err error) []string {
 	}
 	result = append(result, "--", offending)
 	return result
+}
+
+// looksLikeEncodedID returns true if s looks like a base64-encoded Gumroad ID
+// rather than a mistyped shorthand flag. Encoded IDs typically contain digits,
+// '=', '_', '+', or '/' — characters that never appear in flag names. As a
+// fallback, any arg longer than 10 characters is treated as an ID since flag
+// typos are short.
+func looksLikeEncodedID(s string) bool {
+	if len(s) > 10 {
+		return true
+	}
+	for _, c := range s {
+		if (c >= '0' && c <= '9') || c == '=' || c == '_' || c == '+' || c == '/' {
+			return true
+		}
+	}
+	return false
 }
 
 func exitCodeForCommandError(cmd *cobra.Command, err error) int {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -34,6 +34,7 @@ var (
 	Version        = "dev"
 	newRootCommand = NewRootCmd
 	exitProcess    = os.Exit
+	getOSArgs      = func() []string { return os.Args }
 )
 
 func NewRootCmd() *cobra.Command {
@@ -114,7 +115,6 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(completion.NewCompletionCmd())
 	cmd.AddCommand(skill.NewSkillCmd())
 	cmdutil.PropagateExamples(cmd)
-	cmdutil.AllowDashIDs(cmd)
 
 	return cmd
 }
@@ -160,7 +160,30 @@ func Execute() {
 }
 
 func executeRootCommand(stdout, stderr io.Writer) int {
-	return executeCommand(newRootCommand(), stdout, stderr)
+	cmd := newRootCommand()
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+
+	err := cmd.Execute()
+	if err == nil {
+		return 0
+	}
+
+	if isUnknownShorthandError(err) {
+		if newArgs := insertDoubleDashBeforeArg(getOSArgs()[1:], err); newArgs != nil {
+			retryCmd := newRootCommand()
+			retryCmd.SetArgs(newArgs)
+			retryCmd.SetOut(stdout)
+			retryCmd.SetErr(stderr)
+			if retryErr := retryCmd.Execute(); retryErr == nil {
+				return 0
+			} else {
+				return exitCodeForCommandError(retryCmd, retryErr)
+			}
+		}
+	}
+
+	return exitCodeForCommandError(cmd, err)
 }
 
 func executeCommand(cmd *cobra.Command, stdout, stderr io.Writer) int {
@@ -178,6 +201,46 @@ func executeCommand(cmd *cobra.Command, stdout, stderr io.Writer) int {
 	}
 
 	return 0
+}
+
+// isUnknownShorthandError checks if the error is from cobra/pflag rejecting
+// a dash-prefixed argument as an unknown shorthand flag.
+func isUnknownShorthandError(err error) bool {
+	return strings.Contains(err.Error(), "unknown shorthand flag")
+}
+
+// insertDoubleDashBeforeArg finds the arg that caused an "unknown shorthand flag"
+// error and inserts "--" before it so cobra treats it as a positional arg.
+// Returns nil if the offending arg cannot be identified.
+func insertDoubleDashBeforeArg(args []string, err error) []string {
+	// Error format: "unknown shorthand flag: 'c' in -cGksPcArAUU8j_XTYsrnQ=="
+	// The error may include usage text after newlines, so only look at the first line.
+	firstLine := err.Error()
+	if nl := strings.IndexByte(firstLine, '\n'); nl >= 0 {
+		firstLine = firstLine[:nl]
+	}
+	inIdx := strings.LastIndex(firstLine, " in ")
+	if inIdx < 0 {
+		return nil
+	}
+	offending := firstLine[inIdx+4:]
+
+	// Move the offending arg to the end, preceded by "--", so all flags
+	// remain before "--" and are parsed normally.
+	result := make([]string, 0, len(args)+1)
+	found := false
+	for _, arg := range args {
+		if !found && arg == offending {
+			found = true
+			continue // skip it; we'll append it after "--"
+		}
+		result = append(result, arg)
+	}
+	if !found {
+		return nil
+	}
+	result = append(result, "--", offending)
+	return result
 }
 
 func exitCodeForCommandError(cmd *cobra.Command, err error) int {
@@ -231,7 +294,7 @@ func noColorRequested(cmd *cobra.Command) bool {
 	if noColorRequestedFromCommand(cmd) {
 		return true
 	}
-	return noColorRequestedInArgs(os.Args[1:])
+	return noColorRequestedInArgs(getOSArgs()[1:])
 }
 
 func noColorRequestedFromCommand(cmd *cobra.Command) bool {

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -53,6 +53,13 @@ func replaceRootCommandFactory(t *testing.T, factory func() *cobra.Command) {
 	})
 }
 
+func replaceGetOSArgs(t *testing.T, args []string) {
+	t.Helper()
+	previous := getOSArgs
+	getOSArgs = func() []string { return args }
+	t.Cleanup(func() { getOSArgs = previous })
+}
+
 func replaceExitProcess(t *testing.T, exitFn func(int)) {
 	t.Helper()
 
@@ -646,6 +653,24 @@ func TestInsertDoubleDashBeforeArg(t *testing.T) {
 			errors.New("unknown shorthand flag: 'c' in -cGk=="),
 			nil,
 		},
+		{
+			"short flag typo not retried",
+			[]string{"products", "list", "-z"},
+			errors.New("unknown shorthand flag: 'z' in -z"),
+			nil,
+		},
+		{
+			"two-char flag typo not retried",
+			[]string{"products", "list", "-zx"},
+			errors.New("unknown shorthand flag: 'z' in -zx"),
+			nil,
+		},
+		{
+			"alpha-only flag typo not retried",
+			[]string{"products", "list", "-json"},
+			errors.New("unknown shorthand flag: 'j' in -json"),
+			nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -669,8 +694,8 @@ func TestInsertDoubleDashBeforeArg(t *testing.T) {
 }
 
 func TestExecuteRootCommand_RetriesDashPrefixedID(t *testing.T) {
-	called := false
-	simArgs := []string{"gumroad", "view", "-dashID"}
+	var gotArgs []string
+	simArgs := []string{"gumroad", "view", "-dAsh1D=="}
 
 	replaceRootCommandFactory(t, func() *cobra.Command {
 		cmd := &cobra.Command{
@@ -685,7 +710,7 @@ func TestExecuteRootCommand_RetriesDashPrefixedID(t *testing.T) {
 			Use:  "view <id>",
 			Args: cmdutil.ExactArgs(1),
 			RunE: func(c *cobra.Command, args []string) error {
-				called = true
+				gotArgs = args
 				return nil
 			},
 		}
@@ -694,16 +719,48 @@ func TestExecuteRootCommand_RetriesDashPrefixedID(t *testing.T) {
 		return cmd
 	})
 
-	origGetOSArgs := getOSArgs
-	getOSArgs = func() []string { return simArgs }
-	defer func() { getOSArgs = origGetOSArgs }()
+	replaceGetOSArgs(t, simArgs)
 
 	var stdout, stderr bytes.Buffer
 	code := executeRootCommand(&stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("got exit code %d, want 0; stderr=%q", code, stderr.String())
 	}
-	if !called {
-		t.Fatal("expected RunE to be called after retry")
+	if len(gotArgs) != 1 || gotArgs[0] != "-dAsh1D==" {
+		t.Fatalf("RunE got args %v, want [\"-dAsh1D==\"]", gotArgs)
+	}
+}
+
+func TestExecuteRootCommand_DoesNotRetryShortFlagTypo(t *testing.T) {
+	simArgs := []string{"gumroad", "view", "-z"}
+
+	replaceRootCommandFactory(t, func() *cobra.Command {
+		cmd := &cobra.Command{
+			Use:           "gumroad",
+			SilenceUsage:  true,
+			SilenceErrors: true,
+		}
+		cmd.SetFlagErrorFunc(func(c *cobra.Command, err error) error {
+			return cmdutil.NewUsageError(c, err.Error())
+		})
+		sub := &cobra.Command{
+			Use:  "view <id>",
+			Args: cmdutil.ExactArgs(1),
+			RunE: func(c *cobra.Command, args []string) error {
+				t.Fatal("RunE should not be called for a flag typo")
+				return nil
+			},
+		}
+		cmd.AddCommand(sub)
+		cmd.SetArgs(simArgs[1:])
+		return cmd
+	})
+
+	replaceGetOSArgs(t, simArgs)
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommand(&stdout, &stderr)
+	if code == 0 {
+		t.Fatal("expected non-zero exit code for flag typo")
 	}
 }

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -586,3 +586,124 @@ func TestPrintHumanCommandError_NoHint(t *testing.T) {
 		t.Errorf("expected no hint line, got %q", got)
 	}
 }
+
+func TestIsUnknownShorthandError(t *testing.T) {
+	tests := []struct {
+		err  string
+		want bool
+	}{
+		{"unknown shorthand flag: 'c' in -cGk", true},
+		{"unknown flag: --bogus", false},
+		{"missing required argument: <id>", false},
+	}
+	for _, tt := range tests {
+		if got := isUnknownShorthandError(errors.New(tt.err)); got != tt.want {
+			t.Errorf("isUnknownShorthandError(%q) = %v, want %v", tt.err, got, tt.want)
+		}
+	}
+}
+
+func TestInsertDoubleDashBeforeArg(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		err  error
+		want []string
+	}{
+		{
+			"simple dash ID",
+			[]string{"products", "view", "-cGk=="},
+			errors.New("unknown shorthand flag: 'c' in -cGk=="),
+			[]string{"products", "view", "--", "-cGk=="},
+		},
+		{
+			"dash ID with flags before",
+			[]string{"products", "update", "--name", "x", "-cGk=="},
+			errors.New("unknown shorthand flag: 'c' in -cGk=="),
+			[]string{"products", "update", "--name", "x", "--", "-cGk=="},
+		},
+		{
+			"dash ID with flags after",
+			[]string{"products", "view", "-cGk==", "--no-color"},
+			errors.New("unknown shorthand flag: 'c' in -cGk=="),
+			[]string{"products", "view", "--no-color", "--", "-cGk=="},
+		},
+		{
+			"error with usage text appended",
+			[]string{"products", "view", "-cGk=="},
+			errors.New("unknown shorthand flag: 'c' in -cGk==\n\nUsage:\n  gumroad products view <id>"),
+			[]string{"products", "view", "--", "-cGk=="},
+		},
+		{
+			"no in keyword",
+			[]string{"products", "view", "-cGk=="},
+			errors.New("some other error"),
+			nil,
+		},
+		{
+			"offending arg not found",
+			[]string{"products", "view", "abc123"},
+			errors.New("unknown shorthand flag: 'c' in -cGk=="),
+			nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := insertDoubleDashBeforeArg(tt.args, tt.err)
+			if tt.want == nil {
+				if got != nil {
+					t.Fatalf("got %v, want nil", got)
+				}
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("got[%d]=%q, want %q (full: %v)", i, got[i], tt.want[i], got)
+				}
+			}
+		})
+	}
+}
+
+func TestExecuteRootCommand_RetriesDashPrefixedID(t *testing.T) {
+	called := false
+	simArgs := []string{"gumroad", "view", "-dashID"}
+
+	replaceRootCommandFactory(t, func() *cobra.Command {
+		cmd := &cobra.Command{
+			Use:           "gumroad",
+			SilenceUsage:  true,
+			SilenceErrors: true,
+		}
+		cmd.SetFlagErrorFunc(func(c *cobra.Command, err error) error {
+			return cmdutil.NewUsageError(c, err.Error())
+		})
+		sub := &cobra.Command{
+			Use:  "view <id>",
+			Args: cmdutil.ExactArgs(1),
+			RunE: func(c *cobra.Command, args []string) error {
+				called = true
+				return nil
+			},
+		}
+		cmd.AddCommand(sub)
+		cmd.SetArgs(simArgs[1:]) // simulate os.Args[1:]
+		return cmd
+	})
+
+	origGetOSArgs := getOSArgs
+	getOSArgs = func() []string { return simArgs }
+	defer func() { getOSArgs = origGetOSArgs }()
+
+	var stdout, stderr bytes.Buffer
+	code := executeRootCommand(&stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("got exit code %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if !called {
+		t.Fatal("expected RunE to be called after retry")
+	}
+}

--- a/internal/cmdutil/usage.go
+++ b/internal/cmdutil/usage.go
@@ -71,19 +71,6 @@ func ExactArgs(n int) cobra.PositionalArgs {
 	}
 }
 
-// AllowDashIDs walks the command tree and sets ParseErrorsWhitelist.UnknownFlags
-// on commands that accept positional arguments. This prevents cobra from
-// rejecting Gumroad IDs that start with "-" (e.g. "-cGksPcArAUU8j_XTYsrnQ==")
-// as unknown shorthand flags.
-func AllowDashIDs(cmd *cobra.Command) {
-	if len(positionalArgs(cmd.Use)) > 0 {
-		cmd.Flags().ParseErrorsWhitelist.UnknownFlags = true
-	}
-	for _, child := range cmd.Commands() {
-		AllowDashIDs(child)
-	}
-}
-
 // PropagateExamples fills empty command examples from the nearest ancestor.
 func PropagateExamples(cmd *cobra.Command) {
 	propagateExamples(cmd, "")

--- a/internal/cmdutil/usage.go
+++ b/internal/cmdutil/usage.go
@@ -71,6 +71,19 @@ func ExactArgs(n int) cobra.PositionalArgs {
 	}
 }
 
+// AllowDashIDs walks the command tree and sets ParseErrorsWhitelist.UnknownFlags
+// on commands that accept positional arguments. This prevents cobra from
+// rejecting Gumroad IDs that start with "-" (e.g. "-cGksPcArAUU8j_XTYsrnQ==")
+// as unknown shorthand flags.
+func AllowDashIDs(cmd *cobra.Command) {
+	if len(positionalArgs(cmd.Use)) > 0 {
+		cmd.Flags().ParseErrorsWhitelist.UnknownFlags = true
+	}
+	for _, child := range cmd.Commands() {
+		AllowDashIDs(child)
+	}
+}
+
 // PropagateExamples fills empty command examples from the nearest ancestor.
 func PropagateExamples(cmd *cobra.Command) {
 	propagateExamples(cmd, "")

--- a/test/dash_id_test.go
+++ b/test/dash_id_test.go
@@ -1,22 +1,26 @@
 package test
 
 import (
-	"bytes"
+	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
-
-	cmd "github.com/antiwork/gumroad-cli/internal/cmd"
-	"github.com/antiwork/gumroad-cli/internal/testutil"
 )
 
 // TestDashPrefixedIDArgs verifies that every command accepting a positional ID
-// argument correctly handles IDs starting with "-". Without
-// ParseErrorsWhitelist.UnknownFlags, cobra interprets these as shorthand flags
-// and rejects them. The setting is applied centrally by cmdutil.AllowDashIDs.
+// argument correctly handles IDs starting with "-". Cobra normally interprets
+// these as shorthand flags. The CLI catches this error and retries with "--"
+// inserted before the offending arg, so the ID is treated as a positional arg.
 func TestDashPrefixedIDArgs(t *testing.T) {
-	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
-		testutil.JSON(t, w, map[string]any{
+	bin := buildBinary(t)
+
+	var lastPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		lastPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"success":          true,
 			"product":          map[string]any{"id": "p1", "name": "Test"},
 			"offer_code":       map[string]any{"id": "oc1", "name": "TEST"},
 			"variant_category": map[string]any{"id": "vc1", "title": "Size"},
@@ -26,7 +30,15 @@ func TestDashPrefixedIDArgs(t *testing.T) {
 			"payout":           map[string]any{"id": "pay1", "display_payout_period": "Jan 2026", "formatted_amount": "$100"},
 			"skus":             []map[string]any{},
 		})
-	})
+	}))
+	t.Cleanup(srv.Close)
+
+	cfgDir := setupConfig(t)
+	env := []string{
+		"XDG_CONFIG_HOME=" + cfgDir,
+		"GUMROAD_API_BASE_URL=" + srv.URL,
+		"GUMROAD_ACCESS_TOKEN=",
+	}
 
 	dashID := "-cGksPcArAUU8j_XTYsrnQ=="
 
@@ -75,20 +87,24 @@ func TestDashPrefixedIDArgs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			root := cmd.NewRootCmd()
-			root.SetArgs(append(tt.args, "--no-color"))
-			var out bytes.Buffer
-			root.SetOut(&out)
-			root.SetErr(&out)
-
-			err := root.Execute()
+			lastPath = ""
+			args := append(tt.args, "--no-color")
+			out, err := runGR(t, bin, env, args...)
 			if err != nil {
-				combined := out.String()
-				if strings.Contains(combined, "unknown shorthand flag") || strings.Contains(err.Error(), "unknown shorthand flag") {
-					t.Fatalf("dash-prefixed ID %q was parsed as a flag: %v", dashID, err)
+				if strings.Contains(out, "unknown shorthand flag") {
+					t.Fatalf("dash-prefixed ID %q was parsed as a flag:\n%s", dashID, out)
 				}
-				// Other errors (e.g. mock server doesn't match exactly) are acceptable —
-				// the point is that the ID was not mistaken for a flag.
+				if strings.Contains(out, "missing required argument") {
+					t.Fatalf("dash-prefixed ID %q was discarded during flag parsing:\n%s", dashID, out)
+				}
+				// Other errors (e.g. API returns unexpected shape) are acceptable —
+				// the point is that the ID was passed through to the API.
+			}
+			if lastPath == "" {
+				t.Fatalf("API was never called — dash-prefixed ID %q was not passed through", dashID)
+			}
+			if !strings.Contains(lastPath, dashID) {
+				t.Errorf("API path %q does not contain expected ID %q", lastPath, dashID)
 			}
 		})
 	}

--- a/test/dash_id_test.go
+++ b/test/dash_id_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -15,9 +16,12 @@ import (
 func TestDashPrefixedIDArgs(t *testing.T) {
 	bin := buildBinary(t)
 
+	var mu sync.Mutex
 	var lastPath string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		lastPath = r.URL.Path
+		mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"success":          true,
@@ -87,7 +91,9 @@ func TestDashPrefixedIDArgs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			mu.Lock()
 			lastPath = ""
+			mu.Unlock()
 			args := append(tt.args, "--no-color")
 			out, err := runGR(t, bin, env, args...)
 			if err != nil {
@@ -100,11 +106,14 @@ func TestDashPrefixedIDArgs(t *testing.T) {
 				// Other errors (e.g. API returns unexpected shape) are acceptable —
 				// the point is that the ID was passed through to the API.
 			}
-			if lastPath == "" {
+			mu.Lock()
+			path := lastPath
+			mu.Unlock()
+			if path == "" {
 				t.Fatalf("API was never called — dash-prefixed ID %q was not passed through", dashID)
 			}
-			if !strings.Contains(lastPath, dashID) {
-				t.Errorf("API path %q does not contain expected ID %q", lastPath, dashID)
+			if !strings.Contains(path, dashID) {
+				t.Errorf("API path %q does not contain expected ID %q", path, dashID)
 			}
 		})
 	}

--- a/test/dash_id_test.go
+++ b/test/dash_id_test.go
@@ -1,0 +1,95 @@
+package test
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+	"testing"
+
+	cmd "github.com/antiwork/gumroad-cli/internal/cmd"
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+// TestDashPrefixedIDArgs verifies that every command accepting a positional ID
+// argument correctly handles IDs starting with "-". Without
+// ParseErrorsWhitelist.UnknownFlags, cobra interprets these as shorthand flags
+// and rejects them. The setting is applied centrally by cmdutil.AllowDashIDs.
+func TestDashPrefixedIDArgs(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"product":          map[string]any{"id": "p1", "name": "Test"},
+			"offer_code":       map[string]any{"id": "oc1", "name": "TEST"},
+			"variant_category": map[string]any{"id": "vc1", "title": "Size"},
+			"variant":          map[string]any{"id": "v1", "name": "Small"},
+			"sale":             map[string]any{"id": "s1", "email": "test@example.com", "product_name": "Test"},
+			"subscriber":       map[string]any{"id": "sub1", "email_address": "test@example.com"},
+			"payout":           map[string]any{"id": "pay1", "display_payout_period": "Jan 2026", "formatted_amount": "$100"},
+			"skus":             []map[string]any{},
+		})
+	})
+
+	dashID := "-cGksPcArAUU8j_XTYsrnQ=="
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		// products
+		{"products view", []string{"products", "view", dashID}},
+		{"products update", []string{"products", "update", "--name", "x", dashID}},
+		{"products delete", []string{"products", "delete", "--yes", dashID}},
+		{"products publish", []string{"products", "publish", dashID}},
+		{"products unpublish", []string{"products", "unpublish", dashID}},
+		{"products skus", []string{"products", "skus", dashID}},
+
+		// offer-codes
+		{"offer-codes view", []string{"offer-codes", "view", "--product", "p1", dashID}},
+		{"offer-codes update", []string{"offer-codes", "update", "--product", "p1", "--max-purchase-count", "5", dashID}},
+		{"offer-codes delete", []string{"offer-codes", "delete", "--product", "p1", "--yes", dashID}},
+
+		// variant-categories
+		{"variant-categories view", []string{"variant-categories", "view", "--product", "p1", dashID}},
+		{"variant-categories update", []string{"variant-categories", "update", "--product", "p1", "--title", "Color", dashID}},
+		{"variant-categories delete", []string{"variant-categories", "delete", "--product", "p1", "--yes", dashID}},
+
+		// variants
+		{"variants view", []string{"variants", "view", "--product", "p1", "--category", "c1", dashID}},
+		{"variants update", []string{"variants", "update", "--product", "p1", "--category", "c1", "--name", "Large", dashID}},
+		{"variants delete", []string{"variants", "delete", "--product", "p1", "--category", "c1", "--yes", dashID}},
+
+		// sales
+		{"sales view", []string{"sales", "view", dashID}},
+		{"sales refund", []string{"sales", "refund", "--yes", dashID}},
+		{"sales resend-receipt", []string{"sales", "resend-receipt", dashID}},
+		{"sales ship", []string{"sales", "ship", dashID}},
+
+		// subscribers
+		{"subscribers view", []string{"subscribers", "view", dashID}},
+
+		// payouts
+		{"payouts view", []string{"payouts", "view", dashID}},
+
+		// webhooks
+		{"webhooks delete", []string{"webhooks", "delete", "--yes", dashID}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := cmd.NewRootCmd()
+			root.SetArgs(append(tt.args, "--no-color"))
+			var out bytes.Buffer
+			root.SetOut(&out)
+			root.SetErr(&out)
+
+			err := root.Execute()
+			if err != nil {
+				combined := out.String()
+				if strings.Contains(combined, "unknown shorthand flag") || strings.Contains(err.Error(), "unknown shorthand flag") {
+					t.Fatalf("dash-prefixed ID %q was parsed as a flag: %v", dashID, err)
+				}
+				// Other errors (e.g. mock server doesn't match exactly) are acceptable —
+				// the point is that the ID was not mistaken for a flag.
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Gumroad external IDs can start with `-` (e.g. `-cGksPcArAUU8j_XTYsrnQ==`). Cobra interprets these as shorthand flags, producing `unknown shorthand flag: 'c'`. This affects all 22 commands that take an ID as a positional argument.

The fix intercepts the "unknown shorthand flag" error in `executeRootCommand`, extracts the offending arg from the error message, moves it to the end of the arg list preceded by `--`, and retries with a fresh command tree. The `--` separator tells cobra to treat everything after it as positional args. If the retry also fails (e.g., API error), its error is shown instead of the original flag-parsing error.

A table-driven integration test builds the CLI binary and runs all 22 affected commands with a real dash-prefixed ID, verifying the mock API is actually called with the correct path.

## Why

Two other approaches were tried and rejected:

- `SetInterspersed(false)` doesn't help because pflag still tries to parse anything starting with `-` as a flag, regardless of the interspersed setting.
- `ParseErrorsWhitelist.UnknownFlags = true` causes pflag to silently *discard* the unknown flag token rather than adding it to positional args — the command runs with zero args and fails with "missing required argument."

The retry approach is transparent to users (no `--` required), doesn't degrade flag-typo detection, and doesn't modify any individual command files. It works by catching the specific pflag error, reformulating the args with `--`, and re-executing.

---

This PR was implemented with AI assistance using Claude Opus 4.6 and gpt‑5.4 xhigh
