### PR TITLE
Add gumroad files commands (upload, complete, abort)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ gumroad offer-codes   list, view, create, update, delete
 gumroad variant-categories list, view, create, update, delete
 gumroad variants      list, view, create, update, delete
 gumroad custom-fields list, create, update, delete
+gumroad files         upload, complete, abort
 gumroad webhooks      list, create, delete
 gumroad skill         Install or refresh the Claude Code skill
 gumroad completion    bash, zsh, fish, powershell

--- a/internal/cmd/errors.go
+++ b/internal/cmd/errors.go
@@ -91,17 +91,11 @@ func classifyCommandError(err error) commandErrorDetail {
 		if detail.Type == "internal_error" {
 			detail = uploadCleanupFailedDetail(err, cleanup)
 		}
-		// A CleanupFailedError joined alongside a better-classified primary
-		// (API error, auth error, usage error) must not erase that
-		// classification. Attach orphan handles as a secondary Recovery
-		// signal unless the primary already supplied one (UnknownStateError
-		// carries its own manifest).
-		if detail.Recovery == nil {
-			detail.Recovery = &uploadRecoveryInfo{
-				UploadID: cleanup.UploadID,
-				Key:      cleanup.Key,
-			}
-		}
+		// Attach orphan handles as secondary recovery metadata without
+		// erasing any better-primary classification. If the primary
+		// already populated Recovery (UnknownStateError / rejected replay),
+		// cleanup only fills missing upload_id/key fields.
+		detail.Recovery = mergeCleanupRecovery(detail.Recovery, cleanup)
 	}
 
 	return detail
@@ -146,7 +140,7 @@ func classifyPrimaryCause(err error) commandErrorDetail {
 	case errors.As(err, &usageErr):
 		return invalidInputErrorDetail(usageErr.Error())
 	case errors.As(err, &unknownState):
-		return uploadIncompleteDetail(err, unknownState, cleanupFailedFrom(err))
+		return uploadIncompleteDetail(err, unknownState)
 	// ErrPresignExpired is a sentinel distinct from UnknownStateError: the
 	// server never committed, so a retry-the-whole-upload is safe (no
 	// duplicate risk). Classify it explicitly so automation distinguishes
@@ -218,18 +212,28 @@ func invalidInputErrorDetail(message string) commandErrorDetail {
 	}
 }
 
-// cleanupFailedFrom extracts an optional joined CleanupFailedError so the
-// recovery payload carries both state-unknown and abort-orphan identifiers
-// when they co-occur.
-func cleanupFailedFrom(err error) *upload.CleanupFailedError {
-	var cleanup *upload.CleanupFailedError
-	if errors.As(err, &cleanup) {
-		return cleanup
+// mergeCleanupRecovery attaches cleanup orphan handles as secondary recovery
+// metadata without overwriting upload state the primary error already carried.
+func mergeCleanupRecovery(recovery *uploadRecoveryInfo, cleanup *upload.CleanupFailedError) *uploadRecoveryInfo {
+	if cleanup == nil {
+		return recovery
 	}
-	return nil
+	if recovery == nil {
+		return &uploadRecoveryInfo{
+			UploadID: cleanup.UploadID,
+			Key:      cleanup.Key,
+		}
+	}
+	if recovery.UploadID == "" {
+		recovery.UploadID = cleanup.UploadID
+	}
+	if recovery.Key == "" {
+		recovery.Key = cleanup.Key
+	}
+	return recovery
 }
 
-func uploadIncompleteDetail(err error, state *upload.UnknownStateError, cleanup *upload.CleanupFailedError) commandErrorDetail {
+func uploadIncompleteDetail(err error, state *upload.UnknownStateError) commandErrorDetail {
 	recovery := &uploadRecoveryInfo{
 		FileURL:  state.FileURL,
 		UploadID: state.UploadID,
@@ -239,14 +243,6 @@ func uploadIncompleteDetail(err error, state *upload.UnknownStateError, cleanup 
 		recovery.CompletedParts = make([]uploadCompletedPart, len(state.CompletedParts))
 		for i, p := range state.CompletedParts {
 			recovery.CompletedParts[i] = uploadCompletedPart{PartNumber: p.PartNumber, ETag: p.ETag}
-		}
-	}
-	if cleanup != nil {
-		if recovery.UploadID == "" {
-			recovery.UploadID = cleanup.UploadID
-		}
-		if recovery.Key == "" {
-			recovery.Key = cleanup.Key
 		}
 	}
 	// The recovery's file_url is a non-authoritative hint from the presign

--- a/internal/cmd/errors.go
+++ b/internal/cmd/errors.go
@@ -10,10 +10,12 @@ import (
 	"strings"
 
 	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmd/files"
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/config"
 	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/antiwork/gumroad-cli/internal/prompt"
+	"github.com/antiwork/gumroad-cli/internal/upload"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -24,11 +26,29 @@ type commandErrorEnvelope struct {
 }
 
 type commandErrorDetail struct {
-	Type       string `json:"type"`
-	Code       string `json:"code,omitempty"`
-	Message    string `json:"message"`
-	Hint       string `json:"hint,omitempty"`
-	StatusCode int    `json:"status_code,omitempty"`
+	Type       string              `json:"type"`
+	Code       string              `json:"code,omitempty"`
+	Message    string              `json:"message"`
+	Hint       string              `json:"hint,omitempty"`
+	StatusCode int                 `json:"status_code,omitempty"`
+	Recovery   *uploadRecoveryInfo `json:"recovery,omitempty"`
+}
+
+// uploadRecoveryInfo carries the handles a caller needs to reconcile an
+// ambiguous multipart upload: whether the file committed (file_url), the
+// identifiers needed to retry /files/complete or /files/abort (upload_id, key),
+// and the parts already successfully PUT to S3 (so the caller doesn't re-upload
+// bytes on retry).
+type uploadRecoveryInfo struct {
+	FileURL        string                `json:"file_url,omitempty"`
+	UploadID       string                `json:"upload_id,omitempty"`
+	Key            string                `json:"key,omitempty"`
+	CompletedParts []uploadCompletedPart `json:"completed_parts,omitempty"`
+}
+
+type uploadCompletedPart struct {
+	PartNumber int    `json:"part_number"`
+	ETag       string `json:"etag"`
 }
 
 func printStructuredCommandError(w io.Writer, err error) error {
@@ -54,11 +74,103 @@ func classifyCommandError(err error) commandErrorDetail {
 		}
 	}
 
+	// Classify the primary cause with cleanup branches stripped.
+	// CleanupFailedError.Unwrap() exposes the abort call's cause (typically
+	// an *api.APIError from /files/abort). Without stripping, a joined
+	// upload error would surface the abort's APIError as the primary
+	// classification, hiding the cleanup_failed signal the caller needs to
+	// reclaim orphaned storage.
+	detail := classifyPrimaryCause(primaryCause(err))
+
+	var cleanup *upload.CleanupFailedError
+	if errors.As(err, &cleanup) {
+		// If the primary had no better classification than "internal_error"
+		// (plain errors from part-upload failures, context cancellation),
+		// the cleanup failure is the most actionable signal — surface it
+		// as the primary code so automation notices the orphan.
+		if detail.Type == "internal_error" {
+			detail = uploadCleanupFailedDetail(err, cleanup)
+		}
+		// A CleanupFailedError joined alongside a better-classified primary
+		// (API error, auth error, usage error) must not erase that
+		// classification. Attach orphan handles as a secondary Recovery
+		// signal unless the primary already supplied one (UnknownStateError
+		// carries its own manifest).
+		if detail.Recovery == nil {
+			detail.Recovery = &uploadRecoveryInfo{
+				UploadID: cleanup.UploadID,
+				Key:      cleanup.Key,
+			}
+		}
+	}
+
+	return detail
+}
+
+// primaryCause returns err with any *upload.CleanupFailedError branches of a
+// multi-unwrap (errors.Join) tree removed so the primary failure is not
+// shadowed by the abort call's cause. Returns err unchanged if stripping
+// leaves nothing behind (pure cleanup-only failure) or if err is not a
+// multi-unwrap.
+func primaryCause(err error) error {
+	type multiUnwrap interface{ Unwrap() []error }
+	mu, ok := err.(multiUnwrap)
+	if !ok {
+		return err
+	}
+	var kept []error
+	for _, inner := range mu.Unwrap() {
+		if _, isCleanup := inner.(*upload.CleanupFailedError); isCleanup {
+			continue
+		}
+		kept = append(kept, inner)
+	}
+	switch len(kept) {
+	case 0:
+		return err
+	case 1:
+		return kept[0]
+	default:
+		return errors.Join(kept...)
+	}
+}
+
+func classifyPrimaryCause(err error) commandErrorDetail {
 	var usageErr *cmdutil.UsageError
 	var apiErr *api.APIError
+	var unknownState *upload.UnknownStateError
+	var cleanupFailed *upload.CleanupFailedError
+	var rejected *files.CompleteRejectedError
 	switch {
 	case errors.As(err, &usageErr):
 		return invalidInputErrorDetail(usageErr.Error())
+	case errors.As(err, &unknownState):
+		return uploadIncompleteDetail(err, unknownState, cleanupFailedFrom(err))
+	// ErrPresignExpired is a sentinel distinct from UnknownStateError: the
+	// server never committed, so a retry-the-whole-upload is safe (no
+	// duplicate risk). Classify it explicitly so automation distinguishes
+	// "restart" from "reconcile".
+	case errors.Is(err, upload.ErrPresignExpired):
+		return commandErrorDetail{
+			Type:    "upload_error",
+			Code:    "presign_expired",
+			Message: err.Error(),
+			Hint:    "Presigned upload URLs expired mid-flight. Re-run `gumroad files upload` from scratch — a fresh presign round covers all parts.",
+		}
+	// Match CompleteRejectedError before api.APIError so rejected replays
+	// become first-class upload failures. But when the underlying cause
+	// is an auth/access error (401/403), keep the auth classification so
+	// callers are told to refresh credentials rather than treat it as a
+	// pure upload-recovery problem — the orphan handles are still
+	// attached as recovery metadata for later cleanup.
+	case errors.As(err, &rejected):
+		return completeRejectedClassification(err, rejected)
+	// Match CleanupFailedError before api.APIError: when only a cleanup
+	// error is in scope (because primaryCause stripped the primary tree),
+	// we want cleanup_failed classification, not the abort call's APIError
+	// exposed via CleanupFailedError.Unwrap().
+	case errors.As(err, &cleanupFailed):
+		return uploadCleanupFailedDetail(err, cleanupFailed)
 	case errors.As(err, &apiErr):
 		return commandErrorDetail{
 			Type:       "api_error",
@@ -102,6 +214,195 @@ func invalidInputErrorDetail(message string) commandErrorDetail {
 		Type:    "usage_error",
 		Code:    "invalid_input",
 		Message: message,
+	}
+}
+
+// cleanupFailedFrom extracts an optional joined CleanupFailedError so the
+// recovery payload carries both state-unknown and abort-orphan identifiers
+// when they co-occur.
+func cleanupFailedFrom(err error) *upload.CleanupFailedError {
+	var cleanup *upload.CleanupFailedError
+	if errors.As(err, &cleanup) {
+		return cleanup
+	}
+	return nil
+}
+
+func uploadIncompleteDetail(err error, state *upload.UnknownStateError, cleanup *upload.CleanupFailedError) commandErrorDetail {
+	recovery := &uploadRecoveryInfo{
+		FileURL:  state.FileURL,
+		UploadID: state.UploadID,
+		Key:      state.Key,
+	}
+	if len(state.CompletedParts) > 0 {
+		recovery.CompletedParts = make([]uploadCompletedPart, len(state.CompletedParts))
+		for i, p := range state.CompletedParts {
+			recovery.CompletedParts[i] = uploadCompletedPart{PartNumber: p.PartNumber, ETag: p.ETag}
+		}
+	}
+	if cleanup != nil {
+		if recovery.UploadID == "" {
+			recovery.UploadID = cleanup.UploadID
+		}
+		if recovery.Key == "" {
+			recovery.Key = cleanup.Key
+		}
+	}
+	// The recovery's file_url is a non-authoritative hint from the presign
+	// response: the upload package documents the authoritative URL as the
+	// one returned by /files/complete, so a matching file_url is not
+	// proof of commit. Speak in terms of the actions the caller has: use
+	// `files complete` to replay finalize (safe — the same parts remain),
+	// or `files abort` to reclaim storage if they decide to give up.
+	hint := "Do not retry blindly — a retry may create a duplicate. Finalize with `gumroad files complete --recovery <manifest>` to commit without re-uploading, or reclaim storage with `gumroad files abort --upload-id <id> --key <key>`."
+	return commandErrorDetail{
+		Type:     "upload_error",
+		Code:     "complete_state_unknown",
+		Message:  err.Error(),
+		Hint:     hint,
+		Recovery: recovery,
+	}
+}
+
+// printUploadRecovery emits any recovery handles carried by multipart-upload
+// errors so a human operator can reconcile state without re-uploading blindly.
+func printUploadRecovery(w io.Writer, style output.Styler, err error) {
+	var state *upload.UnknownStateError
+	var cleanup *upload.CleanupFailedError
+	var rejected *files.CompleteRejectedError
+	hasState := errors.As(err, &state)
+	hasCleanup := errors.As(err, &cleanup)
+	hasRejected := errors.As(err, &rejected)
+	if !hasState && !hasCleanup && !hasRejected {
+		return
+	}
+
+	uploadID, key := resolveOrphanHandles(state, cleanup, rejected, hasState, hasCleanup, hasRejected)
+
+	fmt.Fprintln(w, style.Dim("Recovery:"))
+	// The upload package says this URL is the presign-side hint and is
+	// not authoritative; avoid phrasing that implies it is.
+	if hasState && state.FileURL != "" {
+		fmt.Fprintln(w, style.Dim("  file_url:  "+state.FileURL)+style.Dim("  (non-authoritative presign hint)"))
+	} else if hasRejected && rejected.FileURL != "" {
+		fmt.Fprintln(w, style.Dim("  file_url:  "+rejected.FileURL)+style.Dim("  (non-authoritative presign hint)"))
+	}
+	if uploadID != "" {
+		fmt.Fprintln(w, style.Dim("  upload_id: "+uploadID))
+	}
+	if key != "" {
+		fmt.Fprintln(w, style.Dim("  key:       "+key))
+	}
+	parts := resolveRecoveryParts(state, rejected, hasState, hasRejected)
+	if n := len(parts); n > 0 {
+		fmt.Fprintln(w, style.Dim(fmt.Sprintf("  completed_parts: %d uploaded (re-finalize with `gumroad files complete --recovery <manifest>` to avoid re-uploading):", n)))
+		for _, p := range parts {
+			fmt.Fprintln(w, style.Dim(fmt.Sprintf("    part_number=%d etag=%s", p.PartNumber, p.ETag)))
+		}
+	}
+	if hasCleanup && (uploadID != "" || key != "") {
+		fmt.Fprintln(w, style.Dim("  cleanup_failed: multipart left orphaned on S3; reclaim with `gumroad files abort --upload-id <id> --key <key>`"))
+	}
+	if hasRejected && (uploadID != "" || key != "") {
+		fmt.Fprintln(w, style.Dim("  finalize_rejected: /files/complete refused this manifest. If the rejection looks recoverable (wrong token, fixable manifest), correct it and re-run `gumroad files complete`; otherwise reclaim the orphan with `gumroad files abort --upload-id <id> --key <key>`."))
+	}
+}
+
+// resolveRecoveryParts returns the completed-parts manifest carried by the
+// error, preferring the UnknownStateError copy (the original uploader
+// produced it) over the CompleteRejectedError copy (echoed back from the
+// manifest the user supplied).
+func resolveRecoveryParts(state *upload.UnknownStateError, rejected *files.CompleteRejectedError, hasState, hasRejected bool) []upload.CompletedPart {
+	if hasState && len(state.CompletedParts) > 0 {
+		return state.CompletedParts
+	}
+	if hasRejected {
+		return rejected.CompletedParts
+	}
+	return nil
+}
+
+// resolveOrphanHandles returns the upload_id/key pair to print, preferring
+// whichever source carries the primary failure identifiers.
+func resolveOrphanHandles(state *upload.UnknownStateError, cleanup *upload.CleanupFailedError, rejected *files.CompleteRejectedError, hasState, hasCleanup, hasRejected bool) (uploadID, key string) {
+	if hasState {
+		uploadID = state.UploadID
+		key = state.Key
+	}
+	if hasRejected {
+		if uploadID == "" {
+			uploadID = rejected.UploadID
+		}
+		if key == "" {
+			key = rejected.Key
+		}
+	}
+	if hasCleanup {
+		if uploadID == "" {
+			uploadID = cleanup.UploadID
+		}
+		if key == "" {
+			key = cleanup.Key
+		}
+	}
+	return uploadID, key
+}
+
+func completeRejectedClassification(err error, rejected *files.CompleteRejectedError) commandErrorDetail {
+	recovery := &uploadRecoveryInfo{
+		FileURL:  rejected.FileURL,
+		UploadID: rejected.UploadID,
+		Key:      rejected.Key,
+	}
+	if len(rejected.CompletedParts) > 0 {
+		recovery.CompletedParts = make([]uploadCompletedPart, len(rejected.CompletedParts))
+		for i, p := range rejected.CompletedParts {
+			recovery.CompletedParts[i] = uploadCompletedPart{PartNumber: p.PartNumber, ETag: p.ETag}
+		}
+	}
+
+	// When the underlying cause is an auth or access-denied API error,
+	// preserve that classification. The primary remediation is refreshing
+	// credentials, not reconciling the upload — the recovery handles are
+	// attached as supplemental metadata for later cleanup.
+	var apiErr *api.APIError
+	if errors.As(err, &apiErr) {
+		code := apiErrorCode(apiErr.StatusCode)
+		if code == "not_authenticated" || code == "access_denied" {
+			return commandErrorDetail{
+				Type:       "api_error",
+				Code:       code,
+				Message:    apiErr.Error(),
+				Hint:       apiErr.GetHint(),
+				StatusCode: apiErr.StatusCode,
+				Recovery:   recovery,
+			}
+		}
+	}
+
+	detail := commandErrorDetail{
+		Type:     "upload_error",
+		Code:     "complete_rejected",
+		Message:  err.Error(),
+		Hint:     "`/files/complete` refused the manifest on replay. If the rejection is recoverable (fixable manifest), correct it and re-run `gumroad files complete`. Otherwise reclaim storage with `gumroad files abort --upload-id <id> --key <key>`.",
+		Recovery: recovery,
+	}
+	if apiErr != nil {
+		detail.StatusCode = apiErr.StatusCode
+	}
+	return detail
+}
+
+func uploadCleanupFailedDetail(err error, cleanup *upload.CleanupFailedError) commandErrorDetail {
+	return commandErrorDetail{
+		Type:    "upload_error",
+		Code:    "cleanup_failed",
+		Message: err.Error(),
+		Hint:    "A multipart upload was left orphaned on S3. Reclaim it with `gumroad files abort --upload-id <id> --key <key>`.",
+		Recovery: &uploadRecoveryInfo{
+			UploadID: cleanup.UploadID,
+			Key:      cleanup.Key,
+		},
 	}
 }
 

--- a/internal/cmd/errors.go
+++ b/internal/cmd/errors.go
@@ -120,7 +120,8 @@ func primaryCause(err error) error {
 	}
 	var kept []error
 	for _, inner := range mu.Unwrap() {
-		if _, isCleanup := inner.(*upload.CleanupFailedError); isCleanup {
+		var cleanup *upload.CleanupFailedError
+		if errors.As(inner, &cleanup) {
 			continue
 		}
 		kept = append(kept, inner)

--- a/internal/cmd/errors_test.go
+++ b/internal/cmd/errors_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,9 +10,12 @@ import (
 	"testing"
 
 	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmd/files"
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/config"
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/antiwork/gumroad-cli/internal/prompt"
+	"github.com/antiwork/gumroad-cli/internal/upload"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -225,5 +229,296 @@ func TestPrintStructuredCommandError_MarshalFallback(t *testing.T) {
 	err := printStructuredCommandError(bytes.NewBuffer(nil), errors.New(strings.Repeat("x", 8)))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestClassifyCommandError_UploadUnknownState_CarriesRecovery(t *testing.T) {
+	state := &upload.UnknownStateError{
+		FileURL:  "https://example.com/attachments/u/k/file.bin",
+		UploadID: "up-1",
+		Key:      "attachments/u/k/original/file.bin",
+		CompletedParts: []upload.CompletedPart{
+			{PartNumber: 1, ETag: "etag-1"},
+			{PartNumber: 2, ETag: "etag-2"},
+		},
+		Cause: errors.New("502 Bad Gateway"),
+	}
+	detail := classifyCommandError(state)
+	if detail.Type != "upload_error" || detail.Code != "complete_state_unknown" {
+		t.Fatalf("type/code = %q/%q", detail.Type, detail.Code)
+	}
+	if detail.Recovery == nil {
+		t.Fatal("expected Recovery to be populated")
+	}
+	if detail.Recovery.FileURL != state.FileURL || detail.Recovery.UploadID != "up-1" || detail.Recovery.Key != state.Key {
+		t.Errorf("recovery handles = %+v", detail.Recovery)
+	}
+	if len(detail.Recovery.CompletedParts) != 2 {
+		t.Errorf("completed parts = %d, want 2", len(detail.Recovery.CompletedParts))
+	}
+	if detail.Hint == "" {
+		t.Error("expected human-facing hint about avoiding blind retry")
+	}
+}
+
+func TestClassifyCommandError_UploadCleanupFailed_CarriesOrphanHandles(t *testing.T) {
+	cleanup := &upload.CleanupFailedError{
+		UploadID: "up-2",
+		Key:      "attachments/u/k/original/file2.bin",
+		Cause:    errors.New("abort 500"),
+	}
+	detail := classifyCommandError(cleanup)
+	if detail.Type != "upload_error" || detail.Code != "cleanup_failed" {
+		t.Fatalf("type/code = %q/%q", detail.Type, detail.Code)
+	}
+	if detail.Recovery == nil || detail.Recovery.UploadID != "up-2" || detail.Recovery.Key != cleanup.Key {
+		t.Errorf("recovery = %+v", detail.Recovery)
+	}
+}
+
+func TestClassifyCommandError_UnknownStateJoinedWithCleanup_MergesHandles(t *testing.T) {
+	state := &upload.UnknownStateError{
+		UploadID: "up-3",
+		Key:      "attachments/u/k/original/file3.bin",
+		Cause:    errors.New("503"),
+	}
+	cleanup := &upload.CleanupFailedError{
+		UploadID: "up-3-cleanup",
+		Key:      "attachments/u/k/original/file3.bin",
+		Cause:    errors.New("abort 500"),
+	}
+	joined := errors.Join(state, cleanup)
+	detail := classifyCommandError(joined)
+	if detail.Code != "complete_state_unknown" {
+		t.Fatalf("code = %q, want complete_state_unknown", detail.Code)
+	}
+	// The state's handles take priority; cleanup fills only missing fields.
+	if detail.Recovery.UploadID != "up-3" {
+		t.Errorf("UploadID = %q, want up-3", detail.Recovery.UploadID)
+	}
+}
+
+func TestPrintUploadRecovery_HumanMode_IncludesFullManifest(t *testing.T) {
+	state := &upload.UnknownStateError{
+		FileURL:  "https://example.com/attachments/u/k/file.bin",
+		UploadID: "up-1",
+		Key:      "attachments/u/k/original/file.bin",
+		CompletedParts: []upload.CompletedPart{
+			{PartNumber: 1, ETag: "etag-alpha"},
+			{PartNumber: 2, ETag: "etag-beta"},
+		},
+		Cause: errors.New("503"),
+	}
+	var buf bytes.Buffer
+	style := output.NewStylerForWriter(&buf, true)
+	printUploadRecovery(&buf, style, state)
+	got := buf.String()
+	for _, want := range []string{
+		"Recovery:",
+		"file_url:",
+		"upload_id:",
+		"key:",
+		"completed_parts: 2",
+		"part_number=1 etag=etag-alpha",
+		"part_number=2 etag=etag-beta",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in output:\n%s", want, got)
+		}
+	}
+}
+
+func TestPrintUploadRecovery_CleanupOnly_PrintsOrphanHandles(t *testing.T) {
+	// A cleanup failure without an UnknownStateError still carries upload_id
+	// and key; the human recovery block must print them, otherwise the
+	// "reclaim with gumroad files abort" hint has nothing to reference.
+	cleanup := &upload.CleanupFailedError{
+		UploadID: "up-orphan",
+		Key:      "attachments/u/k/original/orphan.bin",
+		Cause:    errors.New("abort 500"),
+	}
+	var buf bytes.Buffer
+	style := output.NewStylerForWriter(&buf, true)
+	printUploadRecovery(&buf, style, cleanup)
+	got := buf.String()
+	for _, want := range []string{"upload_id: up-orphan", "key:       attachments/u/k/original/orphan.bin", "gumroad files abort"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in output:\n%s", want, got)
+		}
+	}
+}
+
+func TestPrintUploadRecovery_APIErrorJoinedWithCleanup_PrintsOrphanHandles(t *testing.T) {
+	primary := &api.APIError{StatusCode: 200, Message: "complete rejected"}
+	cleanup := &upload.CleanupFailedError{
+		UploadID: "up-joined",
+		Key:      "attachments/u/k/original/joined.bin",
+		Cause:    errors.New("abort 500"),
+	}
+	joined := errors.Join(primary, cleanup)
+
+	var buf bytes.Buffer
+	style := output.NewStylerForWriter(&buf, true)
+	printUploadRecovery(&buf, style, joined)
+	got := buf.String()
+	for _, want := range []string{"upload_id: up-joined", "key:       attachments/u/k/original/joined.bin"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in output:\n%s", want, got)
+		}
+	}
+}
+
+func TestClassifyCommandError_APIErrorJoinedWithCleanup_PreservesPrimary(t *testing.T) {
+	primary := &api.APIError{StatusCode: 200, Message: "complete rejected"}
+	cleanup := &upload.CleanupFailedError{UploadID: "up-7", Key: "attachments/u/k/original/p.bin", Cause: errors.New("abort 500")}
+	joined := errors.Join(primary, cleanup)
+
+	detail := classifyCommandError(joined)
+	if detail.Type != "api_error" {
+		t.Fatalf("type = %q, want api_error (primary must win over cleanup)", detail.Type)
+	}
+	if detail.Recovery == nil || detail.Recovery.UploadID != "up-7" {
+		t.Errorf("expected cleanup orphan handles attached, got %+v", detail.Recovery)
+	}
+}
+
+// When abort returns an HTTP error, CleanupFailedError.Unwrap exposes it as
+// an *api.APIError. Classification must still report cleanup_failed, not the
+// abort's api_error, so callers know there's an orphan to reclaim.
+func TestClassifyCommandError_CleanupCauseIsAPIError_ClassifiesAsCleanup(t *testing.T) {
+	abortErr := &api.APIError{StatusCode: 500, Message: "abort returned 500"}
+	cleanup := &upload.CleanupFailedError{
+		UploadID: "up-abort-500",
+		Key:      "attachments/u/k/original/p.bin",
+		Cause:    abortErr,
+	}
+	// Simulate the joinAbort shape: primary uploadErr (context canceled) + cleanup.
+	joined := errors.Join(context.Canceled, cleanup)
+
+	detail := classifyCommandError(joined)
+	if detail.Type != "upload_error" || detail.Code != "cleanup_failed" {
+		t.Fatalf("type/code = %q/%q, want upload_error/cleanup_failed", detail.Type, detail.Code)
+	}
+	if detail.Recovery == nil || detail.Recovery.UploadID != "up-abort-500" {
+		t.Errorf("recovery = %+v", detail.Recovery)
+	}
+}
+
+func TestUploadIncompleteDetail_MissingFileURL_AvoidsFileURLHint(t *testing.T) {
+	// Presign may omit file_url per the upload package contract; the hint
+	// must not tell users to "check the returned file_url" in that case.
+	state := &upload.UnknownStateError{
+		UploadID: "up-no-url",
+		Key:      "attachments/u/k/original/p.bin",
+		Cause:    errors.New("503"),
+	}
+	detail := classifyCommandError(state)
+	if strings.Contains(detail.Hint, "file_url") {
+		t.Errorf("hint mentions file_url when it was absent: %q", detail.Hint)
+	}
+	if !strings.Contains(detail.Hint, "files abort") {
+		t.Errorf("hint should still point to abort: %q", detail.Hint)
+	}
+}
+
+func TestUploadIncompleteDetail_HintDoesNotClaimFileURLAuthoritative(t *testing.T) {
+	// The presign file_url is a non-authoritative hint — the hint copy
+	// must not imply checking it proves commit state.
+	state := &upload.UnknownStateError{
+		FileURL:  "https://example.com/attachments/u/k/file.bin",
+		UploadID: "up-with-url",
+		Key:      "attachments/u/k/original/p.bin",
+		Cause:    errors.New("503"),
+	}
+	detail := classifyCommandError(state)
+	if strings.Contains(detail.Hint, "check the returned file_url") {
+		t.Errorf("hint must not frame presign file_url as authoritative commit check: %q", detail.Hint)
+	}
+	if !strings.Contains(detail.Hint, "files complete") {
+		t.Errorf("hint should point to files complete: %q", detail.Hint)
+	}
+}
+
+func TestClassifyCommandError_CompleteRejected_NonAuthIsFirstClassUploadError(t *testing.T) {
+	// A 400 "invalid etag" rejection is an upload-recovery problem, not
+	// an auth issue: surface it as a first-class upload_error/complete_rejected
+	// with the full manifest attached as Recovery metadata.
+	rejected := &files.CompleteRejectedError{
+		FileURL:  "https://example.com/attachments/u/k/file.bin",
+		UploadID: "up-r",
+		Key:      "attachments/u/k/original/file.bin",
+		CompletedParts: []upload.CompletedPart{
+			{PartNumber: 1, ETag: "etag-1"},
+		},
+		Cause: &api.APIError{StatusCode: 400, Message: "invalid etag"},
+	}
+	detail := classifyCommandError(rejected)
+	if detail.Type != "upload_error" || detail.Code != "complete_rejected" {
+		t.Fatalf("type/code = %q/%q, want upload_error/complete_rejected", detail.Type, detail.Code)
+	}
+	if detail.StatusCode != 400 {
+		t.Errorf("StatusCode = %d, want 400 (preserved from underlying APIError)", detail.StatusCode)
+	}
+	if detail.Recovery == nil || detail.Recovery.UploadID != "up-r" || len(detail.Recovery.CompletedParts) != 1 {
+		t.Errorf("Recovery = %+v", detail.Recovery)
+	}
+}
+
+func TestClassifyCommandError_CompleteRejected_AuthCausePreservesAuthClassification(t *testing.T) {
+	// When the rejection is a 401/403, the caller needs to re-authenticate
+	// first; surface api_error/not_authenticated so the normal auth
+	// remediation path fires, while keeping the orphan handles as
+	// Recovery metadata for later cleanup.
+	rejected := &files.CompleteRejectedError{
+		UploadID: "up-auth",
+		Key:      "attachments/u/k/original/p.bin",
+		CompletedParts: []upload.CompletedPart{
+			{PartNumber: 1, ETag: "e1"},
+		},
+		Cause: &api.APIError{StatusCode: 401, Message: "not_authenticated"},
+	}
+	detail := classifyCommandError(rejected)
+	if detail.Type != "api_error" || detail.Code != "not_authenticated" {
+		t.Fatalf("type/code = %q/%q, want api_error/not_authenticated", detail.Type, detail.Code)
+	}
+	if detail.StatusCode != 401 {
+		t.Errorf("StatusCode = %d, want 401", detail.StatusCode)
+	}
+	if detail.Recovery == nil || detail.Recovery.UploadID != "up-auth" {
+		t.Errorf("Recovery should still carry orphan handles: %+v", detail.Recovery)
+	}
+}
+
+func TestClassifyCommandError_PresignExpired(t *testing.T) {
+	detail := classifyCommandError(upload.ErrPresignExpired)
+	if detail.Type != "upload_error" || detail.Code != "presign_expired" {
+		t.Fatalf("type/code = %q/%q, want upload_error/presign_expired", detail.Type, detail.Code)
+	}
+	if !strings.Contains(detail.Hint, "Re-run") {
+		t.Errorf("expected restart-from-scratch hint, got %q", detail.Hint)
+	}
+}
+
+func TestClassifyCommandError_PresignExpiredWithCleanup_KeepsPresignCode(t *testing.T) {
+	// If cleanup also failed, the presign_expired primary classification
+	// must survive the post-hoc cleanup merge — internal_error would
+	// upgrade to cleanup_failed, but a recognized upload code must not.
+	cleanup := &upload.CleanupFailedError{UploadID: "up-p", Key: "k", Cause: errors.New("abort 500")}
+	joined := errors.Join(upload.ErrPresignExpired, cleanup)
+	detail := classifyCommandError(joined)
+	if detail.Code != "presign_expired" {
+		t.Fatalf("code = %q, want presign_expired", detail.Code)
+	}
+	if detail.Recovery == nil || detail.Recovery.UploadID != "up-p" {
+		t.Errorf("cleanup recovery not attached: %+v", detail.Recovery)
+	}
+}
+
+func TestPrintUploadRecovery_NoopForUnrelatedError(t *testing.T) {
+	var buf bytes.Buffer
+	style := output.NewStylerForWriter(&buf, true)
+	printUploadRecovery(&buf, style, errors.New("unrelated"))
+	if buf.Len() != 0 {
+		t.Errorf("expected no output, got %q", buf.String())
 	}
 }

--- a/internal/cmd/errors_test.go
+++ b/internal/cmd/errors_test.go
@@ -276,10 +276,10 @@ func TestClassifyCommandError_UploadCleanupFailed_CarriesOrphanHandles(t *testin
 	}
 }
 
-func TestClassifyCommandError_UnknownStateJoinedWithCleanup_MergesHandles(t *testing.T) {
+func TestClassifyCommandError_UnknownStateJoinedWithCleanup_MergesMissingHandles(t *testing.T) {
 	state := &upload.UnknownStateError{
 		UploadID: "up-3",
-		Key:      "attachments/u/k/original/file3.bin",
+		Key:      "",
 		Cause:    errors.New("503"),
 	}
 	cleanup := &upload.CleanupFailedError{
@@ -295,6 +295,33 @@ func TestClassifyCommandError_UnknownStateJoinedWithCleanup_MergesHandles(t *tes
 	// The state's handles take priority; cleanup fills only missing fields.
 	if detail.Recovery.UploadID != "up-3" {
 		t.Errorf("UploadID = %q, want up-3", detail.Recovery.UploadID)
+	}
+	if detail.Recovery.Key != cleanup.Key {
+		t.Errorf("Key = %q, want %q", detail.Recovery.Key, cleanup.Key)
+	}
+}
+
+func TestClassifyCommandError_UnknownStateJoinedWithCleanup_FillsMissingUploadID(t *testing.T) {
+	state := &upload.UnknownStateError{
+		UploadID: "",
+		Key:      "attachments/u/k/original/file4.bin",
+		Cause:    errors.New("503"),
+	}
+	cleanup := &upload.CleanupFailedError{
+		UploadID: "up-4-cleanup",
+		Key:      "attachments/u/k/original/file4.bin",
+		Cause:    errors.New("abort 500"),
+	}
+
+	detail := classifyCommandError(errors.Join(state, cleanup))
+	if detail.Code != "complete_state_unknown" {
+		t.Fatalf("code = %q, want complete_state_unknown", detail.Code)
+	}
+	if detail.Recovery.UploadID != cleanup.UploadID {
+		t.Errorf("UploadID = %q, want %q", detail.Recovery.UploadID, cleanup.UploadID)
+	}
+	if detail.Recovery.Key != state.Key {
+		t.Errorf("Key = %q, want %q", detail.Recovery.Key, state.Key)
 	}
 }
 

--- a/internal/cmd/errors_test.go
+++ b/internal/cmd/errors_test.go
@@ -382,6 +382,24 @@ func TestClassifyCommandError_APIErrorJoinedWithCleanup_PreservesPrimary(t *test
 	}
 }
 
+func TestClassifyCommandError_APIErrorJoinedWithWrappedCleanup_PreservesPrimary(t *testing.T) {
+	primary := &api.APIError{StatusCode: 403, Message: "Access denied"}
+	cleanup := fmt.Errorf("abort retry exhausted: %w", &upload.CleanupFailedError{
+		UploadID: "up-wrapped",
+		Key:      "attachments/u/k/original/wrapped.bin",
+		Cause:    errors.New("abort 500"),
+	})
+	joined := errors.Join(primary, cleanup)
+
+	detail := classifyCommandError(joined)
+	if detail.Type != "api_error" || detail.Code != "access_denied" {
+		t.Fatalf("type/code = %q/%q, want api_error/access_denied", detail.Type, detail.Code)
+	}
+	if detail.Recovery == nil || detail.Recovery.UploadID != "up-wrapped" {
+		t.Errorf("expected wrapped cleanup orphan handles attached, got %+v", detail.Recovery)
+	}
+}
+
 // When abort returns an HTTP error, CleanupFailedError.Unwrap exposes it as
 // an *api.APIError. Classification must still report cleanup_failed, not the
 // abort's api_error, so callers know there's an orphan to reclaim.

--- a/internal/cmd/files/abort.go
+++ b/internal/cmd/files/abort.go
@@ -1,0 +1,49 @@
+package files
+
+import (
+	"net/url"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+func newAbortCmd() *cobra.Command {
+	var uploadID, key string
+	c := &cobra.Command{
+		Use:   "abort",
+		Short: "Abort an orphaned multipart upload on S3",
+		Args:  cmdutil.ExactArgs(0),
+		Long: "Abort an orphaned multipart upload using the upload_id and key returned in a " +
+			"failed upload's recovery fields. Use this when a previous `gumroad files upload` " +
+			"left a multipart upload behind (cleanup_failed error, or a state-unknown finalize " +
+			"that you decided not to retry).",
+		Example: `  gumroad files abort --upload-id up-123 --key attachments/u/k/original/pack.zip
+  gumroad files abort --upload-id "$(jq -r .error.recovery.upload_id < err.json)" \
+    --key "$(jq -r .error.recovery.key < err.json)"`,
+		RunE: func(c *cobra.Command, _ []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			if uploadID == "" {
+				return cmdutil.MissingFlagError(c, "--upload-id")
+			}
+			if key == "" {
+				return cmdutil.MissingFlagError(c, "--key")
+			}
+
+			ok, err := cmdutil.ConfirmAction(opts, "Abort multipart upload "+uploadID+"? This is irreversible.")
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return cmdutil.PrintCancelledAction(opts, "abort multipart upload "+uploadID, uploadID)
+			}
+
+			params := url.Values{}
+			params.Set("upload_id", uploadID)
+			params.Set("key", key)
+			return cmdutil.RunRequestWithSuccess(opts, "Aborting multipart upload...", "POST", "/files/abort", params, uploadID, "Multipart upload aborted.")
+		},
+	}
+	c.Flags().StringVar(&uploadID, "upload-id", "", "S3 multipart upload_id to abort (required)")
+	c.Flags().StringVar(&key, "key", "", "S3 object key for the upload (required)")
+	return c
+}

--- a/internal/cmd/files/abort_test.go
+++ b/internal/cmd/files/abort_test.go
@@ -1,0 +1,119 @@
+package files
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestAbort_HappyPath_CallsAbortEndpoint(t *testing.T) {
+	called := false
+	var body map[string]string
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/files/abort" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			http.Error(w, "bad", http.StatusNotFound)
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		body = map[string]string{
+			"upload_id": r.PostForm.Get("upload_id"),
+			"key":       r.PostForm.Get("key"),
+		}
+		called = true
+		testutil.JSON(t, w, map[string]any{})
+	})
+
+	cmd := testutil.Command(newAbortCmd(), testutil.JSONOutput(), testutil.Yes(true))
+	cmd.SetArgs([]string{"--upload-id", "up-1", "--key", "attachments/u/k/original/file.bin"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !called {
+		t.Fatal("abort endpoint was not called")
+	}
+	if body["upload_id"] != "up-1" || body["key"] != "attachments/u/k/original/file.bin" {
+		t.Errorf("body = %+v", body)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, out)
+	}
+	if success, _ := resp["success"].(bool); !success {
+		t.Errorf("expected success=true, got %v", resp)
+	}
+}
+
+func TestAbort_NoInput_WithoutYes_BlocksBeforeAPICall(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("abort must not reach the API without confirmation")
+		http.Error(w, "must not call", http.StatusInternalServerError)
+	})
+
+	cmd := testutil.Command(newAbortCmd(), testutil.NoInput(true))
+	cmd.SetArgs([]string{"--upload-id", "up-1", "--key", "attachments/u/k/original/file.bin"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected confirmation error in --no-input mode")
+	}
+}
+
+func TestAbort_MissingUploadID_Errors(t *testing.T) {
+	cmd := testutil.Command(newAbortCmd())
+	cmd.SetArgs([]string{"--key", "attachments/u/k/original/file.bin"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected usage error for missing --upload-id")
+	}
+	if !strings.Contains(err.Error(), "--upload-id") {
+		t.Errorf("error = %v, want mention of --upload-id", err)
+	}
+}
+
+func TestAbort_MissingKey_Errors(t *testing.T) {
+	cmd := testutil.Command(newAbortCmd())
+	cmd.SetArgs([]string{"--upload-id", "up-1"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected usage error for missing --key")
+	}
+	if !strings.Contains(err.Error(), "--key") {
+		t.Errorf("error = %v, want mention of --key", err)
+	}
+}
+
+func TestAbort_StrayPositionalArg_RejectedBeforeAPICall(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("abort must not reach the API when extra args are present")
+		http.Error(w, "must not call", http.StatusInternalServerError)
+	})
+
+	cmd := testutil.Command(newAbortCmd())
+	cmd.SetArgs([]string{"--upload-id", "up-1", "--key", "attachments/u/k/original/p.bin", "stray"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected usage error for stray positional arg")
+	}
+	if !strings.Contains(err.Error(), "unexpected argument") {
+		t.Errorf("error = %v, want 'unexpected argument'", err)
+	}
+}
+
+func TestFilesCmd_AbortIsRegistered(t *testing.T) {
+	cmd := NewFilesCmd()
+	found := false
+	for _, c := range cmd.Commands() {
+		if c.Name() == "abort" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("abort subcommand not registered")
+	}
+}

--- a/internal/cmd/files/complete.go
+++ b/internal/cmd/files/complete.go
@@ -1,0 +1,299 @@
+package files
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/config"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/upload"
+	"github.com/spf13/cobra"
+)
+
+// maxManifestBytes caps the size of a recovery manifest read from a file or
+// stdin. A recovery manifest is a small JSON control document; anything
+// larger is either a mistake (the wrong file piped in) or a non-terminating
+// producer that would otherwise hang the CLI or exhaust memory.
+const maxManifestBytes = 2 * 1024 * 1024 // 2 MB
+
+// completeManifest mirrors the Recovery section of a failed upload's JSON
+// error envelope, so the user can pipe `--json` error output straight back in.
+type completeManifest struct {
+	// FileURL is the canonical URL the server would assign if it already
+	// committed. When non-empty, the upload may already be finalized and a
+	// blind re-finalize would create a duplicate — we gate on confirmation.
+	FileURL        string                 `json:"file_url,omitempty"`
+	UploadID       string                 `json:"upload_id"`
+	Key            string                 `json:"key"`
+	CompletedParts []completeManifestPart `json:"completed_parts"`
+}
+
+type completeManifestPart struct {
+	PartNumber int    `json:"part_number"`
+	ETag       string `json:"etag"`
+}
+
+func newCompleteCmd() *cobra.Command {
+	var recoveryPath string
+	c := &cobra.Command{
+		Use:   "complete",
+		Short: "Finalize an upload that hit an ambiguous /files/complete failure",
+		Args:  cmdutil.ExactArgs(0),
+		Long: "Replay /files/complete with a saved recovery manifest so an upload " +
+			"that left `upload` with a complete_state_unknown error can be " +
+			"finalized without re-uploading any bytes.\n\n" +
+			"The manifest is the `.error.recovery` object from a failed --json " +
+			"upload, or a plain {\"upload_id\": ..., \"key\": ..., \"completed_parts\": [...]} " +
+			"JSON document. Pass `-` to read from stdin.\n\n" +
+			"If the manifest includes a file_url, the upload may have already " +
+			"committed on the server; the command will prompt for confirmation " +
+			"(or require --yes) before replaying /files/complete, since a blind " +
+			"re-finalize can duplicate the attachment.",
+		Example: `  gumroad files upload ./pack.zip --json > err.json
+  jq '.error.recovery' err.json > recovery.json
+  gumroad files complete --recovery recovery.json
+  # When piping on stdin, --yes is required because the manifest consumes the
+  # only input stream and the duplicate-risk prompt has nowhere to read from:
+  jq '.error.recovery' err.json | gumroad files complete --recovery - --yes`,
+		RunE: func(c *cobra.Command, _ []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			if recoveryPath == "" {
+				return cmdutil.MissingFlagError(c, "--recovery")
+			}
+			// --recovery - consumes stdin for the manifest, leaving no
+			// stream for the duplicate-risk confirmation prompt below.
+			// Require --yes (or --dry-run) in that case so the user has
+			// explicitly acknowledged the retry-may-duplicate semantics.
+			if recoveryPath == "-" && !opts.Yes && !opts.DryRun {
+				return cmdutil.UsageErrorf(c,
+					"--recovery - consumes stdin for the manifest, so the duplicate-risk confirmation has nowhere to read from. Save the manifest to a file, or pass --yes to acknowledge the replay risk up front.")
+			}
+
+			manifest, err := readCompleteManifest(recoveryPath, opts.In())
+			if err != nil {
+				return err
+			}
+			if manifest.UploadID == "" || manifest.Key == "" {
+				return cmdutil.UsageErrorf(c, "recovery manifest missing upload_id or key")
+			}
+			if len(manifest.CompletedParts) == 0 {
+				return cmdutil.UsageErrorf(c, "recovery manifest has no completed_parts")
+			}
+			// Validate every part up front, before confirmation, so
+			// malformed manifests fail fast and do not prompt the caller to
+			// acknowledge a replay that cannot succeed. The uploader only
+			// ever produces contiguous part_numbers 1..N, so anything else
+			// would re-finalize the wrong bytes order.
+			for i, p := range manifest.CompletedParts {
+				if p.ETag == "" {
+					return cmdutil.UsageErrorf(c, "completed_parts[%d] missing etag", i)
+				}
+				if p.PartNumber != i+1 {
+					return cmdutil.UsageErrorf(c,
+						"completed_parts[%d].part_number = %d; expected %d (manifests must list parts contiguously from 1)",
+						i, p.PartNumber, i+1)
+				}
+			}
+
+			// Every complete_state_unknown replay is unsafe by default:
+			// /files/complete is the point where the server may have already
+			// committed, and the presign response's file_url is optional —
+			// its absence does not prove the upload didn't commit. Confirm
+			// unconditionally so no recovery path finalizes without the
+			// caller acknowledging the duplicate risk. --yes skips the
+			// prompt; --no-input returns the usual blocking error.
+			prompt := fmt.Sprintf(
+				"Re-finalize multipart upload %s? The server may have already committed it, so a replay can create a duplicate.",
+				manifest.UploadID,
+			)
+			if manifest.FileURL != "" {
+				prompt = fmt.Sprintf(
+					"Re-finalize multipart upload %s? The recovery manifest carries file_url=%s — the server may have already committed this upload, so a replay can create a duplicate.",
+					manifest.UploadID, manifest.FileURL,
+				)
+			}
+			ok, err := cmdutil.ConfirmAction(opts, prompt)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return cmdutil.PrintCancelledAction(opts, "finalize multipart upload "+manifest.UploadID, manifest.UploadID)
+			}
+
+			params := url.Values{}
+			params.Set("upload_id", manifest.UploadID)
+			params.Set("key", manifest.Key)
+			for i, p := range manifest.CompletedParts {
+				params.Set(fmt.Sprintf("parts[%d][part_number]", i), strconv.Itoa(p.PartNumber))
+				params.Set(fmt.Sprintf("parts[%d][etag]", i), p.ETag)
+			}
+
+			if opts.DryRun {
+				return cmdutil.PrintDryRunRequest(opts, "POST", "/files/complete", params)
+			}
+
+			return runComplete(opts, manifest, params)
+		},
+	}
+	c.Flags().StringVar(&recoveryPath, "recovery", "", "Path to the recovery manifest JSON (use `-` for stdin) (required)")
+	return c
+}
+
+// runComplete calls /files/complete and prints the returned file_url in the
+// same shape `files upload` does, so both success paths are interchangeable
+// for scripts that pipe to `jq '.file_url'`. Ambiguous failures are wrapped
+// with *upload.UnknownStateError so the caller keeps the recovery manifest
+// on a retry path — otherwise a single 5xx during replay would strand the
+// upload with no further safe reconciliation option.
+func runComplete(opts cmdutil.Options, manifest completeManifest, params url.Values) error {
+	token, err := config.Token()
+	if err != nil {
+		return err
+	}
+	client := cmdutil.NewAPIClient(opts, token)
+
+	var sp *output.Spinner
+	if cmdutil.ShouldShowSpinner(opts) {
+		sp = output.NewSpinnerTo("Finalizing multipart upload...", opts.Err())
+		sp.Start()
+		defer sp.Stop()
+	}
+
+	data, err := client.PostWithContext(opts.Context, "/files/complete", params)
+	if err != nil {
+		return handleCompleteFailure(client, err, manifest)
+	}
+	if sp != nil {
+		sp.Stop()
+	}
+
+	var resp struct {
+		FileURL string `json:"file_url"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return handleCompleteFailure(client, fmt.Errorf("could not parse /files/complete response: %w", err), manifest)
+	}
+	if resp.FileURL == "" {
+		return handleCompleteFailure(client, errors.New("/files/complete response missing file_url"), manifest)
+	}
+	return renderFileURL(opts, resp.FileURL)
+}
+
+// handleCompleteFailure wraps a /files/complete failure with the recovery
+// manifest so the caller retains actionable state:
+//   - Ambiguous (5xx, 408, 409, 429, transport, parse): *upload.UnknownStateError
+//     — a retry with the same manifest can still succeed.
+//   - Definitive (other 4xx, or HTTP-200-with-success-false): *CompleteRejectedError
+//     — preserves upload_id/key so the caller can run `gumroad files abort`
+//     after verifying that abort is actually the right next step. Unlike
+//     upload.Upload, this recovery command does not auto-abort: the manifest
+//     here is external input, and common causes of a 4xx here (wrong seller
+//     token, slightly wrong manifest) are recoverable with the SAME parts
+//     still present on S3. Auto-aborting would destroy that state.
+func handleCompleteFailure(_ *api.Client, err error, manifest completeManifest) error {
+	parts := make([]upload.CompletedPart, len(manifest.CompletedParts))
+	for i, p := range manifest.CompletedParts {
+		parts[i] = upload.CompletedPart{PartNumber: p.PartNumber, ETag: p.ETag}
+	}
+	var apiErr *api.APIError
+	if errors.As(err, &apiErr) && isDefinitiveCompleteRejection(apiErr.StatusCode) {
+		return &CompleteRejectedError{
+			FileURL:        manifest.FileURL,
+			UploadID:       manifest.UploadID,
+			Key:            manifest.Key,
+			CompletedParts: parts,
+			Cause:          err,
+		}
+	}
+	return &upload.UnknownStateError{
+		FileURL:        manifest.FileURL,
+		UploadID:       manifest.UploadID,
+		Key:            manifest.Key,
+		CompletedParts: parts,
+		Cause:          err,
+	}
+}
+
+// CompleteRejectedError wraps a definitive /files/complete rejection with
+// the full recovery manifest so callers can either correct a caller-side
+// mistake (wrong token, malformed manifest) and re-run `gumroad files
+// complete`, or reclaim the orphaned multipart upload via `gumroad files
+// abort`. It delegates its Error() to the cause, so the API error message
+// still reaches the user; the manifest survives as structured fields for
+// JSON consumers and human recovery output. Keeping CompletedParts is
+// critical for the stdin-piped recovery flow, where a 4xx on replay
+// otherwise consumes the only copy of the manifest.
+type CompleteRejectedError struct {
+	FileURL        string
+	UploadID       string
+	Key            string
+	CompletedParts []upload.CompletedPart
+	Cause          error
+}
+
+func (e *CompleteRejectedError) Error() string { return e.Cause.Error() }
+func (e *CompleteRejectedError) Unwrap() error { return e.Cause }
+
+// isDefinitiveCompleteRejection mirrors internal/upload's classification:
+// transient 4xx (408, 409, 429) and any 5xx remain ambiguous; everything
+// else from a 4xx API rejection is a definitive no-commit.
+func isDefinitiveCompleteRejection(status int) bool {
+	if status >= 500 {
+		return false
+	}
+	switch status {
+	case http.StatusRequestTimeout, http.StatusConflict, http.StatusTooManyRequests:
+		return false
+	}
+	return true
+}
+
+func readCompleteManifest(path string, stdin io.Reader) (completeManifest, error) {
+	var r io.Reader
+	if path == "-" {
+		r = stdin
+	} else {
+		// Stat-before-open: os.Open on a FIFO or device blocks the
+		// process indefinitely until a writer appears, which would
+		// defeat the size cap below and leave the recovery command
+		// hung. Mirrors the guard the upload package uses on its own
+		// file-open path.
+		info, err := os.Stat(path)
+		if err != nil {
+			return completeManifest{}, fmt.Errorf("could not open recovery manifest: %w", err)
+		}
+		if !info.Mode().IsRegular() {
+			return completeManifest{}, fmt.Errorf("recovery manifest %s is not a regular file", path)
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			return completeManifest{}, fmt.Errorf("could not open recovery manifest: %w", err)
+		}
+		defer func() { _ = f.Close() }()
+		r = f
+	}
+	// Read one byte past the cap so we can distinguish "exactly at limit"
+	// from "too large". Recovery manifests are small control JSON; a
+	// producer that outpaces that is almost certainly a mistake (wrong
+	// stream piped in) and should fail fast rather than consume memory.
+	data, err := io.ReadAll(io.LimitReader(r, maxManifestBytes+1))
+	if err != nil {
+		return completeManifest{}, fmt.Errorf("could not read recovery manifest: %w", err)
+	}
+	if int64(len(data)) > maxManifestBytes {
+		return completeManifest{}, fmt.Errorf("recovery manifest exceeds %d bytes; provide only the .error.recovery JSON object", maxManifestBytes)
+	}
+	var manifest completeManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return completeManifest{}, fmt.Errorf("could not parse recovery manifest: %w", err)
+	}
+	return manifest, nil
+}

--- a/internal/cmd/files/complete.go
+++ b/internal/cmd/files/complete.go
@@ -169,7 +169,7 @@ func runComplete(opts cmdutil.Options, manifest completeManifest, params url.Val
 
 	data, err := client.PostWithContext(opts.Context, "/files/complete", params)
 	if err != nil {
-		return handleCompleteFailure(client, err, manifest)
+		return handleCompleteFailure(err, manifest)
 	}
 	if sp != nil {
 		sp.Stop()
@@ -179,10 +179,10 @@ func runComplete(opts cmdutil.Options, manifest completeManifest, params url.Val
 		FileURL string `json:"file_url"`
 	}
 	if err := json.Unmarshal(data, &resp); err != nil {
-		return handleCompleteFailure(client, fmt.Errorf("could not parse /files/complete response: %w", err), manifest)
+		return handleCompleteFailure(fmt.Errorf("could not parse /files/complete response: %w", err), manifest)
 	}
 	if resp.FileURL == "" {
-		return handleCompleteFailure(client, errors.New("/files/complete response missing file_url"), manifest)
+		return handleCompleteFailure(errors.New("/files/complete response missing file_url"), manifest)
 	}
 	return renderFileURL(opts, resp.FileURL)
 }
@@ -198,7 +198,7 @@ func runComplete(opts cmdutil.Options, manifest completeManifest, params url.Val
 //     here is external input, and common causes of a 4xx here (wrong seller
 //     token, slightly wrong manifest) are recoverable with the SAME parts
 //     still present on S3. Auto-aborting would destroy that state.
-func handleCompleteFailure(_ *api.Client, err error, manifest completeManifest) error {
+func handleCompleteFailure(err error, manifest completeManifest) error {
 	parts := make([]upload.CompletedPart, len(manifest.CompletedParts))
 	for i, p := range manifest.CompletedParts {
 		parts[i] = upload.CompletedPart{PartNumber: p.PartNumber, ETag: p.ETag}

--- a/internal/cmd/files/complete_fifo_unix_test.go
+++ b/internal/cmd/files/complete_fifo_unix_test.go
@@ -1,0 +1,45 @@
+//go:build unix
+
+package files
+
+import (
+	"net/http"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestComplete_RejectsFIFO(t *testing.T) {
+	// os.Open on a FIFO blocks forever waiting for a writer. Without a
+	// stat-before-open guard, pointing --recovery at a named pipe would
+	// hang the recovery command and leave a multipart upload unreconciled.
+	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
+		t.Error("must not reach API for a FIFO manifest path")
+	})
+	path := filepath.Join(t.TempDir(), "pipe")
+	if err := syscall.Mkfifo(path, 0o600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		cmd := testutil.Command(newCompleteCmd(), testutil.Yes(true))
+		cmd.SetArgs([]string{"--recovery", path})
+		done <- cmd.Execute()
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected error for FIFO recovery path")
+		}
+		if !strings.Contains(err.Error(), "not a regular file") {
+			t.Errorf("error = %v, want mention of non-regular file", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("files complete hung on FIFO recovery path")
+	}
+}

--- a/internal/cmd/files/complete_test.go
+++ b/internal/cmd/files/complete_test.go
@@ -1,0 +1,467 @@
+package files
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+	"github.com/antiwork/gumroad-cli/internal/upload"
+)
+
+func writeRecovery(t *testing.T, data any) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "recovery.json")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create recovery: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	if err := json.NewEncoder(f).Encode(data); err != nil {
+		t.Fatalf("encode recovery: %v", err)
+	}
+	return path
+}
+
+func TestComplete_HappyPath_IndexedPartsAndReturnsFileURL(t *testing.T) {
+	var received map[string]string
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/files/complete" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			http.Error(w, "bad", http.StatusNotFound)
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		received = map[string]string{}
+		for k, v := range r.PostForm {
+			received[k] = strings.Join(v, ",")
+		}
+		testutil.JSON(t, w, map[string]any{"file_url": "https://example.com/final"})
+	})
+
+	recovery := map[string]any{
+		"upload_id": "up-9",
+		"key":       "attachments/u/k/original/p.bin",
+		"completed_parts": []map[string]any{
+			{"part_number": 1, "etag": "etag-1"},
+			{"part_number": 2, "etag": "etag-2"},
+		},
+	}
+	recoveryPath := writeRecovery(t, recovery)
+
+	cmd := testutil.Command(newCompleteCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"--recovery", recoveryPath})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if received["upload_id"] != "up-9" {
+		t.Errorf("upload_id = %q", received["upload_id"])
+	}
+	if received["key"] != "attachments/u/k/original/p.bin" {
+		t.Errorf("key = %q", received["key"])
+	}
+	for i := 0; i < 2; i++ {
+		if got := received[fmt.Sprintf("parts[%d][part_number]", i)]; got == "" {
+			t.Errorf("missing parts[%d][part_number]", i)
+		}
+		if got := received[fmt.Sprintf("parts[%d][etag]", i)]; got == "" {
+			t.Errorf("missing parts[%d][etag]", i)
+		}
+	}
+	if got := strings.TrimSpace(out); got != "https://example.com/final" {
+		t.Errorf("expected canonical file_url on stdout, got %q", got)
+	}
+}
+
+func TestComplete_JSON_EmitsFileURLEnvelope(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, _ *http.Request) {
+		testutil.JSON(t, w, map[string]any{"file_url": "https://example.com/final"})
+	})
+
+	recoveryPath := writeRecovery(t, map[string]any{
+		"upload_id":       "up-j",
+		"key":             "k",
+		"completed_parts": []map[string]any{{"part_number": 1, "etag": "e1"}},
+	})
+	cmd := testutil.Command(newCompleteCmd(), testutil.JSONOutput(), testutil.Yes(true))
+	cmd.SetArgs([]string{"--recovery", recoveryPath})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var got map[string]string
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("expected JSON output, got %v: %s", err, out)
+	}
+	if got["file_url"] != "https://example.com/final" {
+		t.Errorf("file_url = %q", got["file_url"])
+	}
+}
+
+func TestComplete_ManifestWithoutFileURL_NoInput_StillBlocksReplay(t *testing.T) {
+	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
+		t.Error("must not replay without confirmation even when file_url is absent")
+	})
+	recoveryPath := writeRecovery(t, map[string]any{
+		"upload_id":       "up-no-url",
+		"key":             "k",
+		"completed_parts": []map[string]any{{"part_number": 1, "etag": "e1"}},
+	})
+	cmd := testutil.Command(newCompleteCmd(), testutil.NoInput(true))
+	cmd.SetArgs([]string{"--recovery", recoveryPath})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected confirmation error even when manifest has no file_url")
+	}
+}
+
+func TestComplete_ManifestWithFileURL_NoInput_BlocksReplay(t *testing.T) {
+	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
+		t.Error("must not replay /files/complete without confirmation when file_url is set")
+	})
+
+	recoveryPath := writeRecovery(t, map[string]any{
+		"file_url":        "https://example.com/maybe-committed",
+		"upload_id":       "up-maybe",
+		"key":             "attachments/u/k/original/p.bin",
+		"completed_parts": []map[string]any{{"part_number": 1, "etag": "e1"}},
+	})
+
+	cmd := testutil.Command(newCompleteCmd(), testutil.NoInput(true))
+	cmd.SetArgs([]string{"--recovery", recoveryPath})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected confirmation error when file_url is present and --no-input is set")
+	}
+}
+
+func TestComplete_ManifestWithFileURL_YesFlag_AllowsReplay(t *testing.T) {
+	called := false
+	testutil.Setup(t, func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		testutil.JSON(t, w, map[string]any{"file_url": "https://example.com/final"})
+	})
+
+	recoveryPath := writeRecovery(t, map[string]any{
+		"file_url":        "https://example.com/maybe",
+		"upload_id":       "up-ack",
+		"key":             "k",
+		"completed_parts": []map[string]any{{"part_number": 1, "etag": "e1"}},
+	})
+	cmd := testutil.Command(newCompleteCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"--recovery", recoveryPath})
+	_ = testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if !called {
+		t.Fatal("expected /files/complete to run when --yes acknowledges duplicate risk")
+	}
+}
+
+func TestComplete_MissingRecovery_Errors(t *testing.T) {
+	cmd := testutil.Command(newCompleteCmd())
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--recovery") {
+		t.Fatalf("expected missing flag error, got %v", err)
+	}
+}
+
+func TestComplete_EmptyCompletedParts_Errors(t *testing.T) {
+	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
+		t.Error("must not reach API when manifest is empty")
+	})
+	recoveryPath := writeRecovery(t, map[string]any{
+		"upload_id":       "up-1",
+		"key":             "k",
+		"completed_parts": []any{},
+	})
+	cmd := testutil.Command(newCompleteCmd())
+	cmd.SetArgs([]string{"--recovery", recoveryPath})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "no completed_parts") {
+		t.Fatalf("expected empty parts error, got %v", err)
+	}
+}
+
+func TestComplete_MissingEtag_Errors(t *testing.T) {
+	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
+		t.Error("must not reach API when manifest has a missing etag")
+	})
+	recoveryPath := writeRecovery(t, map[string]any{
+		"upload_id": "up-1",
+		"key":       "k",
+		"completed_parts": []map[string]any{
+			{"part_number": 1, "etag": ""},
+		},
+	})
+	cmd := testutil.Command(newCompleteCmd())
+	cmd.SetArgs([]string{"--recovery", recoveryPath})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "etag") {
+		t.Fatalf("expected etag validation error, got %v", err)
+	}
+}
+
+func TestComplete_StdinRecovery_WorksForPipedJQ(t *testing.T) {
+	var received bool
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		received = true
+		testutil.JSON(t, w, map[string]any{"file_url": "https://example.com/final"})
+	})
+
+	recovery := `{"upload_id":"up-stdin","key":"k","completed_parts":[{"part_number":1,"etag":"e1"}]}`
+	cmd := testutil.Command(newCompleteCmd(), testutil.Stdin(strings.NewReader(recovery)), testutil.Yes(true))
+	cmd.SetArgs([]string{"--recovery", "-"})
+	_ = testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !received {
+		t.Fatal("expected API to be called via stdin manifest")
+	}
+}
+
+func TestComplete_DryRun_EmitsRequestPlan(t *testing.T) {
+	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
+		t.Error("dry-run must not reach the API")
+	})
+	recoveryPath := writeRecovery(t, map[string]any{
+		"upload_id":       "up-dry",
+		"key":             "k",
+		"completed_parts": []map[string]any{{"part_number": 1, "etag": "e1"}},
+	})
+	cmd := testutil.Command(newCompleteCmd(), testutil.DryRun(true))
+	cmd.SetArgs([]string{"--recovery", recoveryPath})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if !strings.Contains(out, "POST") || !strings.Contains(out, "/files/complete") {
+		t.Errorf("expected dry-run output, got %q", out)
+	}
+}
+
+func TestComplete_AmbiguousReplayFailure_PreservesManifest(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"success":false,"message":"upstream timeout"}`, http.StatusBadGateway)
+	})
+	recoveryPath := writeRecovery(t, map[string]any{
+		"upload_id":       "up-retry",
+		"key":             "attachments/u/k/original/p.bin",
+		"completed_parts": []map[string]any{{"part_number": 1, "etag": "e1"}},
+	})
+	cmd := testutil.Command(newCompleteCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"--recovery", recoveryPath})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected ambiguous finalize error")
+	}
+	var state *upload.UnknownStateError
+	if !errors.As(err, &state) {
+		t.Fatalf("expected *upload.UnknownStateError to preserve manifest, got %T: %v", err, err)
+	}
+	if state.UploadID != "up-retry" || state.Key != "attachments/u/k/original/p.bin" {
+		t.Errorf("manifest not preserved: %+v", state)
+	}
+	if len(state.CompletedParts) != 1 || state.CompletedParts[0].ETag != "e1" {
+		t.Errorf("completed_parts not preserved: %+v", state.CompletedParts)
+	}
+}
+
+func TestComplete_DefinitiveFailure_PreservesFullManifestForRetry(t *testing.T) {
+	// Real failure mode: stdin-piped recovery hits 4xx, user loses the
+	// only copy of the manifest unless CompleteRejectedError carries
+	// file_url + completed_parts through.
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/files/complete" {
+			testutil.RawJSON(t, w, `{"success":false,"message":"token invalid"}`)
+			return
+		}
+		t.Errorf("unexpected path: %s", r.URL.Path)
+	})
+	recoveryPath := writeRecovery(t, map[string]any{
+		"file_url":  "https://example.com/attachments/u/k/file.bin",
+		"upload_id": "up-retry",
+		"key":       "attachments/u/k/original/file.bin",
+		"completed_parts": []map[string]any{
+			{"part_number": 1, "etag": "etag-one"},
+			{"part_number": 2, "etag": "etag-two"},
+		},
+	})
+	cmd := testutil.Command(newCompleteCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"--recovery", recoveryPath})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected api error")
+	}
+	var rejected *CompleteRejectedError
+	if !errors.As(err, &rejected) {
+		t.Fatalf("expected *CompleteRejectedError, got %T: %v", err, err)
+	}
+	if rejected.FileURL == "" || rejected.UploadID == "" || rejected.Key == "" {
+		t.Errorf("scalar handles not preserved: %+v", rejected)
+	}
+	if len(rejected.CompletedParts) != 2 || rejected.CompletedParts[0].ETag != "etag-one" {
+		t.Errorf("completed_parts not preserved: %+v", rejected.CompletedParts)
+	}
+}
+
+func TestComplete_DefinitiveAPIFailure_PreservesHandlesWithoutAutoAbort(t *testing.T) {
+	// A 4xx rejection in this recovery command may be a recoverable caller
+	// mistake (wrong token, fixable manifest). Auto-aborting would destroy
+	// the same parts still live on S3; the command must preserve handles
+	// and let the user choose retry vs. abort.
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/files/complete":
+			testutil.RawJSON(t, w, `{"success":false,"message":"invalid etag"}`)
+		case "/files/abort":
+			t.Error("files complete must not auto-abort on definitive rejection")
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	})
+	recoveryPath := writeRecovery(t, map[string]any{
+		"upload_id":       "up-final",
+		"key":             "attachments/u/k/original/p.bin",
+		"completed_parts": []map[string]any{{"part_number": 1, "etag": "bad"}},
+	})
+	cmd := testutil.Command(newCompleteCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"--recovery", recoveryPath})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected api error")
+	}
+	var state *upload.UnknownStateError
+	if errors.As(err, &state) {
+		t.Fatalf("definitive rejection must not be wrapped as UnknownStateError (got one: %+v)", state)
+	}
+	var rejected *CompleteRejectedError
+	if !errors.As(err, &rejected) {
+		t.Fatalf("expected *CompleteRejectedError to carry orphan handles, got %T: %v", err, err)
+	}
+	if rejected.UploadID != "up-final" || rejected.Key != "attachments/u/k/original/p.bin" {
+		t.Errorf("orphan handles lost: %+v", rejected)
+	}
+}
+
+func TestComplete_ManifestNonContiguousParts_Errors(t *testing.T) {
+	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
+		t.Error("must not reach API with malformed part numbering")
+	})
+	// Uploader invariant: contiguous 1..N. A manifest with 1,3 or 2,1
+	// would finalize the wrong bytes order on the server.
+	recoveryPath := writeRecovery(t, map[string]any{
+		"upload_id": "u",
+		"key":       "k",
+		"completed_parts": []map[string]any{
+			{"part_number": 1, "etag": "a"},
+			{"part_number": 3, "etag": "b"},
+		},
+	})
+	cmd := testutil.Command(newCompleteCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"--recovery", recoveryPath})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "expected 2") {
+		t.Fatalf("expected part-number validation error, got %v", err)
+	}
+}
+
+func TestComplete_StdinRecoveryWithoutYes_Errors(t *testing.T) {
+	// --recovery - consumes stdin for the manifest, so the duplicate-risk
+	// prompt would deadlock. The command should reject this combination
+	// with a clear message before any manifest is read.
+	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
+		t.Error("must not reach API when confirmation has no input channel")
+	})
+	cmd := testutil.Command(newCompleteCmd(), testutil.Stdin(strings.NewReader(`{"upload_id":"u","key":"k","completed_parts":[{"part_number":1,"etag":"e"}]}`)))
+	cmd.SetArgs([]string{"--recovery", "-"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected usage error for --recovery - without --yes")
+	}
+	if !strings.Contains(err.Error(), "--yes") {
+		t.Errorf("error should direct to --yes: %v", err)
+	}
+}
+
+func TestComplete_APIResponseMissingFileURL_Errors(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, _ *http.Request) {
+		testutil.JSON(t, w, map[string]any{})
+	})
+	recoveryPath := writeRecovery(t, map[string]any{
+		"upload_id":       "up-x",
+		"key":             "k",
+		"completed_parts": []map[string]any{{"part_number": 1, "etag": "e1"}},
+	})
+	cmd := testutil.Command(newCompleteCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"--recovery", recoveryPath})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "file_url") {
+		t.Fatalf("expected missing file_url error, got %v", err)
+	}
+}
+
+func TestComplete_MissingUploadIDInManifest_Errors(t *testing.T) {
+	recoveryPath := writeRecovery(t, map[string]any{
+		"key":             "k",
+		"completed_parts": []map[string]any{{"part_number": 1, "etag": "e1"}},
+	})
+	cmd := testutil.Command(newCompleteCmd())
+	cmd.SetArgs([]string{"--recovery", recoveryPath})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "upload_id") {
+		t.Fatalf("expected upload_id error, got %v", err)
+	}
+}
+
+func TestComplete_BadRecoveryJSON_Errors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bad.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	cmd := testutil.Command(newCompleteCmd())
+	cmd.SetArgs([]string{"--recovery", path})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "parse") {
+		t.Fatalf("expected parse error, got %v", err)
+	}
+}
+
+func TestComplete_OversizedManifest_Errors(t *testing.T) {
+	// A runaway producer piped into `--recovery -` (or a wrong large file)
+	// must fail fast instead of hanging or exhausting memory.
+	path := filepath.Join(t.TempDir(), "huge.json")
+	// Write 3 MB of zeros — well above the 2 MB cap.
+	big := make([]byte, 3*1024*1024)
+	if err := os.WriteFile(path, big, 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	cmd := testutil.Command(newCompleteCmd())
+	cmd.SetArgs([]string{"--recovery", path})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("expected size-cap error, got %v", err)
+	}
+}
+
+func TestComplete_RecoveryFileMissing_Errors(t *testing.T) {
+	cmd := testutil.Command(newCompleteCmd())
+	cmd.SetArgs([]string{"--recovery", filepath.Join(t.TempDir(), "does-not-exist.json")})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "open") {
+		t.Fatalf("expected open error, got %v", err)
+	}
+}
+
+func TestFilesCmd_CompleteIsRegistered(t *testing.T) {
+	cmd := NewFilesCmd()
+	found := false
+	for _, c := range cmd.Commands() {
+		if c.Name() == "complete" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("complete subcommand not registered")
+	}
+}

--- a/internal/cmd/files/files.go
+++ b/internal/cmd/files/files.go
@@ -1,0 +1,29 @@
+// Package files implements the `gumroad files` command family.
+package files
+
+import "github.com/spf13/cobra"
+
+// NewFilesCmd returns the root command for file operations.
+func NewFilesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "files",
+		Short: "Upload and manage file attachments",
+		Long: "Upload and manage files in your Gumroad seller namespace.\n\n" +
+			"Uploaded files live under your seller's attachments namespace and " +
+			"can be attached to products (see `gumroad products create --help`). " +
+			"After a failed `upload` returns complete_state_unknown recovery " +
+			"fields, use `gumroad files complete --recovery ...` to finalize " +
+			"without re-uploading, or `gumroad files abort` to reclaim the " +
+			"orphaned multipart upload.",
+		Example: `  gumroad files upload ./pack.zip
+  gumroad files upload ./pack.zip --name "Art Pack.zip"
+  gumroad files upload ./pack.zip --json --jq '.file_url'
+  gumroad files complete --recovery recovery.json
+  gumroad files abort --upload-id up-123 --key attachments/u/k/original/pack.zip`,
+	}
+
+	cmd.AddCommand(newUploadCmd())
+	cmd.AddCommand(newCompleteCmd())
+	cmd.AddCommand(newAbortCmd())
+	return cmd
+}

--- a/internal/cmd/files/upload.go
+++ b/internal/cmd/files/upload.go
@@ -1,0 +1,175 @@
+package files
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/config"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/upload"
+	"github.com/spf13/cobra"
+)
+
+// s3HTTPClientForTesting redirects S3 part PUTs at a test server. Production
+// leaves this nil so upload.Upload falls back to its shared client. Tests in
+// this package must not use t.Parallel — overwriting this var across goroutines
+// would race.
+var s3HTTPClientForTesting *http.Client
+
+func newUploadCmd() *cobra.Command {
+	var name string
+	c := &cobra.Command{
+		Use:   "upload <path>",
+		Short: "Upload a file and print the canonical URL",
+		Args:  cmdutil.ExactArgs(1),
+		Example: `  gumroad files upload ./pack.zip
+  gumroad files upload ./pack.zip --name "Art Pack.zip"
+  gumroad files upload ./pack.zip --json --jq '.file_url'`,
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			path := args[0]
+
+			plan, err := upload.Describe(path, upload.Options{Filename: name})
+			if err != nil {
+				return err
+			}
+
+			if opts.DryRun {
+				return renderDryRun(opts, plan)
+			}
+
+			return runUpload(opts, path, plan)
+		},
+	}
+	c.Flags().StringVar(&name, "name", "", "Override the display filename sent to the server (defaults to the basename of <path>)")
+	return c
+}
+
+func runUpload(opts cmdutil.Options, path string, plan upload.Plan) error {
+	token, err := config.Token()
+	if err != nil {
+		return err
+	}
+	client := cmdutil.NewAPIClient(opts, token)
+
+	// Cache the total-bytes label so the progress callback (fires once per
+	// part, up to ~200x on a 20 GB upload) doesn't re-format it each tick.
+	totalLabel := humanBytes(plan.Size)
+	var sp *output.Spinner
+	if cmdutil.ShouldShowSpinner(opts) {
+		sp = output.NewSpinnerTo(spinnerStatus(plan.Filename, 0, totalLabel), opts.Err())
+		sp.Start()
+		defer sp.Stop()
+	}
+
+	progress := func(uploaded int64) {
+		if sp != nil {
+			sp.SetMessage(spinnerStatus(plan.Filename, uploaded, totalLabel))
+		}
+	}
+
+	fileURL, err := upload.Upload(opts.Context, client, path, upload.Options{
+		Filename:   plan.Filename,
+		Progress:   progress,
+		HTTPClient: s3HTTPClientForTesting,
+	})
+	if err != nil {
+		return err
+	}
+	// Drain the spinner before rendering the URL. upload.Upload's contract
+	// permits a final progress callback to fire after it returns, which
+	// would otherwise keep the spinner repainting stderr while stdout is
+	// printing the canonical URL — corrupting the output on a shared TTY.
+	if sp != nil {
+		sp.Stop()
+	}
+	return renderFileURL(opts, fileURL)
+}
+
+func spinnerStatus(filename string, uploaded int64, totalLabel string) string {
+	return fmt.Sprintf("Uploading %s %s / %s", filename, humanBytes(uploaded), totalLabel)
+}
+
+func renderFileURL(opts cmdutil.Options, fileURL string) error {
+	if opts.UsesJSONOutput() {
+		data, err := json.Marshal(map[string]string{"file_url": fileURL})
+		if err != nil {
+			return fmt.Errorf("could not encode JSON output: %w", err)
+		}
+		return output.PrintJSON(opts.Out(), data, opts.JQExpr)
+	}
+	if opts.PlainOutput {
+		return output.PrintPlain(opts.Out(), [][]string{{fileURL}})
+	}
+	return output.Writeln(opts.Out(), fileURL)
+}
+
+type dryRunUploadPlan struct {
+	DryRun    bool   `json:"dry_run"`
+	Action    string `json:"action"`
+	Path      string `json:"path"`
+	Filename  string `json:"filename"`
+	Size      int64  `json:"size"`
+	PartSize  int64  `json:"part_size"`
+	PartCount int    `json:"part_count"`
+}
+
+func renderDryRun(opts cmdutil.Options, plan upload.Plan) error {
+	payload := dryRunUploadPlan{
+		DryRun:    true,
+		Action:    "upload",
+		Path:      plan.Path,
+		Filename:  plan.Filename,
+		Size:      plan.Size,
+		PartSize:  plan.PartSize,
+		PartCount: plan.PartCount,
+	}
+	if opts.UsesJSONOutput() {
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("could not encode dry-run output: %w", err)
+		}
+		return output.PrintJSON(opts.Out(), data, opts.JQExpr)
+	}
+	if opts.PlainOutput {
+		return output.PrintPlain(opts.Out(), [][]string{{
+			"upload",
+			plan.Path,
+			plan.Filename,
+			strconv.FormatInt(plan.Size, 10),
+			strconv.Itoa(plan.PartCount),
+		}})
+	}
+	style := opts.Style()
+	if err := output.Writeln(opts.Out(), style.Yellow("Dry run")+": upload "+plan.Path); err != nil {
+		return err
+	}
+	if err := output.Writef(opts.Out(), "Filename: %s\n", plan.Filename); err != nil {
+		return err
+	}
+	parts := "1 part"
+	if plan.PartCount != 1 {
+		parts = fmt.Sprintf("%d parts", plan.PartCount)
+	}
+	return output.Writef(opts.Out(), "Size: %s (%s)\n", humanBytes(plan.Size), parts)
+}
+
+// humanBytes renders a byte count with IEC-style (1024-based) magnitudes but
+// decimal-unit labels (KB/MB/GB), matching how Gumroad quotes file sizes.
+func humanBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for n/div >= unit && exp < 3 {
+		div *= unit
+		exp++
+	}
+	v := float64(n) / float64(div)
+	units := []string{"KB", "MB", "GB", "TB"}
+	return fmt.Sprintf("%.1f %s", v, units[exp])
+}

--- a/internal/cmd/files/upload_test.go
+++ b/internal/cmd/files/upload_test.go
@@ -1,0 +1,455 @@
+package files
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+	"github.com/antiwork/gumroad-cli/internal/upload"
+)
+
+// uploadServers wires a Rails mock (via testutil.Setup) plus an in-process
+// TLS server for S3 part PUTs. The TLS server lets presigned URLs pass the
+// upload package's https-only check without exposing a test hook from that
+// package. The s3HTTPClientForTesting var is swapped in so S3 requests trust
+// the self-signed cert.
+type uploadServers struct {
+	s3            *httptest.Server
+	s3Calls       atomic.Int32
+	completeCalls atomic.Int32
+	presignBody   map[string]string
+
+	presignHandler http.HandlerFunc
+}
+
+func newUploadServers(t *testing.T) *uploadServers {
+	t.Helper()
+	u := &uploadServers{
+		presignBody: map[string]string{},
+	}
+	u.s3 = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u.s3Calls.Add(1)
+		if r.Method != http.MethodPut {
+			t.Errorf("S3 got %s, want PUT", r.Method)
+			http.Error(w, "bad method", http.StatusBadRequest)
+			return
+		}
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.Header().Set("ETag", `"etag-1"`)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(u.s3.Close)
+
+	prev := s3HTTPClientForTesting
+	s3HTTPClientForTesting = u.s3.Client()
+	t.Cleanup(func() { s3HTTPClientForTesting = prev })
+
+	return u
+}
+
+// dispatch mounts the Rails handler as the testutil.Setup handler.
+func (u *uploadServers) dispatch(t *testing.T) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("parse form: %v", err)
+			http.Error(w, "bad", http.StatusBadRequest)
+			return
+		}
+		switch r.URL.Path {
+		case "/files/presign":
+			for k := range r.PostForm {
+				u.presignBody[k] = r.PostForm.Get(k)
+			}
+			if u.presignHandler != nil {
+				u.presignHandler(w, r)
+				return
+			}
+			u.writeDefaultPresign(t, w)
+		case "/files/complete":
+			u.completeCalls.Add(1)
+			testutil.JSON(t, w, map[string]any{"file_url": "https://example.com/attachments/u/k/original/fixture.bin"})
+		case "/files/abort":
+			testutil.JSON(t, w, map[string]any{})
+		default:
+			t.Errorf("unexpected Rails path: %s", r.URL.Path)
+			http.Error(w, "unexpected", http.StatusNotFound)
+		}
+	}
+}
+
+func (u *uploadServers) writeDefaultPresign(t *testing.T, w http.ResponseWriter) {
+	t.Helper()
+	testutil.JSON(t, w, map[string]any{
+		"upload_id": "up-1",
+		"key":       "attachments/u/k/original/fixture.bin",
+		"file_url":  "https://example.com/attachments/u/k/original/fixture.bin",
+		"parts": []map[string]any{
+			{"part_number": 1, "presigned_url": u.s3.URL + "/part/1"},
+		},
+	})
+}
+
+func writeFixture(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "fixture.bin")
+	if err := os.WriteFile(path, []byte(contents), 0600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+func TestUpload_HappyPath_PrintsURL(t *testing.T) {
+	srv := newUploadServers(t)
+	testutil.Setup(t, srv.dispatch(t))
+
+	path := writeFixture(t, "hello")
+	cmd := testutil.Command(newUploadCmd())
+	cmd.SetArgs([]string{path})
+
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	got := strings.TrimSpace(out)
+	want := "https://example.com/attachments/u/k/original/fixture.bin"
+	if got != want {
+		t.Errorf("stdout = %q, want %q", got, want)
+	}
+	if srv.s3Calls.Load() != 1 {
+		t.Errorf("S3 calls = %d, want 1", srv.s3Calls.Load())
+	}
+	if srv.completeCalls.Load() != 1 {
+		t.Errorf("complete calls = %d, want 1", srv.completeCalls.Load())
+	}
+	if srv.presignBody["filename"] != filepath.Base(path) {
+		t.Errorf("presign filename = %q, want %q", srv.presignBody["filename"], filepath.Base(path))
+	}
+	if srv.presignBody["file_size"] != "5" {
+		t.Errorf("presign file_size = %q, want 5", srv.presignBody["file_size"])
+	}
+}
+
+func TestUpload_NameFlag_OverridesFilename(t *testing.T) {
+	srv := newUploadServers(t)
+	testutil.Setup(t, srv.dispatch(t))
+
+	path := writeFixture(t, "payload")
+	cmd := testutil.Command(newUploadCmd())
+	cmd.SetArgs([]string{path, "--name", "Custom Name.zip"})
+
+	_ = testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if got := srv.presignBody["filename"]; got != "Custom Name.zip" {
+		t.Errorf("presign filename = %q, want %q", got, "Custom Name.zip")
+	}
+}
+
+func TestUpload_JSONOutput_ReturnsFileURLField(t *testing.T) {
+	srv := newUploadServers(t)
+	testutil.Setup(t, srv.dispatch(t))
+
+	path := writeFixture(t, "body")
+	cmd := testutil.Command(newUploadCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{path})
+
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	var resp map[string]string
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("parse JSON: %v\n%s", err, out)
+	}
+	if got := resp["file_url"]; got != "https://example.com/attachments/u/k/original/fixture.bin" {
+		t.Errorf("file_url = %q", got)
+	}
+}
+
+func TestUpload_JQExpression_ExtractsField(t *testing.T) {
+	srv := newUploadServers(t)
+	testutil.Setup(t, srv.dispatch(t))
+
+	path := writeFixture(t, "body")
+	cmd := testutil.Command(newUploadCmd(), testutil.JQ(".file_url"))
+	cmd.SetArgs([]string{path})
+
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	got := strings.TrimSpace(out)
+	got = strings.Trim(got, "\"")
+	if got != "https://example.com/attachments/u/k/original/fixture.bin" {
+		t.Errorf("jq output = %q", out)
+	}
+}
+
+func TestUpload_PlainOutput_SingleRow(t *testing.T) {
+	srv := newUploadServers(t)
+	testutil.Setup(t, srv.dispatch(t))
+
+	path := writeFixture(t, "body")
+	cmd := testutil.Command(newUploadCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{path})
+
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	got := strings.TrimSpace(out)
+	if got != "https://example.com/attachments/u/k/original/fixture.bin" {
+		t.Errorf("plain output = %q", out)
+	}
+}
+
+func TestUpload_DryRun_NoNetworkAndPrintsPlan(t *testing.T) {
+	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
+		t.Error("Rails must not be called in --dry-run")
+	})
+	// Intentionally do not call newUploadServers: neither Rails nor S3 may
+	// be contacted in dry-run mode. An un-injected s3HTTPClientForTesting
+	// pointing at the production default would surface any S3 PUT attempt
+	// as a connect failure, but we assert the cleaner invariant: we never
+	// even get that far.
+
+	path := writeFixture(t, "the bytes")
+	cmd := testutil.Command(newUploadCmd(), testutil.DryRun(true))
+	cmd.SetArgs([]string{path, "--name", "Gift.zip"})
+
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if !strings.Contains(out, "Dry run") {
+		t.Errorf("missing dry run label: %q", out)
+	}
+	if !strings.Contains(out, "Gift.zip") {
+		t.Errorf("missing overridden filename: %q", out)
+	}
+	if !strings.Contains(out, path) {
+		t.Errorf("missing path: %q", out)
+	}
+}
+
+func TestUpload_DryRunJSON_ReturnsPlanStructure(t *testing.T) {
+	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
+		t.Error("Rails must not be called in --dry-run")
+	})
+
+	path := writeFixture(t, "9 bytes!!")
+	cmd := testutil.Command(newUploadCmd(), testutil.JSONOutput(), testutil.DryRun(true))
+	cmd.SetArgs([]string{path})
+
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	var plan dryRunUploadPlan
+	if err := json.Unmarshal([]byte(out), &plan); err != nil {
+		t.Fatalf("parse JSON: %v\n%s", err, out)
+	}
+	if !plan.DryRun || plan.Action != "upload" {
+		t.Errorf("bad envelope: %+v", plan)
+	}
+	if plan.Path != path {
+		t.Errorf("path = %q, want %q", plan.Path, path)
+	}
+	if plan.Filename != filepath.Base(path) {
+		t.Errorf("filename = %q, want %q", plan.Filename, filepath.Base(path))
+	}
+	if plan.Size != 9 {
+		t.Errorf("size = %d, want 9", plan.Size)
+	}
+	if plan.PartCount != 1 {
+		t.Errorf("part_count = %d, want 1", plan.PartCount)
+	}
+}
+
+func TestUpload_MissingFile_Errors(t *testing.T) {
+	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
+		t.Error("should not reach Rails when file is missing")
+	})
+
+	cmd := testutil.Command(newUploadCmd())
+	cmd.SetArgs([]string{filepath.Join(t.TempDir(), "does-not-exist")})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestUpload_EmptyFile_Errors(t *testing.T) {
+	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
+		t.Error("should not reach Rails when file is empty")
+	})
+
+	path := writeFixture(t, "")
+	cmd := testutil.Command(newUploadCmd())
+	cmd.SetArgs([]string{path})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for empty file")
+	}
+	if !strings.Contains(err.Error(), "empty") {
+		t.Errorf("error = %v, want mention of empty", err)
+	}
+}
+
+func TestUpload_CompleteAmbiguous_SurfacesUnknownStateError(t *testing.T) {
+	srv := newUploadServers(t)
+	// Force /files/complete to respond with an HTTP 502 so upload.Upload
+	// treats the outcome as ambiguous and returns *upload.UnknownStateError
+	// carrying the recovery handles.
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		switch r.URL.Path {
+		case "/files/presign":
+			srv.writeDefaultPresign(t, w)
+		case "/files/complete":
+			http.Error(w, `{"success":false,"message":"complete failed"}`, http.StatusBadGateway)
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	})
+	// Also wire the S3 PUT so the orchestrator reaches the complete call.
+	path := writeFixture(t, "payload")
+	cmd := testutil.Command(newUploadCmd())
+	cmd.SetArgs([]string{path})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when /files/complete is ambiguous")
+	}
+	var state *upload.UnknownStateError
+	if !errors.As(err, &state) {
+		t.Fatalf("expected *upload.UnknownStateError, got %T: %v", err, err)
+	}
+	if state.UploadID == "" || state.Key == "" {
+		t.Errorf("recovery handles empty: %+v", state)
+	}
+}
+
+func TestUpload_PresignError_Propagates(t *testing.T) {
+	srv := newUploadServers(t)
+	srv.presignHandler = func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"success": false,
+			"message": "permission denied",
+		})
+	}
+	testutil.Setup(t, srv.dispatch(t))
+
+	path := writeFixture(t, "body")
+	cmd := testutil.Command(newUploadCmd())
+	cmd.SetArgs([]string{path})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected presign error")
+	}
+	if !strings.Contains(err.Error(), "permission denied") {
+		t.Errorf("error = %v, want contains 'permission denied'", err)
+	}
+}
+
+func TestFilesCmd_UploadIsRegistered(t *testing.T) {
+	cmd := NewFilesCmd()
+	found := false
+	for _, c := range cmd.Commands() {
+		if c.Name() == "upload" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("upload subcommand not registered")
+	}
+}
+
+func TestUpload_NonQuietPath_StillPrintsURL(t *testing.T) {
+	srv := newUploadServers(t)
+	testutil.Setup(t, srv.dispatch(t))
+
+	path := writeFixture(t, "body")
+	// Quiet(false) engages the spinner branch in runUpload. Routing Stderr
+	// at io.Discard makes the terminal probe report "no TTY", so Start is
+	// a no-op but the surrounding wiring (NewSpinnerTo + progress closure
+	// with SetMessage) still runs, giving that branch coverage.
+	cmd := testutil.Command(newUploadCmd(),
+		testutil.Quiet(false),
+		testutil.Stderr(io.Discard),
+	)
+	cmd.SetArgs([]string{path})
+
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if !strings.Contains(out, "https://example.com/attachments/u/k/original/fixture.bin") {
+		t.Errorf("stdout = %q", out)
+	}
+}
+
+func TestRenderDryRun_PlainOutputRow(t *testing.T) {
+	var buf bytes.Buffer
+	opts := cmdutil.DefaultOptions()
+	opts.Stdout = &buf
+	opts.PlainOutput = true
+
+	plan := upload.Plan{
+		Path:      "/tmp/fixture.bin",
+		Filename:  "fixture.bin",
+		Size:      42,
+		PartSize:  10,
+		PartCount: 5,
+	}
+	if err := renderDryRun(opts, plan); err != nil {
+		t.Fatalf("renderDryRun: %v", err)
+	}
+	got := strings.TrimSpace(buf.String())
+	want := "upload\t/tmp/fixture.bin\tfixture.bin\t42\t5"
+	if got != want {
+		t.Errorf("plain dry run = %q, want %q", got, want)
+	}
+}
+
+func TestRenderDryRun_MultiPartPluralization(t *testing.T) {
+	var buf bytes.Buffer
+	opts := cmdutil.DefaultOptions()
+	opts.Stdout = &buf
+
+	plan := upload.Plan{
+		Path:      "/tmp/big.bin",
+		Filename:  "big.bin",
+		Size:      500,
+		PartSize:  100,
+		PartCount: 5,
+	}
+	if err := renderDryRun(opts, plan); err != nil {
+		t.Fatalf("renderDryRun: %v", err)
+	}
+	if !strings.Contains(buf.String(), "5 parts") {
+		t.Errorf("expected '5 parts', got %q", buf.String())
+	}
+}
+
+func TestSpinnerStatus_IncludesFilenameAndProgress(t *testing.T) {
+	got := spinnerStatus("pack.zip", 1024*1024*4, "12.0 MB")
+	if !strings.Contains(got, "pack.zip") {
+		t.Errorf("spinnerStatus missing filename: %q", got)
+	}
+	if !strings.Contains(got, "4.0 MB") || !strings.Contains(got, "12.0 MB") {
+		t.Errorf("spinnerStatus missing bytes: %q", got)
+	}
+}
+
+func TestHumanBytes_Magnitudes(t *testing.T) {
+	cases := []struct {
+		in   int64
+		want string
+	}{
+		{0, "0 B"},
+		{1023, "1023 B"},
+		{1024, "1.0 KB"},
+		{1500, "1.5 KB"},
+		{1024 * 1024, "1.0 MB"},
+		{12 * 1024 * 1024, "12.0 MB"},
+		{2 * 1024 * 1024 * 1024, "2.0 GB"},
+		// Stays at TB for very large values (prevents a stray "PB" label).
+		{1024 * 1024 * 1024 * 1024 * 2048, "2048.0 TB"},
+	}
+	for _, c := range cases {
+		if got := humanBytes(c.in); got != c.want {
+			t.Errorf("humanBytes(%d) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -2,18 +2,17 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
 	"strconv"
 	"strings"
 
-	"github.com/antiwork/gumroad-cli/internal/api"
 	"github.com/antiwork/gumroad-cli/internal/cmd/auth"
 	"github.com/antiwork/gumroad-cli/internal/cmd/categories"
 	"github.com/antiwork/gumroad-cli/internal/cmd/completion"
 	"github.com/antiwork/gumroad-cli/internal/cmd/customfields"
+	"github.com/antiwork/gumroad-cli/internal/cmd/files"
 	"github.com/antiwork/gumroad-cli/internal/cmd/licenses"
 	"github.com/antiwork/gumroad-cli/internal/cmd/offercodes"
 	"github.com/antiwork/gumroad-cli/internal/cmd/payouts"
@@ -25,7 +24,6 @@ import (
 	"github.com/antiwork/gumroad-cli/internal/cmd/variants"
 	"github.com/antiwork/gumroad-cli/internal/cmd/webhooks"
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
-	"github.com/antiwork/gumroad-cli/internal/config"
 	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -111,6 +109,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(categories.NewCategoriesCmd())
 	cmd.AddCommand(variants.NewVariantsCmd())
 	cmd.AddCommand(customfields.NewCustomFieldsCmd())
+	cmd.AddCommand(files.NewFilesCmd())
 	cmd.AddCommand(webhooks.NewWebhooksCmd())
 	cmd.AddCommand(completion.NewCompletionCmd())
 	cmd.AddCommand(skill.NewSkillCmd())
@@ -296,24 +295,14 @@ func printHumanCommandError(cmd *cobra.Command, err error) {
 	style := output.NewStylerForWriter(w, noColorRequested(cmd))
 	fmt.Fprintln(w, style.Red("Error: "+err.Error()))
 
-	if hint := hintFromError(err); hint != "" {
+	// classifyCommandError is the single source of truth for error hints
+	// so human and JSON modes stay in sync — particularly for upload
+	// errors, whose recovery guidance is not carried by the
+	// api.HintedError interface.
+	if hint := classifyCommandError(err).Hint; hint != "" {
 		fmt.Fprintln(w, style.Dim("Hint: "+hint))
 	}
-}
-
-func hintFromError(err error) string {
-	var hinted api.HintedError
-	if errors.As(err, &hinted) {
-		return hinted.GetHint()
-	}
-	if errors.Is(err, config.ErrNotAuthenticated) || errors.Is(err, api.ErrNotAuthenticated) {
-		// config.ResolveToken already embeds remediation in the error message;
-		// only add the hint when it would not duplicate.
-		if !strings.Contains(err.Error(), "gumroad auth login") {
-			return api.HintRunAuthLogin
-		}
-	}
-	return ""
+	printUploadRecovery(w, style, err)
 }
 
 func noColorRequested(cmd *cobra.Command) bool {

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/config"
 	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/upload"
 	"github.com/spf13/cobra"
 )
 
@@ -534,7 +535,7 @@ func TestCommandContext_PrefersCommandContext(t *testing.T) {
 	}
 }
 
-func TestHintFromError(t *testing.T) {
+func TestClassifyCommandError_Hint(t *testing.T) {
 	tests := []struct {
 		name string
 		err  error
@@ -552,10 +553,34 @@ func TestHintFromError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := hintFromError(tt.err); got != tt.want {
+			if got := classifyCommandError(tt.err).Hint; got != tt.want {
 				t.Errorf("got %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestPrintHumanCommandError_ShowsUploadRecoveryHint(t *testing.T) {
+	output.SetColorEnabledForTesting(false)
+	defer output.ResetColorEnabledForTesting()
+
+	cmd := &cobra.Command{Use: "test"}
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+
+	state := &upload.UnknownStateError{
+		UploadID: "up-1",
+		Key:      "attachments/u/k/original/p.bin",
+		Cause:    errors.New("503"),
+	}
+	printHumanCommandError(cmd, state)
+
+	got := stderr.String()
+	if !strings.Contains(got, "Hint:") || !strings.Contains(got, "Do not retry blindly") {
+		t.Errorf("expected upload hint in human output, got:\n%s", got)
+	}
+	if !strings.Contains(got, "Recovery:") {
+		t.Errorf("expected recovery block, got:\n%s", got)
 	}
 }
 

--- a/internal/output/spinner.go
+++ b/internal/output/spinner.go
@@ -57,12 +57,26 @@ func (s *Spinner) Start() {
 				fmt.Fprintf(s.writer, "\r\033[K")
 				return
 			default:
-				fmt.Fprintf(s.writer, "\r%s %s", frames[i%len(frames)], s.message)
+				s.mu.Lock()
+				msg := s.message
+				s.mu.Unlock()
+				// \033[K clears to end of line so shorter messages
+				// replacing longer ones leave no trailing characters.
+				fmt.Fprintf(s.writer, "\r\033[K%s %s", frames[i%len(frames)], msg)
 				i++
 				time.Sleep(80 * time.Millisecond)
 			}
 		}
 	}()
+}
+
+// SetMessage replaces the spinner label. It is safe to call from any goroutine
+// and takes effect on the next animation tick. Calls before Start or after Stop
+// are accepted but nothing is rendered.
+func (s *Spinner) SetMessage(message string) {
+	s.mu.Lock()
+	s.message = message
+	s.mu.Unlock()
 }
 
 func (s *Spinner) Stop() {

--- a/internal/output/spinner_test.go
+++ b/internal/output/spinner_test.go
@@ -28,6 +28,7 @@ func TestSpinner_TTY_ActivatesAndStops(t *testing.T) {
 	orig := isSpinnerTerminal
 	isSpinnerTerminal = func(io.Writer) bool { return true }
 	defer func() { isSpinnerTerminal = orig }()
+	t.Setenv("TERM", "xterm-256color")
 
 	s := NewSpinner("loading")
 	s.Start()
@@ -56,6 +57,7 @@ func TestSpinner_DoubleStop(t *testing.T) {
 	orig := isSpinnerTerminal
 	isSpinnerTerminal = func(io.Writer) bool { return true }
 	defer func() { isSpinnerTerminal = orig }()
+	t.Setenv("TERM", "xterm-256color")
 
 	s := NewSpinner("loading")
 	s.Start()
@@ -146,6 +148,7 @@ func TestSpinner_SetMessage_BeforeStartAndAfterStop(t *testing.T) {
 	orig := isSpinnerTerminal
 	isSpinnerTerminal = func(io.Writer) bool { return true }
 	defer func() { isSpinnerTerminal = orig }()
+	t.Setenv("TERM", "xterm-256color")
 	s.Start()
 	time.Sleep(10 * time.Millisecond)
 	s.Stop()
@@ -165,6 +168,7 @@ func TestSpinner_SetMessage_ConcurrentRenders(t *testing.T) {
 	orig := isSpinnerTerminal
 	isSpinnerTerminal = func(io.Writer) bool { return true }
 	defer func() { isSpinnerTerminal = orig }()
+	t.Setenv("TERM", "xterm-256color")
 
 	s := NewSpinnerTo("start", io.Discard)
 	s.Start()

--- a/internal/output/spinner_test.go
+++ b/internal/output/spinner_test.go
@@ -124,3 +124,60 @@ func TestNewSpinner(t *testing.T) {
 		t.Error("spinner should not be active by default")
 	}
 }
+
+func TestSpinner_SetMessage_UpdatesField(t *testing.T) {
+	s := NewSpinner("initial")
+	s.SetMessage("updated")
+
+	s.mu.Lock()
+	got := s.message
+	s.mu.Unlock()
+
+	if got != "updated" {
+		t.Errorf("message = %q, want %q", got, "updated")
+	}
+}
+
+func TestSpinner_SetMessage_BeforeStartAndAfterStop(t *testing.T) {
+	s := NewSpinner("initial")
+	// Before Start: field updates but no rendering goroutine exists.
+	s.SetMessage("before-start")
+
+	orig := isSpinnerTerminal
+	isSpinnerTerminal = func(io.Writer) bool { return true }
+	defer func() { isSpinnerTerminal = orig }()
+	s.Start()
+	time.Sleep(10 * time.Millisecond)
+	s.Stop()
+
+	// After Stop: SetMessage must not panic or race.
+	s.SetMessage("after-stop")
+
+	s.mu.Lock()
+	got := s.message
+	s.mu.Unlock()
+	if got != "after-stop" {
+		t.Errorf("message = %q, want %q", got, "after-stop")
+	}
+}
+
+func TestSpinner_SetMessage_ConcurrentRenders(t *testing.T) {
+	orig := isSpinnerTerminal
+	isSpinnerTerminal = func(io.Writer) bool { return true }
+	defer func() { isSpinnerTerminal = orig }()
+
+	s := NewSpinnerTo("start", io.Discard)
+	s.Start()
+	defer s.Stop()
+
+	// Race detector catches unsynchronized access against the
+	// render goroutine that reads s.message on every tick.
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 200; i++ {
+			s.SetMessage("msg")
+		}
+		close(done)
+	}()
+	<-done
+}


### PR DESCRIPTION
Ref #36.

## What

Adds the `gumroad files` command family built on the multipart orchestrator from #37:

- `gumroad files upload <path>` — runs the presign → part PUTs → complete flow and prints the canonical `file_url`. Supports `--name`, a local-only `--dry-run`, and live byte progress in the spinner label.
- `gumroad files complete --recovery <file|->` — replays `/files/complete` from a saved recovery manifest so an ambiguous finalize can be committed without re-uploading.
- `gumroad files abort --upload-id --key` — reclaims an orphaned multipart upload.

On failure, `--json` output now carries a structured `recovery` object (`file_url`, `upload_id`, `key`, `completed_parts`) and human-mode prints the same handles plus the next command to run. New classified error codes: `complete_state_unknown`, `cleanup_failed`, `complete_rejected`, `presign_expired`.

Infra prep for the progress UX: `internal/output.Spinner` gains a concurrency-safe `SetMessage`.

## Why

Closes the loop on #36's PR 2. PRs 3 and 4 (`--file` on `products create` / `update`) can now call the same orchestrator and inherit consistent structured errors.

Scope note: the plan scoped PR 2 to just `upload`. I extended it to `abort` + `complete` because shipping `upload` alone creates a problem: on an ambiguous `/files/complete` the CLI tells users "don't retry blindly" but without these companions they have no supported way to reconcile. Adding them here means PRs 3 and 4 don't inherit that issue.

Two design calls worth flagging:

- **Confirmation-gated, never auto-destructive.** `files abort` requires confirmation; `files complete` requires confirmation before every replay because `/files/complete` is the commit point and a blind replay can duplicate. `--yes` is the explicit escape hatch.
- **No auto-abort from `files complete`.** Unlike the main upload, the recovery command consumes external manifest input where a 4xx is often a caller-side mistake (wrong token, fixable manifest) with parts still valid on S3. Auto-aborting would destroy recoverable state; instead the command preserves the full manifest in the returned error.

---

This PR was implemented with AI assistance using Claude Opus 4.7 and gpt‑5.4 xhigh