### PR TITLE
Use .sh extension in install script URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ brew install --cask antiwork/cli/gumroad
 **Shell script** (macOS, Linux, Windows via Git Bash):
 
 ```sh
-curl -fsSL https://gumroad.com/install-cli | bash
+curl -fsSL https://gumroad.com/install-cli.sh | bash
 ```
 
 **Go**:

--- a/script/install.sh
+++ b/script/install.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Install script for the Gumroad CLI.
 # Usage:
-#   curl -fsSL https://gumroad.com/install-cli | bash
+#   curl -fsSL https://gumroad.com/install-cli.sh | bash
 #   GUMROAD_BIN_DIR=~/.bin bash install.sh
 
 REPO="antiwork/gumroad-cli"


### PR DESCRIPTION
## What

Update the one-line install command in the README and the install script's usage comment from `https://gumroad.com/install-cli` to `https://gumroad.com/install-cli.sh`.

## Why

Matches the actual filename being served. The `.sh` suffix also makes it clearer to users that they're piping a shell script into bash, which is a safer-looking command than an extensionless URL.

---

This PR was implemented with AI assistance using Claude Opus 4.6.