### PR TITLE
Add file uploads to product creation

### DIFF
--- a/internal/cmd/files/upload.go
+++ b/internal/cmd/files/upload.go
@@ -10,6 +10,7 @@ import (
 	"github.com/antiwork/gumroad-cli/internal/config"
 	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/antiwork/gumroad-cli/internal/upload"
+	"github.com/antiwork/gumroad-cli/internal/uploadcmd"
 	"github.com/spf13/cobra"
 )
 
@@ -54,43 +55,11 @@ func runUpload(opts cmdutil.Options, path string, plan upload.Plan) error {
 		return err
 	}
 	client := cmdutil.NewAPIClient(opts, token)
-
-	// Cache the total-bytes label so the progress callback (fires once per
-	// part, up to ~200x on a 20 GB upload) doesn't re-format it each tick.
-	totalLabel := humanBytes(plan.Size)
-	var sp *output.Spinner
-	if cmdutil.ShouldShowSpinner(opts) {
-		sp = output.NewSpinnerTo(spinnerStatus(plan.Filename, 0, totalLabel), opts.Err())
-		sp.Start()
-		defer sp.Stop()
-	}
-
-	progress := func(uploaded int64) {
-		if sp != nil {
-			sp.SetMessage(spinnerStatus(plan.Filename, uploaded, totalLabel))
-		}
-	}
-
-	fileURL, err := upload.Upload(opts.Context, client, path, upload.Options{
-		Filename:   plan.Filename,
-		Progress:   progress,
-		HTTPClient: s3HTTPClientForTesting,
-	})
+	fileURL, err := uploadcmd.UploadFile(opts, client, path, plan, s3HTTPClientForTesting, plan.Filename)
 	if err != nil {
 		return err
 	}
-	// Drain the spinner before rendering the URL. upload.Upload's contract
-	// permits a final progress callback to fire after it returns, which
-	// would otherwise keep the spinner repainting stderr while stdout is
-	// printing the canonical URL — corrupting the output on a shared TTY.
-	if sp != nil {
-		sp.Stop()
-	}
 	return renderFileURL(opts, fileURL)
-}
-
-func spinnerStatus(filename string, uploaded int64, totalLabel string) string {
-	return fmt.Sprintf("Uploading %s %s / %s", filename, humanBytes(uploaded), totalLabel)
 }
 
 func renderFileURL(opts cmdutil.Options, fileURL string) error {
@@ -154,22 +123,5 @@ func renderDryRun(opts cmdutil.Options, plan upload.Plan) error {
 	if plan.PartCount != 1 {
 		parts = fmt.Sprintf("%d parts", plan.PartCount)
 	}
-	return output.Writef(opts.Out(), "Size: %s (%s)\n", humanBytes(plan.Size), parts)
-}
-
-// humanBytes renders a byte count with IEC-style (1024-based) magnitudes but
-// decimal-unit labels (KB/MB/GB), matching how Gumroad quotes file sizes.
-func humanBytes(n int64) string {
-	const unit = 1024
-	if n < unit {
-		return fmt.Sprintf("%d B", n)
-	}
-	div, exp := int64(unit), 0
-	for n/div >= unit && exp < 3 {
-		div *= unit
-		exp++
-	}
-	v := float64(n) / float64(div)
-	units := []string{"KB", "MB", "GB", "TB"}
-	return fmt.Sprintf("%.1f %s", v, units[exp])
+	return output.Writef(opts.Out(), "Size: %s (%s)\n", uploadcmd.HumanBytes(plan.Size), parts)
 }

--- a/internal/cmd/files/upload.go
+++ b/internal/cmd/files/upload.go
@@ -10,7 +10,7 @@ import (
 	"github.com/antiwork/gumroad-cli/internal/config"
 	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/antiwork/gumroad-cli/internal/upload"
-	"github.com/antiwork/gumroad-cli/internal/uploadcmd"
+	"github.com/antiwork/gumroad-cli/internal/uploadui"
 	"github.com/spf13/cobra"
 )
 
@@ -55,7 +55,7 @@ func runUpload(opts cmdutil.Options, path string, plan upload.Plan) error {
 		return err
 	}
 	client := cmdutil.NewAPIClient(opts, token)
-	fileURL, err := uploadcmd.UploadFile(opts, client, path, plan, s3HTTPClientForTesting, plan.Filename)
+	fileURL, err := uploadui.UploadFile(opts, client, path, plan, s3HTTPClientForTesting, plan.Filename)
 	if err != nil {
 		return err
 	}
@@ -123,5 +123,5 @@ func renderDryRun(opts cmdutil.Options, plan upload.Plan) error {
 	if plan.PartCount != 1 {
 		parts = fmt.Sprintf("%d parts", plan.PartCount)
 	}
-	return output.Writef(opts.Out(), "Size: %s (%s)\n", uploadcmd.HumanBytes(plan.Size), parts)
+	return output.Writef(opts.Out(), "Size: %s (%s)\n", uploadui.HumanBytes(plan.Size), parts)
 }

--- a/internal/cmd/files/upload_test.go
+++ b/internal/cmd/files/upload_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/testutil"
 	"github.com/antiwork/gumroad-cli/internal/upload"
+	"github.com/antiwork/gumroad-cli/internal/uploadcmd"
 )
 
 // uploadServers wires a Rails mock (via testutil.Setup) plus an in-process
@@ -422,16 +423,6 @@ func TestRenderDryRun_MultiPartPluralization(t *testing.T) {
 	}
 }
 
-func TestSpinnerStatus_IncludesFilenameAndProgress(t *testing.T) {
-	got := spinnerStatus("pack.zip", 1024*1024*4, "12.0 MB")
-	if !strings.Contains(got, "pack.zip") {
-		t.Errorf("spinnerStatus missing filename: %q", got)
-	}
-	if !strings.Contains(got, "4.0 MB") || !strings.Contains(got, "12.0 MB") {
-		t.Errorf("spinnerStatus missing bytes: %q", got)
-	}
-}
-
 func TestHumanBytes_Magnitudes(t *testing.T) {
 	cases := []struct {
 		in   int64
@@ -448,7 +439,7 @@ func TestHumanBytes_Magnitudes(t *testing.T) {
 		{1024 * 1024 * 1024 * 1024 * 2048, "2048.0 TB"},
 	}
 	for _, c := range cases {
-		if got := humanBytes(c.in); got != c.want {
+		if got := uploadcmd.HumanBytes(c.in); got != c.want {
 			t.Errorf("humanBytes(%d) = %q, want %q", c.in, got, c.want)
 		}
 	}

--- a/internal/cmd/files/upload_test.go
+++ b/internal/cmd/files/upload_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/testutil"
 	"github.com/antiwork/gumroad-cli/internal/upload"
-	"github.com/antiwork/gumroad-cli/internal/uploadcmd"
+	"github.com/antiwork/gumroad-cli/internal/uploadui"
 )
 
 // uploadServers wires a Rails mock (via testutil.Setup) plus an in-process
@@ -439,7 +439,7 @@ func TestHumanBytes_Magnitudes(t *testing.T) {
 		{1024 * 1024 * 1024 * 1024 * 2048, "2048.0 TB"},
 	}
 	for _, c := range cases {
-		if got := uploadcmd.HumanBytes(c.in); got != c.want {
+		if got := uploadui.HumanBytes(c.in); got != c.want {
 			t.Errorf("humanBytes(%d) = %q, want %q", c.in, got, c.want)
 		}
 	}

--- a/internal/cmd/products/create.go
+++ b/internal/cmd/products/create.go
@@ -13,7 +13,7 @@ import (
 	"github.com/antiwork/gumroad-cli/internal/config"
 	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/antiwork/gumroad-cli/internal/upload"
-	"github.com/antiwork/gumroad-cli/internal/uploadcmd"
+	"github.com/antiwork/gumroad-cli/internal/uploadui"
 	"github.com/spf13/cobra"
 )
 
@@ -193,7 +193,7 @@ func newCreateCmd() *cobra.Command {
 					if len(plannedUploads) > 1 {
 						statusLabel = fmt.Sprintf("%s (%d/%d)", planned.Plan.Filename, i+1, len(plannedUploads))
 					}
-					fileURLs[i], err = uploadcmd.UploadFile(opts, client, planned.Path, planned.Plan, s3HTTPClientForTesting, statusLabel)
+					fileURLs[i], err = uploadui.UploadFile(opts, client, planned.Path, planned.Plan, s3HTTPClientForTesting, statusLabel)
 					if err != nil {
 						return err
 					}
@@ -374,5 +374,5 @@ func renderCreateUploadDryRun(opts cmdutil.Options, plan upload.Plan) error {
 	if plan.PartCount != 1 {
 		parts = fmt.Sprintf("%d parts", plan.PartCount)
 	}
-	return output.Writef(opts.Out(), "Size: %s (%s)\n", uploadcmd.HumanBytes(plan.Size), parts)
+	return output.Writef(opts.Out(), "Size: %s (%s)\n", uploadui.HumanBytes(plan.Size), parts)
 }

--- a/internal/cmd/products/create.go
+++ b/internal/cmd/products/create.go
@@ -1,13 +1,19 @@
 package products
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
 	"net/url"
 	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/config"
 	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/upload"
+	"github.com/antiwork/gumroad-cli/internal/uploadcmd"
 	"github.com/spf13/cobra"
 )
 
@@ -39,6 +45,38 @@ var validSubscriptionDurations = map[string]bool{
 	"yearly": true, "every_two_years": true,
 }
 
+// s3HTTPClientForTesting redirects multipart PUTs at a test TLS server. Tests
+// in this package must not use t.Parallel while mutating this hook.
+var s3HTTPClientForTesting *http.Client
+
+type createUploadInput struct {
+	Path        string
+	DisplayName string
+	Description string
+	Plan        upload.Plan
+}
+
+type dryRunCreateUpload struct {
+	Action    string `json:"action"`
+	Path      string `json:"path"`
+	Filename  string `json:"filename"`
+	Size      int64  `json:"size"`
+	PartSize  int64  `json:"part_size"`
+	PartCount int    `json:"part_count"`
+}
+
+type dryRunCreateRequest struct {
+	Method string     `json:"method"`
+	Path   string     `json:"path"`
+	Params url.Values `json:"params,omitempty"`
+}
+
+type dryRunCreatePayload struct {
+	DryRun  bool                 `json:"dry_run"`
+	Uploads []dryRunCreateUpload `json:"uploads"`
+	Request dryRunCreateRequest  `json:"request"`
+}
+
 func newCreateCmd() *cobra.Command {
 	var name, nativeType, currency, description, customPermalink string
 	var customSummary, customReceipt, subscriptionDuration, taxonomyID string
@@ -46,11 +84,13 @@ func newCreateCmd() *cobra.Command {
 	var maxPurchaseCount int
 	var payWhatYouWant bool
 	var tags []string
+	var files, fileNames, fileDescriptions []string
 
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a new product (as draft)",
 		Example: `  gumroad products create --name "Art Pack" --price 10.00
+  gumroad products create --name "Art Pack" --file ./pack.zip --file-name "Art Pack.zip"
   gumroad products create --name "Newsletter" --type membership --subscription-duration monthly
   gumroad products create --name "E-Book" --type ebook --price 5 --tag art --tag digital`,
 		Args: cmdutil.ExactArgs(0),
@@ -76,6 +116,11 @@ func newCreateCmd() *cobra.Command {
 			}
 
 			if err := cmdutil.RequireNonNegativeIntFlag(c, "max-purchase-count", maxPurchaseCount); err != nil {
+				return err
+			}
+
+			plannedUploads, err := planCreateUploads(c, files, fileNames, fileDescriptions)
+			if err != nil {
 				return err
 			}
 
@@ -128,6 +173,34 @@ func newCreateCmd() *cobra.Command {
 				params.Add("tags[]", t)
 			}
 
+			if len(plannedUploads) > 0 {
+				fileURLs := make([]string, len(plannedUploads))
+				if opts.DryRun {
+					for i := range plannedUploads {
+						fileURLs[i] = dryRunFilePlaceholder(i)
+					}
+					appendCreateUploadParams(params, plannedUploads, fileURLs)
+					return renderCreateDryRun(opts, plannedUploads, params)
+				}
+
+				token, err := config.Token()
+				if err != nil {
+					return err
+				}
+				client := cmdutil.NewAPIClient(opts, token)
+				for i, planned := range plannedUploads {
+					statusLabel := planned.Plan.Filename
+					if len(plannedUploads) > 1 {
+						statusLabel = fmt.Sprintf("%s (%d/%d)", planned.Plan.Filename, i+1, len(plannedUploads))
+					}
+					fileURLs[i], err = uploadcmd.UploadFile(opts, client, planned.Path, planned.Plan, s3HTTPClientForTesting, statusLabel)
+					if err != nil {
+						return err
+					}
+				}
+				appendCreateUploadParams(params, plannedUploads, fileURLs)
+			}
+
 			return cmdutil.RunRequestDecoded[createProductResponse](opts,
 				"Creating product...", "POST", "/products", params,
 				func(resp createProductResponse) error {
@@ -165,6 +238,141 @@ func newCreateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&taxonomyID, "taxonomy-id", "", "Taxonomy/category ID")
 	cmd.Flags().StringVar(&subscriptionDuration, "subscription-duration", "", "Subscription duration (membership only: monthly, quarterly, biannually, yearly, every_two_years)")
 	cmd.Flags().StringArrayVar(&tags, "tag", nil, "Tag (repeatable)")
+	cmd.Flags().StringArrayVar(&files, "file", nil, "Attach a local file to the new product (repeatable)")
+	cmd.Flags().StringArrayVar(&fileNames, "file-name", nil, "Display filename for the matching --file upload (repeatable; use an empty string to skip a slot)")
+	cmd.Flags().StringArrayVar(&fileDescriptions, "file-description", nil, "Description for the matching --file upload (repeatable; use an empty string to skip a slot)")
 
 	return cmd
+}
+
+func planCreateUploads(c *cobra.Command, files, fileNames, fileDescriptions []string) ([]createUploadInput, error) {
+	if len(files) == 0 {
+		if len(fileNames) > 0 {
+			return nil, cmdutil.UsageErrorf(c, "--file-name requires at least one --file")
+		}
+		if len(fileDescriptions) > 0 {
+			return nil, cmdutil.UsageErrorf(c, "--file-description requires at least one --file")
+		}
+		return nil, nil
+	}
+
+	alignedNames, err := alignCreateUploadValues(c, "--file-name", fileNames, len(files))
+	if err != nil {
+		return nil, err
+	}
+	alignedDescriptions, err := alignCreateUploadValues(c, "--file-description", fileDescriptions, len(files))
+	if err != nil {
+		return nil, err
+	}
+
+	uploads := make([]createUploadInput, 0, len(files))
+	for i, path := range files {
+		displayName := strings.TrimSpace(alignedNames[i])
+		plan, err := upload.Describe(path, upload.Options{Filename: displayName})
+		if err != nil {
+			return nil, err
+		}
+		uploads = append(uploads, createUploadInput{
+			Path:        path,
+			DisplayName: displayName,
+			Description: alignedDescriptions[i],
+			Plan:        plan,
+		})
+	}
+	return uploads, nil
+}
+
+func alignCreateUploadValues(c *cobra.Command, flagName string, values []string, count int) ([]string, error) {
+	switch len(values) {
+	case 0:
+		return make([]string, count), nil
+	case count:
+		aligned := make([]string, count)
+		copy(aligned, values)
+		return aligned, nil
+	default:
+		return nil, cmdutil.UsageErrorf(c, "%s must be provided zero times or exactly once per --file (got %d values for %d files)", flagName, len(values), count)
+	}
+}
+
+func appendCreateUploadParams(params url.Values, uploads []createUploadInput, fileURLs []string) {
+	for i, planned := range uploads {
+		params.Set(fmt.Sprintf("files[%d][url]", i), fileURLs[i])
+		if planned.DisplayName != "" {
+			params.Set(fmt.Sprintf("files[%d][display_name]", i), planned.DisplayName)
+		}
+		if planned.Description != "" {
+			params.Set(fmt.Sprintf("files[%d][description]", i), planned.Description)
+		}
+	}
+}
+
+func dryRunFilePlaceholder(i int) string {
+	return fmt.Sprintf("<uploaded:file:%d>", i)
+}
+
+func renderCreateDryRun(opts cmdutil.Options, uploads []createUploadInput, params url.Values) error {
+	if opts.UsesJSONOutput() {
+		payload := dryRunCreatePayload{
+			DryRun:  true,
+			Uploads: make([]dryRunCreateUpload, 0, len(uploads)),
+			Request: dryRunCreateRequest{
+				Method: "POST",
+				Path:   "/products",
+				Params: cmdutil.CloneValues(params),
+			},
+		}
+		for _, planned := range uploads {
+			payload.Uploads = append(payload.Uploads, dryRunCreateUpload{
+				Action:    "upload",
+				Path:      planned.Plan.Path,
+				Filename:  planned.Plan.Filename,
+				Size:      planned.Plan.Size,
+				PartSize:  planned.Plan.PartSize,
+				PartCount: planned.Plan.PartCount,
+			})
+		}
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("could not encode dry-run output: %w", err)
+		}
+		return output.PrintJSON(opts.Out(), data, opts.JQExpr)
+	}
+
+	if opts.PlainOutput {
+		for _, planned := range uploads {
+			if err := output.PrintPlain(opts.Out(), [][]string{{
+				"upload",
+				planned.Plan.Path,
+				planned.Plan.Filename,
+				strconv.FormatInt(planned.Plan.Size, 10),
+				strconv.Itoa(planned.Plan.PartCount),
+			}}); err != nil {
+				return err
+			}
+		}
+		return cmdutil.PrintDryRunRequest(opts, "POST", "/products", params)
+	}
+
+	for _, planned := range uploads {
+		if err := renderCreateUploadDryRun(opts, planned.Plan); err != nil {
+			return err
+		}
+	}
+	return cmdutil.PrintDryRunRequest(opts, "POST", "/products", params)
+}
+
+func renderCreateUploadDryRun(opts cmdutil.Options, plan upload.Plan) error {
+	style := opts.Style()
+	if err := output.Writeln(opts.Out(), style.Yellow("Dry run")+": upload "+plan.Path); err != nil {
+		return err
+	}
+	if err := output.Writef(opts.Out(), "Filename: %s\n", plan.Filename); err != nil {
+		return err
+	}
+	parts := "1 part"
+	if plan.PartCount != 1 {
+		parts = fmt.Sprintf("%d parts", plan.PartCount)
+	}
+	return output.Writef(opts.Out(), "Size: %s (%s)\n", uploadcmd.HumanBytes(plan.Size), parts)
 }

--- a/internal/cmd/products/create_files_test.go
+++ b/internal/cmd/products/create_files_test.go
@@ -1,0 +1,316 @@
+package products
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+type createUploadServers struct {
+	s3 *httptest.Server
+
+	mu               sync.Mutex
+	presignFilenames []string
+	productForm      url.Values
+	s3Calls          int
+	completeCalls    int
+	presignCalls     int
+}
+
+func newCreateUploadServers(t *testing.T) *createUploadServers {
+	t.Helper()
+
+	srv := &createUploadServers{}
+	srv.s3 = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		srv.mu.Lock()
+		srv.s3Calls++
+		srv.mu.Unlock()
+
+		if r.Method != http.MethodPut {
+			t.Errorf("S3 got %s, want PUT", r.Method)
+			http.Error(w, "bad method", http.StatusBadRequest)
+			return
+		}
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.Header().Set("ETag", `"etag-1"`)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.s3.Close)
+
+	prev := s3HTTPClientForTesting
+	s3HTTPClientForTesting = srv.s3.Client()
+	t.Cleanup(func() { s3HTTPClientForTesting = prev })
+
+	return srv
+}
+
+func (srv *createUploadServers) dispatch(t *testing.T) http.HandlerFunc {
+	t.Helper()
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+
+		switch r.URL.Path {
+		case "/files/presign":
+			srv.mu.Lock()
+			srv.presignCalls++
+			n := srv.presignCalls
+			srv.presignFilenames = append(srv.presignFilenames, r.PostForm.Get("filename"))
+			srv.mu.Unlock()
+
+			testutil.JSON(t, w, map[string]any{
+				"upload_id": "up-" + strconv.Itoa(n),
+				"key":       "attachments/u/k/original/" + strconv.Itoa(n) + ".bin",
+				"file_url":  "https://example.com/uploads/up-" + strconv.Itoa(n),
+				"parts": []map[string]any{
+					{"part_number": 1, "presigned_url": srv.s3.URL + "/part/" + strconv.Itoa(n)},
+				},
+			})
+		case "/files/complete":
+			srv.mu.Lock()
+			srv.completeCalls++
+			srv.mu.Unlock()
+
+			testutil.JSON(t, w, map[string]any{
+				"file_url": "https://example.com/uploads/" + r.PostForm.Get("upload_id"),
+			})
+		case "/products":
+			srv.mu.Lock()
+			srv.productForm = cloneURLValues(r.PostForm)
+			srv.mu.Unlock()
+
+			testutil.JSON(t, w, map[string]any{
+				"product": map[string]any{
+					"id":              "prod-upload",
+					"name":            r.PostForm.Get("name"),
+					"formatted_price": "$10",
+				},
+			})
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			http.Error(w, "unexpected", http.StatusNotFound)
+		}
+	}
+}
+
+func (srv *createUploadServers) snapshot() ([]string, url.Values, int, int) {
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	return append([]string(nil), srv.presignFilenames...), cloneURLValues(srv.productForm), srv.s3Calls, srv.completeCalls
+}
+
+func cloneURLValues(values url.Values) url.Values {
+	cloned := make(url.Values, len(values))
+	for key, current := range values {
+		cloned[key] = append([]string(nil), current...)
+	}
+	return cloned
+}
+
+func writeCreateFixture(t *testing.T, contents string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "fixture.bin")
+	if err := os.WriteFile(path, []byte(contents), 0600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+func TestCreate_WithFiles_UploadsAndPostsIndexedFields(t *testing.T) {
+	srv := newCreateUploadServers(t)
+	testutil.Setup(t, srv.dispatch(t))
+
+	firstPath := writeCreateFixture(t, "first")
+	secondPath := writeCreateFixture(t, "second")
+
+	cmd := testutil.Command(newCreateCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{
+		"--name", "Art Pack",
+		"--price", "10.00",
+		"--file", firstPath,
+		"--file", secondPath,
+		"--file-name", "Custom One.zip",
+		"--file-name", "",
+		"--file-description", "",
+		"--file-description", "Second file",
+	})
+
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	presignFilenames, productForm, s3Calls, completeCalls := srv.snapshot()
+	if !reflect.DeepEqual(presignFilenames, []string{"Custom One.zip", filepath.Base(secondPath)}) {
+		t.Fatalf("presign filenames = %v", presignFilenames)
+	}
+	if got := productForm.Get("files[0][url]"); got != "https://example.com/uploads/up-1" {
+		t.Fatalf("files[0][url] = %q", got)
+	}
+	if got := productForm.Get("files[0][display_name]"); got != "Custom One.zip" {
+		t.Fatalf("files[0][display_name] = %q", got)
+	}
+	if got := productForm.Get("files[0][description]"); got != "" {
+		t.Fatalf("files[0][description] = %q, want empty", got)
+	}
+	if got := productForm.Get("files[1][url]"); got != "https://example.com/uploads/up-2" {
+		t.Fatalf("files[1][url] = %q", got)
+	}
+	if got := productForm.Get("files[1][display_name]"); got != "" {
+		t.Fatalf("files[1][display_name] = %q, want empty", got)
+	}
+	if got := productForm.Get("files[1][description]"); got != "Second file" {
+		t.Fatalf("files[1][description] = %q", got)
+	}
+	if s3Calls != 2 {
+		t.Fatalf("S3 calls = %d, want 2", s3Calls)
+	}
+	if completeCalls != 2 {
+		t.Fatalf("complete calls = %d, want 2", completeCalls)
+	}
+	if !strings.Contains(out, "Created draft product:") || !strings.Contains(out, "prod-upload") {
+		t.Fatalf("unexpected output: %q", out)
+	}
+}
+
+func TestCreate_WithFiles_DryRunPrintsUploadsAndPlaceholderRequest(t *testing.T) {
+	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
+		t.Fatal("dry run must not reach the API")
+	})
+
+	firstPath := writeCreateFixture(t, "first")
+	secondPath := writeCreateFixture(t, "second")
+
+	cmd := testutil.Command(newCreateCmd(), testutil.DryRun(true))
+	cmd.SetArgs([]string{
+		"--name", "Art Pack",
+		"--file", firstPath,
+		"--file", secondPath,
+		"--file-name", "Cover.zip",
+		"--file-name", "",
+		"--file-description", "",
+		"--file-description", "Second file",
+	})
+
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if !strings.Contains(out, "Dry run: upload "+firstPath) {
+		t.Fatalf("missing first upload plan: %q", out)
+	}
+	if !strings.Contains(out, "Dry run: upload "+secondPath) {
+		t.Fatalf("missing second upload plan: %q", out)
+	}
+	if !strings.Contains(out, "Dry run: POST /products") {
+		t.Fatalf("missing create request: %q", out)
+	}
+	if !strings.Contains(out, "files[0][url]: <uploaded:file:0>") {
+		t.Fatalf("missing first placeholder URL: %q", out)
+	}
+	if !strings.Contains(out, "files[1][description]: Second file") {
+		t.Fatalf("missing second description: %q", out)
+	}
+}
+
+func TestCreate_WithFiles_DryRunJSONIncludesUploadsAndRequest(t *testing.T) {
+	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
+		t.Fatal("dry run must not reach the API")
+	})
+
+	path := writeCreateFixture(t, "payload")
+
+	cmd := testutil.Command(newCreateCmd(), testutil.DryRun(true), testutil.JSONOutput())
+	cmd.SetArgs([]string{
+		"--name", "Art Pack",
+		"--file", path,
+		"--file-name", "Gift.zip",
+		"--file-description", "Bonus download",
+	})
+
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var payload dryRunCreatePayload
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("parse JSON: %v\n%s", err, out)
+	}
+	if !payload.DryRun {
+		t.Fatalf("expected dry_run=true, got %+v", payload)
+	}
+	if len(payload.Uploads) != 1 {
+		t.Fatalf("uploads = %d, want 1", len(payload.Uploads))
+	}
+	if got := payload.Uploads[0].Filename; got != "Gift.zip" {
+		t.Fatalf("upload filename = %q", got)
+	}
+	if payload.Request.Method != "POST" || payload.Request.Path != "/products" {
+		t.Fatalf("request = %+v", payload.Request)
+	}
+	if got := payload.Request.Params.Get("files[0][url]"); got != "<uploaded:file:0>" {
+		t.Fatalf("files[0][url] = %q", got)
+	}
+	if got := payload.Request.Params.Get("files[0][display_name]"); got != "Gift.zip" {
+		t.Fatalf("files[0][display_name] = %q", got)
+	}
+	if got := payload.Request.Params.Get("files[0][description]"); got != "Bonus download" {
+		t.Fatalf("files[0][description] = %q", got)
+	}
+}
+
+func TestCreate_FileMetadataCountMustMatchFiles(t *testing.T) {
+	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
+		t.Fatal("validation errors must not reach the API")
+	})
+
+	firstPath := writeCreateFixture(t, "first")
+	secondPath := writeCreateFixture(t, "second")
+
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "file name count mismatch",
+			args: []string{
+				"--name", "Art Pack",
+				"--file", firstPath,
+				"--file", secondPath,
+				"--file-name", "Only one name",
+			},
+			want: "--file-name must be provided zero times or exactly once per --file",
+		},
+		{
+			name: "file description count mismatch",
+			args: []string{
+				"--name", "Art Pack",
+				"--file", firstPath,
+				"--file", secondPath,
+				"--file-description", "Only one description",
+			},
+			want: "--file-description must be provided zero times or exactly once per --file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := testutil.Command(newCreateCmd())
+			cmd.SetArgs(tt.args)
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cmd/products/products.go
+++ b/internal/cmd/products/products.go
@@ -14,6 +14,7 @@ func NewProductsCmd() *cobra.Command {
 			"New products are created as drafts; use `gumroad products publish <id>` to publish.",
 		Example: `  gumroad products list
   gumroad products create --name "Art Pack" --price 10.00
+  gumroad products create --name "Art Pack" --file ./pack.zip --file-name "Art Pack.zip"
   gumroad products update <product_id> --name "New Name"
   gumroad products view <id>
   gumroad products publish <id>

--- a/internal/uploadcmd/upload.go
+++ b/internal/uploadcmd/upload.go
@@ -1,0 +1,68 @@
+package uploadcmd
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/upload"
+)
+
+// UploadFile runs one multipart upload while keeping progress presentation in
+// the command layer.
+func UploadFile(opts cmdutil.Options, client *api.Client, path string, plan upload.Plan, httpClient *http.Client, statusLabel string) (string, error) {
+	if statusLabel == "" {
+		statusLabel = plan.Filename
+	}
+
+	totalLabel := HumanBytes(plan.Size)
+	var sp *output.Spinner
+	if cmdutil.ShouldShowSpinner(opts) {
+		sp = output.NewSpinnerTo(uploadSpinnerStatus(statusLabel, 0, totalLabel), opts.Err())
+		sp.Start()
+		defer sp.Stop()
+	}
+
+	progress := func(uploaded int64) {
+		if sp != nil {
+			sp.SetMessage(uploadSpinnerStatus(statusLabel, uploaded, totalLabel))
+		}
+	}
+
+	fileURL, err := upload.Upload(opts.Context, client, path, upload.Options{
+		Filename:   plan.Filename,
+		HTTPClient: httpClient,
+		Progress:   progress,
+	})
+	if err != nil {
+		return "", err
+	}
+	if sp != nil {
+		// Drain the spinner before the caller renders stdout.
+		sp.Stop()
+	}
+	return fileURL, nil
+}
+
+func uploadSpinnerStatus(label string, uploaded int64, totalLabel string) string {
+	return fmt.Sprintf("Uploading %s %s / %s", label, HumanBytes(uploaded), totalLabel)
+}
+
+// HumanBytes renders a byte count with IEC-style (1024-based) magnitudes but
+// decimal-unit labels (KB/MB/GB), matching how Gumroad quotes file sizes.
+func HumanBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for n/div >= unit && exp < 3 {
+		div *= unit
+		exp++
+	}
+	v := float64(n) / float64(div)
+	units := []string{"KB", "MB", "GB", "TB"}
+	return fmt.Sprintf("%.1f %s", v, units[exp])
+}

--- a/internal/uploadui/upload.go
+++ b/internal/uploadui/upload.go
@@ -1,4 +1,4 @@
-package uploadcmd
+package uploadui
 
 import (
 	"fmt"


### PR DESCRIPTION
Issue #36

## What

This adds file attachments to `gumroad products create`.

`--file` can now be repeated on product creation, with optional positional `--file-name` and `--file-description` metadata. The command preflights every file before starting any upload, uploads each one through the existing multipart flow, and sends the resulting canonical URLs to `/products` as indexed `files[n][url]`, `files[n][display_name]`, and `files[n][description]` params.

This also extends `--dry-run` for product creation so it stays local-only while still showing the planned uploads and the final `POST /products` request with placeholder uploaded URLs. To avoid duplicating spinner/progress logic, the shared command-layer upload UI was extracted into `internal/uploadcmd` and reused by both `gumroad files upload` and `gumroad products create --file`.

Coverage includes the create-with-files happy path, dry-run output in human and JSON modes, and validation that `--file-name` / `--file-description` are either omitted or provided once per `--file`. `go test ./...` passes.

## Why

PR 3 is the first place where product creation actually consumes the multipart uploader built in the earlier upload PRs. Reusing that path keeps presign, part upload, complete, and progress behavior consistent instead of introducing a second product-specific upload implementation.

The preflight and dry-run behavior are deliberate guardrails. Validating every file up front avoids starting uploads and then failing halfway through because a later file is unreadable or oversized. Keeping dry-run free of network calls avoids inventing server-assigned values like canonical file URLs, so the output stays accurate without causing side effects.

---

AI disclosure:  This PR was implemented with AI assistance using Claude Opus 4.7 and gpt‑5.4 xhigh