### PR TITLE
Fix sales view crash on numeric order_id

### DIFF
--- a/internal/cmd/sales/sales_test.go
+++ b/internal/cmd/sales/sales_test.go
@@ -605,23 +605,10 @@ func TestView_Plain(t *testing.T) {
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
 		testutil.JSON(t, w, map[string]any{
 			"sale": map[string]any{
-				"id": "s1", "email": "a@b.com", "product_name": "Art",
+				"id": "s1", "email": "a@example.com", "product_name": "Art",
 				"formatted_total_price": "$10", "created_at": "2024-01-15",
 			},
 		})
-	})
-
-	cmd := testutil.Command(newViewCmd(), testutil.PlainOutput())
-	out := testutil.CaptureStdout(func() { _ = cmd.RunE(cmd, []string{"s1"}) })
-	if !strings.Contains(out, "s1") || !strings.Contains(out, "Art") {
-		t.Errorf("plain view missing data: %q", out)
-	}
-}
-
-func TestView_PlainWithOrderID(t *testing.T) {
-	testutil.Setup(t, func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"success":true,"sale":{"id":"s1","email":"a@example.com","product_name":"Art","formatted_total_price":"$10","created_at":"2024-01-15","order_id":535572601}}`))
 	})
 
 	cmd := testutil.Command(newViewCmd(), testutil.PlainOutput())
@@ -630,8 +617,44 @@ func TestView_PlainWithOrderID(t *testing.T) {
 	if execErr != nil {
 		t.Fatalf("RunE failed: %v", execErr)
 	}
-	if !strings.Contains(out, "535572601") {
-		t.Errorf("plain view should include order ID: %q", out)
+	cols := strings.Split(strings.TrimRight(out, "\n"), "\t")
+	if len(cols) != 7 {
+		t.Fatalf("expected 7 tab-separated columns, got %d: %q", len(cols), out)
+	}
+	if cols[0] != "s1" || cols[2] != "Art" || cols[3] != "$10" {
+		t.Errorf("plain view data mismatch: %q", cols)
+	}
+	if cols[6] != "" {
+		t.Errorf("order_id column should be empty when absent, got %q", cols[6])
+	}
+}
+
+func TestView_PlainWithOrderID(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"sale": map[string]any{
+				"id": "s1", "email": "a@example.com", "product_name": "Art",
+				"formatted_total_price": "$10", "created_at": "2024-01-15",
+				"order_id": 535572601,
+			},
+		})
+	})
+
+	cmd := testutil.Command(newViewCmd(), testutil.PlainOutput())
+	var execErr error
+	out := testutil.CaptureStdout(func() { execErr = cmd.RunE(cmd, []string{"s1"}) })
+	if execErr != nil {
+		t.Fatalf("RunE failed: %v", execErr)
+	}
+	cols := strings.Split(strings.TrimRight(out, "\n"), "\t")
+	if len(cols) != 7 {
+		t.Fatalf("expected 7 tab-separated columns, got %d: %q", len(cols), out)
+	}
+	if cols[0] != "s1" || cols[2] != "Art" || cols[3] != "$10" {
+		t.Errorf("plain view data mismatch: %q", cols)
+	}
+	if cols[6] != "535572601" {
+		t.Errorf("order_id column should be 535572601, got %q", cols[6])
 	}
 }
 

--- a/internal/cmd/sales/sales_test.go
+++ b/internal/cmd/sales/sales_test.go
@@ -618,6 +618,23 @@ func TestView_Plain(t *testing.T) {
 	}
 }
 
+func TestView_PlainWithOrderID(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"sale":{"id":"s1","email":"a@example.com","product_name":"Art","formatted_total_price":"$10","created_at":"2024-01-15","order_id":535572601}}`))
+	})
+
+	cmd := testutil.Command(newViewCmd(), testutil.PlainOutput())
+	var execErr error
+	out := testutil.CaptureStdout(func() { execErr = cmd.RunE(cmd, []string{"s1"}) })
+	if execErr != nil {
+		t.Fatalf("RunE failed: %v", execErr)
+	}
+	if !strings.Contains(out, "535572601") {
+		t.Errorf("plain view should include order ID: %q", out)
+	}
+}
+
 func TestView_ShippedStatus(t *testing.T) {
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
 		testutil.JSON(t, w, map[string]any{

--- a/internal/cmd/sales/sales_test.go
+++ b/internal/cmd/sales/sales_test.go
@@ -636,21 +636,44 @@ func TestView_ShippedStatus(t *testing.T) {
 	}
 }
 
-func TestView_WithOrderID(t *testing.T) {
-	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
-		testutil.JSON(t, w, map[string]any{
-			"sale": map[string]any{
-				"id": "s1", "email": "a@b.com", "product_name": "Art",
-				"formatted_total_price": "$10", "created_at": "2024-01-15",
-				"order_id": "ORD-999",
-			},
-		})
-	})
+func TestView_OrderID(t *testing.T) {
+	// Use raw JSON to test wire formats that Go's encoding/json normalizes away
+	// (e.g. 535572601.0 as a float, explicit null).
+	tests := []struct {
+		name      string
+		rawJSON   string // raw JSON response body
+		wantShown string // non-empty means Order: line should contain this
+	}{
+		{"integer", `{"success":true,"sale":{"id":"s1","email":"a@example.com","product_name":"Art","formatted_total_price":"$10","created_at":"2024-01-15","order_id":535572601}}`, "535572601"},
+		{"float", `{"success":true,"sale":{"id":"s1","email":"a@example.com","product_name":"Art","formatted_total_price":"$10","created_at":"2024-01-15","order_id":535572601.0}}`, "535572601"},
+		{"zero", `{"success":true,"sale":{"id":"s1","email":"a@example.com","product_name":"Art","formatted_total_price":"$10","created_at":"2024-01-15","order_id":0}}`, ""},
+		{"null", `{"success":true,"sale":{"id":"s1","email":"a@example.com","product_name":"Art","formatted_total_price":"$10","created_at":"2024-01-15","order_id":null}}`, ""},
+		{"absent", `{"success":true,"sale":{"id":"s1","email":"a@example.com","product_name":"Art","formatted_total_price":"$10","created_at":"2024-01-15"}}`, ""},
+	}
 
-	cmd := newViewCmd()
-	out := testutil.CaptureStdout(func() { _ = cmd.RunE(cmd, []string{"s1"}) })
-	if !strings.Contains(out, "ORD-999") {
-		t.Errorf("should show order ID: %q", out)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testutil.Setup(t, func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tt.rawJSON))
+			})
+
+			cmd := newViewCmd()
+			var execErr error
+			out := testutil.CaptureStdout(func() { execErr = cmd.RunE(cmd, []string{"s1"}) })
+			if execErr != nil {
+				t.Fatalf("RunE failed: %v", execErr)
+			}
+			if tt.wantShown != "" {
+				if !strings.Contains(out, "Order: "+tt.wantShown) {
+					t.Errorf("should show Order: %s, got: %q", tt.wantShown, out)
+				}
+			} else {
+				if strings.Contains(out, "Order:") {
+					t.Errorf("should not show Order line, got: %q", out)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/cmd/sales/view.go
+++ b/internal/cmd/sales/view.go
@@ -39,11 +39,13 @@ func newViewCmd() *cobra.Command {
 				style := opts.Style()
 
 				if opts.PlainOutput {
-					row := []string{s.ID, s.Email, s.ProductName, s.FormattedTotal, s.CreatedAt, fmt.Sprintf("refunded=%v", s.Refunded)}
+					orderID := ""
 					if s.OrderID > 0 {
-						row = append(row, fmt.Sprintf("%d", s.OrderID))
+						orderID = fmt.Sprintf("%d", s.OrderID)
 					}
-					return output.PrintPlain(opts.Out(), [][]string{row})
+					return output.PrintPlain(opts.Out(), [][]string{
+						{s.ID, s.Email, s.ProductName, s.FormattedTotal, s.CreatedAt, fmt.Sprintf("refunded=%v", s.Refunded), orderID},
+					})
 				}
 
 				if err := output.Writef(opts.Out(), "%s  %s\n", style.Bold(s.ProductName), s.FormattedTotal); err != nil {

--- a/internal/cmd/sales/view.go
+++ b/internal/cmd/sales/view.go
@@ -39,9 +39,11 @@ func newViewCmd() *cobra.Command {
 				style := opts.Style()
 
 				if opts.PlainOutput {
-					return output.PrintPlain(opts.Out(), [][]string{
-						{s.ID, s.Email, s.ProductName, s.FormattedTotal, s.CreatedAt, fmt.Sprintf("refunded=%v", s.Refunded)},
-					})
+					row := []string{s.ID, s.Email, s.ProductName, s.FormattedTotal, s.CreatedAt, fmt.Sprintf("refunded=%v", s.Refunded)}
+					if s.OrderID > 0 {
+						row = append(row, fmt.Sprintf("%d", s.OrderID))
+					}
+					return output.PrintPlain(opts.Out(), [][]string{row})
 				}
 
 				if err := output.Writef(opts.Out(), "%s  %s\n", style.Bold(s.ProductName), s.FormattedTotal); err != nil {

--- a/internal/cmd/sales/view.go
+++ b/internal/cmd/sales/view.go
@@ -21,13 +21,13 @@ func newViewCmd() *cobra.Command {
 			return cmdutil.RunRequest(opts, "Fetching sale...", "GET", cmdutil.JoinPath("sales", args[0]), url.Values{}, func(data json.RawMessage) error {
 				var resp struct {
 					Sale struct {
-						ID             string `json:"id"`
-						Email          string `json:"email"`
-						ProductName    string `json:"product_name"`
-						FormattedTotal string `json:"formatted_total_price"`
-						CreatedAt      string `json:"created_at"`
-						Refunded       bool   `json:"refunded"`
-						Shipped        bool   `json:"shipped"`
+						ID             string      `json:"id"`
+						Email          string      `json:"email"`
+						ProductName    string      `json:"product_name"`
+						FormattedTotal string      `json:"formatted_total_price"`
+						CreatedAt      string      `json:"created_at"`
+						Refunded       bool        `json:"refunded"`
+						Shipped        bool        `json:"shipped"`
 						OrderID        api.JSONInt `json:"order_id"`
 					} `json:"sale"`
 				}

--- a/internal/cmd/sales/view.go
+++ b/internal/cmd/sales/view.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/antiwork/gumroad-cli/internal/api"
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
@@ -27,7 +28,7 @@ func newViewCmd() *cobra.Command {
 						CreatedAt      string `json:"created_at"`
 						Refunded       bool   `json:"refunded"`
 						Shipped        bool   `json:"shipped"`
-						OrderID        string `json:"order_id"`
+						OrderID        api.JSONInt `json:"order_id"`
 					} `json:"sale"`
 				}
 				if err := json.Unmarshal(data, &resp); err != nil {
@@ -49,8 +50,8 @@ func newViewCmd() *cobra.Command {
 				if err := output.Writef(opts.Out(), "Sale ID: %s\n", s.ID); err != nil {
 					return err
 				}
-				if s.OrderID != "" {
-					if err := output.Writef(opts.Out(), "Order: %s\n", s.OrderID); err != nil {
+				if s.OrderID > 0 {
+					if err := output.Writef(opts.Out(), "Order: %d\n", s.OrderID); err != nil {
 						return err
 					}
 				}


### PR DESCRIPTION
## What

`sales view` crashes with `json: cannot unmarshal number into Go struct field .sale.order_id of type string`. The `OrderID` field was typed as `string`, but the Gumroad API returns it as a bare JSON number (e.g. `535572601`). Changed the type to `api.JSONInt`, which already exists in the codebase for exactly this class of API inconsistency (fields that arrive as int, float, null, or absent).

## Why

Found during a live smoke test against the real API. The previous test used a fabricated string value (`"ORD-999"`) that masked the mismatch. The API consistently returns `order_id` as a number, which `string` can't unmarshal.

Using `api.JSONInt` instead of raw `json.Number` keeps the fix consistent with how other commands handle the same Gumroad API quirk (inconsistent numeric types). The guard was also tightened from `!= ""` to `> 0` so that zero-valued order IDs (absent/null) are suppressed.

Tests use raw JSON response bodies to exercise the actual wire formats (integer, float `535572601.0`, zero, null, absent) that Go's `encoding/json` would otherwise normalize away.

---

This PR was implemented with AI assistance using Claude Opus 4.6 and gpt‑5.4 xhigh