### PR TITLE
Add internal/upload multipart orchestrator

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -78,6 +78,14 @@ func (c *Client) Post(path string, params url.Values) (json.RawMessage, error) {
 	return c.do("POST", path, params)
 }
 
+// PostWithContext runs a POST under ctx instead of the client's baked-in
+// context. Use this when a single call's lifetime must be bounded
+// independently — e.g. best-effort cleanup that should honor the caller's
+// cancellation.
+func (c *Client) PostWithContext(ctx context.Context, path string, params url.Values) (json.RawMessage, error) {
+	return c.doWithContext(ctx, "POST", path, params)
+}
+
 func (c *Client) Put(path string, params url.Values) (json.RawMessage, error) {
 	return c.do("PUT", path, params)
 }
@@ -99,6 +107,10 @@ func (c *Client) debugf(format string, args ...any) {
 }
 
 func (c *Client) do(method, path string, params url.Values) (json.RawMessage, error) {
+	return c.doWithContext(c.requestContext(), method, path, params)
+}
+
+func (c *Client) doWithContext(ctx context.Context, method, path string, params url.Values) (json.RawMessage, error) {
 	baseURL := c.baseURL
 	if baseURL == "" {
 		baseURL = defaultBaseURL()
@@ -132,7 +144,7 @@ func (c *Client) do(method, path string, params url.Values) (json.RawMessage, er
 			body = strings.NewReader(encodedParams)
 		}
 
-		req, err := http.NewRequestWithContext(c.requestContext(), method, requestURL, body)
+		req, err := http.NewRequestWithContext(ctx, method, requestURL, body)
 		if err != nil {
 			c.debugf("request method=%s url=%s phase=build err=%q", method, logURL, err)
 			return nil, fmt.Errorf("could not create request: %w", err)
@@ -150,7 +162,7 @@ func (c *Client) do(method, path string, params url.Values) (json.RawMessage, er
 			if shouldRetry(method, attempt, 0) {
 				delay := retryDelay(attempt, "")
 				c.debugf("retry method=%s url=%s attempt=%d wait=%s reason=%q", method, logURL, attempt+1, delay, err)
-				if err := c.snooze(delay); err != nil {
+				if err := c.snoozeCtx(ctx, delay); err != nil {
 					return nil, fmt.Errorf("request failed: %w", err)
 				}
 				continue
@@ -165,7 +177,7 @@ func (c *Client) do(method, path string, params url.Values) (json.RawMessage, er
 			if isRetryableReadError(readErr) && shouldRetry(method, attempt, 0) {
 				delay := retryDelay(attempt, "")
 				c.debugf("retry method=%s url=%s attempt=%d wait=%s reason=%q", method, logURL, attempt+1, delay, readErr)
-				if err := c.snooze(delay); err != nil {
+				if err := c.snoozeCtx(ctx, delay); err != nil {
 					return nil, fmt.Errorf("request failed: %w", err)
 				}
 				continue
@@ -177,7 +189,7 @@ func (c *Client) do(method, path string, params url.Values) (json.RawMessage, er
 		if shouldRetry(method, attempt, resp.StatusCode) {
 			delay := retryDelay(attempt, resp.Header.Get("Retry-After"))
 			c.debugf("retry method=%s url=%s attempt=%d wait=%s reason=%q", method, logURL, attempt+1, delay, resp.Status)
-			if err := c.snooze(delay); err != nil {
+			if err := c.snoozeCtx(ctx, delay); err != nil {
 				return nil, fmt.Errorf("request failed: %w", err)
 			}
 			continue
@@ -233,11 +245,11 @@ func normalizeContext(ctx context.Context) context.Context {
 	return context.Background()
 }
 
-func (c *Client) snooze(delay time.Duration) error {
+func (c *Client) snoozeCtx(ctx context.Context, delay time.Duration) error {
 	if c.sleep != nil {
-		return c.sleep(c.requestContext(), delay)
+		return c.sleep(ctx, delay)
 	}
-	return sleepContext(c.requestContext(), delay)
+	return sleepContext(ctx, delay)
 }
 
 func sleepContext(ctx context.Context, delay time.Duration) error {

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -79,9 +79,9 @@ func (c *Client) Post(path string, params url.Values) (json.RawMessage, error) {
 }
 
 // PostWithContext runs a POST under ctx instead of the client's baked-in
-// context. Use this when a single call's lifetime must be bounded
-// independently — e.g. best-effort cleanup that should honor the caller's
-// cancellation.
+// context. Use this when a single call needs its own independent lifetime —
+// e.g. best-effort cleanup that must still run after the original request
+// context has been canceled.
 func (c *Client) PostWithContext(ctx context.Context, path string, params url.Values) (json.RawMessage, error) {
 	return c.doWithContext(ctx, "POST", path, params)
 }

--- a/internal/upload/upload.go
+++ b/internal/upload/upload.go
@@ -1,0 +1,722 @@
+// Package upload orchestrates Gumroad's S3 multipart upload flow:
+// presign → parallel part PUTs → complete, with best-effort abort on failure.
+package upload
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/antiwork/gumroad-cli/internal/api"
+)
+
+// PartSize is the fixed multipart part size the Gumroad API expects.
+const PartSize int64 = 100 * 1024 * 1024
+
+// activePartSize is the part size used by Describe and Upload. It is equal
+// to PartSize in production; tests override it to avoid 100 MB+ fixtures.
+var activePartSize int64 = PartSize
+
+// allowInsecureUploadDestination is a test-only escape hatch: tests use
+// httptest.NewServer (http://127.0.0.1:PORT), which would otherwise fail
+// validatePresignParts's https check. Production code must leave this false.
+var allowInsecureUploadDestination bool
+
+// MaxFileSize is the server-side upload cap.
+const MaxFileSize int64 = 20 * 1024 * 1024 * 1024
+
+// DefaultConcurrency is the default number of part uploads in flight.
+const DefaultConcurrency = 4
+
+// DefaultPartTimeout bounds each part PUT attempt so a stalled S3 peer
+// cannot hang the upload indefinitely. 60 minutes sets a lower throughput
+// bound of roughly 230 kbps on a 100 MB part, which covers healthy slow
+// links (mobile data, congested Wi-Fi) with margin. Uploads slower than
+// that should set Options.PartTimeout explicitly.
+const DefaultPartTimeout = 60 * time.Minute
+
+const (
+	maxPartRetries = 2
+	maxS3ErrorBody = 4 * 1024
+
+	abortTimeout = 10 * time.Second
+
+	// errorBodyReadTimeout bounds how long we spend reading an S3 error
+	// response body for classification. A slow/hostile peer that drips
+	// bytes would otherwise keep the worker (and the upload's cleanup
+	// path) waiting until the per-part timeout.
+	errorBodyReadTimeout = 500 * time.Millisecond
+
+	s3ExpiredMarker = "Request has expired"
+)
+
+// Backoff durations are vars so tests can shrink them; production callers
+// should treat them as constants.
+var (
+	initialPartRetryBackoff = 200 * time.Millisecond
+	maxPartRetryBackoff     = 2 * time.Second
+)
+
+// ErrPresignExpired is returned when S3 rejects a part PUT because the
+// presigned URL has expired. The caller must retry the whole upload; the
+// orchestrator does not refresh URLs mid-flight.
+var ErrPresignExpired = errors.New("presigned URL expired; restart the upload")
+
+// ErrCompleteStateUnknown is the sentinel matched by errors.Is on any error
+// returned from Upload where /files/complete did not produce a definitive
+// response (5xx, transient 4xx, transport, parse). Callers MUST verify
+// server-side state before retrying — blind retry risks duplicate files.
+// The concrete error implements *UnknownStateError and carries the handles
+// needed for that verification.
+var ErrCompleteStateUnknown = errors.New("upload state unknown; /files/complete did not return a definitive response")
+
+// UnknownStateError is returned from Upload when the complete phase failed
+// ambiguously. It carries the identifiers a caller needs to reconcile: the
+// canonical file_url (to check whether the server committed — empty if the
+// presign response did not include it), the upload_id/key (to abort the
+// orphan later if it did not), and the completed part manifest so the
+// caller can retry /files/complete without re-uploading the file.
+type UnknownStateError struct {
+	FileURL        string
+	UploadID       string
+	Key            string
+	CompletedParts []CompletedPart
+	Cause          error
+}
+
+// CompletedPart is one entry of the manifest passed to /files/complete.
+// Callers use these to retry finalize after an ambiguous failure.
+type CompletedPart struct {
+	PartNumber int
+	ETag       string
+}
+
+func (e *UnknownStateError) Error() string {
+	return fmt.Sprintf("upload state unknown: %s", e.Cause)
+}
+
+func (e *UnknownStateError) Unwrap() error {
+	return e.Cause
+}
+
+func (e *UnknownStateError) Is(target error) bool {
+	return target == ErrCompleteStateUnknown
+}
+
+// CleanupFailedError wraps a /files/abort failure together with the handles
+// needed to retry cleanup (e.g. from a separate job). It is always returned
+// joined with the original upload error via errors.Join, so callers keep
+// access to both: errors.Is on the upload cause, errors.As on this type for
+// the orphan identifiers.
+type CleanupFailedError struct {
+	UploadID string
+	Key      string
+	Cause    error
+}
+
+func (e *CleanupFailedError) Error() string {
+	return fmt.Sprintf("multipart cleanup failed (upload_id=%s key=%s): %s", e.UploadID, e.Key, e.Cause)
+}
+
+func (e *CleanupFailedError) Unwrap() error {
+	return e.Cause
+}
+
+// Plan is the preflight view of a planned upload. It is returned by Describe
+// and is suitable for --dry-run rendering; it makes no network calls.
+type Plan struct {
+	Path      string
+	Filename  string
+	Size      int64
+	PartSize  int64
+	PartCount int
+}
+
+// Options configures Describe and Upload.
+type Options struct {
+	// Filename overrides the display filename sent to presign. Defaults to
+	// filepath.Base(path) when empty.
+	Filename string
+
+	// HTTPClient is used only for S3 part PUTs. Defaults to a client with no
+	// overall timeout (each PUT's lifetime is bounded by context and the
+	// presigned URL's 15-minute expiry). Tests inject this to redirect S3
+	// traffic at an in-process httptest.Server.
+	HTTPClient *http.Client
+
+	// Concurrency bounds the number of part PUTs in flight. Defaults to
+	// DefaultConcurrency. Values <= 0 use the default.
+	Concurrency int
+
+	// Progress, when non-nil, is called with the cumulative number of bytes
+	// uploaded so far. Invocations are serialized and monotonic — callbacks
+	// never run concurrently and the value never goes backwards. A slow or
+	// blocked callback does NOT stall part uploads; it also does not keep
+	// Upload from returning. The last callback may therefore run after
+	// Upload has already returned the file URL.
+	Progress func(bytesUploaded int64)
+
+	// PartTimeout bounds each part PUT attempt (including retries). Zero
+	// means DefaultPartTimeout. Set to a negative value to disable; negative
+	// timeouts let a stalled S3 peer hang the upload indefinitely.
+	PartTimeout time.Duration
+}
+
+// Describe performs local-only preflight: it stats the file, validates
+// size bounds, and computes the part count. It never touches the network.
+func Describe(path string, opts Options) (Plan, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return Plan{}, fmt.Errorf("could not stat file: %w", err)
+	}
+	return planFromStat(path, info, opts)
+}
+
+// planFromStat builds a Plan from already-stat'd file info. Shared between
+// Describe (public preflight, stats the path) and Upload (post-open, stats
+// the open file descriptor so the upload pins one stable snapshot).
+func planFromStat(path string, info os.FileInfo, opts Options) (Plan, error) {
+	if info.IsDir() {
+		return Plan{}, fmt.Errorf("%s is a directory", path)
+	}
+	if !info.Mode().IsRegular() {
+		return Plan{}, fmt.Errorf("%s is not a regular file", path)
+	}
+	size := info.Size()
+	if size == 0 {
+		return Plan{}, fmt.Errorf("%s is empty", path)
+	}
+	if size > MaxFileSize {
+		return Plan{}, fmt.Errorf("file size %d bytes exceeds maximum of %d bytes (20 GB)", size, MaxFileSize)
+	}
+
+	filename := strings.TrimSpace(opts.Filename)
+	if filename == "" {
+		filename = filepath.Base(path)
+	}
+
+	ps := activePartSize
+	partCount := int((size + ps - 1) / ps)
+	return Plan{
+		Path:      path,
+		Filename:  filename,
+		Size:      size,
+		PartSize:  ps,
+		PartCount: partCount,
+	}, nil
+}
+
+// Upload runs the full multipart flow and returns the canonical file_url.
+// Every HTTP call — presign, part PUTs, complete, abort — is bounded by ctx.
+// The *api.Client supplies auth and base URL only; its baked-in context is
+// ignored so upload cancellation actually bounds all in-flight work.
+func Upload(ctx context.Context, client *api.Client, path string, opts Options) (string, error) {
+	// Stat first: os.Open on a FIFO/device would block the process until a
+	// writer appears (Unix semantics, not bound by ctx). Checking the mode
+	// up front turns that hang into a clear error. A TOCTOU race where the
+	// path is swapped between Stat and Open is caught by the post-open
+	// f.Stat() check below.
+	preInfo, err := os.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("could not stat file: %w", err)
+	}
+	if !preInfo.Mode().IsRegular() {
+		return "", fmt.Errorf("%s is not a regular file", path)
+	}
+
+	// Pin the upload to a single FD so presign metadata and part PUTs read
+	// the same bytes even if the path is mutated concurrently.
+	f, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("could not open file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	info, err := f.Stat()
+	if err != nil {
+		return "", fmt.Errorf("could not stat file: %w", err)
+	}
+	plan, err := planFromStat(path, info, opts)
+	if err != nil {
+		return "", err
+	}
+
+	presignResp, err := presign(ctx, client, plan.Filename, plan.Size)
+	if err != nil {
+		// A partially-parsed response may still carry the handles needed to
+		// abort an orphaned multipart upload; if so, clean up.
+		if presignResp.UploadID != "" && presignResp.Key != "" {
+			return "", joinAbort(err, presignResp.UploadID, presignResp.Key, safeAbort(client, presignResp.UploadID, presignResp.Key))
+		}
+		return "", err
+	}
+
+	if err := validatePresignParts(presignResp.Parts, plan.PartCount); err != nil {
+		return "", joinAbort(err, presignResp.UploadID, presignResp.Key, safeAbort(client, presignResp.UploadID, presignResp.Key))
+	}
+
+	httpClient := opts.HTTPClient
+	if httpClient == nil {
+		httpClient = sharedS3Client
+	}
+
+	concurrency := opts.Concurrency
+	if concurrency <= 0 {
+		concurrency = DefaultConcurrency
+	}
+
+	partTimeout := opts.PartTimeout
+	if partTimeout == 0 {
+		partTimeout = DefaultPartTimeout
+	}
+
+	etags, err := uploadAllParts(ctx, httpClient, f, presignResp.Parts, plan.PartSize, plan.Size, concurrency, partTimeout, opts.Progress)
+	if err != nil {
+		return "", joinAbort(err, presignResp.UploadID, presignResp.Key, safeAbort(client, presignResp.UploadID, presignResp.Key))
+	}
+
+	// If ctx is already canceled before we even attempt the finalize, the
+	// request hasn't left the client — no server state, abort is safe.
+	// Once PostWithContext runs, any transport/write failure could still
+	// have delivered bytes to the server, so we can't claim that path is
+	// also definitive.
+	if err := ctx.Err(); err != nil {
+		return "", joinAbort(err, presignResp.UploadID, presignResp.Key, safeAbort(client, presignResp.UploadID, presignResp.Key))
+	}
+
+	fileURL, err := completeUpload(ctx, client, presignResp.UploadID, presignResp.Key, presignResp.Parts, etags)
+	if err != nil {
+		var apiErr *api.APIError
+		if errors.As(err, &apiErr) && isDefinitiveCompleteRejection(apiErr.StatusCode) {
+			return "", joinAbort(err, presignResp.UploadID, presignResp.Key, safeAbort(client, presignResp.UploadID, presignResp.Key))
+		}
+		// Ambiguous (5xx, 408, 409, 429, transport/write/read failures):
+		// the server may have committed. Skip abort so we don't race the
+		// commit or tear down a successful upload.
+		completed := make([]CompletedPart, len(presignResp.Parts))
+		for i, p := range presignResp.Parts {
+			completed[i] = CompletedPart{PartNumber: p.PartNumber, ETag: etags[i]}
+		}
+		return "", &UnknownStateError{
+			FileURL:        presignResp.FileURL,
+			UploadID:       presignResp.UploadID,
+			Key:            presignResp.Key,
+			CompletedParts: completed,
+			Cause:          err,
+		}
+	}
+	return fileURL, nil
+}
+
+// isDefinitiveCompleteRejection reports whether a /files/complete status code
+// contractually means the request was rejected without committing — i.e.
+// abort is safe. Gumroad reports many failures as HTTP 200 with
+// {"success":false}, which api.Client surfaces as an APIError with
+// StatusCode == 200; that is still an explicit rejection and counts as
+// definitive. Transient 4xxs (408, 409, 429) and 5xx are ambiguous.
+func isDefinitiveCompleteRejection(status int) bool {
+	if status >= 500 {
+		return false
+	}
+	switch status {
+	case http.StatusRequestTimeout, http.StatusConflict, http.StatusTooManyRequests:
+		return false
+	}
+	return true
+}
+
+type presignResponse struct {
+	UploadID string        `json:"upload_id"`
+	Key      string        `json:"key"`
+	FileURL  string        `json:"file_url"`
+	Parts    []presignPart `json:"parts"`
+}
+
+type presignPart struct {
+	PartNumber   int    `json:"part_number"`
+	PresignedURL string `json:"presigned_url"`
+}
+
+func presign(ctx context.Context, client *api.Client, filename string, size int64) (presignResponse, error) {
+	params := url.Values{}
+	params.Set("filename", filename)
+	params.Set("file_size", strconv.FormatInt(size, 10))
+
+	data, err := client.PostWithContext(ctx, "/files/presign", params)
+	if err != nil {
+		return presignResponse{}, err
+	}
+
+	// Return whatever parsed successfully so the caller can still attempt
+	// /files/abort via upload_id/key if Rails already created the multipart
+	// upload but returned a malformed/incomplete response.
+	var resp presignResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return resp, fmt.Errorf("could not parse presign response: %w", err)
+	}
+	// file_url is optional: the authoritative URL comes from /files/complete.
+	// The presign copy is only used to populate UnknownStateError for ambiguous
+	// complete failures, so rejecting presigns without it would be a needless
+	// compatibility requirement.
+	if resp.UploadID == "" || resp.Key == "" {
+		return resp, errors.New("presign response missing upload_id or key")
+	}
+	return resp, nil
+}
+
+func completeUpload(ctx context.Context, client *api.Client, uploadID, key string, parts []presignPart, etags []string) (string, error) {
+	params := url.Values{}
+	params.Set("upload_id", uploadID)
+	params.Set("key", key)
+	for i, p := range parts {
+		params.Set(fmt.Sprintf("parts[%d][part_number]", i), strconv.Itoa(p.PartNumber))
+		params.Set(fmt.Sprintf("parts[%d][etag]", i), etags[i])
+	}
+
+	data, err := client.PostWithContext(ctx, "/files/complete", params)
+	if err != nil {
+		return "", err
+	}
+
+	var resp struct {
+		FileURL string `json:"file_url"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return "", fmt.Errorf("could not parse complete response: %w", err)
+	}
+	if resp.FileURL == "" {
+		return "", errors.New("complete response missing file_url")
+	}
+	return resp.FileURL, nil
+}
+
+// safeAbort posts /files/abort under a fresh context so the cleanup attempt
+// runs even when the caller's upload context is already canceled — which is
+// exactly when we most want to reclaim the orphaned multipart. Bounded by
+// abortTimeout so a hung backend cannot hold the caller indefinitely. It
+// returns the abort error so callers can surface it (joined with the main
+// error) together with the upload_id/key needed to retry cleanup later.
+func safeAbort(client *api.Client, uploadID, key string) error {
+	abortCtx, cancel := context.WithTimeout(context.Background(), abortTimeout)
+	defer cancel()
+	params := url.Values{}
+	params.Set("upload_id", uploadID)
+	params.Set("key", key)
+	_, err := client.PostWithContext(abortCtx, "/files/abort", params)
+	return err
+}
+
+// joinAbort wraps an upload failure with cleanup info when /files/abort also
+// failed, so callers keep the original error semantics (errors.Is still
+// matches) but can also errors.As into *CleanupFailedError to retry the
+// orphan cleanup from the upload_id and key.
+func joinAbort(uploadErr error, uploadID, key string, abortErr error) error {
+	if abortErr == nil {
+		return uploadErr
+	}
+	return errors.Join(uploadErr, &CleanupFailedError{
+		UploadID: uploadID,
+		Key:      key,
+		Cause:    abortErr,
+	})
+}
+
+// sharedS3Client is used by every Upload call that does not inject an
+// HTTPClient. Sharing one instance avoids accumulating idle-connection
+// pools and transport timers across repeated uploads in a long-lived
+// process. It bounds the opaque failure modes that Go's default HTTP
+// client leaves unbounded — hung TCP handshake, stalled TLS, silent peer
+// — without setting http.Client.Timeout, which would cap the total PUT
+// duration and kill legitimately slow uploads of a 100 MB part.
+var sharedS3Client = &http.Client{
+	Transport: &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		ResponseHeaderTimeout: 60 * time.Second,
+	},
+}
+
+// validatePresignParts guards against server-side inconsistencies (duplicate,
+// missing, zero, or out-of-order part numbers) before any PUT touches S3,
+// since part_number directly drives the file byte-range offset. It also
+// requires each presigned URL to be HTTPS — file bytes leave this process
+// over that URL, so we refuse to stream them over plain text even if the
+// server is misconfigured or compromised.
+func validatePresignParts(parts []presignPart, expected int) error {
+	if len(parts) != expected {
+		return fmt.Errorf("presign returned %d parts, expected %d", len(parts), expected)
+	}
+	for i, p := range parts {
+		if p.PartNumber != i+1 {
+			return fmt.Errorf("presign returned part_number %d at index %d, expected %d", p.PartNumber, i, i+1)
+		}
+		if p.PresignedURL == "" {
+			return fmt.Errorf("presign returned empty URL for part %d", p.PartNumber)
+		}
+		if !allowInsecureUploadDestination && !strings.HasPrefix(p.PresignedURL, "https://") {
+			return fmt.Errorf("presign returned non-https URL for part %d", p.PartNumber)
+		}
+	}
+	return nil
+}
+
+func uploadAllParts(
+	ctx context.Context,
+	httpClient *http.Client,
+	f *os.File,
+	parts []presignPart,
+	partSize, totalSize int64,
+	concurrency int,
+	partTimeout time.Duration,
+	progress func(int64),
+) ([]string, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	etags := make([]string, len(parts))
+	sem := make(chan struct{}, concurrency)
+
+	var firstErr error
+	var errMu sync.Mutex
+	setErr := func(err error) {
+		errMu.Lock()
+		if firstErr == nil {
+			firstErr = err
+			cancel()
+		}
+		errMu.Unlock()
+	}
+
+	// Progress dispatch: workers enqueue cumulative-byte updates on a
+	// buffered channel (cap = len(parts) so sends never block). A dedicated
+	// goroutine drains the channel sequentially, which gives us both
+	// serialization and monotonicity without ever holding the worker's
+	// semaphore slot across a potentially-slow callback. After wg.Wait we
+	// close the channel; we do not block on callback drain, so a hung
+	// callback cannot keep Upload from returning.
+	var progressCh chan int64
+	if progress != nil {
+		progressCh = make(chan int64, len(parts))
+		go func() {
+			for n := range progressCh {
+				progress(n)
+			}
+		}()
+	}
+	var uploaded int64
+	var progMu sync.Mutex
+	reportProgress := func(size int64) {
+		if progressCh == nil {
+			return
+		}
+		progMu.Lock()
+		uploaded += size
+		progressCh <- uploaded
+		progMu.Unlock()
+	}
+
+	var wg sync.WaitGroup
+	for i := range parts {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+
+			select {
+			case sem <- struct{}{}:
+			case <-ctx.Done():
+				setErr(ctx.Err())
+				return
+			}
+
+			partNumber := parts[i].PartNumber
+			offset := int64(partNumber-1) * partSize
+			size := partSize
+			if offset+size > totalSize {
+				size = totalSize - offset
+			}
+
+			etag, err := uploadPart(ctx, httpClient, f, parts[i].PresignedURL, offset, size, partTimeout)
+			// Release the slot before the potentially-slow progress callback
+			// so a blocked callback cannot starve the worker pool.
+			<-sem
+
+			if err != nil {
+				setErr(fmt.Errorf("upload part %d: %w", partNumber, err))
+				return
+			}
+			etags[i] = etag
+			reportProgress(size)
+		}(i)
+	}
+	wg.Wait()
+	if progressCh != nil {
+		close(progressCh)
+	}
+
+	if firstErr != nil {
+		return nil, firstErr
+	}
+	return etags, nil
+}
+
+func uploadPart(ctx context.Context, client *http.Client, f *os.File, presignedURL string, offset, size int64, partTimeout time.Duration) (string, error) {
+	var lastErr error
+	for attempt := 0; attempt <= maxPartRetries; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+
+		attemptCtx := ctx
+		cancelAttempt := func() {}
+		if partTimeout > 0 {
+			attemptCtx, cancelAttempt = context.WithTimeout(ctx, partTimeout)
+		}
+		etag, err := putPart(attemptCtx, client, presignedURL, f, offset, size)
+		cancelAttempt()
+
+		if err == nil {
+			return etag, nil
+		}
+		// Parent-ctx cancellation beats any attempt-level error: honor the
+		// caller's intent to stop.
+		if parentErr := ctx.Err(); parentErr != nil {
+			return "", parentErr
+		}
+		if !isRetryablePartError(err) {
+			return "", err
+		}
+		lastErr = err
+		if attempt == maxPartRetries {
+			break
+		}
+		if err := sleepBackoff(ctx, attempt); err != nil {
+			return "", err
+		}
+	}
+	return "", lastErr
+}
+
+func putPart(ctx context.Context, client *http.Client, presignedURL string, f *os.File, offset, size int64) (string, error) {
+	body := io.NewSectionReader(f, offset, size)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, presignedURL, body)
+	if err != nil {
+		return "", fmt.Errorf("could not create request: %w", err)
+	}
+	req.ContentLength = size
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+
+	// On non-2xx: read a bounded snippet for error classification, then
+	// close immediately. Both the byte count (maxS3ErrorBody) and the read
+	// duration (errorBodyReadTimeout) are capped so a peer that streams
+	// bytes slowly — or an unbounded error body — cannot stall the worker.
+	// Losing classification on a slow body just means we surface a generic
+	// S3 error instead of ErrPresignExpired, which retry/abort already
+	// handle.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		snippet := readBoundedBody(resp.Body, maxS3ErrorBody, errorBodyReadTimeout)
+		_ = resp.Body.Close()
+		if resp.StatusCode == http.StatusForbidden && bytes.Contains(snippet, []byte(s3ExpiredMarker)) {
+			return "", ErrPresignExpired
+		}
+		return "", &s3StatusError{status: resp.StatusCode, body: bytes.TrimSpace(snippet)}
+	}
+
+	// 2xx path: close immediately without draining. S3 PUT success bodies
+	// are empty, so there's nothing meaningful to drain. Skipping the drain
+	// forfeits connection reuse on that socket but guarantees a peer that
+	// trickles bytes after the header cannot stall the worker pool.
+	defer func() { _ = resp.Body.Close() }()
+
+	etag := strings.Trim(resp.Header.Get("ETag"), `"`)
+	if etag == "" {
+		return "", errors.New("S3 response missing ETag header")
+	}
+	return etag, nil
+}
+
+// readBoundedBody reads at most maxBytes from r, giving up after timeout.
+// The caller owns r and must Close it; on timeout the read goroutine will
+// unblock when Close cancels the underlying Read.
+func readBoundedBody(r io.Reader, maxBytes int64, timeout time.Duration) []byte {
+	result := make(chan []byte, 1)
+	go func() {
+		b, _ := io.ReadAll(io.LimitReader(r, maxBytes))
+		result <- b
+	}()
+	select {
+	case b := <-result:
+		return b
+	case <-time.After(timeout):
+		return nil
+	}
+}
+
+type s3StatusError struct {
+	status int
+	body   []byte
+}
+
+func (e *s3StatusError) Error() string {
+	if len(e.body) == 0 {
+		return fmt.Sprintf("S3 returned HTTP %d", e.status)
+	}
+	return fmt.Sprintf("S3 returned HTTP %d: %s", e.status, e.body)
+}
+
+// isRetryablePartError classifies errors returned from a single part PUT
+// attempt. The caller must have already cleared parent-context cancellation;
+// context.DeadlineExceeded here therefore means the inner per-part timeout
+// fired (stalled peer), which is retryable with a fresh deadline.
+func isRetryablePartError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, ErrPresignExpired) {
+		return false
+	}
+	var s3Err *s3StatusError
+	if errors.As(err, &s3Err) {
+		return s3Err.status == http.StatusTooManyRequests || s3Err.status >= 500
+	}
+	return true
+}
+
+func sleepBackoff(ctx context.Context, attempt int) error {
+	backoff := float64(initialPartRetryBackoff) * math.Pow(2, float64(attempt))
+	if backoff > float64(maxPartRetryBackoff) {
+		backoff = float64(maxPartRetryBackoff)
+	}
+	timer := time.NewTimer(time.Duration(backoff))
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/internal/upload/upload.go
+++ b/internal/upload/upload.go
@@ -166,7 +166,7 @@ type Options struct {
 	// never run concurrently and the value never goes backwards. A slow or
 	// blocked callback does NOT stall part uploads; it also does not keep
 	// Upload from returning. The last callback may therefore run after
-	// Upload has already returned the file URL.
+	// Upload has already returned — including after it returns an error.
 	Progress func(bytesUploaded int64)
 
 	// PartTimeout bounds each part PUT attempt (including retries). Zero
@@ -227,8 +227,9 @@ func Upload(ctx context.Context, client *api.Client, path string, opts Options) 
 	// Stat first: os.Open on a FIFO/device would block the process until a
 	// writer appears (Unix semantics, not bound by ctx). Checking the mode
 	// up front turns that hang into a clear error. A TOCTOU race where the
-	// path is swapped between Stat and Open is caught by the post-open
-	// f.Stat() check below.
+	// path is swapped between Stat and Open is still possible; the post-open
+	// f.Stat() check below only catches non-regular replacements if os.Open
+	// itself returns instead of blocking first.
 	preInfo, err := os.Stat(path)
 	if err != nil {
 		return "", fmt.Errorf("could not stat file: %w", err)
@@ -624,6 +625,9 @@ func putPart(ctx context.Context, client *http.Client, presignedURL string, f *o
 		return "", fmt.Errorf("could not create request: %w", err)
 	}
 	req.ContentLength = size
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(io.NewSectionReader(f, offset, size)), nil
+	}
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -668,10 +672,12 @@ func readBoundedBody(r io.Reader, maxBytes int64, timeout time.Duration) []byte 
 		b, _ := io.ReadAll(io.LimitReader(r, maxBytes))
 		result <- b
 	}()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
 	select {
 	case b := <-result:
 		return b
-	case <-time.After(timeout):
+	case <-timer.C:
 		return nil
 	}
 }

--- a/internal/upload/upload.go
+++ b/internal/upload/upload.go
@@ -220,9 +220,11 @@ func planFromStat(path string, info os.FileInfo, opts Options) (Plan, error) {
 }
 
 // Upload runs the full multipart flow and returns the canonical file_url.
-// Every HTTP call — presign, part PUTs, complete, abort — is bounded by ctx.
+// presign, part PUTs, and /files/complete are bounded by ctx; /files/abort
+// runs under an independent 10-second timeout so cleanup still fires when
+// ctx is already canceled, which also means ctx cannot shorten or skip it.
 // The *api.Client supplies auth and base URL only; its baked-in context is
-// ignored so upload cancellation actually bounds all in-flight work.
+// ignored so ctx bounds all in-flight work except that abort cleanup.
 func Upload(ctx context.Context, client *api.Client, path string, opts Options) (string, error) {
 	// Stat first: os.Open on a FIFO/device would block the process until a
 	// writer appears (Unix semantics, not bound by ctx). Checking the mode

--- a/internal/upload/upload_fifo_unix_test.go
+++ b/internal/upload/upload_fifo_unix_test.go
@@ -1,0 +1,71 @@
+//go:build unix
+
+package upload
+
+import (
+	"context"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestDescribe_RejectsFIFO(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pipe")
+	if err := syscall.Mkfifo(path, 0o600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+
+	// Run Describe in a goroutine so an accidental blocking read on the
+	// FIFO would show up as a test timeout rather than hanging the harness.
+	done := make(chan error, 1)
+	go func() {
+		_, err := Describe(path, Options{})
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected error for FIFO")
+		}
+		if !strings.Contains(err.Error(), "not a regular file") {
+			t.Errorf("error = %v, want mention of regular file", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Describe hung on a FIFO")
+	}
+}
+
+func TestUpload_RejectsFIFO(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pipe")
+	if err := syscall.Mkfifo(path, 0o600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+
+	mock := &railsMock{}
+	client, _ := setupServers(t, mock, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("S3 must not be reached for a FIFO path")
+	}))
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := Upload(context.Background(), client, path, Options{})
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "not a regular file") {
+			t.Errorf("error = %v, want mention of regular file", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Upload hung on a FIFO — pre-Open stat check missing")
+	}
+	if mock.presignCalls.Load() != 0 {
+		t.Errorf("presign called for FIFO")
+	}
+}

--- a/internal/upload/upload_test.go
+++ b/internal/upload/upload_test.go
@@ -11,12 +11,10 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"testing"
 	"time"
 
@@ -277,70 +275,6 @@ func TestDescribe_RejectsMissing(t *testing.T) {
 	_, err := Describe(filepath.Join(t.TempDir(), "does-not-exist"), Options{})
 	if err == nil {
 		t.Fatal("expected error for missing file")
-	}
-}
-
-func TestDescribe_RejectsFIFO(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("FIFOs are a Unix concept")
-	}
-	path := filepath.Join(t.TempDir(), "pipe")
-	if err := syscall.Mkfifo(path, 0o600); err != nil {
-		t.Fatalf("mkfifo: %v", err)
-	}
-
-	// Run Describe in a goroutine so an accidental blocking read on the
-	// FIFO would show up as a test timeout rather than hanging the harness.
-	done := make(chan error, 1)
-	go func() {
-		_, err := Describe(path, Options{})
-		done <- err
-	}()
-	select {
-	case err := <-done:
-		if err == nil {
-			t.Fatal("expected error for FIFO")
-		}
-		if !strings.Contains(err.Error(), "not a regular file") {
-			t.Errorf("error = %v, want mention of regular file", err)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("Describe hung on a FIFO")
-	}
-}
-
-func TestUpload_RejectsFIFO(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("FIFOs are a Unix concept")
-	}
-	path := filepath.Join(t.TempDir(), "pipe")
-	if err := syscall.Mkfifo(path, 0o600); err != nil {
-		t.Fatalf("mkfifo: %v", err)
-	}
-
-	mock := &railsMock{}
-	client, _ := setupServers(t, mock, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Error("S3 must not be reached for a FIFO path")
-	}))
-
-	done := make(chan error, 1)
-	go func() {
-		_, err := Upload(context.Background(), client, path, Options{})
-		done <- err
-	}()
-	select {
-	case err := <-done:
-		if err == nil {
-			t.Fatal("expected error")
-		}
-		if !strings.Contains(err.Error(), "not a regular file") {
-			t.Errorf("error = %v, want mention of regular file", err)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("Upload hung on a FIFO — pre-Open stat check missing")
-	}
-	if mock.presignCalls.Load() != 0 {
-		t.Errorf("presign called for FIFO")
 	}
 }
 

--- a/internal/upload/upload_test.go
+++ b/internal/upload/upload_test.go
@@ -1131,6 +1131,70 @@ func TestUpload_PartTimeoutFiresOnStalledS3(t *testing.T) {
 	}
 }
 
+func TestPutPart_Follows307RedirectWithBody(t *testing.T) {
+	path := writeFile(t, 16)
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open fixture: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	const (
+		offset = int64(3)
+		size   = int64(5)
+	)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	wantBody := data[offset : offset+size]
+
+	var redirectURL string
+	var redirectCalls atomic.Int32
+	var finalCalls atomic.Int32
+	s3 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/redirect":
+			redirectCalls.Add(1)
+			http.Redirect(w, r, redirectURL, http.StatusTemporaryRedirect)
+		case "/final":
+			finalCalls.Add(1)
+			if r.Method != http.MethodPut {
+				t.Errorf("method = %s, want PUT", r.Method)
+			}
+			gotBody, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read redirected body: %v", err)
+				http.Error(w, "read body", http.StatusInternalServerError)
+				return
+			}
+			if !bytes.Equal(gotBody, wantBody) {
+				t.Errorf("redirected body = %v, want %v", gotBody, wantBody)
+			}
+			w.Header().Set("ETag", `"redirect-etag"`)
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer s3.Close()
+	redirectURL = s3.URL + "/final"
+
+	etag, err := putPart(context.Background(), s3.Client(), s3.URL+"/redirect", f, offset, size)
+	if err != nil {
+		t.Fatalf("putPart: %v", err)
+	}
+	if etag != "redirect-etag" {
+		t.Errorf("etag = %q, want redirect-etag", etag)
+	}
+	if redirectCalls.Load() != 1 {
+		t.Errorf("redirectCalls = %d, want 1", redirectCalls.Load())
+	}
+	if finalCalls.Load() != 1 {
+		t.Errorf("finalCalls = %d, want 1", finalCalls.Load())
+	}
+}
+
 func TestUpload_SlowProgressCallbackDoesNotStallWorkers(t *testing.T) {
 	// With Concurrency=1 and a progress callback that blocks, earlier
 	// designs held the semaphore slot across the callback and froze the

--- a/internal/upload/upload_test.go
+++ b/internal/upload/upload_test.go
@@ -1295,32 +1295,37 @@ func TestUpload_SuccessBodyDrainBounded(t *testing.T) {
 }
 
 func TestUpload_PresignPartialResponseTriggersAbort(t *testing.T) {
-	// If presign validation fails but upload_id/key were returned, Upload
-	// must still attempt /files/abort so the server-side multipart is not
-	// orphaned.
+	// If the presign body parses upload_id/key successfully but then fails
+	// — e.g. a later field has the wrong type — the server has already
+	// created the multipart upload. Upload must call /files/abort using
+	// the salvaged handles instead of leaking the orphan.
 	setTestPartSize(t, 100)
 	path := writeFile(t, 50)
 
 	mock := &railsMock{}
 	client, _ := setupServers(t, mock, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Error("S3 should not be reached when presign validation fails")
+		t.Error("S3 must not be reached when presign parsing fails")
 	}))
 	mock.presign = func(w http.ResponseWriter, r *http.Request) {
-		// upload_id and key present, file_url missing — validation fails but
-		// the server has already created the multipart upload.
-		testutil.JSON(t, w, map[string]any{
-			"upload_id": "up-orphan",
-			"key":       "attachments/orphan",
-			"parts":     []map[string]any{{"part_number": 1, "presigned_url": "https://s3/p1"}},
-		})
+		// `parts` is a string instead of an array: json.Unmarshal populates
+		// UploadID and Key in order, then fails on the type mismatch,
+		// returning the partially-filled struct alongside the parse error.
+		_, _ = io.WriteString(w, `{"success":true,"upload_id":"up-orphan","key":"attachments/orphan","parts":"not_an_array"}`)
 	}
 
 	_, err := Upload(context.Background(), client, path, Options{})
 	if err == nil {
 		t.Fatal("expected error")
 	}
+	if !strings.Contains(err.Error(), "parse presign response") {
+		t.Errorf("error = %v, want parse-presign error", err)
+	}
 	if mock.abortCalls.Load() != 1 {
 		t.Errorf("abortCalls = %d, want 1 (orphan must be cleaned up)", mock.abortCalls.Load())
+	}
+	var cleanup *CleanupFailedError
+	if errors.As(err, &cleanup) {
+		t.Errorf("abort unexpectedly failed: %v", cleanup)
 	}
 }
 

--- a/internal/upload/upload_test.go
+++ b/internal/upload/upload_test.go
@@ -1,0 +1,1456 @@
+package upload
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+// TestMain bypasses the https-only destination check for the whole package
+// because every test targets an httptest.Server on http://127.0.0.1. The
+// check itself is exercised directly via TestValidatePresignParts_HTTPSOnly.
+func TestMain(m *testing.M) {
+	allowInsecureUploadDestination = true
+	os.Exit(m.Run())
+}
+
+// setTestPartSize swaps activePartSize for the duration of a test so we can
+// exercise multi-part flows without 100 MB+ fixtures.
+func setTestPartSize(t *testing.T, v int64) {
+	t.Helper()
+	prev := activePartSize
+	activePartSize = v
+	t.Cleanup(func() { activePartSize = prev })
+}
+
+// shortBackoff collapses part-upload retry waits so retry tests don't spend
+// ~600 ms in backoff sleeps.
+func shortBackoff(t *testing.T) {
+	t.Helper()
+	prevInitial, prevMax := initialPartRetryBackoff, maxPartRetryBackoff
+	initialPartRetryBackoff = time.Millisecond
+	maxPartRetryBackoff = time.Millisecond
+	t.Cleanup(func() {
+		initialPartRetryBackoff = prevInitial
+		maxPartRetryBackoff = prevMax
+	})
+}
+
+// writeFile creates a fixture with `size` bytes of predictable content so
+// tests can verify that per-part byte ranges were streamed correctly.
+func writeFile(t *testing.T, size int64) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "fixture.bin")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create fixture: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	buf := make([]byte, 1024)
+	for i := range buf {
+		buf[i] = byte(i)
+	}
+	remaining := size
+	for remaining > 0 {
+		n := int64(len(buf))
+		if n > remaining {
+			n = remaining
+		}
+		if _, err := f.Write(buf[:n]); err != nil {
+			t.Fatalf("write fixture: %v", err)
+		}
+		remaining -= n
+	}
+	return path
+}
+
+// railsMock tracks calls to the Rails endpoints and delegates each to a
+// handler. Any handler left nil returns an unexpected-endpoint failure.
+type railsMock struct {
+	presign  http.HandlerFunc
+	complete http.HandlerFunc
+	abortH   http.HandlerFunc
+
+	presignCalls  atomic.Int32
+	completeCalls atomic.Int32
+	abortCalls    atomic.Int32
+
+	completeBody url.Values
+	completeMu   sync.Mutex
+}
+
+// dispatch routes the request by path and records the call. It also captures
+// the parsed form body from /files/complete because several tests assert on
+// the indexed parts[n][...] encoding.
+func (m *railsMock) dispatch(t *testing.T, w http.ResponseWriter, r *http.Request) {
+	t.Helper()
+	switch r.URL.Path {
+	case "/files/presign":
+		m.presignCalls.Add(1)
+		if m.presign == nil {
+			t.Errorf("unexpected /files/presign call")
+			http.Error(w, "unexpected", http.StatusInternalServerError)
+			return
+		}
+		m.presign(w, r)
+	case "/files/complete":
+		m.completeCalls.Add(1)
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("parse complete form: %v", err)
+		}
+		m.completeMu.Lock()
+		m.completeBody = r.PostForm
+		m.completeMu.Unlock()
+		if m.complete == nil {
+			t.Errorf("unexpected /files/complete call")
+			http.Error(w, "unexpected", http.StatusInternalServerError)
+			return
+		}
+		m.complete(w, r)
+	case "/files/abort":
+		m.abortCalls.Add(1)
+		if m.abortH == nil {
+			testutil.JSON(t, w, map[string]any{})
+			return
+		}
+		m.abortH(w, r)
+	default:
+		t.Errorf("unexpected Rails path: %s", r.URL.Path)
+		http.Error(w, "unexpected", http.StatusNotFound)
+	}
+}
+
+func (m *railsMock) completeForm() url.Values {
+	m.completeMu.Lock()
+	defer m.completeMu.Unlock()
+	return m.completeBody
+}
+
+// setupServers wires a Rails mock (via testutil.Setup so the env + token are
+// configured) and an S3 mock. The returned client hits the Rails mock; the
+// S3 URL is available for the Rails mock to embed in presign responses.
+func setupServers(t *testing.T, mock *railsMock, s3 http.Handler) (*api.Client, string) {
+	t.Helper()
+	s3srv := httptest.NewServer(s3)
+	t.Cleanup(s3srv.Close)
+
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		mock.dispatch(t, w, r)
+	})
+
+	client := api.NewClient("test-token", "test", false)
+	return client, s3srv.URL
+}
+
+func writePresignResponse(t *testing.T, w http.ResponseWriter, uploadID, key, fileURL string, partURLs []string) {
+	t.Helper()
+	parts := make([]map[string]any, len(partURLs))
+	for i, u := range partURLs {
+		parts[i] = map[string]any{
+			"part_number":   i + 1,
+			"presigned_url": u,
+		}
+	}
+	testutil.JSON(t, w, map[string]any{
+		"upload_id": uploadID,
+		"key":       key,
+		"file_url":  fileURL,
+		"parts":     parts,
+	})
+}
+
+func partPath(i int) string {
+	return "/part/" + strconv.Itoa(i)
+}
+
+func partNumberFromPath(p string) int {
+	parts := strings.Split(p, "/")
+	n, _ := strconv.Atoi(parts[len(parts)-1])
+	return n
+}
+
+// --- Describe tests ---
+
+func TestDescribe_HappyPath(t *testing.T) {
+	setTestPartSize(t, 10)
+	path := writeFile(t, 25)
+
+	plan, err := Describe(path, Options{})
+	if err != nil {
+		t.Fatalf("Describe: %v", err)
+	}
+	if plan.Path != path {
+		t.Errorf("Path = %q, want %q", plan.Path, path)
+	}
+	if plan.Filename != filepath.Base(path) {
+		t.Errorf("Filename = %q, want %q", plan.Filename, filepath.Base(path))
+	}
+	if plan.Size != 25 {
+		t.Errorf("Size = %d, want 25", plan.Size)
+	}
+	if plan.PartSize != 10 {
+		t.Errorf("PartSize = %d, want 10", plan.PartSize)
+	}
+	if plan.PartCount != 3 {
+		t.Errorf("PartCount = %d, want 3", plan.PartCount)
+	}
+}
+
+func TestDescribe_FilenameOverride(t *testing.T) {
+	setTestPartSize(t, 10)
+	path := writeFile(t, 5)
+
+	plan, err := Describe(path, Options{Filename: "pack.zip"})
+	if err != nil {
+		t.Fatalf("Describe: %v", err)
+	}
+	if plan.Filename != "pack.zip" {
+		t.Errorf("Filename = %q, want pack.zip", plan.Filename)
+	}
+}
+
+func TestDescribe_RejectsEmpty(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "empty.bin")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	_ = f.Close()
+
+	_, err = Describe(path, Options{})
+	if err == nil {
+		t.Fatal("expected error for empty file")
+	}
+	if !strings.Contains(err.Error(), "empty") {
+		t.Errorf("error = %v, want mention of empty", err)
+	}
+}
+
+func TestDescribe_RejectsOversize(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "huge.bin")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	// Sparse file: reports 20 GB + 1 B but occupies ~0 bytes on disk.
+	if err := f.Truncate(MaxFileSize + 1); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	_ = f.Close()
+
+	_, err = Describe(path, Options{})
+	if err == nil {
+		t.Fatal("expected error for oversize file")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("error = %v, want mention of exceeds", err)
+	}
+}
+
+func TestDescribe_RejectsDirectory(t *testing.T) {
+	_, err := Describe(t.TempDir(), Options{})
+	if err == nil {
+		t.Fatal("expected error for directory")
+	}
+}
+
+func TestDescribe_RejectsMissing(t *testing.T) {
+	_, err := Describe(filepath.Join(t.TempDir(), "does-not-exist"), Options{})
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestDescribe_RejectsFIFO(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("FIFOs are a Unix concept")
+	}
+	path := filepath.Join(t.TempDir(), "pipe")
+	if err := syscall.Mkfifo(path, 0o600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+
+	// Run Describe in a goroutine so an accidental blocking read on the
+	// FIFO would show up as a test timeout rather than hanging the harness.
+	done := make(chan error, 1)
+	go func() {
+		_, err := Describe(path, Options{})
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected error for FIFO")
+		}
+		if !strings.Contains(err.Error(), "not a regular file") {
+			t.Errorf("error = %v, want mention of regular file", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Describe hung on a FIFO")
+	}
+}
+
+func TestUpload_RejectsFIFO(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("FIFOs are a Unix concept")
+	}
+	path := filepath.Join(t.TempDir(), "pipe")
+	if err := syscall.Mkfifo(path, 0o600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+
+	mock := &railsMock{}
+	client, _ := setupServers(t, mock, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("S3 must not be reached for a FIFO path")
+	}))
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := Upload(context.Background(), client, path, Options{})
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "not a regular file") {
+			t.Errorf("error = %v, want mention of regular file", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Upload hung on a FIFO — pre-Open stat check missing")
+	}
+	if mock.presignCalls.Load() != 0 {
+		t.Errorf("presign called for FIFO")
+	}
+}
+
+// --- Upload happy paths ---
+
+func TestUpload_HappyPath_MultiPart(t *testing.T) {
+	setTestPartSize(t, 5)
+	const fileSize int64 = 12 // 3 parts: 5+5+2
+	path := writeFile(t, fileSize)
+
+	var s3mu sync.Mutex
+	received := map[int][]byte{}
+	s3Handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("S3 got %s, want PUT", r.Method)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+			return
+		}
+		pn := partNumberFromPath(r.URL.Path)
+		s3mu.Lock()
+		received[pn] = body
+		s3mu.Unlock()
+		w.Header().Set("ETag", fmt.Sprintf(`"etag-%d"`, pn))
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mock := &railsMock{}
+	client, s3URL := setupServers(t, mock, s3Handler)
+
+	mock.presign = func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("parse: %v", err)
+		}
+		if r.FormValue("filename") != filepath.Base(path) {
+			t.Errorf("filename = %q", r.FormValue("filename"))
+		}
+		if r.FormValue("file_size") != strconv.FormatInt(fileSize, 10) {
+			t.Errorf("file_size = %q", r.FormValue("file_size"))
+		}
+		urls := []string{s3URL + partPath(1), s3URL + partPath(2), s3URL + partPath(3)}
+		writePresignResponse(t, w, "up-1", "attachments/user/abc/original/fixture.bin",
+			"https://example.com/attachments/user/abc/original/fixture.bin", urls)
+	}
+	mock.complete = func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"file_url": "https://example.com/attachments/user/abc/original/fixture.bin",
+		})
+	}
+
+	fileURL, err := Upload(context.Background(), client, path, Options{})
+	if err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+	if fileURL != "https://example.com/attachments/user/abc/original/fixture.bin" {
+		t.Errorf("fileURL = %q", fileURL)
+	}
+	if mock.presignCalls.Load() != 1 {
+		t.Errorf("presignCalls = %d, want 1", mock.presignCalls.Load())
+	}
+	if mock.completeCalls.Load() != 1 {
+		t.Errorf("completeCalls = %d, want 1", mock.completeCalls.Load())
+	}
+	if mock.abortCalls.Load() != 0 {
+		t.Errorf("abortCalls = %d, want 0 (no failure)", mock.abortCalls.Load())
+	}
+
+	// Verify bytes: part 1 = bytes 0..5, part 2 = 5..10, part 3 = 10..12.
+	original, _ := os.ReadFile(path)
+	s3mu.Lock()
+	defer s3mu.Unlock()
+	for i, want := range [][]byte{original[0:5], original[5:10], original[10:12]} {
+		got := received[i+1]
+		if !bytes.Equal(got, want) {
+			t.Errorf("part %d bytes = %v, want %v", i+1, got, want)
+		}
+	}
+
+	// Verify complete form has indexed parts[n][part_number]/[etag].
+	form := mock.completeForm()
+	if form.Get("upload_id") != "up-1" {
+		t.Errorf("upload_id = %q", form.Get("upload_id"))
+	}
+	for i := 0; i < 3; i++ {
+		if got := form.Get(fmt.Sprintf("parts[%d][part_number]", i)); got != strconv.Itoa(i+1) {
+			t.Errorf("parts[%d][part_number] = %q", i, got)
+		}
+		if got := form.Get(fmt.Sprintf("parts[%d][etag]", i)); got != fmt.Sprintf("etag-%d", i+1) {
+			t.Errorf("parts[%d][etag] = %q", i, got)
+		}
+	}
+}
+
+func TestUpload_HappyPath_SinglePart(t *testing.T) {
+	setTestPartSize(t, 100)
+	path := writeFile(t, 50)
+
+	s3Handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.Header().Set("ETag", `"single-etag"`)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mock := &railsMock{}
+	client, s3URL := setupServers(t, mock, s3Handler)
+
+	mock.presign = func(w http.ResponseWriter, r *http.Request) {
+		writePresignResponse(t, w, "up-1", "attachments/u/key/original/fixture.bin",
+			"https://example.com/u/fixture.bin", []string{s3URL + partPath(1)})
+	}
+	mock.complete = func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{"file_url": "https://example.com/u/fixture.bin"})
+	}
+
+	fileURL, err := Upload(context.Background(), client, path, Options{})
+	if err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+	if fileURL != "https://example.com/u/fixture.bin" {
+		t.Errorf("fileURL = %q", fileURL)
+	}
+
+	form := mock.completeForm()
+	if form.Get("parts[0][etag]") != "single-etag" {
+		t.Errorf("parts[0][etag] = %q (ETag quotes not stripped?)", form.Get("parts[0][etag]"))
+	}
+}
+
+func TestUpload_FilenameOverride(t *testing.T) {
+	setTestPartSize(t, 100)
+	path := writeFile(t, 10)
+
+	var seenFilename string
+	s3Handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("ETag", `"e"`)
+	})
+
+	mock := &railsMock{}
+	client, s3URL := setupServers(t, mock, s3Handler)
+
+	mock.presign = func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		seenFilename = r.FormValue("filename")
+		writePresignResponse(t, w, "up", "k", "https://f", []string{s3URL + partPath(1)})
+	}
+	mock.complete = func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{"file_url": "https://f"})
+	}
+
+	if _, err := Upload(context.Background(), client, path, Options{Filename: "override.zip"}); err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+	if seenFilename != "override.zip" {
+		t.Errorf("seenFilename = %q, want override.zip", seenFilename)
+	}
+}
+
+func TestUpload_ProgressCallback(t *testing.T) {
+	setTestPartSize(t, 5)
+	const fileSize int64 = 12
+	path := writeFile(t, fileSize)
+
+	s3Handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		pn := partNumberFromPath(r.URL.Path)
+		w.Header().Set("ETag", fmt.Sprintf(`"e-%d"`, pn))
+	})
+
+	mock := &railsMock{}
+	client, s3URL := setupServers(t, mock, s3Handler)
+	mock.presign = func(w http.ResponseWriter, r *http.Request) {
+		urls := []string{s3URL + partPath(1), s3URL + partPath(2), s3URL + partPath(3)}
+		writePresignResponse(t, w, "u", "k", "https://f", urls)
+	}
+	mock.complete = func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{"file_url": "https://f"})
+	}
+
+	var last atomic.Int64
+	var calls atomic.Int32
+	_, err := Upload(context.Background(), client, path, Options{
+		Concurrency: 1,
+		Progress: func(n int64) {
+			if prev := last.Load(); n < prev {
+				t.Errorf("progress went backwards: %d < %d", n, prev)
+			}
+			last.Store(n)
+			calls.Add(1)
+		},
+	})
+	if err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+	// Progress is async; poll for the expected 3 callbacks.
+	deadline := time.Now().Add(time.Second)
+	for calls.Load() < 3 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := last.Load(); got != fileSize {
+		t.Errorf("final progress = %d, want %d", got, fileSize)
+	}
+	if got := calls.Load(); got != 3 {
+		t.Errorf("progress calls = %d, want 3 (one per part)", got)
+	}
+}
+
+// --- Upload failure paths ---
+
+func TestUpload_PresignFailure(t *testing.T) {
+	setTestPartSize(t, 100)
+	path := writeFile(t, 10)
+
+	mock := &railsMock{}
+	client, _ := setupServers(t, mock, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("S3 should not be called when presign fails")
+	}))
+
+	mock.presign = func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, `{"success":false,"message":"filename is required"}`)
+	}
+
+	_, err := Upload(context.Background(), client, path, Options{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if mock.abortCalls.Load() != 0 {
+		t.Errorf("abortCalls = %d, want 0 (no upload to abort)", mock.abortCalls.Load())
+	}
+	if mock.completeCalls.Load() != 0 {
+		t.Errorf("completeCalls = %d, want 0", mock.completeCalls.Load())
+	}
+}
+
+func TestUpload_PartFailureRetries(t *testing.T) {
+	setTestPartSize(t, 100)
+	shortBackoff(t)
+	path := writeFile(t, 50)
+
+	var attempts atomic.Int32
+	s3Handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		if n == 1 {
+			http.Error(w, "overloaded", http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.Header().Set("ETag", `"retried"`)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mock := &railsMock{}
+	client, s3URL := setupServers(t, mock, s3Handler)
+	mock.presign = func(w http.ResponseWriter, r *http.Request) {
+		writePresignResponse(t, w, "u", "k", "https://f", []string{s3URL + partPath(1)})
+	}
+	mock.complete = func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{"file_url": "https://f"})
+	}
+
+	fileURL, err := Upload(context.Background(), client, path, Options{})
+	if err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+	if fileURL != "https://f" {
+		t.Errorf("fileURL = %q", fileURL)
+	}
+	if attempts.Load() != 2 {
+		t.Errorf("attempts = %d, want 2", attempts.Load())
+	}
+	if mock.abortCalls.Load() != 0 {
+		t.Errorf("abortCalls = %d, want 0 (retry succeeded)", mock.abortCalls.Load())
+	}
+}
+
+func TestUpload_PartFailureExhausts(t *testing.T) {
+	setTestPartSize(t, 100)
+	shortBackoff(t)
+	path := writeFile(t, 50)
+
+	var attempts atomic.Int32
+	s3Handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		http.Error(w, "still overloaded", http.StatusServiceUnavailable)
+	})
+
+	mock := &railsMock{}
+	client, s3URL := setupServers(t, mock, s3Handler)
+	mock.presign = func(w http.ResponseWriter, r *http.Request) {
+		writePresignResponse(t, w, "u", "k", "https://f", []string{s3URL + partPath(1)})
+	}
+
+	_, err := Upload(context.Background(), client, path, Options{})
+	if err == nil {
+		t.Fatal("expected error after retries exhausted")
+	}
+	if attempts.Load() != int32(maxPartRetries+1) {
+		t.Errorf("attempts = %d, want %d", attempts.Load(), maxPartRetries+1)
+	}
+	if mock.abortCalls.Load() != 1 {
+		t.Errorf("abortCalls = %d, want 1", mock.abortCalls.Load())
+	}
+	if mock.completeCalls.Load() != 0 {
+		t.Errorf("completeCalls = %d, want 0", mock.completeCalls.Load())
+	}
+}
+
+func TestUpload_CompleteFailure(t *testing.T) {
+	setTestPartSize(t, 100)
+	path := writeFile(t, 50)
+
+	s3Handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.Header().Set("ETag", `"e"`)
+	})
+
+	mock := &railsMock{}
+	client, s3URL := setupServers(t, mock, s3Handler)
+	mock.presign = func(w http.ResponseWriter, r *http.Request) {
+		writePresignResponse(t, w, "u", "k", "https://f", []string{s3URL + partPath(1)})
+	}
+	mock.complete = func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, `{"success":false,"message":"invalid key"}`)
+	}
+
+	_, err := Upload(context.Background(), client, path, Options{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if errors.Is(err, ErrCompleteStateUnknown) {
+		t.Errorf("definitive 4xx should not be wrapped as ErrCompleteStateUnknown: %v", err)
+	}
+	if mock.abortCalls.Load() != 1 {
+		t.Errorf("abortCalls = %d, want 1", mock.abortCalls.Load())
+	}
+}
+
+func TestUpload_CompleteAmbiguousResponse(t *testing.T) {
+	// success:true but file_url missing: the server may or may not have
+	// committed. Must surface as UnknownStateError (matching
+	// ErrCompleteStateUnknown via errors.Is) with populated recovery
+	// metadata, and must NOT abort — a blind abort could tear down a
+	// successful commit.
+	setTestPartSize(t, 100)
+	path := writeFile(t, 50)
+
+	s3Handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.Header().Set("ETag", `"e"`)
+	})
+
+	mock := &railsMock{}
+	client, s3URL := setupServers(t, mock, s3Handler)
+	mock.presign = func(w http.ResponseWriter, r *http.Request) {
+		writePresignResponse(t, w, "up-7", "attachments/key-7", "https://example/u/7", []string{s3URL + partPath(1)})
+	}
+	mock.complete = func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{})
+	}
+
+	_, err := Upload(context.Background(), client, path, Options{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, ErrCompleteStateUnknown) {
+		t.Errorf("errors.Is(err, ErrCompleteStateUnknown) = false, want true: %v", err)
+	}
+	var unk *UnknownStateError
+	if !errors.As(err, &unk) {
+		t.Fatalf("errors.As *UnknownStateError failed: %v", err)
+	}
+	if unk.FileURL != "https://example/u/7" {
+		t.Errorf("FileURL = %q", unk.FileURL)
+	}
+	if unk.UploadID != "up-7" {
+		t.Errorf("UploadID = %q", unk.UploadID)
+	}
+	if unk.Key != "attachments/key-7" {
+		t.Errorf("Key = %q", unk.Key)
+	}
+	if unk.Cause == nil {
+		t.Error("Cause is nil")
+	}
+	if len(unk.CompletedParts) != 1 {
+		t.Fatalf("CompletedParts = %d, want 1", len(unk.CompletedParts))
+	}
+	if unk.CompletedParts[0].PartNumber != 1 || unk.CompletedParts[0].ETag != "e" {
+		t.Errorf("CompletedParts[0] = %+v", unk.CompletedParts[0])
+	}
+	if mock.abortCalls.Load() != 0 {
+		t.Errorf("abortCalls = %d, want 0 (ambiguous state, must not abort)", mock.abortCalls.Load())
+	}
+}
+
+func TestUpload_CompleteSuccessFalseIsDefinitive(t *testing.T) {
+	// Gumroad returns many rejections as HTTP 200 with {"success":false}.
+	// api.Client surfaces that as an APIError with StatusCode==200. Upload
+	// must treat it as a definitive rejection (abort, no ambiguous wrap).
+	setTestPartSize(t, 100)
+	path := writeFile(t, 50)
+
+	s3Handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.Header().Set("ETag", `"e"`)
+	})
+
+	mock := &railsMock{}
+	client, s3URL := setupServers(t, mock, s3Handler)
+	mock.presign = func(w http.ResponseWriter, r *http.Request) {
+		writePresignResponse(t, w, "u", "k", "https://f", []string{s3URL + partPath(1)})
+	}
+	mock.complete = func(w http.ResponseWriter, r *http.Request) {
+		// HTTP 200, but envelope says the request failed.
+		_, _ = io.WriteString(w, `{"success":false,"message":"invalid etag for part 1"}`)
+	}
+
+	_, err := Upload(context.Background(), client, path, Options{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if errors.Is(err, ErrCompleteStateUnknown) {
+		t.Errorf("explicit rejection must not be ErrCompleteStateUnknown: %v", err)
+	}
+	if mock.abortCalls.Load() != 1 {
+		t.Errorf("abortCalls = %d, want 1 (definitive rejection)", mock.abortCalls.Load())
+	}
+}
+
+func TestUpload_CompleteTransient4xx(t *testing.T) {
+	// 408/409/429 are 4xx but not definitive rejections — a 429 rate-limited
+	// response, for instance, does not prove the commit did not happen.
+	// Treat these as ambiguous and skip abort.
+	for _, status := range []int{http.StatusRequestTimeout, http.StatusConflict, http.StatusTooManyRequests} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			setTestPartSize(t, 100)
+			path := writeFile(t, 50)
+
+			s3Handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = io.Copy(io.Discard, r.Body)
+				w.Header().Set("ETag", `"e"`)
+			})
+
+			mock := &railsMock{}
+			client, s3URL := setupServers(t, mock, s3Handler)
+			mock.presign = func(w http.ResponseWriter, r *http.Request) {
+				writePresignResponse(t, w, "u", "k", "https://f", []string{s3URL + partPath(1)})
+			}
+			mock.complete = func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(status)
+				_, _ = fmt.Fprintf(w, `{"success":false,"message":"transient %d"}`, status)
+			}
+
+			_, err := Upload(context.Background(), client, path, Options{})
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !errors.Is(err, ErrCompleteStateUnknown) {
+				t.Errorf("error = %v, want wrapped ErrCompleteStateUnknown", err)
+			}
+			if mock.abortCalls.Load() != 0 {
+				t.Errorf("abortCalls = %d, want 0 (transient 4xx is ambiguous, must not abort)", mock.abortCalls.Load())
+			}
+		})
+	}
+}
+
+func TestUpload_CompleteServerError(t *testing.T) {
+	// /files/complete 5xx is ambiguous. Must wrap with ErrCompleteStateUnknown
+	// and must NOT fire abort (could race the server's in-flight commit or
+	// tear down a finalized upload).
+	setTestPartSize(t, 100)
+	path := writeFile(t, 50)
+
+	s3Handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.Header().Set("ETag", `"e"`)
+	})
+
+	mock := &railsMock{}
+	client, s3URL := setupServers(t, mock, s3Handler)
+	mock.presign = func(w http.ResponseWriter, r *http.Request) {
+		writePresignResponse(t, w, "u", "k", "https://f", []string{s3URL + partPath(1)})
+	}
+	mock.complete = func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, `{"success":false,"message":"database unreachable"}`)
+	}
+
+	_, err := Upload(context.Background(), client, path, Options{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, ErrCompleteStateUnknown) {
+		t.Errorf("error = %v, want wrapped ErrCompleteStateUnknown", err)
+	}
+	if mock.abortCalls.Load() != 0 {
+		t.Errorf("abortCalls = %d, want 0 (5xx is ambiguous, must not abort)", mock.abortCalls.Load())
+	}
+}
+
+func TestUpload_ProgressCallbackMonotonicUnderConcurrency(t *testing.T) {
+	// With Concurrency > 1, parts finish in parallel. The serialized +
+	// monotonic contract on Options.Progress must hold: no callback runs
+	// concurrently, and cumulative bytes never go backwards.
+	setTestPartSize(t, 5)
+	const fileSize int64 = 20 // 4 parts of 5
+	path := writeFile(t, fileSize)
+
+	s3Handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		pn := partNumberFromPath(r.URL.Path)
+		w.Header().Set("ETag", fmt.Sprintf(`"e-%d"`, pn))
+	})
+
+	mock := &railsMock{}
+	client, s3URL := setupServers(t, mock, s3Handler)
+	mock.presign = func(w http.ResponseWriter, r *http.Request) {
+		urls := []string{s3URL + partPath(1), s3URL + partPath(2), s3URL + partPath(3), s3URL + partPath(4)}
+		writePresignResponse(t, w, "u", "k", "https://f", urls)
+	}
+	mock.complete = func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{"file_url": "https://f"})
+	}
+
+	var inFlight atomic.Int32
+	var maxInFlight atomic.Int32
+	var last atomic.Int64
+	var calls atomic.Int32
+
+	_, err := Upload(context.Background(), client, path, Options{
+		Concurrency: 4,
+		Progress: func(n int64) {
+			cur := inFlight.Add(1)
+			defer inFlight.Add(-1)
+			for {
+				max := maxInFlight.Load()
+				if cur <= max || maxInFlight.CompareAndSwap(max, cur) {
+					break
+				}
+			}
+			if prev := last.Load(); n < prev {
+				t.Errorf("progress went backwards: %d after %d", n, prev)
+			}
+			last.Store(n)
+			calls.Add(1)
+		},
+	})
+	if err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+	// Progress is async: poll for all 4 callbacks before asserting the final
+	// value. Doc comment on Options.Progress explicitly allows callbacks to
+	// run after Upload returns.
+	deadline := time.Now().Add(time.Second)
+	for calls.Load() < 4 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := maxInFlight.Load(); got > 1 {
+		t.Errorf("maxInFlight = %d, want 1 (callback must not run concurrently)", got)
+	}
+	if got := last.Load(); got != fileSize {
+		t.Errorf("final progress = %d, want %d", got, fileSize)
+	}
+}
+
+func TestUpload_AbortFailureSurfacesCleanupInfo(t *testing.T) {
+	// When /files/abort itself fails after parts were already in flight, the
+	// caller needs both the original error AND the upload_id/key to retry
+	// cleanup later. Upload joins them so errors.Is still matches the cause
+	// and errors.As surfaces *CleanupFailedError.
+	setTestPartSize(t, 100)
+	shortBackoff(t)
+	path := writeFile(t, 50)
+
+	s3Handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "still overloaded", http.StatusServiceUnavailable)
+	})
+
+	mock := &railsMock{}
+	client, s3URL := setupServers(t, mock, s3Handler)
+	mock.presign = func(w http.ResponseWriter, r *http.Request) {
+		writePresignResponse(t, w, "up-99", "attachments/key-99", "https://f", []string{s3URL + partPath(1)})
+	}
+	mock.abortH = func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, `{"success":false,"message":"abort failed"}`)
+	}
+
+	_, err := Upload(context.Background(), client, path, Options{})
+	if err == nil {
+		t.Fatal("expected part-upload error")
+	}
+	if !strings.Contains(err.Error(), "upload part 1") {
+		t.Errorf("original part error not present in %v", err)
+	}
+	var cleanup *CleanupFailedError
+	if !errors.As(err, &cleanup) {
+		t.Fatalf("errors.As *CleanupFailedError failed: %v", err)
+	}
+	if cleanup.UploadID != "up-99" || cleanup.Key != "attachments/key-99" {
+		t.Errorf("cleanup metadata = %+v", cleanup)
+	}
+	if cleanup.Cause == nil {
+		t.Error("CleanupFailedError.Cause is nil")
+	}
+	if mock.abortCalls.Load() != 1 {
+		t.Errorf("abortCalls = %d, want 1", mock.abortCalls.Load())
+	}
+}
+
+func TestUpload_ExpiredPresign(t *testing.T) {
+	setTestPartSize(t, 100)
+	path := writeFile(t, 50)
+
+	var attempts atomic.Int32
+	s3Handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = fmt.Fprintf(w, `<?xml version="1.0"?><Error><Code>AccessDenied</Code><Message>%s</Message></Error>`, s3ExpiredMarker)
+	})
+
+	mock := &railsMock{}
+	client, s3URL := setupServers(t, mock, s3Handler)
+	mock.presign = func(w http.ResponseWriter, r *http.Request) {
+		writePresignResponse(t, w, "u", "k", "https://f", []string{s3URL + partPath(1)})
+	}
+
+	_, err := Upload(context.Background(), client, path, Options{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, ErrPresignExpired) {
+		t.Errorf("error = %v, want ErrPresignExpired", err)
+	}
+	// Expired should NOT retry.
+	if attempts.Load() != 1 {
+		t.Errorf("attempts = %d, want 1 (expiry must not retry)", attempts.Load())
+	}
+	if mock.abortCalls.Load() != 1 {
+		t.Errorf("abortCalls = %d, want 1", mock.abortCalls.Load())
+	}
+}
+
+func TestUpload_ContextCancellation(t *testing.T) {
+	setTestPartSize(t, 100)
+	path := writeFile(t, 50)
+
+	s3Handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("S3 should not be reached when context is canceled")
+	})
+
+	mock := &railsMock{}
+	client, _ := setupServers(t, mock, s3Handler)
+	mock.presign = func(w http.ResponseWriter, r *http.Request) {
+		t.Error("presign should not run when context is canceled before Upload")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := Upload(ctx, client, path, Options{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("error = %v, want context.Canceled", err)
+	}
+}
+
+func TestUpload_AbortRunsAfterCanceledPartUpload(t *testing.T) {
+	// The plan explicitly calls out that context cancellation must still
+	// trigger /files/abort. safeAbort uses a fresh background context with
+	// abortTimeout precisely so a canceled upload does not leak a multipart
+	// upload on S3.
+	setTestPartSize(t, 100)
+	shortBackoff(t)
+	path := writeFile(t, 50)
+
+	// release is closed on test cleanup so the S3 handler unblocks even if
+	// the server never observed the client-side disconnect.
+	release := make(chan struct{})
+	started := make(chan struct{}, 1)
+	s3Handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		select {
+		case <-r.Context().Done():
+		case <-release:
+		}
+	})
+
+	mock := &railsMock{}
+	client, s3URL := setupServers(t, mock, s3Handler)
+
+	// Register AFTER setupServers: t.Cleanup is LIFO, so close(release) must
+	// run BEFORE the httptest server's Close blocks on in-flight handlers.
+	t.Cleanup(func() { close(release) })
+
+	mock.presign = func(w http.ResponseWriter, r *http.Request) {
+		writePresignResponse(t, w, "u", "k", "https://f", []string{s3URL + partPath(1)})
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := Upload(ctx, client, path, Options{})
+		done <- err
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		cancel()
+		t.Fatal("part upload never reached S3 within 5 s")
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	case <-time.After(abortTimeout + time.Second):
+		t.Fatal("Upload did not return after cancellation")
+	}
+
+	if mock.abortCalls.Load() != 1 {
+		t.Errorf("abortCalls = %d, want 1 (abort must run despite upload ctx cancellation)", mock.abortCalls.Load())
+	}
+}
+
+func TestUpload_RejectsEmpty(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "empty")
+	f, _ := os.Create(path)
+	_ = f.Close()
+
+	mock := &railsMock{}
+	client, _ := setupServers(t, mock, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach S3")
+	}))
+
+	_, err := Upload(context.Background(), client, path, Options{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if mock.presignCalls.Load() != 0 {
+		t.Errorf("presign called for empty file")
+	}
+}
+
+func TestUpload_RejectsOversize(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "huge")
+	f, _ := os.Create(path)
+	if err := f.Truncate(MaxFileSize + 1); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	_ = f.Close()
+
+	mock := &railsMock{}
+	client, _ := setupServers(t, mock, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach S3")
+	}))
+
+	_, err := Upload(context.Background(), client, path, Options{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if mock.presignCalls.Load() != 0 {
+		t.Errorf("presign called for oversize file")
+	}
+}
+
+func TestUpload_PresignWrongPartCount(t *testing.T) {
+	setTestPartSize(t, 5)
+	path := writeFile(t, 12) // expects 3 parts
+
+	mock := &railsMock{}
+	client, s3URL := setupServers(t, mock, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach S3")
+	}))
+	mock.presign = func(w http.ResponseWriter, r *http.Request) {
+		// Return only 2 parts instead of 3.
+		writePresignResponse(t, w, "u", "k", "https://f", []string{s3URL + partPath(1), s3URL + partPath(2)})
+	}
+
+	_, err := Upload(context.Background(), client, path, Options{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if mock.abortCalls.Load() != 1 {
+		t.Errorf("abortCalls = %d, want 1 (presign succeeded, must abort)", mock.abortCalls.Load())
+	}
+}
+
+// writePresignWithPartNumbers mints a presign response with caller-supplied
+// part_number values, deriving each URL from urlBase via partPath. Used to
+// drive malformed-part_number scenarios through validatePresignParts.
+func writePresignWithPartNumbers(t *testing.T, w http.ResponseWriter, uploadID, key, fileURL, urlBase string, numbers []int) {
+	t.Helper()
+	parts := make([]map[string]any, len(numbers))
+	for i, n := range numbers {
+		parts[i] = map[string]any{
+			"part_number":   n,
+			"presigned_url": urlBase + partPath(n),
+		}
+	}
+	testutil.JSON(t, w, map[string]any{
+		"upload_id": uploadID,
+		"key":       key,
+		"file_url":  fileURL,
+		"parts":     parts,
+	})
+}
+
+func TestUpload_PartTimeoutFiresOnStalledS3(t *testing.T) {
+	// A peer that accepts the connection but never responds must not hang
+	// the upload forever — Options.PartTimeout bounds each attempt.
+	setTestPartSize(t, 100)
+	shortBackoff(t)
+	path := writeFile(t, 50)
+
+	var attempts atomic.Int32
+	s3Handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		_, _ = io.Copy(io.Discard, r.Body)
+		<-r.Context().Done() // never respond; wait for client abort
+	})
+
+	mock := &railsMock{}
+	client, s3URL := setupServers(t, mock, s3Handler)
+	mock.presign = func(w http.ResponseWriter, r *http.Request) {
+		writePresignResponse(t, w, "u", "k", "https://f", []string{s3URL + partPath(1)})
+	}
+
+	_, err := Upload(context.Background(), client, path, Options{PartTimeout: 50 * time.Millisecond})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("error = %v, want context.DeadlineExceeded", err)
+	}
+	// Per-part timeout is retryable, so attempts should equal maxPartRetries+1.
+	if got := attempts.Load(); got != int32(maxPartRetries+1) {
+		t.Errorf("attempts = %d, want %d (inner timeout should retry)", got, maxPartRetries+1)
+	}
+	if mock.abortCalls.Load() != 1 {
+		t.Errorf("abortCalls = %d, want 1", mock.abortCalls.Load())
+	}
+}
+
+func TestUpload_SlowProgressCallbackDoesNotStallWorkers(t *testing.T) {
+	// With Concurrency=1 and a progress callback that blocks, earlier
+	// designs held the semaphore slot across the callback and froze the
+	// second part. The slot is now released before the callback runs.
+	setTestPartSize(t, 5)
+	const fileSize int64 = 10 // 2 parts
+	path := writeFile(t, fileSize)
+
+	s3Handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		pn := partNumberFromPath(r.URL.Path)
+		w.Header().Set("ETag", fmt.Sprintf(`"e-%d"`, pn))
+	})
+
+	mock := &railsMock{}
+	client, s3URL := setupServers(t, mock, s3Handler)
+	mock.presign = func(w http.ResponseWriter, r *http.Request) {
+		writePresignResponse(t, w, "u", "k", "https://f", []string{s3URL + partPath(1), s3URL + partPath(2)})
+	}
+	mock.complete = func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{"file_url": "https://f"})
+	}
+
+	var released atomic.Int32
+	firstCallbackEntered := make(chan struct{})
+	gateCallback := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		_, err := Upload(context.Background(), client, path, Options{
+			Concurrency: 1,
+			Progress: func(n int64) {
+				// Block the first progress invocation until the test signals.
+				// Before the fix, this would prevent the second part from
+				// ever acquiring a semaphore slot.
+				if released.Add(1) == 1 {
+					close(firstCallbackEntered)
+					<-gateCallback
+				}
+			},
+		})
+		done <- err
+	}()
+
+	select {
+	case <-firstCallbackEntered:
+	case <-time.After(5 * time.Second):
+		close(gateCallback)
+		t.Fatal("progress callback never fired")
+	}
+
+	// Give the second part a chance to run independently of the blocked
+	// callback. If the slot were still held, nothing would happen.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if mock.completeCalls.Load() > 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if mock.completeCalls.Load() == 0 {
+		close(gateCallback)
+		<-done
+		t.Fatal("upload stalled: second part never ran while the first progress callback was blocked")
+	}
+
+	close(gateCallback)
+	if err := <-done; err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+}
+
+func TestUpload_ErrorBodyNotDrained(t *testing.T) {
+	// If S3 returns an error with a very large (or slow-streaming) body, we
+	// must not block the worker draining it. The per-part timeout also
+	// bounds this, but the test shows we return well before the timeout.
+	setTestPartSize(t, 100)
+	shortBackoff(t)
+	path := writeFile(t, 50)
+
+	// Handler writes a 5xx header and then a body that takes ~3 s to stream.
+	// A drain-to-EOF would block; closing immediately on non-2xx returns fast.
+	s3Handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusInternalServerError)
+		flusher, _ := w.(http.Flusher)
+		for i := 0; i < 30; i++ {
+			_, _ = w.Write([]byte("error data "))
+			if flusher != nil {
+				flusher.Flush()
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	})
+
+	mock := &railsMock{}
+	client, s3URL := setupServers(t, mock, s3Handler)
+	mock.presign = func(w http.ResponseWriter, r *http.Request) {
+		writePresignResponse(t, w, "u", "k", "https://f", []string{s3URL + partPath(1)})
+	}
+
+	start := time.Now()
+	_, err := Upload(context.Background(), client, path, Options{PartTimeout: 10 * time.Second})
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	// Three attempts with 1 ms backoff in shortBackoff; each attempt should
+	// close on the 5xx snippet and retry. Total time must be far less than
+	// 3 s * 3 attempts = 9 s.
+	if elapsed > 2*time.Second {
+		t.Errorf("took %s — error body drain appears to be blocking", elapsed)
+	}
+}
+
+func TestUpload_SuccessBodyDrainBounded(t *testing.T) {
+	// A peer that returns 200 + ETag and then trickles body bytes must not
+	// stall the worker. The success path closes the body instead of
+	// draining to EOF.
+	setTestPartSize(t, 100)
+	path := writeFile(t, 50)
+
+	s3Handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.Header().Set("ETag", `"slow-etag"`)
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		if flusher != nil {
+			flusher.Flush() // send the header immediately
+		}
+		// Then trickle bytes slowly. If putPart drains to EOF on success,
+		// this would block ~3s; with the fix, it returns immediately.
+		for i := 0; i < 30; i++ {
+			_, _ = w.Write([]byte("slow "))
+			if flusher != nil {
+				flusher.Flush()
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	})
+
+	mock := &railsMock{}
+	client, s3URL := setupServers(t, mock, s3Handler)
+	mock.presign = func(w http.ResponseWriter, r *http.Request) {
+		writePresignResponse(t, w, "u", "k", "https://f", []string{s3URL + partPath(1)})
+	}
+	mock.complete = func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{"file_url": "https://f"})
+	}
+
+	start := time.Now()
+	fileURL, err := Upload(context.Background(), client, path, Options{PartTimeout: 10 * time.Second})
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+	if fileURL != "https://f" {
+		t.Errorf("fileURL = %q", fileURL)
+	}
+	if elapsed > 1*time.Second {
+		t.Errorf("took %s — success-path drain appears to be blocking", elapsed)
+	}
+}
+
+func TestUpload_PresignPartialResponseTriggersAbort(t *testing.T) {
+	// If presign validation fails but upload_id/key were returned, Upload
+	// must still attempt /files/abort so the server-side multipart is not
+	// orphaned.
+	setTestPartSize(t, 100)
+	path := writeFile(t, 50)
+
+	mock := &railsMock{}
+	client, _ := setupServers(t, mock, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("S3 should not be reached when presign validation fails")
+	}))
+	mock.presign = func(w http.ResponseWriter, r *http.Request) {
+		// upload_id and key present, file_url missing — validation fails but
+		// the server has already created the multipart upload.
+		testutil.JSON(t, w, map[string]any{
+			"upload_id": "up-orphan",
+			"key":       "attachments/orphan",
+			"parts":     []map[string]any{{"part_number": 1, "presigned_url": "https://s3/p1"}},
+		})
+	}
+
+	_, err := Upload(context.Background(), client, path, Options{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if mock.abortCalls.Load() != 1 {
+		t.Errorf("abortCalls = %d, want 1 (orphan must be cleaned up)", mock.abortCalls.Load())
+	}
+}
+
+func TestValidatePresignParts_HTTPSOnly(t *testing.T) {
+	// Directly exercise the production code path (allowInsecureUploadDestination
+	// set back to false) to confirm plain http URLs are rejected before any
+	// PUT leaves the process.
+	prev := allowInsecureUploadDestination
+	allowInsecureUploadDestination = false
+	t.Cleanup(func() { allowInsecureUploadDestination = prev })
+
+	tests := []struct {
+		name   string
+		url    string
+		wantOK bool
+	}{
+		{"https", "https://s3.amazonaws.com/bucket/key?x=y", true},
+		{"http_plaintext", "http://s3.amazonaws.com/bucket/key", false},
+		{"other_scheme", "file:///etc/passwd", false},
+		{"empty", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePresignParts([]presignPart{{PartNumber: 1, PresignedURL: tt.url}}, 1)
+			if (err == nil) != tt.wantOK {
+				t.Errorf("validatePresignParts(%q) err = %v, wantOK = %v", tt.url, err, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestUpload_PresignPartNumberValidation(t *testing.T) {
+	setTestPartSize(t, 5)
+	const fileSize int64 = 12 // 3 parts
+
+	tests := []struct {
+		name    string
+		numbers []int // must have length 3
+	}{
+		{"duplicate", []int{1, 1, 2}},
+		{"gap", []int{1, 3, 4}},
+		{"zero", []int{0, 1, 2}},
+		{"out_of_order", []int{2, 1, 3}},
+		{"negative", []int{-1, 1, 2}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeFile(t, fileSize)
+			mock := &railsMock{}
+			client, s3URL := setupServers(t, mock, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Error("S3 must not be reached with invalid part numbers")
+			}))
+			mock.presign = func(w http.ResponseWriter, r *http.Request) {
+				writePresignWithPartNumbers(t, w, "u", "k", "https://f", s3URL, tt.numbers)
+			}
+
+			_, err := Upload(context.Background(), client, path, Options{})
+			if err == nil {
+				t.Fatal("expected error for invalid part numbers")
+			}
+			if mock.abortCalls.Load() != 1 {
+				t.Errorf("abortCalls = %d, want 1 (presign succeeded, must abort)", mock.abortCalls.Load())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Part of #36

## What

PR 1 of four. Adds a small Go package that uploads a file to Gumroad in chunks: 
- it asks the server for presigned URLs,
- streams each chunk to S3 in parallel, 
- then tells the server the upload is done. 

If anything goes wrong it tries to clean up the half-finished upload. If it can't tell whether the final step succeeded, it returns enough information (upload id, storage key, per-part ETags) for a caller to check or retry without re-uploading the whole file.

No new commands in this PR, just the library. Exposes a small helper on `api.Client` so individual requests can carry their own context.

## Why

The three follow-up PRs (`gumroad files upload`, `--file` on products create/update) all drive the same upload flow. Putting that flow in one library, with its own tests, means each later PR is a thin wrapper instead of a re-implementation.

---

This PR was implemented with AI assistance using Claude Opus 4.7 and gpt‑5.4 xhigh