### PR TITLE
Add file support to product updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,19 @@ gumroad completion    bash, zsh, fish, powershell
 
 Run `gumroad <command> --help` for usage details and examples.
 
+## File attachments
+
+```sh
+# Upload a file and print the canonical Gumroad URL
+gumroad files upload ./pack.zip
+
+# Add a new file to a product while keeping its current attachments
+gumroad products update <product_id> --file ./pack.zip
+
+# Replace the current file set, preserving only the IDs you keep explicitly
+gumroad products update <product_id> --replace-files --keep-file <file_id> --file ./new-pack.zip
+```
+
 ## Output modes
 
 | Flag | Output | Use case |

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -11,7 +12,6 @@ import (
 	"net/url"
 	"os"
 	"strconv"
-	"strings"
 	"syscall"
 	"time"
 )
@@ -90,6 +90,10 @@ func (c *Client) Put(path string, params url.Values) (json.RawMessage, error) {
 	return c.do("PUT", path, params)
 }
 
+func (c *Client) PutJSON(path string, payload any) (json.RawMessage, error) {
+	return c.doJSONWithContext(c.requestContext(), "PUT", path, payload)
+}
+
 func (c *Client) Delete(path string, params url.Values) (json.RawMessage, error) {
 	return c.do("DELETE", path, params)
 }
@@ -126,7 +130,35 @@ func (c *Client) doWithContext(ctx context.Context, method, path string, params 
 			logURL += "?" + redactQueryValues(params).Encode()
 		}
 	}
+	var bodyBytes []byte
+	contentType := ""
+	if method != "GET" && encodedParams != "" {
+		bodyBytes = []byte(encodedParams)
+		contentType = "application/x-www-form-urlencoded"
+	}
+	return c.doPreparedWithContext(ctx, method, requestURL, logURL, bodyBytes, contentType)
+}
 
+func (c *Client) doJSONWithContext(ctx context.Context, method, path string, payload any) (json.RawMessage, error) {
+	baseURL := c.baseURL
+	if baseURL == "" {
+		baseURL = defaultBaseURL()
+	}
+
+	bodyBytes, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("could not encode request body: %w", err)
+	}
+	requestURL := baseURL + path
+	return c.doPreparedWithContext(ctx, method, requestURL, requestURL, bodyBytes, "application/json")
+}
+
+func (c *Client) doPreparedWithContext(
+	ctx context.Context,
+	method, requestURL, logURL string,
+	bodyBytes []byte,
+	contentType string,
+) (json.RawMessage, error) {
 	logResponse := func(statusCode int, size int, apiErr error, started time.Time) {
 		duration := time.Since(started).Round(time.Millisecond)
 		if apiErr != nil {
@@ -140,8 +172,8 @@ func (c *Client) doWithContext(ctx context.Context, method, path string, params 
 		start := time.Now()
 
 		var body io.Reader
-		if method != "GET" && encodedParams != "" {
-			body = strings.NewReader(encodedParams)
+		if len(bodyBytes) > 0 {
+			body = bytes.NewReader(bodyBytes)
 		}
 
 		req, err := http.NewRequestWithContext(ctx, method, requestURL, body)
@@ -152,8 +184,8 @@ func (c *Client) doWithContext(ctx context.Context, method, path string, params 
 
 		req.Header.Set("Authorization", "Bearer "+c.token)
 		req.Header.Set("User-Agent", "gumroad/"+c.version)
-		if body != nil {
-			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		if contentType != "" {
+			req.Header.Set("Content-Type", contentType)
 		}
 		c.debugf("request method=%s url=%s attempt=%d", method, logURL, attempt+1)
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -78,12 +78,20 @@ func (c *Client) Post(path string, params url.Values) (json.RawMessage, error) {
 	return c.do("POST", path, params)
 }
 
+func (c *Client) PostJSON(path string, payload any) (json.RawMessage, error) {
+	return c.doJSONWithContext(c.requestContext(), "POST", path, payload)
+}
+
 // PostWithContext runs a POST under ctx instead of the client's baked-in
 // context. Use this when a single call needs its own independent lifetime —
 // e.g. best-effort cleanup that must still run after the original request
 // context has been canceled.
 func (c *Client) PostWithContext(ctx context.Context, path string, params url.Values) (json.RawMessage, error) {
 	return c.doWithContext(ctx, "POST", path, params)
+}
+
+func (c *Client) PostJSONWithContext(ctx context.Context, path string, payload any) (json.RawMessage, error) {
+	return c.doJSONWithContext(ctx, "POST", path, payload)
 }
 
 func (c *Client) Put(path string, params url.Values) (json.RawMessage, error) {

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -255,6 +255,47 @@ func TestClient_PutJSON(t *testing.T) {
 	}
 }
 
+func TestClient_PostJSON(t *testing.T) {
+	var gotMethod string
+	var gotContentType string
+	var gotBody map[string]any
+	srv := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotContentType = r.Header.Get("Content-Type")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("Decode failed: %v", err)
+		}
+		if err := json.NewEncoder(w).Encode(map[string]any{"success": true}); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	})
+	c := newTestClient(srv)
+
+	payload := map[string]any{
+		"upload_id": "up-1",
+		"parts": []any{
+			map[string]any{"part_number": 1, "etag": "etag-1"},
+		},
+	}
+	_, err := c.PostJSON("/files/complete", payload)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotMethod != "POST" {
+		t.Errorf("got method %q, want POST", gotMethod)
+	}
+	if gotContentType != "application/json" {
+		t.Errorf("got Content-Type=%q, want application/json", gotContentType)
+	}
+	if gotBody["upload_id"] != "up-1" {
+		t.Errorf("got upload_id=%v, want up-1", gotBody["upload_id"])
+	}
+	parts, ok := gotBody["parts"].([]any)
+	if !ok || len(parts) != 1 {
+		t.Fatalf("got parts=%#v, want 1-element array", gotBody["parts"])
+	}
+}
+
 func TestClient_Delete(t *testing.T) {
 	var gotMethod string
 	srv := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -216,6 +216,45 @@ func TestClient_Put(t *testing.T) {
 	}
 }
 
+func TestClient_PutJSON(t *testing.T) {
+	var gotMethod string
+	var gotContentType string
+	var gotBody map[string]any
+	srv := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotContentType = r.Header.Get("Content-Type")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("Decode failed: %v", err)
+		}
+		if err := json.NewEncoder(w).Encode(map[string]any{"success": true}); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	})
+	c := newTestClient(srv)
+
+	payload := map[string]any{
+		"files": []any{},
+		"name":  "updated",
+	}
+	_, err := c.PutJSON("/resource/1", payload)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotMethod != "PUT" {
+		t.Errorf("got method %q, want PUT", gotMethod)
+	}
+	if gotContentType != "application/json" {
+		t.Errorf("got Content-Type=%q, want application/json", gotContentType)
+	}
+	if gotBody["name"] != "updated" {
+		t.Errorf("got name=%v, want updated", gotBody["name"])
+	}
+	files, ok := gotBody["files"].([]any)
+	if !ok || len(files) != 0 {
+		t.Errorf("got files=%#v, want empty array", gotBody["files"])
+	}
+}
+
 func TestClient_Delete(t *testing.T) {
 	var gotMethod string
 	srv := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {

--- a/internal/cmd/files/complete.go
+++ b/internal/cmd/files/complete.go
@@ -40,10 +40,14 @@ type completeManifestPart struct {
 }
 
 type dryRunCompleteRequest struct {
-	DryRun bool           `json:"dry_run"`
 	Method string         `json:"method"`
 	Path   string         `json:"path"`
 	Body   map[string]any `json:"body"`
+}
+
+type dryRunCompletePayload struct {
+	DryRun  bool                  `json:"dry_run"`
+	Request dryRunCompleteRequest `json:"request"`
 }
 
 func newCompleteCmd() *cobra.Command {
@@ -163,11 +167,13 @@ func buildCompleteJSONBody(manifest completeManifest) map[string]any {
 func renderCompleteDryRun(opts cmdutil.Options, path string, body map[string]any) error {
 	switch {
 	case opts.UsesJSONOutput():
-		payload := dryRunCompleteRequest{
+		payload := dryRunCompletePayload{
 			DryRun: true,
-			Method: http.MethodPost,
-			Path:   path,
-			Body:   body,
+			Request: dryRunCompleteRequest{
+				Method: http.MethodPost,
+				Path:   path,
+				Body:   body,
+			},
 		}
 		data, err := json.Marshal(payload)
 		if err != nil {

--- a/internal/cmd/files/complete.go
+++ b/internal/cmd/files/complete.go
@@ -6,9 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
-	"strconv"
 
 	"github.com/antiwork/gumroad-cli/internal/api"
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
@@ -39,6 +37,13 @@ type completeManifest struct {
 type completeManifestPart struct {
 	PartNumber int    `json:"part_number"`
 	ETag       string `json:"etag"`
+}
+
+type dryRunCompleteRequest struct {
+	DryRun bool           `json:"dry_run"`
+	Method string         `json:"method"`
+	Path   string         `json:"path"`
+	Body   map[string]any `json:"body"`
 }
 
 func newCompleteCmd() *cobra.Command {
@@ -128,23 +133,64 @@ func newCompleteCmd() *cobra.Command {
 				return cmdutil.PrintCancelledAction(opts, "finalize multipart upload "+manifest.UploadID, manifest.UploadID)
 			}
 
-			params := url.Values{}
-			params.Set("upload_id", manifest.UploadID)
-			params.Set("key", manifest.Key)
-			for i, p := range manifest.CompletedParts {
-				params.Set(fmt.Sprintf("parts[%d][part_number]", i), strconv.Itoa(p.PartNumber))
-				params.Set(fmt.Sprintf("parts[%d][etag]", i), p.ETag)
-			}
-
+			body := buildCompleteJSONBody(manifest)
 			if opts.DryRun {
-				return cmdutil.PrintDryRunRequest(opts, "POST", "/files/complete", params)
+				return renderCompleteDryRun(opts, "/files/complete", body)
 			}
 
-			return runComplete(opts, manifest, params)
+			return runComplete(opts, manifest, body)
 		},
 	}
 	c.Flags().StringVar(&recoveryPath, "recovery", "", "Path to the recovery manifest JSON (use `-` for stdin) (required)")
 	return c
+}
+
+func buildCompleteJSONBody(manifest completeManifest) map[string]any {
+	parts := make([]map[string]any, len(manifest.CompletedParts))
+	for i, p := range manifest.CompletedParts {
+		parts[i] = map[string]any{
+			"part_number": p.PartNumber,
+			"etag":        p.ETag,
+		}
+	}
+	return map[string]any{
+		"upload_id": manifest.UploadID,
+		"key":       manifest.Key,
+		"parts":     parts,
+	}
+}
+
+func renderCompleteDryRun(opts cmdutil.Options, path string, body map[string]any) error {
+	switch {
+	case opts.UsesJSONOutput():
+		payload := dryRunCompleteRequest{
+			DryRun: true,
+			Method: http.MethodPost,
+			Path:   path,
+			Body:   body,
+		}
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("could not encode dry-run output: %w", err)
+		}
+		return output.PrintJSON(opts.Out(), data, opts.JQExpr)
+	case opts.PlainOutput:
+		data, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("could not encode dry-run output: %w", err)
+		}
+		return output.PrintPlain(opts.Out(), [][]string{{http.MethodPost, path, string(data)}})
+	default:
+		style := opts.Style()
+		if err := output.Writeln(opts.Out(), style.Yellow("Dry run")+": "+http.MethodPost+" "+path); err != nil {
+			return err
+		}
+		data, err := json.MarshalIndent(body, "", "  ")
+		if err != nil {
+			return fmt.Errorf("could not encode dry-run output: %w", err)
+		}
+		return output.Writeln(opts.Out(), string(data))
+	}
 }
 
 // runComplete calls /files/complete and prints the returned file_url in the
@@ -153,7 +199,7 @@ func newCompleteCmd() *cobra.Command {
 // with *upload.UnknownStateError so the caller keeps the recovery manifest
 // on a retry path — otherwise a single 5xx during replay would strand the
 // upload with no further safe reconciliation option.
-func runComplete(opts cmdutil.Options, manifest completeManifest, params url.Values) error {
+func runComplete(opts cmdutil.Options, manifest completeManifest, body map[string]any) error {
 	token, err := config.Token()
 	if err != nil {
 		return err
@@ -167,7 +213,7 @@ func runComplete(opts cmdutil.Options, manifest completeManifest, params url.Val
 		defer sp.Stop()
 	}
 
-	data, err := client.PostWithContext(opts.Context, "/files/complete", params)
+	data, err := client.PostJSONWithContext(opts.Context, "/files/complete", body)
 	if err != nil {
 		return handleCompleteFailure(err, manifest)
 	}

--- a/internal/cmd/files/complete_test.go
+++ b/internal/cmd/files/complete_test.go
@@ -243,6 +243,31 @@ func TestComplete_DryRun_EmitsRequestPlan(t *testing.T) {
 	}
 }
 
+func TestComplete_DryRunJSON_UsesRequestEnvelope(t *testing.T) {
+	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
+		t.Error("dry-run must not reach the API")
+	})
+	recoveryPath := writeRecovery(t, map[string]any{
+		"upload_id":       "up-json-dry",
+		"key":             "k",
+		"completed_parts": []map[string]any{{"part_number": 1, "etag": "e1"}},
+	})
+	cmd := testutil.Command(newCompleteCmd(), testutil.DryRun(true), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--recovery", recoveryPath})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var payload dryRunCompletePayload
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("expected JSON dry-run output, got %v: %s", err, out)
+	}
+	if !payload.DryRun || payload.Request.Method != http.MethodPost || payload.Request.Path != "/files/complete" {
+		t.Fatalf("unexpected dry-run payload: %+v", payload)
+	}
+	if got := payload.Request.Body["upload_id"]; got != "up-json-dry" {
+		t.Fatalf("upload_id = %#v, want up-json-dry", got)
+	}
+}
+
 func TestComplete_AmbiguousReplayFailure_PreservesManifest(t *testing.T) {
 	testutil.Setup(t, func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, `{"success":false,"message":"upstream timeout"}`, http.StatusBadGateway)

--- a/internal/cmd/files/complete_test.go
+++ b/internal/cmd/files/complete_test.go
@@ -28,20 +28,16 @@ func writeRecovery(t *testing.T, data any) string {
 	return path
 }
 
-func TestComplete_HappyPath_IndexedPartsAndReturnsFileURL(t *testing.T) {
-	var received map[string]string
+func TestComplete_HappyPath_JSONBodyAndReturnsFileURL(t *testing.T) {
+	var received map[string]any
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/files/complete" {
 			t.Errorf("unexpected path: %s", r.URL.Path)
 			http.Error(w, "bad", http.StatusNotFound)
 			return
 		}
-		if err := r.ParseForm(); err != nil {
-			t.Fatalf("parse form: %v", err)
-		}
-		received = map[string]string{}
-		for k, v := range r.PostForm {
-			received[k] = strings.Join(v, ",")
+		if err := json.NewDecoder(r.Body).Decode(&received); err != nil {
+			t.Fatalf("decode JSON: %v", err)
 		}
 		testutil.JSON(t, w, map[string]any{"file_url": "https://example.com/final"})
 	})
@@ -66,12 +62,20 @@ func TestComplete_HappyPath_IndexedPartsAndReturnsFileURL(t *testing.T) {
 	if received["key"] != "attachments/u/k/original/p.bin" {
 		t.Errorf("key = %q", received["key"])
 	}
+	parts, ok := received["parts"].([]any)
+	if !ok || len(parts) != 2 {
+		t.Fatalf("parts = %#v, want 2-element array", received["parts"])
+	}
 	for i := 0; i < 2; i++ {
-		if got := received[fmt.Sprintf("parts[%d][part_number]", i)]; got == "" {
-			t.Errorf("missing parts[%d][part_number]", i)
+		part, ok := parts[i].(map[string]any)
+		if !ok {
+			t.Fatalf("parts[%d] = %#v, want object", i, parts[i])
 		}
-		if got := received[fmt.Sprintf("parts[%d][etag]", i)]; got == "" {
-			t.Errorf("missing parts[%d][etag]", i)
+		if got := int(part["part_number"].(float64)); got != i+1 {
+			t.Errorf("parts[%d].part_number = %d, want %d", i, got, i+1)
+		}
+		if got := part["etag"]; got != fmt.Sprintf("etag-%d", i+1) {
+			t.Errorf("parts[%d].etag = %v", i, got)
 		}
 	}
 	if got := strings.TrimSpace(out); got != "https://example.com/final" {

--- a/internal/cmd/products/create.go
+++ b/internal/cmd/products/create.go
@@ -189,19 +189,21 @@ func newCreateCmd() *cobra.Command {
 					return err
 				}
 				body := buildProductJSONBody(params, buildCreateUploadFilesPayload(plannedUploads, fileURLs))
-				err = cmdutil.RunWithToken(opts, token, "Creating product...",
+				data, err := cmdutil.RunWithTokenData(opts, token, "Creating product...",
 					func(client *api.Client) (json.RawMessage, error) {
 						return client.PostJSON("/products", body)
-					},
-					func(data json.RawMessage) error {
-						resp, err := cmdutil.DecodeJSON[createProductResponse](data)
-						if err != nil {
-							return err
-						}
-						return renderCreateProductResult(opts, resp)
-					},
-				)
-				return wrapPartialUploadError(err, fileURLs)
+					})
+				if err != nil {
+					return wrapPartialUploadError(err, fileURLs)
+				}
+				if opts.UsesJSONOutput() {
+					return cmdutil.PrintJSONResponse(opts, data)
+				}
+				resp, err := cmdutil.DecodeJSON[createProductResponse](data)
+				if err != nil {
+					return err
+				}
+				return renderCreateProductResult(opts, resp)
 			}
 
 			return cmdutil.RunRequestDecoded[createProductResponse](opts,

--- a/internal/cmd/products/create.go
+++ b/internal/cmd/products/create.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/antiwork/gumroad-cli/internal/api"
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/config"
 	"github.com/antiwork/gumroad-cli/internal/output"
@@ -66,9 +67,9 @@ type dryRunCreateUpload struct {
 }
 
 type dryRunCreateRequest struct {
-	Method string     `json:"method"`
-	Path   string     `json:"path"`
-	Params url.Values `json:"params,omitempty"`
+	Method string         `json:"method"`
+	Path   string         `json:"path"`
+	Body   map[string]any `json:"body,omitempty"`
 }
 
 type dryRunCreatePayload struct {
@@ -179,8 +180,8 @@ func newCreateCmd() *cobra.Command {
 					for i := range plannedUploads {
 						fileURLs[i] = dryRunFilePlaceholder(i)
 					}
-					appendCreateUploadParams(params, plannedUploads, fileURLs)
-					return renderCreateDryRun(opts, plannedUploads, params)
+					body := buildCreateProductJSONBody(params, buildCreateUploadFilesPayload(plannedUploads, fileURLs))
+					return renderCreateDryRun(opts, plannedUploads, body)
 				}
 
 				token, err := config.Token()
@@ -198,28 +199,25 @@ func newCreateCmd() *cobra.Command {
 						return err
 					}
 				}
-				appendCreateUploadParams(params, plannedUploads, fileURLs)
+				body := buildCreateProductJSONBody(params, buildCreateUploadFilesPayload(plannedUploads, fileURLs))
+				return cmdutil.RunWithToken(opts, token, "Creating product...",
+					func(client *api.Client) (json.RawMessage, error) {
+						return client.PostJSON("/products", body)
+					},
+					func(data json.RawMessage) error {
+						resp, err := cmdutil.DecodeJSON[createProductResponse](data)
+						if err != nil {
+							return err
+						}
+						return renderCreateProductResult(opts, resp)
+					},
+				)
 			}
 
 			return cmdutil.RunRequestDecoded[createProductResponse](opts,
 				"Creating product...", "POST", "/products", params,
 				func(resp createProductResponse) error {
-					p := resp.Product
-					if opts.PlainOutput {
-						return output.PrintPlain(opts.Out(), [][]string{
-							{p.ID, p.Name, p.FormattedPrice},
-						})
-					}
-					if opts.Quiet {
-						return nil
-					}
-					s := opts.Style()
-					if err := output.Writef(opts.Out(), "%s %s (%s)\n",
-						s.Bold("Created draft product:"), p.Name, s.Dim(p.ID)); err != nil {
-						return err
-					}
-					return output.Writef(opts.Out(), "\n%s gumroad products publish %s\n",
-						s.Dim("Publish with:"), p.ID)
+					return renderCreateProductResult(opts, resp)
 				})
 		},
 	}
@@ -295,23 +293,52 @@ func alignCreateUploadValues(c *cobra.Command, flagName string, values []string,
 	}
 }
 
-func appendCreateUploadParams(params url.Values, uploads []createUploadInput, fileURLs []string) {
+func buildCreateUploadFilesPayload(uploads []createUploadInput, fileURLs []string) []map[string]any {
+	files := make([]map[string]any, 0, len(uploads))
 	for i, planned := range uploads {
-		params.Set(fmt.Sprintf("files[%d][url]", i), fileURLs[i])
+		entry := map[string]any{"url": fileURLs[i]}
 		if planned.DisplayName != "" {
-			params.Set(fmt.Sprintf("files[%d][display_name]", i), planned.DisplayName)
+			entry["display_name"] = planned.DisplayName
 		}
 		if planned.Description != "" {
-			params.Set(fmt.Sprintf("files[%d][description]", i), planned.Description)
+			entry["description"] = planned.Description
 		}
+		files = append(files, entry)
 	}
+	return files
 }
 
 func dryRunFilePlaceholder(i int) string {
 	return fmt.Sprintf("<uploaded:file:%d>", i)
 }
 
-func renderCreateDryRun(opts cmdutil.Options, uploads []createUploadInput, params url.Values) error {
+func buildCreateProductJSONBody(params url.Values, files []map[string]any) map[string]any {
+	body := make(map[string]any, len(params)+1)
+	keys := make([]string, 0, len(params))
+	for key := range params {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		values := append([]string(nil), params[key]...)
+		switch key {
+		case "tags[]":
+			body["tags"] = values
+		default:
+			if len(values) == 1 {
+				body[key] = values[0]
+			} else if len(values) > 1 {
+				body[key] = values
+			}
+		}
+	}
+
+	body["files"] = files
+	return body
+}
+
+func renderCreateDryRun(opts cmdutil.Options, uploads []createUploadInput, body map[string]any) error {
 	if opts.UsesJSONOutput() {
 		payload := dryRunCreatePayload{
 			DryRun:  true,
@@ -319,7 +346,7 @@ func renderCreateDryRun(opts cmdutil.Options, uploads []createUploadInput, param
 			Request: dryRunCreateRequest{
 				Method: "POST",
 				Path:   "/products",
-				Params: cmdutil.CloneValues(params),
+				Body:   body,
 			},
 		}
 		for _, planned := range uploads {
@@ -351,7 +378,11 @@ func renderCreateDryRun(opts cmdutil.Options, uploads []createUploadInput, param
 				return err
 			}
 		}
-		return cmdutil.PrintDryRunRequest(opts, "POST", "/products", params)
+		data, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("could not encode dry-run output: %w", err)
+		}
+		return output.PrintPlain(opts.Out(), [][]string{{"POST", "/products", string(data)}})
 	}
 
 	for _, planned := range uploads {
@@ -359,7 +390,15 @@ func renderCreateDryRun(opts cmdutil.Options, uploads []createUploadInput, param
 			return err
 		}
 	}
-	return cmdutil.PrintDryRunRequest(opts, "POST", "/products", params)
+	style := opts.Style()
+	if err := output.Writeln(opts.Out(), style.Yellow("Dry run")+": POST /products"); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(body, "", "  ")
+	if err != nil {
+		return fmt.Errorf("could not encode dry-run output: %w", err)
+	}
+	return output.Writeln(opts.Out(), string(data))
 }
 
 func renderCreateUploadDryRun(opts cmdutil.Options, plan upload.Plan) error {
@@ -375,4 +414,23 @@ func renderCreateUploadDryRun(opts cmdutil.Options, plan upload.Plan) error {
 		parts = fmt.Sprintf("%d parts", plan.PartCount)
 	}
 	return output.Writef(opts.Out(), "Size: %s (%s)\n", uploadui.HumanBytes(plan.Size), parts)
+}
+
+func renderCreateProductResult(opts cmdutil.Options, resp createProductResponse) error {
+	p := resp.Product
+	if opts.PlainOutput {
+		return output.PrintPlain(opts.Out(), [][]string{
+			{p.ID, p.Name, p.FormattedPrice},
+		})
+	}
+	if opts.Quiet {
+		return nil
+	}
+	s := opts.Style()
+	if err := output.Writef(opts.Out(), "%s %s (%s)\n",
+		s.Bold("Created draft product:"), p.Name, s.Dim(p.ID)); err != nil {
+		return err
+	}
+	return output.Writef(opts.Out(), "\n%s gumroad products publish %s\n",
+		s.Dim("Publish with:"), p.ID)
 }

--- a/internal/cmd/products/create.go
+++ b/internal/cmd/products/create.go
@@ -312,6 +312,27 @@ func dryRunFilePlaceholder(i int) string {
 	return fmt.Sprintf("<uploaded:file:%d>", i)
 }
 
+func dryRunProductUpload(plan upload.Plan) dryRunCreateUpload {
+	return dryRunCreateUpload{
+		Action:    "upload",
+		Path:      plan.Path,
+		Filename:  plan.Filename,
+		Size:      plan.Size,
+		PartSize:  plan.PartSize,
+		PartCount: plan.PartCount,
+	}
+}
+
+func renderProductUploadDryRunPlain(opts cmdutil.Options, plan upload.Plan) error {
+	return output.PrintPlain(opts.Out(), [][]string{{
+		"upload",
+		plan.Path,
+		plan.Filename,
+		strconv.FormatInt(plan.Size, 10),
+		strconv.Itoa(plan.PartCount),
+	}})
+}
+
 func renderCreateDryRun(opts cmdutil.Options, uploads []createUploadInput, body map[string]any) error {
 	if opts.UsesJSONOutput() {
 		payload := dryRunCreatePayload{
@@ -324,14 +345,7 @@ func renderCreateDryRun(opts cmdutil.Options, uploads []createUploadInput, body 
 			},
 		}
 		for _, planned := range uploads {
-			payload.Uploads = append(payload.Uploads, dryRunCreateUpload{
-				Action:    "upload",
-				Path:      planned.Plan.Path,
-				Filename:  planned.Plan.Filename,
-				Size:      planned.Plan.Size,
-				PartSize:  planned.Plan.PartSize,
-				PartCount: planned.Plan.PartCount,
-			})
+			payload.Uploads = append(payload.Uploads, dryRunProductUpload(planned.Plan))
 		}
 		data, err := json.Marshal(payload)
 		if err != nil {
@@ -342,13 +356,7 @@ func renderCreateDryRun(opts cmdutil.Options, uploads []createUploadInput, body 
 
 	if opts.PlainOutput {
 		for _, planned := range uploads {
-			if err := output.PrintPlain(opts.Out(), [][]string{{
-				"upload",
-				planned.Plan.Path,
-				planned.Plan.Filename,
-				strconv.FormatInt(planned.Plan.Size, 10),
-				strconv.Itoa(planned.Plan.PartCount),
-			}}); err != nil {
+			if err := renderProductUploadDryRunPlain(opts, planned.Plan); err != nil {
 				return err
 			}
 		}
@@ -360,7 +368,7 @@ func renderCreateDryRun(opts cmdutil.Options, uploads []createUploadInput, body 
 	}
 
 	for _, planned := range uploads {
-		if err := renderCreateUploadDryRun(opts, planned.Plan); err != nil {
+		if err := renderProductUploadDryRun(opts, planned.Plan); err != nil {
 			return err
 		}
 	}
@@ -375,7 +383,7 @@ func renderCreateDryRun(opts cmdutil.Options, uploads []createUploadInput, body 
 	return output.Writeln(opts.Out(), string(data))
 }
 
-func renderCreateUploadDryRun(opts cmdutil.Options, plan upload.Plan) error {
+func renderProductUploadDryRun(opts cmdutil.Options, plan upload.Plan) error {
 	style := opts.Style()
 	if err := output.Writeln(opts.Out(), style.Yellow("Dry run")+": upload "+plan.Path); err != nil {
 		return err

--- a/internal/cmd/products/create.go
+++ b/internal/cmd/products/create.go
@@ -3,7 +3,6 @@ package products
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"net/url"
 	"sort"
 	"strconv"
@@ -45,10 +44,6 @@ var validSubscriptionDurations = map[string]bool{
 	"monthly": true, "quarterly": true, "biannually": true,
 	"yearly": true, "every_two_years": true,
 }
-
-// s3HTTPClientForTesting redirects multipart PUTs at a test TLS server. Tests
-// in this package must not use t.Parallel while mutating this hook.
-var s3HTTPClientForTesting *http.Client
 
 type createUploadInput struct {
 	Path        string
@@ -175,12 +170,12 @@ func newCreateCmd() *cobra.Command {
 			}
 
 			if len(plannedUploads) > 0 {
-				fileURLs := make([]string, len(plannedUploads))
 				if opts.DryRun {
+					fileURLs := make([]string, len(plannedUploads))
 					for i := range plannedUploads {
 						fileURLs[i] = dryRunFilePlaceholder(i)
 					}
-					body := buildCreateProductJSONBody(params, buildCreateUploadFilesPayload(plannedUploads, fileURLs))
+					body := buildProductJSONBody(params, buildCreateUploadFilesPayload(plannedUploads, fileURLs))
 					return renderCreateDryRun(opts, plannedUploads, body)
 				}
 
@@ -189,17 +184,11 @@ func newCreateCmd() *cobra.Command {
 					return err
 				}
 				client := cmdutil.NewAPIClient(opts, token)
-				for i, planned := range plannedUploads {
-					statusLabel := planned.Plan.Filename
-					if len(plannedUploads) > 1 {
-						statusLabel = fmt.Sprintf("%s (%d/%d)", planned.Plan.Filename, i+1, len(plannedUploads))
-					}
-					fileURLs[i], err = uploadui.UploadFile(opts, client, planned.Path, planned.Plan, s3HTTPClientForTesting, statusLabel)
-					if err != nil {
-						return err
-					}
+				fileURLs, err := uploadBatch(opts, client, createBatchUploadInputs(plannedUploads))
+				if err != nil {
+					return err
 				}
-				body := buildCreateProductJSONBody(params, buildCreateUploadFilesPayload(plannedUploads, fileURLs))
+				body := buildProductJSONBody(params, buildCreateUploadFilesPayload(plannedUploads, fileURLs))
 				return cmdutil.RunWithToken(opts, token, "Creating product...",
 					func(client *api.Client) (json.RawMessage, error) {
 						return client.PostJSON("/products", body)
@@ -308,34 +297,19 @@ func buildCreateUploadFilesPayload(uploads []createUploadInput, fileURLs []strin
 	return files
 }
 
-func dryRunFilePlaceholder(i int) string {
-	return fmt.Sprintf("<uploaded:file:%d>", i)
-}
-
-func buildCreateProductJSONBody(params url.Values, files []map[string]any) map[string]any {
-	body := make(map[string]any, len(params)+1)
-	keys := make([]string, 0, len(params))
-	for key := range params {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-
-	for _, key := range keys {
-		values := append([]string(nil), params[key]...)
-		switch key {
-		case "tags[]":
-			body["tags"] = values
-		default:
-			if len(values) == 1 {
-				body[key] = values[0]
-			} else if len(values) > 1 {
-				body[key] = values
-			}
+func createBatchUploadInputs(uploads []createUploadInput) []batchUploadInput {
+	inputs := make([]batchUploadInput, len(uploads))
+	for i, current := range uploads {
+		inputs[i] = batchUploadInput{
+			Path: current.Path,
+			Plan: current.Plan,
 		}
 	}
+	return inputs
+}
 
-	body["files"] = files
-	return body
+func dryRunFilePlaceholder(i int) string {
+	return fmt.Sprintf("<uploaded:file:%d>", i)
 }
 
 func renderCreateDryRun(opts cmdutil.Options, uploads []createUploadInput, body map[string]any) error {

--- a/internal/cmd/products/create.go
+++ b/internal/cmd/products/create.go
@@ -189,7 +189,7 @@ func newCreateCmd() *cobra.Command {
 					return err
 				}
 				body := buildProductJSONBody(params, buildCreateUploadFilesPayload(plannedUploads, fileURLs))
-				return cmdutil.RunWithToken(opts, token, "Creating product...",
+				err = cmdutil.RunWithToken(opts, token, "Creating product...",
 					func(client *api.Client) (json.RawMessage, error) {
 						return client.PostJSON("/products", body)
 					},
@@ -201,6 +201,7 @@ func newCreateCmd() *cobra.Command {
 						return renderCreateProductResult(opts, resp)
 					},
 				)
+				return wrapPartialUploadError(err, fileURLs)
 			}
 
 			return cmdutil.RunRequestDecoded[createProductResponse](opts,

--- a/internal/cmd/products/create_files_test.go
+++ b/internal/cmd/products/create_files_test.go
@@ -22,6 +22,7 @@ type createUploadServers struct {
 	mu               sync.Mutex
 	presignFilenames []string
 	productJSON      map[string]any
+	productStatus    int
 	s3Calls          int
 	completeCalls    int
 	abortCalls       int
@@ -108,7 +109,12 @@ func (srv *createUploadServers) dispatch(t *testing.T) http.HandlerFunc {
 			}
 			srv.mu.Lock()
 			srv.productJSON = body
+			status := srv.productStatus
 			srv.mu.Unlock()
+			if status != 0 {
+				http.Error(w, "product failed", status)
+				return
+			}
 
 			testutil.JSON(t, w, map[string]any{
 				"product": map[string]any{
@@ -394,5 +400,38 @@ func TestCreate_WithFiles_PartialFailureIncludesUploadedURLs(t *testing.T) {
 	}
 	if completeCalls != 2 {
 		t.Fatalf("complete calls = %d, want 2", completeCalls)
+	}
+}
+
+func TestCreate_WithFiles_ProductCreateFailureIncludesUploadedURLs(t *testing.T) {
+	srv := newCreateUploadServers(t)
+	srv.productStatus = http.StatusBadGateway
+	testutil.Setup(t, srv.dispatch(t))
+
+	path := writeCreateFixture(t, "first")
+	cmd := testutil.Command(newCreateCmd())
+	cmd.SetArgs([]string{
+		"--name", "Art Pack",
+		"--price", "10.00",
+		"--file", path,
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected create failure")
+	}
+	if !strings.Contains(err.Error(), "https://example.com/uploads/up-1") {
+		t.Fatalf("expected uploaded URL in error, got %v", err)
+	}
+
+	_, productJSON, s3Calls, completeCalls := srv.snapshot()
+	if len(productJSON) == 0 {
+		t.Fatal("expected product create payload to be attempted")
+	}
+	if s3Calls != 1 {
+		t.Fatalf("S3 calls = %d, want 1", s3Calls)
+	}
+	if completeCalls != 1 {
+		t.Fatalf("complete calls = %d, want 1", completeCalls)
 	}
 }

--- a/internal/cmd/products/create_files_test.go
+++ b/internal/cmd/products/create_files_test.go
@@ -24,7 +24,9 @@ type createUploadServers struct {
 	productJSON      map[string]any
 	s3Calls          int
 	completeCalls    int
+	abortCalls       int
 	presignCalls     int
+	failCompleteOn   int
 }
 
 func newCreateUploadServers(t *testing.T) *createUploadServers {
@@ -84,11 +86,21 @@ func (srv *createUploadServers) dispatch(t *testing.T) http.HandlerFunc {
 			}
 			srv.mu.Lock()
 			srv.completeCalls++
+			completeCalls := srv.completeCalls
 			srv.mu.Unlock()
+			if srv.failCompleteOn == completeCalls {
+				http.Error(w, "complete failed", http.StatusBadGateway)
+				return
+			}
 
 			testutil.JSON(t, w, map[string]any{
 				"file_url": "https://example.com/uploads/" + body["upload_id"].(string),
 			})
+		case "/files/abort":
+			srv.mu.Lock()
+			srv.abortCalls++
+			srv.mu.Unlock()
+			testutil.JSON(t, w, map[string]any{})
 		case "/products":
 			var body map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -346,5 +358,41 @@ func TestCreate_FileMetadataCountMustMatchFiles(t *testing.T) {
 				t.Fatalf("error = %v, want %q", err, tt.want)
 			}
 		})
+	}
+}
+
+func TestCreate_WithFiles_PartialFailureIncludesUploadedURLs(t *testing.T) {
+	srv := newCreateUploadServers(t)
+	srv.failCompleteOn = 2
+	testutil.Setup(t, srv.dispatch(t))
+
+	firstPath := writeCreateFixture(t, "first")
+	secondPath := writeCreateFixture(t, "second")
+
+	cmd := testutil.Command(newCreateCmd())
+	cmd.SetArgs([]string{
+		"--name", "Art Pack",
+		"--price", "10.00",
+		"--file", firstPath,
+		"--file", secondPath,
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected upload failure")
+	}
+	if !strings.Contains(err.Error(), "https://example.com/uploads/up-1") {
+		t.Fatalf("expected uploaded URL in error, got %v", err)
+	}
+
+	_, productJSON, s3Calls, completeCalls := srv.snapshot()
+	if len(productJSON) != 0 {
+		t.Fatalf("unexpected product create payload: %#v", productJSON)
+	}
+	if s3Calls != 2 {
+		t.Fatalf("S3 calls = %d, want 2", s3Calls)
+	}
+	if completeCalls != 2 {
+		t.Fatalf("complete calls = %d, want 2", completeCalls)
 	}
 }

--- a/internal/cmd/products/create_files_test.go
+++ b/internal/cmd/products/create_files_test.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -22,7 +21,7 @@ type createUploadServers struct {
 
 	mu               sync.Mutex
 	presignFilenames []string
-	productForm      url.Values
+	productJSON      map[string]any
 	s3Calls          int
 	completeCalls    int
 	presignCalls     int
@@ -59,12 +58,11 @@ func (srv *createUploadServers) dispatch(t *testing.T) http.HandlerFunc {
 	t.Helper()
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		if err := r.ParseForm(); err != nil {
-			t.Fatalf("parse form: %v", err)
-		}
-
 		switch r.URL.Path {
 		case "/files/presign":
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("parse form: %v", err)
+			}
 			srv.mu.Lock()
 			srv.presignCalls++
 			n := srv.presignCalls
@@ -80,22 +78,30 @@ func (srv *createUploadServers) dispatch(t *testing.T) http.HandlerFunc {
 				},
 			})
 		case "/files/complete":
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode complete body: %v", err)
+			}
 			srv.mu.Lock()
 			srv.completeCalls++
 			srv.mu.Unlock()
 
 			testutil.JSON(t, w, map[string]any{
-				"file_url": "https://example.com/uploads/" + r.PostForm.Get("upload_id"),
+				"file_url": "https://example.com/uploads/" + body["upload_id"].(string),
 			})
 		case "/products":
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode product body: %v", err)
+			}
 			srv.mu.Lock()
-			srv.productForm = cloneURLValues(r.PostForm)
+			srv.productJSON = body
 			srv.mu.Unlock()
 
 			testutil.JSON(t, w, map[string]any{
 				"product": map[string]any{
 					"id":              "prod-upload",
-					"name":            r.PostForm.Get("name"),
+					"name":            body["name"],
 					"formatted_price": "$10",
 				},
 			})
@@ -106,18 +112,20 @@ func (srv *createUploadServers) dispatch(t *testing.T) http.HandlerFunc {
 	}
 }
 
-func (srv *createUploadServers) snapshot() ([]string, url.Values, int, int) {
+func (srv *createUploadServers) snapshot() ([]string, map[string]any, int, int) {
 	srv.mu.Lock()
 	defer srv.mu.Unlock()
-	return append([]string(nil), srv.presignFilenames...), cloneURLValues(srv.productForm), srv.s3Calls, srv.completeCalls
-}
-
-func cloneURLValues(values url.Values) url.Values {
-	cloned := make(url.Values, len(values))
-	for key, current := range values {
-		cloned[key] = append([]string(nil), current...)
+	productJSON := map[string]any{}
+	if srv.productJSON != nil {
+		data, err := json.Marshal(srv.productJSON)
+		if err != nil {
+			panic(err)
+		}
+		if err := json.Unmarshal(data, &productJSON); err != nil {
+			panic(err)
+		}
 	}
-	return cloned
+	return append([]string(nil), srv.presignFilenames...), productJSON, srv.s3Calls, srv.completeCalls
 }
 
 func writeCreateFixture(t *testing.T, contents string) string {
@@ -128,6 +136,24 @@ func writeCreateFixture(t *testing.T, contents string) string {
 		t.Fatalf("write fixture: %v", err)
 	}
 	return path
+}
+
+func createJSONFiles(t *testing.T, body map[string]any) []map[string]any {
+	t.Helper()
+
+	raw, ok := body["files"].([]any)
+	if !ok {
+		t.Fatalf("files payload has wrong type: %T", body["files"])
+	}
+	files := make([]map[string]any, len(raw))
+	for i, current := range raw {
+		file, ok := current.(map[string]any)
+		if !ok {
+			t.Fatalf("files[%d] has wrong type: %T", i, current)
+		}
+		files[i] = file
+	}
+	return files
 }
 
 func TestCreate_WithFiles_UploadsAndPostsIndexedFields(t *testing.T) {
@@ -151,27 +177,31 @@ func TestCreate_WithFiles_UploadsAndPostsIndexedFields(t *testing.T) {
 
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	presignFilenames, productForm, s3Calls, completeCalls := srv.snapshot()
+	presignFilenames, productJSON, s3Calls, completeCalls := srv.snapshot()
 	if !reflect.DeepEqual(presignFilenames, []string{"Custom One.zip", filepath.Base(secondPath)}) {
 		t.Fatalf("presign filenames = %v", presignFilenames)
 	}
-	if got := productForm.Get("files[0][url]"); got != "https://example.com/uploads/up-1" {
-		t.Fatalf("files[0][url] = %q", got)
+	files := createJSONFiles(t, productJSON)
+	if len(files) != 2 {
+		t.Fatalf("files payload len = %d, want 2", len(files))
 	}
-	if got := productForm.Get("files[0][display_name]"); got != "Custom One.zip" {
-		t.Fatalf("files[0][display_name] = %q", got)
+	if got := files[0]["url"]; got != "https://example.com/uploads/up-1" {
+		t.Fatalf("files[0].url = %#v", got)
 	}
-	if got := productForm.Get("files[0][description]"); got != "" {
-		t.Fatalf("files[0][description] = %q, want empty", got)
+	if got := files[0]["display_name"]; got != "Custom One.zip" {
+		t.Fatalf("files[0].display_name = %#v", got)
 	}
-	if got := productForm.Get("files[1][url]"); got != "https://example.com/uploads/up-2" {
-		t.Fatalf("files[1][url] = %q", got)
+	if _, ok := files[0]["description"]; ok {
+		t.Fatalf("files[0].description should be omitted, got %#v", files[0]["description"])
 	}
-	if got := productForm.Get("files[1][display_name]"); got != "" {
-		t.Fatalf("files[1][display_name] = %q, want empty", got)
+	if got := files[1]["url"]; got != "https://example.com/uploads/up-2" {
+		t.Fatalf("files[1].url = %#v", got)
 	}
-	if got := productForm.Get("files[1][description]"); got != "Second file" {
-		t.Fatalf("files[1][description] = %q", got)
+	if _, ok := files[1]["display_name"]; ok {
+		t.Fatalf("files[1].display_name should be omitted, got %#v", files[1]["display_name"])
+	}
+	if got := files[1]["description"]; got != "Second file" {
+		t.Fatalf("files[1].description = %#v", got)
 	}
 	if s3Calls != 2 {
 		t.Fatalf("S3 calls = %d, want 2", s3Calls)
@@ -213,10 +243,10 @@ func TestCreate_WithFiles_DryRunPrintsUploadsAndPlaceholderRequest(t *testing.T)
 	if !strings.Contains(out, "Dry run: POST /products") {
 		t.Fatalf("missing create request: %q", out)
 	}
-	if !strings.Contains(out, "files[0][url]: <uploaded:file:0>") {
+	if !strings.Contains(out, "uploaded:file:0") {
 		t.Fatalf("missing first placeholder URL: %q", out)
 	}
-	if !strings.Contains(out, "files[1][description]: Second file") {
+	if !strings.Contains(out, "\"description\": \"Second file\"") {
 		t.Fatalf("missing second description: %q", out)
 	}
 }
@@ -254,14 +284,18 @@ func TestCreate_WithFiles_DryRunJSONIncludesUploadsAndRequest(t *testing.T) {
 	if payload.Request.Method != "POST" || payload.Request.Path != "/products" {
 		t.Fatalf("request = %+v", payload.Request)
 	}
-	if got := payload.Request.Params.Get("files[0][url]"); got != "<uploaded:file:0>" {
-		t.Fatalf("files[0][url] = %q", got)
+	files := createJSONFiles(t, payload.Request.Body)
+	if len(files) != 1 {
+		t.Fatalf("files payload len = %d, want 1", len(files))
 	}
-	if got := payload.Request.Params.Get("files[0][display_name]"); got != "Gift.zip" {
-		t.Fatalf("files[0][display_name] = %q", got)
+	if got := files[0]["url"]; got != "<uploaded:file:0>" {
+		t.Fatalf("files[0].url = %#v", got)
 	}
-	if got := payload.Request.Params.Get("files[0][description]"); got != "Bonus download" {
-		t.Fatalf("files[0][description] = %q", got)
+	if got := files[0]["display_name"]; got != "Gift.zip" {
+		t.Fatalf("files[0].display_name = %#v", got)
+	}
+	if got := files[0]["description"]; got != "Bonus download" {
+		t.Fatalf("files[0].description = %#v", got)
 	}
 }
 

--- a/internal/cmd/products/create_files_test.go
+++ b/internal/cmd/products/create_files_test.go
@@ -435,3 +435,38 @@ func TestCreate_WithFiles_ProductCreateFailureIncludesUploadedURLs(t *testing.T)
 		t.Fatalf("complete calls = %d, want 1", completeCalls)
 	}
 }
+
+func TestCreate_WithFiles_RenderFailureDoesNotIncludeUploadedURLs(t *testing.T) {
+	srv := newCreateUploadServers(t)
+	testutil.Setup(t, srv.dispatch(t))
+
+	path := writeCreateFixture(t, "first")
+	cmd := testutil.Command(newCreateCmd(), testutil.JSONOutput(), testutil.JQ(".bad[syntax"))
+	cmd.SetArgs([]string{
+		"--name", "Art Pack",
+		"--price", "10.00",
+		"--file", path,
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected render failure")
+	}
+	if !strings.Contains(err.Error(), "invalid jq expression") {
+		t.Fatalf("expected jq error, got %v", err)
+	}
+	if strings.Contains(err.Error(), "https://example.com/uploads/up-1") {
+		t.Fatalf("unexpected uploaded URL in render error: %v", err)
+	}
+
+	_, productJSON, s3Calls, completeCalls := srv.snapshot()
+	if len(productJSON) == 0 {
+		t.Fatal("expected product create payload to be attempted")
+	}
+	if s3Calls != 1 {
+		t.Fatalf("S3 calls = %d, want 1", s3Calls)
+	}
+	if completeCalls != 1 {
+		t.Fatalf("complete calls = %d, want 1", completeCalls)
+	}
+}

--- a/internal/cmd/products/file_updates.go
+++ b/internal/cmd/products/file_updates.go
@@ -1,0 +1,408 @@
+package products
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/upload"
+	"github.com/spf13/cobra"
+)
+
+// productUploadHTTPClientForTesting redirects S3 part PUTs at a test server.
+// Production leaves this nil so upload.Upload falls back to its shared client.
+// Tests in this package must not use t.Parallel while mutating this var.
+var productUploadHTTPClientForTesting *http.Client
+
+type requestedProductUpload struct {
+	Path        string
+	DisplayName string
+	Description string
+}
+
+type plannedProductUpload struct {
+	requestedProductUpload
+	Plan upload.Plan
+}
+
+type existingProductFile struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
+type productFileUpdatePlan struct {
+	Existing  []existingProductFile
+	Preserved []existingProductFile
+	Removed   []existingProductFile
+	Uploads   []requestedProductUpload
+}
+
+type productFilesResponse struct {
+	Product struct {
+		Files []existingProductFile `json:"files"`
+	} `json:"product"`
+}
+
+type dryRunUpdateBody struct {
+	DryRun bool           `json:"dry_run"`
+	Method string         `json:"method"`
+	Path   string         `json:"path"`
+	Body   map[string]any `json:"body"`
+}
+
+func collectRequestedProductUploads(
+	cmd *cobra.Command,
+	paths, names, descriptions []string,
+) ([]requestedProductUpload, error) {
+	if len(names) != 0 && len(names) != len(paths) {
+		return nil, cmdutil.UsageErrorf(cmd,
+			"--file-name must be provided either zero times or exactly once per --file")
+	}
+	if len(descriptions) != 0 && len(descriptions) != len(paths) {
+		return nil, cmdutil.UsageErrorf(cmd,
+			"--file-description must be provided either zero times or exactly once per --file")
+	}
+
+	uploads := make([]requestedProductUpload, len(paths))
+	for i, path := range paths {
+		uploadSpec := requestedProductUpload{Path: path}
+		if len(names) != 0 {
+			uploadSpec.DisplayName = names[i]
+		}
+		if len(descriptions) != 0 {
+			uploadSpec.Description = descriptions[i]
+		}
+		uploads[i] = uploadSpec
+	}
+	return uploads, nil
+}
+
+func fetchExistingProductFiles(client *api.Client, productID string) ([]existingProductFile, error) {
+	data, err := client.Get(cmdutil.JoinPath("products", productID), url.Values{})
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := cmdutil.DecodeJSON[productFilesResponse](data)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Product.Files, nil
+}
+
+func planProductFileUpdate(
+	cmd *cobra.Command,
+	existing []existingProductFile,
+	uploads []requestedProductUpload,
+	keepIDs, removeIDs []string,
+	replaceFiles bool,
+) (productFileUpdatePlan, error) {
+	if len(keepIDs) > 0 && !replaceFiles {
+		return productFileUpdatePlan{}, cmdutil.UsageErrorf(cmd,
+			"--keep-file can only be used together with --replace-files")
+	}
+
+	keepSet := make(map[string]struct{}, len(keepIDs))
+	for _, id := range keepIDs {
+		keepSet[id] = struct{}{}
+	}
+	removeSet := make(map[string]struct{}, len(removeIDs))
+	for _, id := range removeIDs {
+		removeSet[id] = struct{}{}
+	}
+
+	var conflicts []string
+	for id := range keepSet {
+		if _, ok := removeSet[id]; ok {
+			conflicts = append(conflicts, id)
+		}
+	}
+	if len(conflicts) > 0 {
+		sort.Strings(conflicts)
+		return productFileUpdatePlan{}, cmdutil.UsageErrorf(cmd,
+			"cannot use --keep-file and --remove-file for the same id(s): %s",
+			joinComma(conflicts))
+	}
+
+	existingByID := make(map[string]existingProductFile, len(existing))
+	for _, file := range existing {
+		existingByID[file.ID] = file
+	}
+
+	if err := ensureKnownFileIDs(cmd, "--keep-file", keepSet, existingByID); err != nil {
+		return productFileUpdatePlan{}, err
+	}
+	if err := ensureKnownFileIDs(cmd, "--remove-file", removeSet, existingByID); err != nil {
+		return productFileUpdatePlan{}, err
+	}
+
+	plan := productFileUpdatePlan{
+		Existing: existing,
+		Uploads:  uploads,
+	}
+
+	for _, file := range existing {
+		_, explicitlyRemoved := removeSet[file.ID]
+		preserve := !replaceFiles
+		if replaceFiles {
+			_, preserve = keepSet[file.ID]
+		}
+		if explicitlyRemoved {
+			preserve = false
+		}
+
+		if preserve {
+			plan.Preserved = append(plan.Preserved, file)
+		} else {
+			plan.Removed = append(plan.Removed, file)
+		}
+	}
+
+	return plan, nil
+}
+
+func ensureKnownFileIDs(
+	cmd *cobra.Command,
+	flagName string,
+	requested map[string]struct{},
+	existing map[string]existingProductFile,
+) error {
+	if len(requested) == 0 {
+		return nil
+	}
+
+	var unknown []string
+	for id := range requested {
+		if _, ok := existing[id]; !ok {
+			unknown = append(unknown, id)
+		}
+	}
+	if len(unknown) == 0 {
+		return nil
+	}
+
+	sort.Strings(unknown)
+	return cmdutil.UsageErrorf(cmd, "unknown %s id(s): %s", flagName, joinComma(unknown))
+}
+
+func describeProductUploads(uploads []requestedProductUpload) ([]plannedProductUpload, error) {
+	planned := make([]plannedProductUpload, len(uploads))
+	for i, requested := range uploads {
+		plan, err := upload.Describe(requested.Path, upload.Options{Filename: requested.DisplayName})
+		if err != nil {
+			return nil, err
+		}
+
+		planned[i] = plannedProductUpload{
+			requestedProductUpload: requested,
+			Plan:                   plan,
+		}
+	}
+	return planned, nil
+}
+
+func appendProductFilesParams(params url.Values, plan productFileUpdatePlan, uploadURLs []string) {
+	index := 0
+	for _, file := range plan.Preserved {
+		params.Set(fmt.Sprintf("files[%d][id]", index), file.ID)
+		index++
+	}
+	for i, requested := range plan.Uploads {
+		params.Set(fmt.Sprintf("files[%d][url]", index), uploadURLs[i])
+		if requested.DisplayName != "" {
+			params.Set(fmt.Sprintf("files[%d][display_name]", index), requested.DisplayName)
+		}
+		if requested.Description != "" {
+			params.Set(fmt.Sprintf("files[%d][description]", index), requested.Description)
+		}
+		index++
+	}
+}
+
+func placeholderUploadURLs(count int) []string {
+	urls := make([]string, count)
+	for i := 0; i < count; i++ {
+		urls[i] = fmt.Sprintf("<uploaded:file:%d>", i)
+	}
+	return urls
+}
+
+func fileUpdateNeedsJSONBody(plan productFileUpdatePlan) bool {
+	return len(plan.Preserved) == 0 && len(plan.Uploads) == 0
+}
+
+func buildProductUpdateJSONBody(params url.Values, files []map[string]any) map[string]any {
+	body := make(map[string]any, len(params)+1)
+	keys := make([]string, 0, len(params))
+	for key := range params {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		values := append([]string(nil), params[key]...)
+		switch key {
+		case "tags[]":
+			body["tags"] = values
+		default:
+			if len(values) == 1 {
+				body[key] = values[0]
+			} else if len(values) > 1 {
+				body[key] = values
+			}
+		}
+	}
+
+	body["files"] = files
+	return body
+}
+
+func renderProductUpdateDryRunJSON(opts cmdutil.Options, path string, body map[string]any) error {
+	payload := dryRunUpdateBody{
+		DryRun: true,
+		Method: http.MethodPut,
+		Path:   path,
+		Body:   body,
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("could not encode dry-run output: %w", err)
+	}
+	return output.PrintJSON(opts.Out(), data, opts.JQExpr)
+}
+
+func renderProductUpdateDryRunPlain(opts cmdutil.Options, path string, body map[string]any) error {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("could not encode dry-run output: %w", err)
+	}
+	return output.PrintPlain(opts.Out(), [][]string{{
+		http.MethodPut,
+		path,
+		string(data),
+	}})
+}
+
+func renderProductUpdateDryRunHuman(opts cmdutil.Options, path string, body map[string]any) error {
+	style := opts.Style()
+	if err := output.Writeln(opts.Out(), style.Yellow("Dry run")+": "+http.MethodPut+" "+path); err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(body, "", "  ")
+	if err != nil {
+		return fmt.Errorf("could not encode dry-run output: %w", err)
+	}
+	return output.Writeln(opts.Out(), string(data))
+}
+
+func renderClearAllFilesDryRun(opts cmdutil.Options, path string, params url.Values) error {
+	body := buildProductUpdateJSONBody(params, []map[string]any{})
+	switch {
+	case opts.UsesJSONOutput():
+		return renderProductUpdateDryRunJSON(opts, path, body)
+	case opts.PlainOutput:
+		return renderProductUpdateDryRunPlain(opts, path, body)
+	default:
+		return renderProductUpdateDryRunHuman(opts, path, body)
+	}
+}
+
+func runProductUpdateJSON(
+	opts cmdutil.Options,
+	client *api.Client,
+	path, productID string,
+	body map[string]any,
+) error {
+	var sp *output.Spinner
+	if cmdutil.ShouldShowSpinner(opts) {
+		sp = output.NewSpinnerTo("Updating product...", opts.Err())
+		sp.Start()
+		defer sp.Stop()
+	}
+
+	data, err := client.PutJSON(path, body)
+	if err != nil {
+		return err
+	}
+	if sp != nil {
+		sp.Stop()
+	}
+	return cmdutil.PrintMutationSuccess(opts, data, productID, "Product "+productID+" updated.")
+}
+
+func confirmProductFileRemoval(opts cmdutil.Options, productID string, removed []existingProductFile) (bool, error) {
+	if len(removed) == 0 {
+		return true, nil
+	}
+
+	label := "1 existing file"
+	if len(removed) != 1 {
+		label = strconv.Itoa(len(removed)) + " existing files"
+	}
+
+	message := fmt.Sprintf("Update product %s and remove %s?", productID, label)
+	return cmdutil.ConfirmAction(opts, message)
+}
+
+func uploadProductFile(opts cmdutil.Options, client *api.Client, planned plannedProductUpload) (string, error) {
+	totalLabel := humanUploadBytes(planned.Plan.Size)
+	var sp *output.Spinner
+	if cmdutil.ShouldShowSpinner(opts) {
+		sp = output.NewSpinnerTo(productUploadStatus(planned.Plan.Filename, 0, totalLabel), opts.Err())
+		sp.Start()
+		defer sp.Stop()
+	}
+
+	progress := func(uploaded int64) {
+		if sp != nil {
+			sp.SetMessage(productUploadStatus(planned.Plan.Filename, uploaded, totalLabel))
+		}
+	}
+
+	fileURL, err := upload.Upload(opts.Context, client, planned.Path, upload.Options{
+		Filename:   planned.Plan.Filename,
+		Progress:   progress,
+		HTTPClient: productUploadHTTPClientForTesting,
+	})
+	if err != nil {
+		return "", err
+	}
+	if sp != nil {
+		sp.Stop()
+	}
+	return fileURL, nil
+}
+
+func productUploadStatus(filename string, uploaded int64, totalLabel string) string {
+	return fmt.Sprintf("Uploading %s %s / %s", filename, humanUploadBytes(uploaded), totalLabel)
+}
+
+// humanUploadBytes matches the file upload command's byte formatting so both
+// entry points report multipart progress consistently.
+func humanUploadBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for n/div >= unit && exp < 3 {
+		div *= unit
+		exp++
+	}
+	v := float64(n) / float64(div)
+	units := []string{"KB", "MB", "GB", "TB"}
+	return fmt.Sprintf("%.1f %s", v, units[exp])
+}
+
+func joinComma(values []string) string {
+	return strings.Join(values, ", ")
+}

--- a/internal/cmd/products/file_updates.go
+++ b/internal/cmd/products/file_updates.go
@@ -49,33 +49,37 @@ type productFilesResponse struct {
 type dryRunUpdateBody struct {
 	DryRun  bool                 `json:"dry_run"`
 	Uploads []dryRunCreateUpload `json:"uploads"`
-	Method  string               `json:"method"`
-	Path    string               `json:"path"`
-	Body    map[string]any       `json:"body"`
+	Request dryRunCreateRequest  `json:"request"`
 }
 
 func collectRequestedProductUploads(
 	cmd *cobra.Command,
 	paths, names, descriptions []string,
 ) ([]requestedProductUpload, error) {
-	if len(names) != 0 && len(names) != len(paths) {
-		return nil, cmdutil.UsageErrorf(cmd,
-			"--file-name must be provided either zero times or exactly once per --file")
+	if len(paths) == 0 {
+		if len(names) > 0 {
+			return nil, cmdutil.UsageErrorf(cmd, "--file-name requires at least one --file")
+		}
+		if len(descriptions) > 0 {
+			return nil, cmdutil.UsageErrorf(cmd, "--file-description requires at least one --file")
+		}
+		return nil, nil
 	}
-	if len(descriptions) != 0 && len(descriptions) != len(paths) {
-		return nil, cmdutil.UsageErrorf(cmd,
-			"--file-description must be provided either zero times or exactly once per --file")
+
+	alignedNames, err := alignCreateUploadValues(cmd, "--file-name", names, len(paths))
+	if err != nil {
+		return nil, err
+	}
+	alignedDescriptions, err := alignCreateUploadValues(cmd, "--file-description", descriptions, len(paths))
+	if err != nil {
+		return nil, err
 	}
 
 	uploads := make([]requestedProductUpload, len(paths))
 	for i, path := range paths {
 		uploadSpec := requestedProductUpload{Path: path}
-		if len(names) != 0 {
-			uploadSpec.DisplayName = names[i]
-		}
-		if len(descriptions) != 0 {
-			uploadSpec.Description = descriptions[i]
-		}
+		uploadSpec.DisplayName = strings.TrimSpace(alignedNames[i])
+		uploadSpec.Description = alignedDescriptions[i]
 		uploads[i] = uploadSpec
 	}
 	return uploads, nil
@@ -256,9 +260,11 @@ func renderProductUpdateDryRunJSON(
 	payload := dryRunUpdateBody{
 		DryRun:  true,
 		Uploads: make([]dryRunCreateUpload, 0, len(uploads)),
-		Method:  http.MethodPut,
-		Path:    path,
-		Body:    body,
+		Request: dryRunCreateRequest{
+			Method: http.MethodPut,
+			Path:   path,
+			Body:   body,
+		},
 	}
 	for _, planned := range uploads {
 		payload.Uploads = append(payload.Uploads, dryRunProductUpload(planned.Plan))

--- a/internal/cmd/products/file_updates.go
+++ b/internal/cmd/products/file_updates.go
@@ -386,6 +386,7 @@ func runProductUpdateJSON(
 	client *api.Client,
 	path, productID string,
 	body map[string]any,
+	uploadedURLs []string,
 ) error {
 	var sp *output.Spinner
 	if cmdutil.ShouldShowSpinner(opts) {
@@ -396,7 +397,7 @@ func runProductUpdateJSON(
 
 	data, err := client.PutJSON(path, body)
 	if err != nil {
-		return err
+		return wrapPartialUploadError(err, uploadedURLs)
 	}
 	if sp != nil {
 		sp.Stop()

--- a/internal/cmd/products/file_updates.go
+++ b/internal/cmd/products/file_updates.go
@@ -47,9 +47,16 @@ type productFilesResponse struct {
 }
 
 type dryRunUpdateBody struct {
-	DryRun  bool                 `json:"dry_run"`
-	Uploads []dryRunCreateUpload `json:"uploads"`
-	Request dryRunCreateRequest  `json:"request"`
+	DryRun    bool                 `json:"dry_run"`
+	Uploads   []dryRunCreateUpload `json:"uploads"`
+	Preserved []dryRunExistingFile `json:"preserved"`
+	Removed   []dryRunExistingFile `json:"removed"`
+	Request   dryRunCreateRequest  `json:"request"`
+}
+
+type dryRunExistingFile struct {
+	ID   string `json:"id"`
+	Name string `json:"name,omitempty"`
 }
 
 func collectRequestedProductUploads(
@@ -105,31 +112,9 @@ func planProductFileUpdate(
 	keepIDs, removeIDs []string,
 	replaceFiles bool,
 ) (productFileUpdatePlan, error) {
-	if len(keepIDs) > 0 && !replaceFiles {
-		return productFileUpdatePlan{}, cmdutil.UsageErrorf(cmd,
-			"--keep-file can only be used together with --replace-files")
-	}
-
-	keepSet := make(map[string]struct{}, len(keepIDs))
-	for _, id := range keepIDs {
-		keepSet[id] = struct{}{}
-	}
-	removeSet := make(map[string]struct{}, len(removeIDs))
-	for _, id := range removeIDs {
-		removeSet[id] = struct{}{}
-	}
-
-	var conflicts []string
-	for id := range keepSet {
-		if _, ok := removeSet[id]; ok {
-			conflicts = append(conflicts, id)
-		}
-	}
-	if len(conflicts) > 0 {
-		sort.Strings(conflicts)
-		return productFileUpdatePlan{}, cmdutil.UsageErrorf(cmd,
-			"cannot use --keep-file and --remove-file for the same id(s): %s",
-			joinComma(conflicts))
+	keepSet, removeSet, err := validateProductFileSelections(cmd, keepIDs, removeIDs, replaceFiles)
+	if err != nil {
+		return productFileUpdatePlan{}, err
 	}
 
 	existingByID := make(map[string]existingProductFile, len(existing))
@@ -209,6 +194,41 @@ func describeProductUploads(uploads []requestedProductUpload) ([]plannedProductU
 	return planned, nil
 }
 
+func validateProductFileSelections(
+	cmd *cobra.Command,
+	keepIDs, removeIDs []string,
+	replaceFiles bool,
+) (map[string]struct{}, map[string]struct{}, error) {
+	if len(keepIDs) > 0 && !replaceFiles {
+		return nil, nil, cmdutil.UsageErrorf(cmd,
+			"--keep-file can only be used together with --replace-files")
+	}
+
+	keepSet := make(map[string]struct{}, len(keepIDs))
+	for _, id := range keepIDs {
+		keepSet[id] = struct{}{}
+	}
+	removeSet := make(map[string]struct{}, len(removeIDs))
+	for _, id := range removeIDs {
+		removeSet[id] = struct{}{}
+	}
+
+	var conflicts []string
+	for id := range keepSet {
+		if _, ok := removeSet[id]; ok {
+			conflicts = append(conflicts, id)
+		}
+	}
+	if len(conflicts) > 0 {
+		sort.Strings(conflicts)
+		return nil, nil, cmdutil.UsageErrorf(cmd,
+			"cannot use --keep-file and --remove-file for the same id(s): %s",
+			joinComma(conflicts))
+	}
+
+	return keepSet, removeSet, nil
+}
+
 func buildProductUpdateFilesPayload(plan productFileUpdatePlan, uploadURLs []string) []map[string]any {
 	files := make([]map[string]any, 0, len(plan.Preserved)+len(plan.Uploads))
 	for _, file := range plan.Preserved {
@@ -238,28 +258,32 @@ func placeholderUploadURLs(count int) []string {
 func renderProductUpdateDryRun(
 	opts cmdutil.Options,
 	path string,
+	plan productFileUpdatePlan,
 	uploads []plannedProductUpload,
 	body map[string]any,
 ) error {
 	switch {
 	case opts.UsesJSONOutput():
-		return renderProductUpdateDryRunJSON(opts, path, uploads, body)
+		return renderProductUpdateDryRunJSON(opts, path, plan, uploads, body)
 	case opts.PlainOutput:
-		return renderProductUpdateDryRunPlain(opts, path, uploads, body)
+		return renderProductUpdateDryRunPlain(opts, path, plan, uploads, body)
 	default:
-		return renderProductUpdateDryRunHuman(opts, path, uploads, body)
+		return renderProductUpdateDryRunHuman(opts, path, plan, uploads, body)
 	}
 }
 
 func renderProductUpdateDryRunJSON(
 	opts cmdutil.Options,
 	path string,
+	plan productFileUpdatePlan,
 	uploads []plannedProductUpload,
 	body map[string]any,
 ) error {
 	payload := dryRunUpdateBody{
-		DryRun:  true,
-		Uploads: make([]dryRunCreateUpload, 0, len(uploads)),
+		DryRun:    true,
+		Uploads:   make([]dryRunCreateUpload, 0, len(uploads)),
+		Preserved: make([]dryRunExistingFile, 0, len(plan.Preserved)),
+		Removed:   make([]dryRunExistingFile, 0, len(plan.Removed)),
 		Request: dryRunCreateRequest{
 			Method: http.MethodPut,
 			Path:   path,
@@ -268,6 +292,12 @@ func renderProductUpdateDryRunJSON(
 	}
 	for _, planned := range uploads {
 		payload.Uploads = append(payload.Uploads, dryRunProductUpload(planned.Plan))
+	}
+	for _, current := range plan.Preserved {
+		payload.Preserved = append(payload.Preserved, dryRunExistingProductFile(current))
+	}
+	for _, current := range plan.Removed {
+		payload.Removed = append(payload.Removed, dryRunExistingProductFile(current))
 	}
 	data, err := json.Marshal(payload)
 	if err != nil {
@@ -279,9 +309,28 @@ func renderProductUpdateDryRunJSON(
 func renderProductUpdateDryRunPlain(
 	opts cmdutil.Options,
 	path string,
+	plan productFileUpdatePlan,
 	uploads []plannedProductUpload,
 	body map[string]any,
 ) error {
+	for _, current := range plan.Preserved {
+		if err := output.PrintPlain(opts.Out(), [][]string{{
+			"preserve",
+			current.ID,
+			current.Name,
+		}}); err != nil {
+			return err
+		}
+	}
+	for _, current := range plan.Removed {
+		if err := output.PrintPlain(opts.Out(), [][]string{{
+			"remove",
+			current.ID,
+			current.Name,
+		}}); err != nil {
+			return err
+		}
+	}
 	for _, planned := range uploads {
 		if err := renderProductUploadDryRunPlain(opts, planned.Plan); err != nil {
 			return err
@@ -301,9 +350,20 @@ func renderProductUpdateDryRunPlain(
 func renderProductUpdateDryRunHuman(
 	opts cmdutil.Options,
 	path string,
+	plan productFileUpdatePlan,
 	uploads []plannedProductUpload,
 	body map[string]any,
 ) error {
+	for _, current := range plan.Preserved {
+		if err := output.Writeln(opts.Out(), "Preserve existing file: "+formatExistingProductFileLabel(current)); err != nil {
+			return err
+		}
+	}
+	for _, current := range plan.Removed {
+		if err := output.Writeln(opts.Out(), "Remove existing file: "+formatExistingProductFileLabel(current)); err != nil {
+			return err
+		}
+	}
 	for _, planned := range uploads {
 		if err := renderProductUploadDryRun(opts, planned.Plan); err != nil {
 			return err
@@ -348,14 +408,56 @@ func confirmProductFileRemoval(opts cmdutil.Options, productID string, removed [
 	if len(removed) == 0 {
 		return true, nil
 	}
+	return cmdutil.ConfirmAction(opts, productFileRemovalMessage(productID, removed))
+}
 
+func dryRunExistingProductFile(file existingProductFile) dryRunExistingFile {
+	return dryRunExistingFile{
+		ID:   file.ID,
+		Name: file.Name,
+	}
+}
+
+func formatExistingProductFileLabel(file existingProductFile) string {
+	name := strings.TrimSpace(file.Name)
+	switch {
+	case name == "":
+		return file.ID
+	case name == file.ID:
+		return name
+	default:
+		return fmt.Sprintf("%s (%s)", name, file.ID)
+	}
+}
+
+func summarizeExistingProductFiles(files []existingProductFile, max int) string {
+	if len(files) == 0 {
+		return ""
+	}
+	if max <= 0 || max > len(files) {
+		max = len(files)
+	}
+	labels := make([]string, 0, max+1)
+	for _, current := range files[:max] {
+		labels = append(labels, formatExistingProductFileLabel(current))
+	}
+	if extra := len(files) - max; extra > 0 {
+		labels = append(labels, fmt.Sprintf("and %d more", extra))
+	}
+	return strings.Join(labels, ", ")
+}
+
+func productFileRemovalMessage(productID string, removed []existingProductFile) string {
 	label := "1 existing file"
 	if len(removed) != 1 {
 		label = strconv.Itoa(len(removed)) + " existing files"
 	}
 
 	message := fmt.Sprintf("Update product %s and remove %s?", productID, label)
-	return cmdutil.ConfirmAction(opts, message)
+	if summary := summarizeExistingProductFiles(removed, 5); summary != "" {
+		message = fmt.Sprintf("Update product %s and remove %s: %s?", productID, label, summary)
+	}
+	return message
 }
 
 func joinComma(values []string) string {

--- a/internal/cmd/products/file_updates.go
+++ b/internal/cmd/products/file_updates.go
@@ -47,10 +47,11 @@ type productFilesResponse struct {
 }
 
 type dryRunUpdateBody struct {
-	DryRun bool           `json:"dry_run"`
-	Method string         `json:"method"`
-	Path   string         `json:"path"`
-	Body   map[string]any `json:"body"`
+	DryRun  bool                 `json:"dry_run"`
+	Uploads []dryRunCreateUpload `json:"uploads"`
+	Method  string               `json:"method"`
+	Path    string               `json:"path"`
+	Body    map[string]any       `json:"body"`
 }
 
 func collectRequestedProductUploads(
@@ -230,23 +231,37 @@ func placeholderUploadURLs(count int) []string {
 	return urls
 }
 
-func renderProductUpdateDryRun(opts cmdutil.Options, path string, body map[string]any) error {
+func renderProductUpdateDryRun(
+	opts cmdutil.Options,
+	path string,
+	uploads []plannedProductUpload,
+	body map[string]any,
+) error {
 	switch {
 	case opts.UsesJSONOutput():
-		return renderProductUpdateDryRunJSON(opts, path, body)
+		return renderProductUpdateDryRunJSON(opts, path, uploads, body)
 	case opts.PlainOutput:
-		return renderProductUpdateDryRunPlain(opts, path, body)
+		return renderProductUpdateDryRunPlain(opts, path, uploads, body)
 	default:
-		return renderProductUpdateDryRunHuman(opts, path, body)
+		return renderProductUpdateDryRunHuman(opts, path, uploads, body)
 	}
 }
 
-func renderProductUpdateDryRunJSON(opts cmdutil.Options, path string, body map[string]any) error {
+func renderProductUpdateDryRunJSON(
+	opts cmdutil.Options,
+	path string,
+	uploads []plannedProductUpload,
+	body map[string]any,
+) error {
 	payload := dryRunUpdateBody{
-		DryRun: true,
-		Method: http.MethodPut,
-		Path:   path,
-		Body:   body,
+		DryRun:  true,
+		Uploads: make([]dryRunCreateUpload, 0, len(uploads)),
+		Method:  http.MethodPut,
+		Path:    path,
+		Body:    body,
+	}
+	for _, planned := range uploads {
+		payload.Uploads = append(payload.Uploads, dryRunProductUpload(planned.Plan))
 	}
 	data, err := json.Marshal(payload)
 	if err != nil {
@@ -255,7 +270,17 @@ func renderProductUpdateDryRunJSON(opts cmdutil.Options, path string, body map[s
 	return output.PrintJSON(opts.Out(), data, opts.JQExpr)
 }
 
-func renderProductUpdateDryRunPlain(opts cmdutil.Options, path string, body map[string]any) error {
+func renderProductUpdateDryRunPlain(
+	opts cmdutil.Options,
+	path string,
+	uploads []plannedProductUpload,
+	body map[string]any,
+) error {
+	for _, planned := range uploads {
+		if err := renderProductUploadDryRunPlain(opts, planned.Plan); err != nil {
+			return err
+		}
+	}
 	data, err := json.Marshal(body)
 	if err != nil {
 		return fmt.Errorf("could not encode dry-run output: %w", err)
@@ -267,7 +292,17 @@ func renderProductUpdateDryRunPlain(opts cmdutil.Options, path string, body map[
 	}})
 }
 
-func renderProductUpdateDryRunHuman(opts cmdutil.Options, path string, body map[string]any) error {
+func renderProductUpdateDryRunHuman(
+	opts cmdutil.Options,
+	path string,
+	uploads []plannedProductUpload,
+	body map[string]any,
+) error {
+	for _, planned := range uploads {
+		if err := renderProductUploadDryRun(opts, planned.Plan); err != nil {
+			return err
+		}
+	}
 	style := opts.Style()
 	if err := output.Writeln(opts.Out(), style.Yellow("Dry run")+": "+http.MethodPut+" "+path); err != nil {
 		return err

--- a/internal/cmd/products/file_updates.go
+++ b/internal/cmd/products/file_updates.go
@@ -209,22 +209,22 @@ func describeProductUploads(uploads []requestedProductUpload) ([]plannedProductU
 	return planned, nil
 }
 
-func appendProductFilesParams(params url.Values, plan productFileUpdatePlan, uploadURLs []string) {
-	index := 0
+func buildProductUpdateFilesPayload(plan productFileUpdatePlan, uploadURLs []string) []map[string]any {
+	files := make([]map[string]any, 0, len(plan.Preserved)+len(plan.Uploads))
 	for _, file := range plan.Preserved {
-		params.Set(fmt.Sprintf("files[%d][id]", index), file.ID)
-		index++
+		files = append(files, map[string]any{"id": file.ID})
 	}
 	for i, requested := range plan.Uploads {
-		params.Set(fmt.Sprintf("files[%d][url]", index), uploadURLs[i])
+		entry := map[string]any{"url": uploadURLs[i]}
 		if requested.DisplayName != "" {
-			params.Set(fmt.Sprintf("files[%d][display_name]", index), requested.DisplayName)
+			entry["display_name"] = requested.DisplayName
 		}
 		if requested.Description != "" {
-			params.Set(fmt.Sprintf("files[%d][description]", index), requested.Description)
+			entry["description"] = requested.Description
 		}
-		index++
+		files = append(files, entry)
 	}
+	return files
 }
 
 func placeholderUploadURLs(count int) []string {
@@ -233,10 +233,6 @@ func placeholderUploadURLs(count int) []string {
 		urls[i] = fmt.Sprintf("<uploaded:file:%d>", i)
 	}
 	return urls
-}
-
-func fileUpdateNeedsJSONBody(plan productFileUpdatePlan) bool {
-	return len(plan.Preserved) == 0 && len(plan.Uploads) == 0
 }
 
 func buildProductUpdateJSONBody(params url.Values, files []map[string]any) map[string]any {
@@ -263,6 +259,17 @@ func buildProductUpdateJSONBody(params url.Values, files []map[string]any) map[s
 
 	body["files"] = files
 	return body
+}
+
+func renderProductUpdateDryRun(opts cmdutil.Options, path string, body map[string]any) error {
+	switch {
+	case opts.UsesJSONOutput():
+		return renderProductUpdateDryRunJSON(opts, path, body)
+	case opts.PlainOutput:
+		return renderProductUpdateDryRunPlain(opts, path, body)
+	default:
+		return renderProductUpdateDryRunHuman(opts, path, body)
+	}
 }
 
 func renderProductUpdateDryRunJSON(opts cmdutil.Options, path string, body map[string]any) error {
@@ -302,18 +309,6 @@ func renderProductUpdateDryRunHuman(opts cmdutil.Options, path string, body map[
 		return fmt.Errorf("could not encode dry-run output: %w", err)
 	}
 	return output.Writeln(opts.Out(), string(data))
-}
-
-func renderClearAllFilesDryRun(opts cmdutil.Options, path string, params url.Values) error {
-	body := buildProductUpdateJSONBody(params, []map[string]any{})
-	switch {
-	case opts.UsesJSONOutput():
-		return renderProductUpdateDryRunJSON(opts, path, body)
-	case opts.PlainOutput:
-		return renderProductUpdateDryRunPlain(opts, path, body)
-	default:
-		return renderProductUpdateDryRunHuman(opts, path, body)
-	}
 }
 
 func runProductUpdateJSON(

--- a/internal/cmd/products/file_updates.go
+++ b/internal/cmd/products/file_updates.go
@@ -30,14 +30,17 @@ type plannedProductUpload struct {
 type existingProductFile struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
-	URL  string `json:"url"`
 }
 
 type productFileUpdatePlan struct {
-	Existing  []existingProductFile
 	Preserved []existingProductFile
 	Removed   []existingProductFile
 	Uploads   []requestedProductUpload
+}
+
+type productFileSelections struct {
+	Keep   map[string]struct{}
+	Remove map[string]struct{}
 }
 
 type productFilesResponse struct {
@@ -109,36 +112,30 @@ func planProductFileUpdate(
 	cmd *cobra.Command,
 	existing []existingProductFile,
 	uploads []requestedProductUpload,
-	keepIDs, removeIDs []string,
+	selections productFileSelections,
 	replaceFiles bool,
 ) (productFileUpdatePlan, error) {
-	keepSet, removeSet, err := validateProductFileSelections(cmd, keepIDs, removeIDs, replaceFiles)
-	if err != nil {
-		return productFileUpdatePlan{}, err
-	}
-
 	existingByID := make(map[string]existingProductFile, len(existing))
 	for _, file := range existing {
 		existingByID[file.ID] = file
 	}
 
-	if err := ensureKnownFileIDs(cmd, "--keep-file", keepSet, existingByID); err != nil {
+	if err := ensureKnownFileIDs(cmd, "--keep-file", selections.Keep, existingByID); err != nil {
 		return productFileUpdatePlan{}, err
 	}
-	if err := ensureKnownFileIDs(cmd, "--remove-file", removeSet, existingByID); err != nil {
+	if err := ensureKnownFileIDs(cmd, "--remove-file", selections.Remove, existingByID); err != nil {
 		return productFileUpdatePlan{}, err
 	}
 
 	plan := productFileUpdatePlan{
-		Existing: existing,
-		Uploads:  uploads,
+		Uploads: uploads,
 	}
 
 	for _, file := range existing {
-		_, explicitlyRemoved := removeSet[file.ID]
+		_, explicitlyRemoved := selections.Remove[file.ID]
 		preserve := !replaceFiles
 		if replaceFiles {
-			_, preserve = keepSet[file.ID]
+			_, preserve = selections.Keep[file.ID]
 		}
 		if explicitlyRemoved {
 			preserve = false
@@ -198,9 +195,9 @@ func validateProductFileSelections(
 	cmd *cobra.Command,
 	keepIDs, removeIDs []string,
 	replaceFiles bool,
-) (map[string]struct{}, map[string]struct{}, error) {
+) (productFileSelections, error) {
 	if len(keepIDs) > 0 && !replaceFiles {
-		return nil, nil, cmdutil.UsageErrorf(cmd,
+		return productFileSelections{}, cmdutil.UsageErrorf(cmd,
 			"--keep-file can only be used together with --replace-files")
 	}
 
@@ -221,12 +218,15 @@ func validateProductFileSelections(
 	}
 	if len(conflicts) > 0 {
 		sort.Strings(conflicts)
-		return nil, nil, cmdutil.UsageErrorf(cmd,
+		return productFileSelections{}, cmdutil.UsageErrorf(cmd,
 			"cannot use --keep-file and --remove-file for the same id(s): %s",
 			joinComma(conflicts))
 	}
 
-	return keepSet, removeSet, nil
+	return productFileSelections{
+		Keep:   keepSet,
+		Remove: removeSet,
+	}, nil
 }
 
 func buildProductUpdateFilesPayload(plan productFileUpdatePlan, uploadURLs []string) []map[string]any {
@@ -412,10 +412,7 @@ func confirmProductFileRemoval(opts cmdutil.Options, productID string, removed [
 }
 
 func dryRunExistingProductFile(file existingProductFile) dryRunExistingFile {
-	return dryRunExistingFile{
-		ID:   file.ID,
-		Name: file.Name,
-	}
+	return dryRunExistingFile(file)
 }
 
 func formatExistingProductFileLabel(file existingProductFile) string {

--- a/internal/cmd/products/file_updates.go
+++ b/internal/cmd/products/file_updates.go
@@ -16,11 +16,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// productUploadHTTPClientForTesting redirects S3 part PUTs at a test server.
-// Production leaves this nil so upload.Upload falls back to its shared client.
-// Tests in this package must not use t.Parallel while mutating this var.
-var productUploadHTTPClientForTesting *http.Client
-
 type requestedProductUpload struct {
 	Path        string
 	DisplayName string
@@ -235,32 +230,6 @@ func placeholderUploadURLs(count int) []string {
 	return urls
 }
 
-func buildProductUpdateJSONBody(params url.Values, files []map[string]any) map[string]any {
-	body := make(map[string]any, len(params)+1)
-	keys := make([]string, 0, len(params))
-	for key := range params {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-
-	for _, key := range keys {
-		values := append([]string(nil), params[key]...)
-		switch key {
-		case "tags[]":
-			body["tags"] = values
-		default:
-			if len(values) == 1 {
-				body[key] = values[0]
-			} else if len(values) > 1 {
-				body[key] = values
-			}
-		}
-	}
-
-	body["files"] = files
-	return body
-}
-
 func renderProductUpdateDryRun(opts cmdutil.Options, path string, body map[string]any) error {
 	switch {
 	case opts.UsesJSONOutput():
@@ -348,56 +317,17 @@ func confirmProductFileRemoval(opts cmdutil.Options, productID string, removed [
 	return cmdutil.ConfirmAction(opts, message)
 }
 
-func uploadProductFile(opts cmdutil.Options, client *api.Client, planned plannedProductUpload) (string, error) {
-	totalLabel := humanUploadBytes(planned.Plan.Size)
-	var sp *output.Spinner
-	if cmdutil.ShouldShowSpinner(opts) {
-		sp = output.NewSpinnerTo(productUploadStatus(planned.Plan.Filename, 0, totalLabel), opts.Err())
-		sp.Start()
-		defer sp.Stop()
-	}
-
-	progress := func(uploaded int64) {
-		if sp != nil {
-			sp.SetMessage(productUploadStatus(planned.Plan.Filename, uploaded, totalLabel))
-		}
-	}
-
-	fileURL, err := upload.Upload(opts.Context, client, planned.Path, upload.Options{
-		Filename:   planned.Plan.Filename,
-		Progress:   progress,
-		HTTPClient: productUploadHTTPClientForTesting,
-	})
-	if err != nil {
-		return "", err
-	}
-	if sp != nil {
-		sp.Stop()
-	}
-	return fileURL, nil
-}
-
-func productUploadStatus(filename string, uploaded int64, totalLabel string) string {
-	return fmt.Sprintf("Uploading %s %s / %s", filename, humanUploadBytes(uploaded), totalLabel)
-}
-
-// humanUploadBytes matches the file upload command's byte formatting so both
-// entry points report multipart progress consistently.
-func humanUploadBytes(n int64) string {
-	const unit = 1024
-	if n < unit {
-		return fmt.Sprintf("%d B", n)
-	}
-	div, exp := int64(unit), 0
-	for n/div >= unit && exp < 3 {
-		div *= unit
-		exp++
-	}
-	v := float64(n) / float64(div)
-	units := []string{"KB", "MB", "GB", "TB"}
-	return fmt.Sprintf("%.1f %s", v, units[exp])
-}
-
 func joinComma(values []string) string {
 	return strings.Join(values, ", ")
+}
+
+func productBatchUploadInputs(uploads []plannedProductUpload) []batchUploadInput {
+	inputs := make([]batchUploadInput, len(uploads))
+	for i, current := range uploads {
+		inputs[i] = batchUploadInput{
+			Path: current.Path,
+			Plan: current.Plan,
+		}
+	}
+	return inputs
 }

--- a/internal/cmd/products/products.go
+++ b/internal/cmd/products/products.go
@@ -15,6 +15,8 @@ func NewProductsCmd() *cobra.Command {
 		Example: `  gumroad products list
   gumroad products create --name "Art Pack" --price 10.00
   gumroad products update <product_id> --name "New Name"
+  gumroad products update <product_id> --file ./pack.zip
+  gumroad products update <product_id> --replace-files --keep-file file_123 --file ./new-pack.zip
   gumroad products view <id>
   gumroad products publish <id>
   gumroad products unpublish <id>

--- a/internal/cmd/products/products_test.go
+++ b/internal/cmd/products/products_test.go
@@ -875,6 +875,37 @@ func TestUpdate_DryRun(t *testing.T) {
 	}
 }
 
+func TestUpdate_DryRunJSON_UsesRequestEnvelope(t *testing.T) {
+	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
+		t.Error("should not reach API in dry-run mode")
+	})
+
+	cmd := testutil.Command(newUpdateCmd(), testutil.DryRun(true), testutil.JSONOutput())
+	cmd.SetArgs([]string{"prod1", "--name", "X", "--tag", "art"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var payload dryRunUpdateBody
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("expected JSON dry-run output, got %v: %s", err, out)
+	}
+	if !payload.DryRun || payload.Request.Method != "PUT" || payload.Request.Path != "/products/prod1" {
+		t.Fatalf("unexpected dry-run payload: %+v", payload)
+	}
+	if len(payload.Uploads) != 0 {
+		t.Fatalf("expected no uploads, got %+v", payload.Uploads)
+	}
+	if got := payload.Request.Body["name"]; got != "X" {
+		t.Fatalf("name = %#v, want X", got)
+	}
+	tags, ok := payload.Request.Body["tags"].([]any)
+	if !ok || len(tags) != 1 || tags[0] != "art" {
+		t.Fatalf("tags = %#v", payload.Request.Body["tags"])
+	}
+	if _, ok := payload.Request.Body["files"]; ok {
+		t.Fatalf("did not expect files field in non-file dry-run body: %#v", payload.Request.Body)
+	}
+}
+
 func TestUpdate_Tags(t *testing.T) {
 	var gotForm url.Values
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {

--- a/internal/cmd/products/update.go
+++ b/internal/cmd/products/update.go
@@ -134,6 +134,11 @@ func newUpdateCmd() *cobra.Command {
 				return err
 			}
 
+			plannedUploads, err := describeProductUploads(filePlan.Uploads)
+			if err != nil {
+				return err
+			}
+
 			ok, err := confirmProductFileRemoval(opts, args[0], filePlan.Removed)
 			if err != nil {
 				return err
@@ -142,25 +147,17 @@ func newUpdateCmd() *cobra.Command {
 				return cmdutil.PrintCancelledAction(opts, "update product "+args[0], args[0])
 			}
 
-			plannedUploads, err := describeProductUploads(filePlan.Uploads)
-			if err != nil {
-				return err
-			}
 			if opts.DryRun {
-				payload := buildProductUpdateJSONBody(params,
+				payload := buildProductJSONBody(params,
 					buildProductUpdateFilesPayload(filePlan, placeholderUploadURLs(len(plannedUploads))))
 				return renderProductUpdateDryRun(opts, path, payload)
 			}
 
-			uploadedURLs := make([]string, len(plannedUploads))
-			for i, planned := range plannedUploads {
-				fileURL, err := uploadProductFile(opts, client, planned)
-				if err != nil {
-					return err
-				}
-				uploadedURLs[i] = fileURL
+			uploadedURLs, err := uploadBatch(opts, client, productBatchUploadInputs(plannedUploads))
+			if err != nil {
+				return err
 			}
-			payload := buildProductUpdateJSONBody(params, buildProductUpdateFilesPayload(filePlan, uploadedURLs))
+			payload := buildProductJSONBody(params, buildProductUpdateFilesPayload(filePlan, uploadedURLs))
 			return runProductUpdateJSON(opts, client, path, args[0], payload)
 		},
 	}

--- a/internal/cmd/products/update.go
+++ b/internal/cmd/products/update.go
@@ -115,11 +115,15 @@ func newUpdateCmd() *cobra.Command {
 				flags.Changed("replace-files")
 			if !fileFlagsChanged {
 				if opts.DryRun && opts.UsesJSONOutput() {
-					return renderProductUpdateDryRun(opts, path, nil, buildProductJSONBody(params, nil))
+					return renderProductUpdateDryRun(opts, path, productFileUpdatePlan{}, nil, buildProductJSONBody(params, nil))
 				}
 				return cmdutil.RunRequestWithSuccess(opts,
 					"Updating product...", "PUT", path, params,
 					args[0], "Product "+args[0]+" updated.")
+			}
+
+			if _, _, err := validateProductFileSelections(c, keepFileIDs, removeFileIDs, replaceFiles); err != nil {
+				return err
 			}
 
 			token, err := config.Token()
@@ -153,7 +157,7 @@ func newUpdateCmd() *cobra.Command {
 			if opts.DryRun {
 				payload := buildProductJSONBody(params,
 					buildProductUpdateFilesPayload(filePlan, placeholderUploadURLs(len(plannedUploads))))
-				return renderProductUpdateDryRun(opts, path, plannedUploads, payload)
+				return renderProductUpdateDryRun(opts, path, filePlan, plannedUploads, payload)
 			}
 
 			uploadedURLs, err := uploadBatch(opts, client, productBatchUploadInputs(plannedUploads))
@@ -161,7 +165,10 @@ func newUpdateCmd() *cobra.Command {
 				return err
 			}
 			payload := buildProductJSONBody(params, buildProductUpdateFilesPayload(filePlan, uploadedURLs))
-			return runProductUpdateJSON(opts, client, path, args[0], payload)
+			if err := runProductUpdateJSON(opts, client, path, args[0], payload); err != nil {
+				return wrapPartialUploadError(err, uploadedURLs)
+			}
+			return nil
 		},
 	}
 

--- a/internal/cmd/products/update.go
+++ b/internal/cmd/products/update.go
@@ -142,22 +142,14 @@ func newUpdateCmd() *cobra.Command {
 				return cmdutil.PrintCancelledAction(opts, "update product "+args[0], args[0])
 			}
 
-			if fileUpdateNeedsJSONBody(filePlan) {
-				if opts.DryRun {
-					return renderClearAllFilesDryRun(opts, path, params)
-				}
-				payload := buildProductUpdateJSONBody(params, []map[string]any{})
-				return runProductUpdateJSON(opts, client, path, args[0], payload)
-			}
-
 			plannedUploads, err := describeProductUploads(filePlan.Uploads)
 			if err != nil {
 				return err
 			}
 			if opts.DryRun {
-				dryRunParams := cmdutil.CloneValues(params)
-				appendProductFilesParams(dryRunParams, filePlan, placeholderUploadURLs(len(plannedUploads)))
-				return cmdutil.PrintDryRunRequest(opts, "PUT", path, dryRunParams)
+				payload := buildProductUpdateJSONBody(params,
+					buildProductUpdateFilesPayload(filePlan, placeholderUploadURLs(len(plannedUploads))))
+				return renderProductUpdateDryRun(opts, path, payload)
 			}
 
 			uploadedURLs := make([]string, len(plannedUploads))
@@ -168,10 +160,8 @@ func newUpdateCmd() *cobra.Command {
 				}
 				uploadedURLs[i] = fileURL
 			}
-			appendProductFilesParams(params, filePlan, uploadedURLs)
-			return cmdutil.RunRequestWithSuccess(opts,
-				"Updating product...", "PUT", path, params,
-				args[0], "Product "+args[0]+" updated.")
+			payload := buildProductUpdateJSONBody(params, buildProductUpdateFilesPayload(filePlan, uploadedURLs))
+			return runProductUpdateJSON(opts, client, path, args[0], payload)
 		},
 	}
 

--- a/internal/cmd/products/update.go
+++ b/internal/cmd/products/update.go
@@ -127,6 +127,11 @@ func newUpdateCmd() *cobra.Command {
 				return err
 			}
 
+			plannedUploads, err := describeProductUploads(requestedUploads)
+			if err != nil {
+				return err
+			}
+
 			token, err := config.Token()
 			if err != nil {
 				return err
@@ -138,11 +143,6 @@ func newUpdateCmd() *cobra.Command {
 			}
 
 			filePlan, err := planProductFileUpdate(c, existingFiles, requestedUploads, selections, replaceFiles)
-			if err != nil {
-				return err
-			}
-
-			plannedUploads, err := describeProductUploads(filePlan.Uploads)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/products/update.go
+++ b/internal/cmd/products/update.go
@@ -150,7 +150,7 @@ func newUpdateCmd() *cobra.Command {
 			if opts.DryRun {
 				payload := buildProductJSONBody(params,
 					buildProductUpdateFilesPayload(filePlan, placeholderUploadURLs(len(plannedUploads))))
-				return renderProductUpdateDryRun(opts, path, payload)
+				return renderProductUpdateDryRun(opts, path, plannedUploads, payload)
 			}
 
 			uploadedURLs, err := uploadBatch(opts, client, productBatchUploadInputs(plannedUploads))

--- a/internal/cmd/products/update.go
+++ b/internal/cmd/products/update.go
@@ -114,6 +114,9 @@ func newUpdateCmd() *cobra.Command {
 				flags.Changed("remove-file") ||
 				flags.Changed("replace-files")
 			if !fileFlagsChanged {
+				if opts.DryRun && opts.UsesJSONOutput() {
+					return renderProductUpdateDryRun(opts, path, nil, buildProductJSONBody(params, nil))
+				}
 				return cmdutil.RunRequestWithSuccess(opts,
 					"Updating product...", "PUT", path, params,
 					args[0], "Product "+args[0]+" updated.")

--- a/internal/cmd/products/update.go
+++ b/internal/cmd/products/update.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -16,13 +17,21 @@ func newUpdateCmd() *cobra.Command {
 	var maxPurchaseCount int
 	var payWhatYouWant bool
 	var tags []string
+	var files []string
+	var fileNames []string
+	var fileDescriptions []string
+	var keepFileIDs []string
+	var removeFileIDs []string
+	var replaceFiles bool
 
 	cmd := &cobra.Command{
 		Use:   "update <product_id>",
 		Short: "Update a product",
 		Example: `  gumroad products update <id> --name "New Name"
   gumroad products update <id> --price 15.00 --currency eur
-  gumroad products update <id> --tag art --tag digital`,
+  gumroad products update <id> --tag art --tag digital
+  gumroad products update <id> --file ./pack.zip
+  gumroad products update <id> --replace-files --keep-file file_123 --file ./new-pack.zip`,
 		Args: cmdutil.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
@@ -33,6 +42,8 @@ func newUpdateCmd() *cobra.Command {
 				"custom-permalink", "custom-summary", "custom-receipt",
 				"pay-what-you-want", "suggested-price", "max-purchase-count",
 				"taxonomy-id", "tag",
+				"file", "file-name", "file-description",
+				"keep-file", "remove-file", "replace-files",
 			); err != nil {
 				return err
 			}
@@ -41,6 +52,10 @@ func newUpdateCmd() *cobra.Command {
 				return cmdutil.UsageErrorf(c, "--name cannot be empty")
 			}
 			if err := cmdutil.RequireNonNegativeIntFlag(c, "max-purchase-count", maxPurchaseCount); err != nil {
+				return err
+			}
+			requestedUploads, err := collectRequestedProductUploads(c, files, fileNames, fileDescriptions)
+			if err != nil {
 				return err
 			}
 
@@ -92,6 +107,68 @@ func newUpdateCmd() *cobra.Command {
 			}
 
 			path := cmdutil.JoinPath("products", args[0])
+			fileFlagsChanged := flags.Changed("file") ||
+				flags.Changed("file-name") ||
+				flags.Changed("file-description") ||
+				flags.Changed("keep-file") ||
+				flags.Changed("remove-file") ||
+				flags.Changed("replace-files")
+			if !fileFlagsChanged {
+				return cmdutil.RunRequestWithSuccess(opts,
+					"Updating product...", "PUT", path, params,
+					args[0], "Product "+args[0]+" updated.")
+			}
+
+			token, err := config.Token()
+			if err != nil {
+				return err
+			}
+			client := cmdutil.NewAPIClient(opts, token)
+			existingFiles, err := fetchExistingProductFiles(client, args[0])
+			if err != nil {
+				return err
+			}
+
+			filePlan, err := planProductFileUpdate(c, existingFiles, requestedUploads, keepFileIDs, removeFileIDs, replaceFiles)
+			if err != nil {
+				return err
+			}
+
+			ok, err := confirmProductFileRemoval(opts, args[0], filePlan.Removed)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return cmdutil.PrintCancelledAction(opts, "update product "+args[0], args[0])
+			}
+
+			if fileUpdateNeedsJSONBody(filePlan) {
+				if opts.DryRun {
+					return renderClearAllFilesDryRun(opts, path, params)
+				}
+				payload := buildProductUpdateJSONBody(params, []map[string]any{})
+				return runProductUpdateJSON(opts, client, path, args[0], payload)
+			}
+
+			plannedUploads, err := describeProductUploads(filePlan.Uploads)
+			if err != nil {
+				return err
+			}
+			if opts.DryRun {
+				dryRunParams := cmdutil.CloneValues(params)
+				appendProductFilesParams(dryRunParams, filePlan, placeholderUploadURLs(len(plannedUploads)))
+				return cmdutil.PrintDryRunRequest(opts, "PUT", path, dryRunParams)
+			}
+
+			uploadedURLs := make([]string, len(plannedUploads))
+			for i, planned := range plannedUploads {
+				fileURL, err := uploadProductFile(opts, client, planned)
+				if err != nil {
+					return err
+				}
+				uploadedURLs[i] = fileURL
+			}
+			appendProductFilesParams(params, filePlan, uploadedURLs)
 			return cmdutil.RunRequestWithSuccess(opts,
 				"Updating product...", "PUT", path, params,
 				args[0], "Product "+args[0]+" updated.")
@@ -110,6 +187,12 @@ func newUpdateCmd() *cobra.Command {
 	cmd.Flags().IntVar(&maxPurchaseCount, "max-purchase-count", 0, "New maximum number of purchases")
 	cmd.Flags().StringVar(&taxonomyID, "taxonomy-id", "", "New taxonomy/category ID")
 	cmd.Flags().StringArrayVar(&tags, "tag", nil, "Tag (repeatable, replaces all existing tags)")
+	cmd.Flags().StringArrayVar(&files, "file", nil, "Attach a new local file (repeatable)")
+	cmd.Flags().StringArrayVar(&fileNames, "file-name", nil, "Display name for the matching --file (repeatable)")
+	cmd.Flags().StringArrayVar(&fileDescriptions, "file-description", nil, "Description for the matching --file (repeatable)")
+	cmd.Flags().StringArrayVar(&keepFileIDs, "keep-file", nil, "Existing file ID to preserve when using --replace-files (repeatable)")
+	cmd.Flags().StringArrayVar(&removeFileIDs, "remove-file", nil, "Existing file ID to remove (repeatable)")
+	cmd.Flags().BoolVar(&replaceFiles, "replace-files", false, "Replace the current file set instead of preserving existing files by default")
 
 	return cmd
 }

--- a/internal/cmd/products/update.go
+++ b/internal/cmd/products/update.go
@@ -166,10 +166,7 @@ func newUpdateCmd() *cobra.Command {
 				return err
 			}
 			payload := buildProductJSONBody(params, buildProductUpdateFilesPayload(filePlan, uploadedURLs))
-			if err := runProductUpdateJSON(opts, client, path, args[0], payload); err != nil {
-				return wrapPartialUploadError(err, uploadedURLs)
-			}
-			return nil
+			return runProductUpdateJSON(opts, client, path, args[0], payload, uploadedURLs)
 		},
 	}
 

--- a/internal/cmd/products/update.go
+++ b/internal/cmd/products/update.go
@@ -122,7 +122,8 @@ func newUpdateCmd() *cobra.Command {
 					args[0], "Product "+args[0]+" updated.")
 			}
 
-			if _, _, err := validateProductFileSelections(c, keepFileIDs, removeFileIDs, replaceFiles); err != nil {
+			selections, err := validateProductFileSelections(c, keepFileIDs, removeFileIDs, replaceFiles)
+			if err != nil {
 				return err
 			}
 
@@ -136,7 +137,7 @@ func newUpdateCmd() *cobra.Command {
 				return err
 			}
 
-			filePlan, err := planProductFileUpdate(c, existingFiles, requestedUploads, keepFileIDs, removeFileIDs, replaceFiles)
+			filePlan, err := planProductFileUpdate(c, existingFiles, requestedUploads, selections, replaceFiles)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/products/update_files_test.go
+++ b/internal/cmd/products/update_files_test.go
@@ -22,11 +22,12 @@ type productUpdateFileServers struct {
 
 	s3 *httptest.Server
 
-	getCalls     atomic.Int32
-	putCalls     atomic.Int32
-	jsonPutCalls atomic.Int32
-	s3Calls      atomic.Int32
-	completeSeq  atomic.Int32
+	getCalls       atomic.Int32
+	putCalls       atomic.Int32
+	jsonPutCalls   atomic.Int32
+	s3Calls        atomic.Int32
+	completeSeq    atomic.Int32
+	failCompleteOn int32
 
 	putForm     url.Values
 	putJSON     map[string]any
@@ -52,9 +53,9 @@ func newProductUpdateFileServers(t *testing.T) *productUpdateFileServers {
 	}))
 	t.Cleanup(s.s3.Close)
 
-	prev := productUploadHTTPClientForTesting
-	productUploadHTTPClientForTesting = s.s3.Client()
-	t.Cleanup(func() { productUploadHTTPClientForTesting = prev })
+	prev := s3HTTPClientForTesting
+	s3HTTPClientForTesting = s.s3.Client()
+	t.Cleanup(func() { s3HTTPClientForTesting = prev })
 
 	return s
 }
@@ -109,6 +110,10 @@ func (s *productUpdateFileServers) dispatch(t *testing.T) http.HandlerFunc {
 			})
 		case "/files/complete":
 			seq := s.completeSeq.Add(1)
+			if s.failCompleteOn == seq {
+				http.Error(w, "complete failed", http.StatusBadGateway)
+				return
+			}
 			testutil.JSON(t, w, map[string]any{
 				"file_url": fmt.Sprintf("https://example.com/attachments/u/k/original/upload-%d.bin", seq),
 			})
@@ -376,6 +381,59 @@ func TestUpdate_KeepFileRequiresReplaceFiles(t *testing.T) {
 	}
 }
 
+func TestUpdate_InvalidUploadFailsBeforeRemovalConfirmation(t *testing.T) {
+	srv := newProductUpdateFileServers(t)
+	srv.existingFiles = []existingProductFile{{ID: "file_a"}}
+	testutil.Setup(t, srv.dispatch(t))
+
+	missingPath := filepath.Join(t.TempDir(), "missing.bin")
+	cmd := testutil.Command(newUpdateCmd(), testutil.NoInput(true))
+	cmd.SetArgs([]string{"prod1", "--replace-files", "--file", missingPath})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected local file validation error")
+	}
+	if !strings.Contains(err.Error(), "could not stat file") {
+		t.Fatalf("expected stat error, got %v", err)
+	}
+	if strings.Contains(err.Error(), "--yes") {
+		t.Fatalf("expected validation to happen before confirmation, got %v", err)
+	}
+	if srv.putCalls.Load() != 0 {
+		t.Fatalf("unexpected PUT calls: %d", srv.putCalls.Load())
+	}
+	if srv.s3Calls.Load() != 0 {
+		t.Fatalf("unexpected S3 calls: %d", srv.s3Calls.Load())
+	}
+}
+
+func TestUpdate_FileUploadFailureIncludesUploadedURLs(t *testing.T) {
+	srv := newProductUpdateFileServers(t)
+	srv.failCompleteOn = 2
+	testutil.Setup(t, srv.dispatch(t))
+
+	firstPath := writeProductUploadFixture(t, "first")
+	secondPath := writeProductUploadFixture(t, "second")
+	cmd := testutil.Command(newUpdateCmd())
+	cmd.SetArgs([]string{
+		"prod1",
+		"--file", firstPath,
+		"--file", secondPath,
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected upload failure")
+	}
+	if !strings.Contains(err.Error(), "https://example.com/attachments/u/k/original/upload-1.bin") {
+		t.Fatalf("expected uploaded URL in error, got %v", err)
+	}
+	if srv.putCalls.Load() != 0 {
+		t.Fatalf("unexpected PUT calls: %d", srv.putCalls.Load())
+	}
+}
+
 func TestUpdate_ReplaceFilesClearAllDryRunJSON(t *testing.T) {
 	srv := newProductUpdateFileServers(t)
 	srv.existingFiles = []existingProductFile{{ID: "file_a"}}
@@ -435,7 +493,7 @@ func TestUpdate_ReplaceFilesClearAllDryRunHuman(t *testing.T) {
 	}
 }
 
-func TestBuildProductUpdateJSONBody_MapsTagsAndRepeatedValues(t *testing.T) {
+func TestBuildProductJSONBody_MapsTagsAndRepeatedValues(t *testing.T) {
 	params := url.Values{
 		"name":   {"Updated"},
 		"tags[]": {"art", "digital"},
@@ -443,7 +501,7 @@ func TestBuildProductUpdateJSONBody_MapsTagsAndRepeatedValues(t *testing.T) {
 	}
 	files := []map[string]any{{"id": "file_a"}}
 
-	body := buildProductUpdateJSONBody(params, files)
+	body := buildProductJSONBody(params, files)
 	if got := body["name"]; got != "Updated" {
 		t.Fatalf("name = %#v, want Updated", got)
 	}
@@ -461,24 +519,10 @@ func TestBuildProductUpdateJSONBody_MapsTagsAndRepeatedValues(t *testing.T) {
 	}
 }
 
-func TestProductUploadStatusAndHumanUploadBytes(t *testing.T) {
-	if got := productUploadStatus("pack.zip", 4*1024*1024, "12.0 MB"); !strings.Contains(got, "pack.zip") || !strings.Contains(got, "4.0 MB") || !strings.Contains(got, "12.0 MB") {
-		t.Fatalf("productUploadStatus = %q", got)
-	}
-
-	cases := []struct {
-		in   int64
-		want string
-	}{
-		{0, "0 B"},
-		{1024, "1.0 KB"},
-		{5 * 1024 * 1024, "5.0 MB"},
-		{2 * 1024 * 1024 * 1024, "2.0 GB"},
-	}
-	for _, c := range cases {
-		if got := humanUploadBytes(c.in); got != c.want {
-			t.Fatalf("humanUploadBytes(%d) = %q, want %q", c.in, got, c.want)
-		}
+func TestWrapPartialUploadErrorIncludesUploadedURLs(t *testing.T) {
+	err := wrapPartialUploadError(fmt.Errorf("boom"), []string{"one", "two"})
+	if !strings.Contains(err.Error(), "one") || !strings.Contains(err.Error(), "two") {
+		t.Fatalf("wrapped error = %v", err)
 	}
 }
 

--- a/internal/cmd/products/update_files_test.go
+++ b/internal/cmd/products/update_files_test.go
@@ -1,6 +1,7 @@
 package products
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -357,5 +358,128 @@ func TestUpdate_KeepFileRequiresReplaceFiles(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "--replace-files") {
 		t.Fatalf("expected keep-file usage error, got %v", err)
+	}
+}
+
+func TestUpdate_ReplaceFilesClearAllDryRunJSON(t *testing.T) {
+	srv := newProductUpdateFileServers(t)
+	srv.existingFiles = []existingProductFile{{ID: "file_a"}}
+	testutil.Setup(t, srv.dispatch(t))
+
+	cmd := testutil.Command(newUpdateCmd(), testutil.DryRun(true), testutil.JSONOutput())
+	cmd.SetArgs([]string{"prod1", "--replace-files"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var payload dryRunUpdateBody
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("parse JSON: %v\n%s", err, out)
+	}
+	if !payload.DryRun || payload.Method != http.MethodPut || payload.Path != "/products/prod1" {
+		t.Fatalf("unexpected dry-run envelope: %+v", payload)
+	}
+	files, ok := payload.Body["files"].([]any)
+	if !ok {
+		t.Fatalf("files payload has wrong type: %T", payload.Body["files"])
+	}
+	if len(files) != 0 {
+		t.Fatalf("expected empty files array, got %#v", files)
+	}
+}
+
+func TestUpdate_ReplaceFilesClearAllDryRunPlain(t *testing.T) {
+	srv := newProductUpdateFileServers(t)
+	srv.existingFiles = []existingProductFile{{ID: "file_a"}}
+	testutil.Setup(t, srv.dispatch(t))
+
+	cmd := testutil.Command(newUpdateCmd(), testutil.DryRun(true), testutil.PlainOutput())
+	cmd.SetArgs([]string{"prod1", "--replace-files"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "PUT\t/products/prod1\t") {
+		t.Fatalf("plain dry-run missing request line: %q", out)
+	}
+	if !strings.Contains(out, "\"files\":[]") {
+		t.Fatalf("plain dry-run missing empty files array: %q", out)
+	}
+}
+
+func TestUpdate_ReplaceFilesClearAllDryRunHuman(t *testing.T) {
+	srv := newProductUpdateFileServers(t)
+	srv.existingFiles = []existingProductFile{{ID: "file_a"}}
+	testutil.Setup(t, srv.dispatch(t))
+
+	cmd := testutil.Command(newUpdateCmd(), testutil.DryRun(true))
+	cmd.SetArgs([]string{"prod1", "--replace-files"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "Dry run: PUT /products/prod1") {
+		t.Fatalf("human dry-run missing request line: %q", out)
+	}
+	if !strings.Contains(out, "\"files\": []") {
+		t.Fatalf("human dry-run missing empty files array: %q", out)
+	}
+}
+
+func TestBuildProductUpdateJSONBody_MapsTagsAndRepeatedValues(t *testing.T) {
+	params := url.Values{
+		"name":   {"Updated"},
+		"tags[]": {"art", "digital"},
+		"other":  {"one", "two"},
+	}
+	files := []map[string]any{{"id": "file_a"}}
+
+	body := buildProductUpdateJSONBody(params, files)
+	if got := body["name"]; got != "Updated" {
+		t.Fatalf("name = %#v, want Updated", got)
+	}
+	tags, ok := body["tags"].([]string)
+	if !ok || len(tags) != 2 || tags[0] != "art" || tags[1] != "digital" {
+		t.Fatalf("tags = %#v", body["tags"])
+	}
+	other, ok := body["other"].([]string)
+	if !ok || len(other) != 2 || other[0] != "one" || other[1] != "two" {
+		t.Fatalf("other = %#v", body["other"])
+	}
+	gotFiles, ok := body["files"].([]map[string]any)
+	if !ok || len(gotFiles) != 1 || gotFiles[0]["id"] != "file_a" {
+		t.Fatalf("files = %#v", body["files"])
+	}
+}
+
+func TestProductUploadStatusAndHumanUploadBytes(t *testing.T) {
+	if got := productUploadStatus("pack.zip", 4*1024*1024, "12.0 MB"); !strings.Contains(got, "pack.zip") || !strings.Contains(got, "4.0 MB") || !strings.Contains(got, "12.0 MB") {
+		t.Fatalf("productUploadStatus = %q", got)
+	}
+
+	cases := []struct {
+		in   int64
+		want string
+	}{
+		{0, "0 B"},
+		{1024, "1.0 KB"},
+		{5 * 1024 * 1024, "5.0 MB"},
+		{2 * 1024 * 1024 * 1024, "2.0 GB"},
+	}
+	for _, c := range cases {
+		if got := humanUploadBytes(c.in); got != c.want {
+			t.Fatalf("humanUploadBytes(%d) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestRenderProductUpdateDryRunJSON_Direct(t *testing.T) {
+	var buf bytes.Buffer
+	opts := testutil.TestOptions(testutil.Stdout(&buf), testutil.JSONOutput())
+	body := map[string]any{"files": []map[string]any{}}
+
+	if err := renderProductUpdateDryRunJSON(opts, "/products/prod1", body); err != nil {
+		t.Fatalf("renderProductUpdateDryRunJSON: %v", err)
+	}
+	var payload dryRunUpdateBody
+	if err := json.Unmarshal(buf.Bytes(), &payload); err != nil {
+		t.Fatalf("parse output: %v\n%s", err, buf.String())
+	}
+	if payload.Path != "/products/prod1" || payload.Method != http.MethodPut || !payload.DryRun {
+		t.Fatalf("unexpected JSON dry-run output: %+v", payload)
 	}
 }

--- a/internal/cmd/products/update_files_test.go
+++ b/internal/cmd/products/update_files_test.go
@@ -28,6 +28,7 @@ type productUpdateFileServers struct {
 	s3Calls        atomic.Int32
 	completeSeq    atomic.Int32
 	failCompleteOn int32
+	putStatus      int
 
 	putForm     url.Values
 	putJSON     map[string]any
@@ -87,6 +88,10 @@ func (s *productUpdateFileServers) dispatch(t *testing.T) http.HandlerFunc {
 						t.Fatalf("ParseForm failed: %v", err)
 					}
 					s.putForm = r.PostForm
+				}
+				if s.putStatus != 0 {
+					http.Error(w, "update failed", s.putStatus)
+					return
 				}
 				testutil.JSON(t, w, map[string]any{})
 			default:
@@ -260,6 +265,9 @@ func TestUpdate_KeepAndRemoveSameIDErrors(t *testing.T) {
 	if !strings.Contains(err.Error(), "--keep-file") || !strings.Contains(err.Error(), "--remove-file") {
 		t.Fatalf("expected conflict error, got %v", err)
 	}
+	if srv.getCalls.Load() != 0 {
+		t.Fatalf("unexpected GET calls: %d", srv.getCalls.Load())
+	}
 	if srv.putCalls.Load() != 0 {
 		t.Fatalf("unexpected PUT calls: %d", srv.putCalls.Load())
 	}
@@ -290,8 +298,8 @@ func TestUpdate_UnknownRemoveFileErrorsAfterPrefetch(t *testing.T) {
 func TestUpdate_ReplaceFilesClearAllUsesJSONBody(t *testing.T) {
 	srv := newProductUpdateFileServers(t)
 	srv.existingFiles = []existingProductFile{
-		{ID: "file_a"},
-		{ID: "file_b"},
+		{ID: "file_a", Name: "Old A.pdf"},
+		{ID: "file_b", Name: "Old B.pdf"},
 	}
 	testutil.Setup(t, srv.dispatch(t))
 
@@ -333,8 +341,8 @@ func TestUpdate_ReplaceFilesNoInputRequiresYes(t *testing.T) {
 func TestUpdate_FileDryRunPrefetchesButDoesNotUploadOrPut(t *testing.T) {
 	srv := newProductUpdateFileServers(t)
 	srv.existingFiles = []existingProductFile{
-		{ID: "file_a"},
-		{ID: "file_b"},
+		{ID: "file_a", Name: "Old A.pdf"},
+		{ID: "file_b", Name: "Old B.pdf"},
 	}
 	testutil.Setup(t, srv.dispatch(t))
 
@@ -370,6 +378,12 @@ func TestUpdate_FileDryRunPrefetchesButDoesNotUploadOrPut(t *testing.T) {
 	}
 	if payload.Uploads[0].PartCount != 1 {
 		t.Fatalf("upload part count = %d, want 1", payload.Uploads[0].PartCount)
+	}
+	if len(payload.Preserved) != 1 || payload.Preserved[0].ID != "file_b" || payload.Preserved[0].Name != "Old B.pdf" {
+		t.Fatalf("preserved = %+v", payload.Preserved)
+	}
+	if len(payload.Removed) != 1 || payload.Removed[0].ID != "file_a" || payload.Removed[0].Name != "Old A.pdf" {
+		t.Fatalf("removed = %+v", payload.Removed)
 	}
 	files := productUpdateJSONFiles(t, payload.Request.Body)
 	if len(files) != 2 || files[0]["id"] != "file_b" {
@@ -428,6 +442,26 @@ func TestUpdate_FileDryRunHumanIncludesUploadPlan(t *testing.T) {
 	}
 }
 
+func TestUpdate_DryRunHumanIncludesExistingFileNames(t *testing.T) {
+	srv := newProductUpdateFileServers(t)
+	srv.existingFiles = []existingProductFile{
+		{ID: "file_a", Name: "Old A.pdf"},
+		{ID: "file_b", Name: "Old B.pdf"},
+	}
+	testutil.Setup(t, srv.dispatch(t))
+
+	cmd := testutil.Command(newUpdateCmd(), testutil.DryRun(true))
+	cmd.SetArgs([]string{"prod1", "--remove-file", "file_a"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "Preserve existing file: Old B.pdf (file_b)") {
+		t.Fatalf("human dry-run missing preserved file: %q", out)
+	}
+	if !strings.Contains(out, "Remove existing file: Old A.pdf (file_a)") {
+		t.Fatalf("human dry-run missing removed file: %q", out)
+	}
+}
+
 func TestUpdate_KeepFileRequiresReplaceFiles(t *testing.T) {
 	srv := newProductUpdateFileServers(t)
 	srv.existingFiles = []existingProductFile{{ID: "file_a"}}
@@ -441,6 +475,9 @@ func TestUpdate_KeepFileRequiresReplaceFiles(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "--replace-files") {
 		t.Fatalf("expected keep-file usage error, got %v", err)
+	}
+	if srv.getCalls.Load() != 0 {
+		t.Fatalf("unexpected GET calls: %d", srv.getCalls.Load())
 	}
 }
 
@@ -523,6 +560,30 @@ func TestUpdate_FileUploadFailureIncludesUploadedURLs(t *testing.T) {
 	}
 }
 
+func TestUpdate_ProductUpdateFailureIncludesUploadedURLs(t *testing.T) {
+	srv := newProductUpdateFileServers(t)
+	srv.putStatus = http.StatusBadGateway
+	testutil.Setup(t, srv.dispatch(t))
+
+	path := writeProductUploadFixture(t, "first")
+	cmd := testutil.Command(newUpdateCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{
+		"prod1",
+		"--file", path,
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected update failure")
+	}
+	if !strings.Contains(err.Error(), "https://example.com/attachments/u/k/original/upload-1.bin") {
+		t.Fatalf("expected uploaded URL in error, got %v", err)
+	}
+	if srv.putCalls.Load() != 1 {
+		t.Fatalf("PUT calls = %d, want 1", srv.putCalls.Load())
+	}
+}
+
 func TestUpdate_ReplaceFilesClearAllDryRunJSON(t *testing.T) {
 	srv := newProductUpdateFileServers(t)
 	srv.existingFiles = []existingProductFile{{ID: "file_a"}}
@@ -541,6 +602,12 @@ func TestUpdate_ReplaceFilesClearAllDryRunJSON(t *testing.T) {
 	}
 	if len(payload.Uploads) != 0 {
 		t.Fatalf("expected no uploads, got %+v", payload.Uploads)
+	}
+	if len(payload.Preserved) != 0 {
+		t.Fatalf("expected no preserved files, got %+v", payload.Preserved)
+	}
+	if len(payload.Removed) != 1 || payload.Removed[0].ID != "file_a" {
+		t.Fatalf("removed = %+v", payload.Removed)
 	}
 	files, ok := payload.Request.Body["files"].([]any)
 	if !ok {
@@ -618,12 +685,35 @@ func TestWrapPartialUploadErrorIncludesUploadedURLs(t *testing.T) {
 	}
 }
 
+func TestWrapPartialUploadErrorNilStaysNil(t *testing.T) {
+	if err := wrapPartialUploadError(nil, []string{"one"}); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestProductFileRemovalMessageIncludesNames(t *testing.T) {
+	message := productFileRemovalMessage("prod1", []existingProductFile{
+		{ID: "file_a", Name: "Old A.pdf"},
+		{ID: "file_b", Name: "Old B.pdf"},
+		{ID: "file_c"},
+	})
+	if !strings.Contains(message, "Update product prod1 and remove 3 existing files:") {
+		t.Fatalf("unexpected message: %q", message)
+	}
+	if !strings.Contains(message, "Old A.pdf (file_a)") || !strings.Contains(message, "Old B.pdf (file_b)") {
+		t.Fatalf("unexpected message: %q", message)
+	}
+	if !strings.Contains(message, "file_c") {
+		t.Fatalf("unexpected summary: %q", message)
+	}
+}
+
 func TestRenderProductUpdateDryRunJSON_Direct(t *testing.T) {
 	var buf bytes.Buffer
 	opts := testutil.TestOptions(testutil.Stdout(&buf), testutil.JSONOutput())
 	body := map[string]any{"files": []map[string]any{}}
 
-	if err := renderProductUpdateDryRunJSON(opts, "/products/prod1", nil, body); err != nil {
+	if err := renderProductUpdateDryRunJSON(opts, "/products/prod1", productFileUpdatePlan{}, nil, body); err != nil {
 		t.Fatalf("renderProductUpdateDryRunJSON: %v", err)
 	}
 	var payload dryRunUpdateBody
@@ -635,5 +725,8 @@ func TestRenderProductUpdateDryRunJSON_Direct(t *testing.T) {
 	}
 	if len(payload.Uploads) != 0 {
 		t.Fatalf("expected no uploads, got %+v", payload.Uploads)
+	}
+	if len(payload.Preserved) != 0 || len(payload.Removed) != 0 {
+		t.Fatalf("unexpected file delta: preserved=%+v removed=%+v", payload.Preserved, payload.Removed)
 	}
 }

--- a/internal/cmd/products/update_files_test.go
+++ b/internal/cmd/products/update_files_test.go
@@ -371,7 +371,7 @@ func TestUpdate_FileDryRunPrefetchesButDoesNotUploadOrPut(t *testing.T) {
 	if payload.Uploads[0].PartCount != 1 {
 		t.Fatalf("upload part count = %d, want 1", payload.Uploads[0].PartCount)
 	}
-	files := productUpdateJSONFiles(t, payload.Body)
+	files := productUpdateJSONFiles(t, payload.Request.Body)
 	if len(files) != 2 || files[0]["id"] != "file_b" {
 		t.Fatalf("dry-run files payload = %#v", files)
 	}
@@ -389,7 +389,15 @@ func TestUpdate_FileDryRunPlainIncludesUploadPlan(t *testing.T) {
 	cmd.SetArgs([]string{"prod1", "--file", path})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	if !strings.Contains(out, "upload\t"+path+"\t"+filepath.Base(path)+"\t11\t1") {
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("plain dry-run missing upload/request lines: %q", out)
+	}
+	fields := strings.Split(lines[0], "\t")
+	if len(fields) != 5 {
+		t.Fatalf("plain dry-run upload row = %q", lines[0])
+	}
+	if fields[0] != "upload" || filepath.Base(fields[1]) != filepath.Base(path) || fields[2] != filepath.Base(path) || fields[3] != "11" || fields[4] != "1" {
 		t.Fatalf("plain dry-run missing upload plan: %q", out)
 	}
 	if !strings.Contains(out, "PUT\t/products/prod1\t") {
@@ -433,6 +441,32 @@ func TestUpdate_KeepFileRequiresReplaceFiles(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "--replace-files") {
 		t.Fatalf("expected keep-file usage error, got %v", err)
+	}
+}
+
+func TestCollectRequestedProductUploads_RequiresFileForMetadataFlags(t *testing.T) {
+	cmd := newUpdateCmd()
+
+	_, err := collectRequestedProductUploads(cmd, nil, []string{" Gift.zip "}, nil)
+	if err == nil || !strings.Contains(err.Error(), "--file-name requires at least one --file") {
+		t.Fatalf("expected --file-name usage error, got %v", err)
+	}
+
+	_, err = collectRequestedProductUploads(cmd, nil, nil, []string{"Bonus"})
+	if err == nil || !strings.Contains(err.Error(), "--file-description requires at least one --file") {
+		t.Fatalf("expected --file-description usage error, got %v", err)
+	}
+}
+
+func TestCollectRequestedProductUploads_TrimsDisplayName(t *testing.T) {
+	cmd := newUpdateCmd()
+
+	uploads, err := collectRequestedProductUploads(cmd, []string{"./pack.zip"}, []string{"  Gift.zip  "}, []string{""})
+	if err != nil {
+		t.Fatalf("collectRequestedProductUploads: %v", err)
+	}
+	if len(uploads) != 1 || uploads[0].DisplayName != "Gift.zip" {
+		t.Fatalf("uploads = %+v", uploads)
 	}
 }
 
@@ -502,15 +536,15 @@ func TestUpdate_ReplaceFilesClearAllDryRunJSON(t *testing.T) {
 	if err := json.Unmarshal([]byte(out), &payload); err != nil {
 		t.Fatalf("parse JSON: %v\n%s", err, out)
 	}
-	if !payload.DryRun || payload.Method != http.MethodPut || payload.Path != "/products/prod1" {
+	if payload.Request.Method != http.MethodPut || payload.Request.Path != "/products/prod1" {
 		t.Fatalf("unexpected dry-run envelope: %+v", payload)
 	}
 	if len(payload.Uploads) != 0 {
 		t.Fatalf("expected no uploads, got %+v", payload.Uploads)
 	}
-	files, ok := payload.Body["files"].([]any)
+	files, ok := payload.Request.Body["files"].([]any)
 	if !ok {
-		t.Fatalf("files payload has wrong type: %T", payload.Body["files"])
+		t.Fatalf("files payload has wrong type: %T", payload.Request.Body["files"])
 	}
 	if len(files) != 0 {
 		t.Fatalf("expected empty files array, got %#v", files)
@@ -596,7 +630,7 @@ func TestRenderProductUpdateDryRunJSON_Direct(t *testing.T) {
 	if err := json.Unmarshal(buf.Bytes(), &payload); err != nil {
 		t.Fatalf("parse output: %v\n%s", err, buf.String())
 	}
-	if payload.Path != "/products/prod1" || payload.Method != http.MethodPut || !payload.DryRun {
+	if payload.Request.Path != "/products/prod1" || payload.Request.Method != http.MethodPut || !payload.DryRun {
 		t.Fatalf("unexpected JSON dry-run output: %+v", payload)
 	}
 	if len(payload.Uploads) != 0 {

--- a/internal/cmd/products/update_files_test.go
+++ b/internal/cmd/products/update_files_test.go
@@ -1,0 +1,361 @@
+package products
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+type productUpdateFileServers struct {
+	existingFiles []existingProductFile
+
+	s3 *httptest.Server
+
+	getCalls     atomic.Int32
+	putCalls     atomic.Int32
+	jsonPutCalls atomic.Int32
+	s3Calls      atomic.Int32
+	completeSeq  atomic.Int32
+
+	putForm     url.Values
+	putJSON     map[string]any
+	presignBody map[string]string
+}
+
+func newProductUpdateFileServers(t *testing.T) *productUpdateFileServers {
+	t.Helper()
+
+	s := &productUpdateFileServers{
+		presignBody: map[string]string{},
+	}
+	s.s3 = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.s3Calls.Add(1)
+		if r.Method != http.MethodPut {
+			t.Errorf("S3 got %s, want PUT", r.Method)
+			http.Error(w, "bad method", http.StatusBadRequest)
+			return
+		}
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.Header().Set("ETag", `"etag-1"`)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(s.s3.Close)
+
+	prev := productUploadHTTPClientForTesting
+	productUploadHTTPClientForTesting = s.s3.Client()
+	t.Cleanup(func() { productUploadHTTPClientForTesting = prev })
+
+	return s
+}
+
+func (s *productUpdateFileServers) dispatch(t *testing.T) http.HandlerFunc {
+	t.Helper()
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/products/prod1":
+			switch r.Method {
+			case http.MethodGet:
+				s.getCalls.Add(1)
+				testutil.JSON(t, w, map[string]any{
+					"product": map[string]any{
+						"id":    "prod1",
+						"files": s.existingFiles,
+					},
+				})
+			case http.MethodPut:
+				s.putCalls.Add(1)
+				if strings.HasPrefix(r.Header.Get("Content-Type"), "application/json") {
+					s.jsonPutCalls.Add(1)
+					if err := json.NewDecoder(r.Body).Decode(&s.putJSON); err != nil {
+						t.Fatalf("decode JSON body: %v", err)
+					}
+				} else {
+					if err := r.ParseForm(); err != nil {
+						t.Fatalf("ParseForm failed: %v", err)
+					}
+					s.putForm = cmdValuesClone(r.PostForm)
+				}
+				testutil.JSON(t, w, map[string]any{})
+			default:
+				t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+				http.Error(w, "unexpected", http.StatusMethodNotAllowed)
+			}
+		case "/files/presign":
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm failed: %v", err)
+			}
+			for key := range r.PostForm {
+				s.presignBody[key] = r.PostForm.Get(key)
+			}
+			testutil.JSON(t, w, map[string]any{
+				"upload_id": "up-1",
+				"key":       "attachments/u/k/original/upload.bin",
+				"file_url":  "https://example.com/attachments/u/k/original/upload.bin",
+				"parts": []map[string]any{
+					{"part_number": 1, "presigned_url": s.s3.URL + "/part/1"},
+				},
+			})
+		case "/files/complete":
+			seq := s.completeSeq.Add(1)
+			testutil.JSON(t, w, map[string]any{
+				"file_url": fmt.Sprintf("https://example.com/attachments/u/k/original/upload-%d.bin", seq),
+			})
+		case "/files/abort":
+			testutil.JSON(t, w, map[string]any{})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected", http.StatusNotFound)
+		}
+	}
+}
+
+func writeProductUploadFixture(t *testing.T, contents string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "fixture.bin")
+	if err := os.WriteFile(path, []byte(contents), 0600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+func cmdValuesClone(values url.Values) url.Values {
+	cloned := make(url.Values, len(values))
+	for key, current := range values {
+		cloned[key] = append([]string(nil), current...)
+	}
+	return cloned
+}
+
+func TestUpdate_FilePreservesExistingByDefault(t *testing.T) {
+	srv := newProductUpdateFileServers(t)
+	srv.existingFiles = []existingProductFile{
+		{ID: "file_a", Name: "Old A"},
+		{ID: "file_b", Name: "Old B"},
+	}
+	testutil.Setup(t, srv.dispatch(t))
+
+	path := writeProductUploadFixture(t, "fresh bytes")
+	cmd := testutil.Command(newUpdateCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{
+		"prod1",
+		"--file", path,
+		"--file-name", "New Pack.zip",
+		"--file-description", "Updated bundle",
+	})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if srv.getCalls.Load() != 1 {
+		t.Fatalf("GET calls = %d, want 1", srv.getCalls.Load())
+	}
+	if srv.putCalls.Load() != 1 {
+		t.Fatalf("PUT calls = %d, want 1", srv.putCalls.Load())
+	}
+	if srv.jsonPutCalls.Load() != 0 {
+		t.Fatalf("expected form PUT, got %d JSON PUTs", srv.jsonPutCalls.Load())
+	}
+	if srv.s3Calls.Load() != 1 {
+		t.Fatalf("S3 calls = %d, want 1", srv.s3Calls.Load())
+	}
+	if srv.presignBody["filename"] != "New Pack.zip" {
+		t.Fatalf("presign filename = %q, want New Pack.zip", srv.presignBody["filename"])
+	}
+
+	if got := srv.putForm.Get("files[0][id]"); got != "file_a" {
+		t.Fatalf("files[0][id] = %q, want file_a", got)
+	}
+	if got := srv.putForm.Get("files[1][id]"); got != "file_b" {
+		t.Fatalf("files[1][id] = %q, want file_b", got)
+	}
+	if got := srv.putForm.Get("files[2][url]"); got != "https://example.com/attachments/u/k/original/upload-1.bin" {
+		t.Fatalf("files[2][url] = %q", got)
+	}
+	if got := srv.putForm.Get("files[2][display_name]"); got != "New Pack.zip" {
+		t.Fatalf("files[2][display_name] = %q", got)
+	}
+	if got := srv.putForm.Get("files[2][description]"); got != "Updated bundle" {
+		t.Fatalf("files[2][description] = %q", got)
+	}
+}
+
+func TestUpdate_RemoveFilePreservesOthers(t *testing.T) {
+	srv := newProductUpdateFileServers(t)
+	srv.existingFiles = []existingProductFile{
+		{ID: "file_a"},
+		{ID: "file_b"},
+	}
+	testutil.Setup(t, srv.dispatch(t))
+
+	cmd := testutil.Command(newUpdateCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"prod1", "--remove-file", "file_a"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if got := srv.putForm.Get("files[0][id]"); got != "file_b" {
+		t.Fatalf("files[0][id] = %q, want file_b", got)
+	}
+	if got := srv.putForm.Get("files[1][id]"); got != "" {
+		t.Fatalf("unexpected second preserved file: %q", got)
+	}
+}
+
+func TestUpdate_ReplaceFilesKeepsOnlyRequestedIDs(t *testing.T) {
+	srv := newProductUpdateFileServers(t)
+	srv.existingFiles = []existingProductFile{
+		{ID: "file_a"},
+		{ID: "file_b"},
+		{ID: "file_c"},
+	}
+	testutil.Setup(t, srv.dispatch(t))
+
+	cmd := testutil.Command(newUpdateCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"prod1", "--replace-files", "--keep-file", "file_b"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if got := srv.putForm.Get("files[0][id]"); got != "file_b" {
+		t.Fatalf("files[0][id] = %q, want file_b", got)
+	}
+	if got := srv.putForm.Get("files[1][id]"); got != "" {
+		t.Fatalf("unexpected extra preserved file: %q", got)
+	}
+}
+
+func TestUpdate_KeepAndRemoveSameIDErrors(t *testing.T) {
+	srv := newProductUpdateFileServers(t)
+	srv.existingFiles = []existingProductFile{{ID: "file_a"}}
+	testutil.Setup(t, srv.dispatch(t))
+
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{"prod1", "--replace-files", "--keep-file", "file_a", "--remove-file", "file_a"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected usage error")
+	}
+	if !strings.Contains(err.Error(), "--keep-file") || !strings.Contains(err.Error(), "--remove-file") {
+		t.Fatalf("expected conflict error, got %v", err)
+	}
+	if srv.putCalls.Load() != 0 {
+		t.Fatalf("unexpected PUT calls: %d", srv.putCalls.Load())
+	}
+}
+
+func TestUpdate_UnknownRemoveFileErrorsAfterPrefetch(t *testing.T) {
+	srv := newProductUpdateFileServers(t)
+	srv.existingFiles = []existingProductFile{{ID: "file_a"}}
+	testutil.Setup(t, srv.dispatch(t))
+
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{"prod1", "--remove-file", "missing"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected usage error")
+	}
+	if !strings.Contains(err.Error(), "unknown --remove-file") {
+		t.Fatalf("expected unknown remove-file error, got %v", err)
+	}
+	if srv.getCalls.Load() != 1 {
+		t.Fatalf("GET calls = %d, want 1", srv.getCalls.Load())
+	}
+	if srv.putCalls.Load() != 0 {
+		t.Fatalf("unexpected PUT calls: %d", srv.putCalls.Load())
+	}
+}
+
+func TestUpdate_ReplaceFilesClearAllUsesJSONBody(t *testing.T) {
+	srv := newProductUpdateFileServers(t)
+	srv.existingFiles = []existingProductFile{
+		{ID: "file_a"},
+		{ID: "file_b"},
+	}
+	testutil.Setup(t, srv.dispatch(t))
+
+	cmd := testutil.Command(newUpdateCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"prod1", "--replace-files"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if srv.jsonPutCalls.Load() != 1 {
+		t.Fatalf("JSON PUT calls = %d, want 1", srv.jsonPutCalls.Load())
+	}
+	files, ok := srv.putJSON["files"].([]any)
+	if !ok {
+		t.Fatalf("files payload has wrong type: %T", srv.putJSON["files"])
+	}
+	if len(files) != 0 {
+		t.Fatalf("files payload = %#v, want empty array", files)
+	}
+}
+
+func TestUpdate_ReplaceFilesNoInputRequiresYes(t *testing.T) {
+	srv := newProductUpdateFileServers(t)
+	srv.existingFiles = []existingProductFile{{ID: "file_a"}}
+	testutil.Setup(t, srv.dispatch(t))
+
+	cmd := testutil.Command(newUpdateCmd(), testutil.NoInput(true))
+	cmd.SetArgs([]string{"prod1", "--replace-files"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected confirmation error")
+	}
+	if !strings.Contains(err.Error(), "--yes") {
+		t.Fatalf("expected --yes hint, got %v", err)
+	}
+	if srv.putCalls.Load() != 0 {
+		t.Fatalf("unexpected PUT calls: %d", srv.putCalls.Load())
+	}
+}
+
+func TestUpdate_FileDryRunPrefetchesButDoesNotUploadOrPut(t *testing.T) {
+	srv := newProductUpdateFileServers(t)
+	srv.existingFiles = []existingProductFile{
+		{ID: "file_a"},
+		{ID: "file_b"},
+	}
+	testutil.Setup(t, srv.dispatch(t))
+
+	path := writeProductUploadFixture(t, "fresh bytes")
+	cmd := testutil.Command(newUpdateCmd(), testutil.DryRun(true))
+	cmd.SetArgs([]string{"prod1", "--file", path, "--remove-file", "file_a"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if srv.getCalls.Load() != 1 {
+		t.Fatalf("GET calls = %d, want 1", srv.getCalls.Load())
+	}
+	if srv.s3Calls.Load() != 0 {
+		t.Fatalf("unexpected S3 calls: %d", srv.s3Calls.Load())
+	}
+	if srv.putCalls.Load() != 0 {
+		t.Fatalf("unexpected PUT calls: %d", srv.putCalls.Load())
+	}
+	if !strings.Contains(out, "files[0][id]: file_b") {
+		t.Fatalf("dry-run output missing preserved id: %q", out)
+	}
+	if !strings.Contains(out, "<uploaded:file:0>") {
+		t.Fatalf("dry-run output missing placeholder upload URL: %q", out)
+	}
+}
+
+func TestUpdate_KeepFileRequiresReplaceFiles(t *testing.T) {
+	srv := newProductUpdateFileServers(t)
+	srv.existingFiles = []existingProductFile{{ID: "file_a"}}
+	testutil.Setup(t, srv.dispatch(t))
+
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{"prod1", "--keep-file", "file_a"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected usage error")
+	}
+	if !strings.Contains(err.Error(), "--replace-files") {
+		t.Fatalf("expected keep-file usage error, got %v", err)
+	}
+}

--- a/internal/cmd/products/update_files_test.go
+++ b/internal/cmd/products/update_files_test.go
@@ -356,12 +356,67 @@ func TestUpdate_FileDryRunPrefetchesButDoesNotUploadOrPut(t *testing.T) {
 	if err := json.Unmarshal([]byte(out), &payload); err != nil {
 		t.Fatalf("parse JSON: %v\n%s", err, out)
 	}
+	if len(payload.Uploads) != 1 {
+		t.Fatalf("uploads = %d, want 1", len(payload.Uploads))
+	}
+	if payload.Uploads[0].Path != path {
+		t.Fatalf("upload path = %q, want %q", payload.Uploads[0].Path, path)
+	}
+	if payload.Uploads[0].Filename != filepath.Base(path) {
+		t.Fatalf("upload filename = %q, want %q", payload.Uploads[0].Filename, filepath.Base(path))
+	}
+	if payload.Uploads[0].Size != int64(len("fresh bytes")) {
+		t.Fatalf("upload size = %d, want %d", payload.Uploads[0].Size, len("fresh bytes"))
+	}
+	if payload.Uploads[0].PartCount != 1 {
+		t.Fatalf("upload part count = %d, want 1", payload.Uploads[0].PartCount)
+	}
 	files := productUpdateJSONFiles(t, payload.Body)
 	if len(files) != 2 || files[0]["id"] != "file_b" {
 		t.Fatalf("dry-run files payload = %#v", files)
 	}
 	if files[1]["url"] != "<uploaded:file:0>" {
 		t.Fatalf("dry-run upload placeholder = %#v", files[1]["url"])
+	}
+}
+
+func TestUpdate_FileDryRunPlainIncludesUploadPlan(t *testing.T) {
+	srv := newProductUpdateFileServers(t)
+	testutil.Setup(t, srv.dispatch(t))
+
+	path := writeProductUploadFixture(t, "fresh bytes")
+	cmd := testutil.Command(newUpdateCmd(), testutil.DryRun(true), testutil.PlainOutput())
+	cmd.SetArgs([]string{"prod1", "--file", path})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "upload\t"+path+"\t"+filepath.Base(path)+"\t11\t1") {
+		t.Fatalf("plain dry-run missing upload plan: %q", out)
+	}
+	if !strings.Contains(out, "PUT\t/products/prod1\t") {
+		t.Fatalf("plain dry-run missing request line: %q", out)
+	}
+}
+
+func TestUpdate_FileDryRunHumanIncludesUploadPlan(t *testing.T) {
+	srv := newProductUpdateFileServers(t)
+	testutil.Setup(t, srv.dispatch(t))
+
+	path := writeProductUploadFixture(t, "fresh bytes")
+	cmd := testutil.Command(newUpdateCmd(), testutil.DryRun(true))
+	cmd.SetArgs([]string{"prod1", "--file", path})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "Dry run: upload "+path) {
+		t.Fatalf("human dry-run missing upload line: %q", out)
+	}
+	if !strings.Contains(out, "Filename: "+filepath.Base(path)) {
+		t.Fatalf("human dry-run missing filename: %q", out)
+	}
+	if !strings.Contains(out, "Size: 11 B (1 part)") {
+		t.Fatalf("human dry-run missing size/part count: %q", out)
+	}
+	if !strings.Contains(out, "Dry run: PUT /products/prod1") {
+		t.Fatalf("human dry-run missing request line: %q", out)
 	}
 }
 
@@ -450,6 +505,9 @@ func TestUpdate_ReplaceFilesClearAllDryRunJSON(t *testing.T) {
 	if !payload.DryRun || payload.Method != http.MethodPut || payload.Path != "/products/prod1" {
 		t.Fatalf("unexpected dry-run envelope: %+v", payload)
 	}
+	if len(payload.Uploads) != 0 {
+		t.Fatalf("expected no uploads, got %+v", payload.Uploads)
+	}
 	files, ok := payload.Body["files"].([]any)
 	if !ok {
 		t.Fatalf("files payload has wrong type: %T", payload.Body["files"])
@@ -531,7 +589,7 @@ func TestRenderProductUpdateDryRunJSON_Direct(t *testing.T) {
 	opts := testutil.TestOptions(testutil.Stdout(&buf), testutil.JSONOutput())
 	body := map[string]any{"files": []map[string]any{}}
 
-	if err := renderProductUpdateDryRunJSON(opts, "/products/prod1", body); err != nil {
+	if err := renderProductUpdateDryRunJSON(opts, "/products/prod1", nil, body); err != nil {
 		t.Fatalf("renderProductUpdateDryRunJSON: %v", err)
 	}
 	var payload dryRunUpdateBody
@@ -540,5 +598,8 @@ func TestRenderProductUpdateDryRunJSON_Direct(t *testing.T) {
 	}
 	if payload.Path != "/products/prod1" || payload.Method != http.MethodPut || !payload.DryRun {
 		t.Fatalf("unexpected JSON dry-run output: %+v", payload)
+	}
+	if len(payload.Uploads) != 0 {
+		t.Fatalf("expected no uploads, got %+v", payload.Uploads)
 	}
 }

--- a/internal/cmd/products/update_files_test.go
+++ b/internal/cmd/products/update_files_test.go
@@ -85,7 +85,7 @@ func (s *productUpdateFileServers) dispatch(t *testing.T) http.HandlerFunc {
 					if err := r.ParseForm(); err != nil {
 						t.Fatalf("ParseForm failed: %v", err)
 					}
-					s.putForm = cmdValuesClone(r.PostForm)
+					s.putForm = r.PostForm
 				}
 				testutil.JSON(t, w, map[string]any{})
 			default:
@@ -131,12 +131,22 @@ func writeProductUploadFixture(t *testing.T, contents string) string {
 	return path
 }
 
-func cmdValuesClone(values url.Values) url.Values {
-	cloned := make(url.Values, len(values))
-	for key, current := range values {
-		cloned[key] = append([]string(nil), current...)
+func productUpdateJSONFiles(t *testing.T, body map[string]any) []map[string]any {
+	t.Helper()
+
+	raw, ok := body["files"].([]any)
+	if !ok {
+		t.Fatalf("files payload has wrong type: %T", body["files"])
 	}
-	return cloned
+	files := make([]map[string]any, len(raw))
+	for i, current := range raw {
+		file, ok := current.(map[string]any)
+		if !ok {
+			t.Fatalf("files[%d] has wrong type: %T", i, current)
+		}
+		files[i] = file
+	}
+	return files
 }
 
 func TestUpdate_FilePreservesExistingByDefault(t *testing.T) {
@@ -163,8 +173,8 @@ func TestUpdate_FilePreservesExistingByDefault(t *testing.T) {
 	if srv.putCalls.Load() != 1 {
 		t.Fatalf("PUT calls = %d, want 1", srv.putCalls.Load())
 	}
-	if srv.jsonPutCalls.Load() != 0 {
-		t.Fatalf("expected form PUT, got %d JSON PUTs", srv.jsonPutCalls.Load())
+	if srv.jsonPutCalls.Load() != 1 {
+		t.Fatalf("expected JSON PUT, got %d JSON PUTs", srv.jsonPutCalls.Load())
 	}
 	if srv.s3Calls.Load() != 1 {
 		t.Fatalf("S3 calls = %d, want 1", srv.s3Calls.Load())
@@ -173,20 +183,24 @@ func TestUpdate_FilePreservesExistingByDefault(t *testing.T) {
 		t.Fatalf("presign filename = %q, want New Pack.zip", srv.presignBody["filename"])
 	}
 
-	if got := srv.putForm.Get("files[0][id]"); got != "file_a" {
-		t.Fatalf("files[0][id] = %q, want file_a", got)
+	files := productUpdateJSONFiles(t, srv.putJSON)
+	if len(files) != 3 {
+		t.Fatalf("files payload len = %d, want 3", len(files))
 	}
-	if got := srv.putForm.Get("files[1][id]"); got != "file_b" {
-		t.Fatalf("files[1][id] = %q, want file_b", got)
+	if files[0]["id"] != "file_a" {
+		t.Fatalf("files[0].id = %#v, want file_a", files[0]["id"])
 	}
-	if got := srv.putForm.Get("files[2][url]"); got != "https://example.com/attachments/u/k/original/upload-1.bin" {
-		t.Fatalf("files[2][url] = %q", got)
+	if files[1]["id"] != "file_b" {
+		t.Fatalf("files[1].id = %#v, want file_b", files[1]["id"])
 	}
-	if got := srv.putForm.Get("files[2][display_name]"); got != "New Pack.zip" {
-		t.Fatalf("files[2][display_name] = %q", got)
+	if files[2]["url"] != "https://example.com/attachments/u/k/original/upload-1.bin" {
+		t.Fatalf("files[2].url = %#v", files[2]["url"])
 	}
-	if got := srv.putForm.Get("files[2][description]"); got != "Updated bundle" {
-		t.Fatalf("files[2][description] = %q", got)
+	if files[2]["display_name"] != "New Pack.zip" {
+		t.Fatalf("files[2].display_name = %#v", files[2]["display_name"])
+	}
+	if files[2]["description"] != "Updated bundle" {
+		t.Fatalf("files[2].description = %#v", files[2]["description"])
 	}
 }
 
@@ -202,11 +216,9 @@ func TestUpdate_RemoveFilePreservesOthers(t *testing.T) {
 	cmd.SetArgs([]string{"prod1", "--remove-file", "file_a"})
 	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	if got := srv.putForm.Get("files[0][id]"); got != "file_b" {
-		t.Fatalf("files[0][id] = %q, want file_b", got)
-	}
-	if got := srv.putForm.Get("files[1][id]"); got != "" {
-		t.Fatalf("unexpected second preserved file: %q", got)
+	files := productUpdateJSONFiles(t, srv.putJSON)
+	if len(files) != 1 || files[0]["id"] != "file_b" {
+		t.Fatalf("files payload = %#v, want only file_b", files)
 	}
 }
 
@@ -223,11 +235,9 @@ func TestUpdate_ReplaceFilesKeepsOnlyRequestedIDs(t *testing.T) {
 	cmd.SetArgs([]string{"prod1", "--replace-files", "--keep-file", "file_b"})
 	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	if got := srv.putForm.Get("files[0][id]"); got != "file_b" {
-		t.Fatalf("files[0][id] = %q, want file_b", got)
-	}
-	if got := srv.putForm.Get("files[1][id]"); got != "" {
-		t.Fatalf("unexpected extra preserved file: %q", got)
+	files := productUpdateJSONFiles(t, srv.putJSON)
+	if len(files) != 1 || files[0]["id"] != "file_b" {
+		t.Fatalf("files payload = %#v, want only file_b", files)
 	}
 }
 
@@ -324,7 +334,7 @@ func TestUpdate_FileDryRunPrefetchesButDoesNotUploadOrPut(t *testing.T) {
 	testutil.Setup(t, srv.dispatch(t))
 
 	path := writeProductUploadFixture(t, "fresh bytes")
-	cmd := testutil.Command(newUpdateCmd(), testutil.DryRun(true))
+	cmd := testutil.Command(newUpdateCmd(), testutil.DryRun(true), testutil.JSONOutput())
 	cmd.SetArgs([]string{"prod1", "--file", path, "--remove-file", "file_a"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
@@ -337,11 +347,16 @@ func TestUpdate_FileDryRunPrefetchesButDoesNotUploadOrPut(t *testing.T) {
 	if srv.putCalls.Load() != 0 {
 		t.Fatalf("unexpected PUT calls: %d", srv.putCalls.Load())
 	}
-	if !strings.Contains(out, "files[0][id]: file_b") {
-		t.Fatalf("dry-run output missing preserved id: %q", out)
+	var payload dryRunUpdateBody
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("parse JSON: %v\n%s", err, out)
 	}
-	if !strings.Contains(out, "<uploaded:file:0>") {
-		t.Fatalf("dry-run output missing placeholder upload URL: %q", out)
+	files := productUpdateJSONFiles(t, payload.Body)
+	if len(files) != 2 || files[0]["id"] != "file_b" {
+		t.Fatalf("dry-run files payload = %#v", files)
+	}
+	if files[1]["url"] != "<uploaded:file:0>" {
+		t.Fatalf("dry-run upload placeholder = %#v", files[1]["url"])
 	}
 }
 

--- a/internal/cmd/products/update_files_test.go
+++ b/internal/cmd/products/update_files_test.go
@@ -526,6 +526,9 @@ func TestUpdate_InvalidUploadFailsBeforeRemovalConfirmation(t *testing.T) {
 	if strings.Contains(err.Error(), "--yes") {
 		t.Fatalf("expected validation to happen before confirmation, got %v", err)
 	}
+	if srv.getCalls.Load() != 0 {
+		t.Fatalf("unexpected GET calls: %d", srv.getCalls.Load())
+	}
 	if srv.putCalls.Load() != 0 {
 		t.Fatalf("unexpected PUT calls: %d", srv.putCalls.Load())
 	}

--- a/internal/cmd/products/update_files_test.go
+++ b/internal/cmd/products/update_files_test.go
@@ -584,6 +584,32 @@ func TestUpdate_ProductUpdateFailureIncludesUploadedURLs(t *testing.T) {
 	}
 }
 
+func TestUpdate_RenderFailureDoesNotIncludeUploadedURLs(t *testing.T) {
+	srv := newProductUpdateFileServers(t)
+	testutil.Setup(t, srv.dispatch(t))
+
+	path := writeProductUploadFixture(t, "first")
+	cmd := testutil.Command(newUpdateCmd(), testutil.Yes(true), testutil.JSONOutput(), testutil.JQ(".bad[syntax"))
+	cmd.SetArgs([]string{
+		"prod1",
+		"--file", path,
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected render failure")
+	}
+	if !strings.Contains(err.Error(), "invalid jq expression") {
+		t.Fatalf("expected jq error, got %v", err)
+	}
+	if strings.Contains(err.Error(), "https://example.com/attachments/u/k/original/upload-1.bin") {
+		t.Fatalf("unexpected uploaded URL in render error: %v", err)
+	}
+	if srv.putCalls.Load() != 1 {
+		t.Fatalf("PUT calls = %d, want 1", srv.putCalls.Load())
+	}
+}
+
 func TestUpdate_ReplaceFilesClearAllDryRunJSON(t *testing.T) {
 	srv := newProductUpdateFileServers(t)
 	srv.existingFiles = []existingProductFile{{ID: "file_a"}}

--- a/internal/cmd/products/upload_helpers.go
+++ b/internal/cmd/products/upload_helpers.go
@@ -56,6 +56,9 @@ func uploadBatch(opts cmdutil.Options, client *api.Client, uploads []batchUpload
 }
 
 func wrapPartialUploadError(err error, uploadedURLs []string) error {
+	if err == nil {
+		return nil
+	}
 	if len(uploadedURLs) == 0 {
 		return err
 	}

--- a/internal/cmd/products/upload_helpers.go
+++ b/internal/cmd/products/upload_helpers.go
@@ -1,0 +1,93 @@
+package products
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/upload"
+	"github.com/antiwork/gumroad-cli/internal/uploadui"
+)
+
+// s3HTTPClientForTesting redirects multipart PUTs at a test TLS server. Tests
+// in this package must not use t.Parallel while mutating this hook.
+var s3HTTPClientForTesting *http.Client
+
+type batchUploadInput struct {
+	Path string
+	Plan upload.Plan
+}
+
+type partialUploadError struct {
+	cause        error
+	uploadedURLs []string
+}
+
+func (e *partialUploadError) Error() string {
+	if len(e.uploadedURLs) == 0 {
+		return e.cause.Error()
+	}
+	return fmt.Sprintf("%v (previously uploaded file URLs: %s)", e.cause, strings.Join(e.uploadedURLs, ", "))
+}
+
+func (e *partialUploadError) Unwrap() error {
+	return e.cause
+}
+
+func uploadBatch(opts cmdutil.Options, client *api.Client, uploads []batchUploadInput) ([]string, error) {
+	urls := make([]string, len(uploads))
+	for i, current := range uploads {
+		statusLabel := current.Plan.Filename
+		if len(uploads) > 1 {
+			statusLabel = fmt.Sprintf("%s (%d/%d)", current.Plan.Filename, i+1, len(uploads))
+		}
+
+		fileURL, err := uploadui.UploadFile(opts, client, current.Path, current.Plan, s3HTTPClientForTesting, statusLabel)
+		if err != nil {
+			return nil, wrapPartialUploadError(err, urls[:i])
+		}
+		urls[i] = fileURL
+	}
+	return urls, nil
+}
+
+func wrapPartialUploadError(err error, uploadedURLs []string) error {
+	if len(uploadedURLs) == 0 {
+		return err
+	}
+	copied := append([]string(nil), uploadedURLs...)
+	return &partialUploadError{
+		cause:        err,
+		uploadedURLs: copied,
+	}
+}
+
+func buildProductJSONBody(params url.Values, files []map[string]any) map[string]any {
+	body := make(map[string]any, len(params)+1)
+	keys := make([]string, 0, len(params))
+	for key := range params {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		values := append([]string(nil), params[key]...)
+		switch key {
+		case "tags[]":
+			body["tags"] = values
+		default:
+			if len(values) == 1 {
+				body[key] = values[0]
+			} else if len(values) > 1 {
+				body[key] = values
+			}
+		}
+	}
+
+	body["files"] = files
+	return body
+}

--- a/internal/cmd/products/upload_helpers.go
+++ b/internal/cmd/products/upload_helpers.go
@@ -88,6 +88,8 @@ func buildProductJSONBody(params url.Values, files []map[string]any) map[string]
 		}
 	}
 
-	body["files"] = files
+	if files != nil {
+		body["files"] = files
+	}
 	return body
 }

--- a/internal/cmdutil/read.go
+++ b/internal/cmdutil/read.go
@@ -56,7 +56,7 @@ func Run(opts Options, spinnerMessage string, run ClientRunner, render func(json
 		return err
 	}
 	if opts.UsesJSONOutput() {
-		return output.PrintJSON(opts.Out(), normalizeJSONBody(data), opts.JQExpr)
+		return PrintJSONResponse(opts, data)
 	}
 	return render(data)
 }
@@ -70,7 +70,7 @@ func RunDecoded[T any](opts Options, spinnerMessage string, run ClientRunner, re
 		return err
 	}
 	if opts.UsesJSONOutput() {
-		return output.PrintJSON(opts.Out(), normalizeJSONBody(data), opts.JQExpr)
+		return PrintJSONResponse(opts, data)
 	}
 
 	decoded, err := DecodeJSON[T](data)
@@ -116,14 +116,20 @@ func RunRequestWithSuccess(opts Options, spinnerMessage, method, path string, pa
 // RunWithToken executes a caller-provided client operation with a
 // caller-supplied token.
 func RunWithToken(opts Options, token, spinnerMessage string, run ClientRunner, render func(json.RawMessage) error) error {
-	data, err := runWithTokenData(opts, token, spinnerMessage, run)
+	data, err := RunWithTokenData(opts, token, spinnerMessage, run)
 	if err != nil {
 		return err
 	}
 	if opts.UsesJSONOutput() {
-		return output.PrintJSON(opts.Out(), normalizeJSONBody(data), opts.JQExpr)
+		return PrintJSONResponse(opts, data)
 	}
 	return render(data)
+}
+
+// RunWithTokenData executes a caller-provided client operation with a
+// caller-supplied token and returns the raw response body without rendering it.
+func RunWithTokenData(opts Options, token, spinnerMessage string, run ClientRunner) (json.RawMessage, error) {
+	return runWithTokenData(opts, token, spinnerMessage, run)
 }
 
 func runAuthenticatedData(opts Options, spinnerMessage string, run ClientRunner) (json.RawMessage, error) {
@@ -154,6 +160,12 @@ func normalizeJSONBody(data json.RawMessage) json.RawMessage {
 		return json.RawMessage("null")
 	}
 	return data
+}
+
+// PrintJSONResponse renders a raw API response using the command's JSON/JQ
+// settings while preserving the shared empty-body normalization.
+func PrintJSONResponse(opts Options, data json.RawMessage) error {
+	return output.PrintJSON(opts.Out(), normalizeJSONBody(data), opts.JQExpr)
 }
 
 type mutationOutput struct {

--- a/internal/cmdutil/read.go
+++ b/internal/cmdutil/read.go
@@ -110,7 +110,7 @@ func RunRequestWithSuccess(opts Options, spinnerMessage, method, path string, pa
 	if err != nil {
 		return err
 	}
-	return renderMutationSuccess(opts, data, id, successMessage)
+	return PrintMutationSuccess(opts, data, id, successMessage)
 }
 
 // RunWithToken executes a caller-provided client operation with a
@@ -182,6 +182,12 @@ func printMutationPayload(opts Options, payload mutationOutput) error {
 		return fmt.Errorf("could not encode JSON output: %w", err)
 	}
 	return output.PrintJSON(opts.Out(), data, opts.JQExpr)
+}
+
+// PrintMutationSuccess renders a successful mutating command with the shared
+// human/plain/JSON envelope used across the CLI.
+func PrintMutationSuccess(opts Options, data json.RawMessage, id, successMessage string) error {
+	return renderMutationSuccess(opts, data, id, successMessage)
 }
 
 func renderMutationSuccess(opts Options, data json.RawMessage, id, successMessage string) error {

--- a/internal/upload/upload.go
+++ b/internal/upload/upload.go
@@ -381,15 +381,24 @@ func presign(ctx context.Context, client *api.Client, filename string, size int6
 }
 
 func completeUpload(ctx context.Context, client *api.Client, uploadID, key string, parts []presignPart, etags []string) (string, error) {
-	params := url.Values{}
-	params.Set("upload_id", uploadID)
-	params.Set("key", key)
+	body := map[string]any{
+		"upload_id": uploadID,
+		"key":       key,
+		"parts":     make([]map[string]any, len(parts)),
+	}
+	payloadParts := body["parts"].([]map[string]any)
 	for i, p := range parts {
-		params.Set(fmt.Sprintf("parts[%d][part_number]", i), strconv.Itoa(p.PartNumber))
-		params.Set(fmt.Sprintf("parts[%d][etag]", i), etags[i])
+		payloadParts[i] = map[string]any{
+			"part_number": p.PartNumber,
+			"etag":        etags[i],
+		}
 	}
 
-	data, err := client.PostWithContext(ctx, "/files/complete", params)
+	// Rails expects params[:parts] to be an actual array of hashes.
+	// Indexed form keys like parts[0][part_number] decode to a hash keyed
+	// by "0", which Array(params[:parts]) turns into [["0", {...}]] and
+	// ultimately produces part_number=0 on the backend.
+	data, err := client.PostJSONWithContext(ctx, "/files/complete", body)
 	if err != nil {
 		return "", err
 	}

--- a/internal/upload/upload_test.go
+++ b/internal/upload/upload_test.go
@@ -3,6 +3,7 @@ package upload
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -93,12 +94,13 @@ type railsMock struct {
 	abortCalls    atomic.Int32
 
 	completeBody url.Values
+	completeJSON map[string]any
 	completeMu   sync.Mutex
 }
 
 // dispatch routes the request by path and records the call. It also captures
-// the parsed form body from /files/complete because several tests assert on
-// the indexed parts[n][...] encoding.
+// the request body from /files/complete because several tests assert on the
+// multipart-finalize payload shape.
 func (m *railsMock) dispatch(t *testing.T, w http.ResponseWriter, r *http.Request) {
 	t.Helper()
 	switch r.URL.Path {
@@ -112,11 +114,21 @@ func (m *railsMock) dispatch(t *testing.T, w http.ResponseWriter, r *http.Reques
 		m.presign(w, r)
 	case "/files/complete":
 		m.completeCalls.Add(1)
-		if err := r.ParseForm(); err != nil {
-			t.Errorf("parse complete form: %v", err)
-		}
 		m.completeMu.Lock()
-		m.completeBody = r.PostForm
+		if strings.HasPrefix(r.Header.Get("Content-Type"), "application/json") {
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode complete json: %v", err)
+			}
+			m.completeJSON = body
+			m.completeBody = nil
+		} else {
+			if err := r.ParseForm(); err != nil {
+				t.Errorf("parse complete form: %v", err)
+			}
+			m.completeBody = r.PostForm
+			m.completeJSON = nil
+		}
 		m.completeMu.Unlock()
 		if m.complete == nil {
 			t.Errorf("unexpected /files/complete call")
@@ -141,6 +153,12 @@ func (m *railsMock) completeForm() url.Values {
 	m.completeMu.Lock()
 	defer m.completeMu.Unlock()
 	return m.completeBody
+}
+
+func (m *railsMock) completeJSONBody() map[string]any {
+	m.completeMu.Lock()
+	defer m.completeMu.Unlock()
+	return m.completeJSON
 }
 
 // setupServers wires a Rails mock (via testutil.Setup so the env + token are
@@ -356,17 +374,24 @@ func TestUpload_HappyPath_MultiPart(t *testing.T) {
 		}
 	}
 
-	// Verify complete form has indexed parts[n][part_number]/[etag].
-	form := mock.completeForm()
-	if form.Get("upload_id") != "up-1" {
-		t.Errorf("upload_id = %q", form.Get("upload_id"))
+	body := mock.completeJSONBody()
+	if body["upload_id"] != "up-1" {
+		t.Errorf("upload_id = %v", body["upload_id"])
+	}
+	parts, ok := body["parts"].([]any)
+	if !ok || len(parts) != 3 {
+		t.Fatalf("parts = %#v, want 3-element array", body["parts"])
 	}
 	for i := 0; i < 3; i++ {
-		if got := form.Get(fmt.Sprintf("parts[%d][part_number]", i)); got != strconv.Itoa(i+1) {
-			t.Errorf("parts[%d][part_number] = %q", i, got)
+		part, ok := parts[i].(map[string]any)
+		if !ok {
+			t.Fatalf("parts[%d] = %#v, want object", i, parts[i])
 		}
-		if got := form.Get(fmt.Sprintf("parts[%d][etag]", i)); got != fmt.Sprintf("etag-%d", i+1) {
-			t.Errorf("parts[%d][etag] = %q", i, got)
+		if got := int(part["part_number"].(float64)); got != i+1 {
+			t.Errorf("parts[%d].part_number = %d, want %d", i, got, i+1)
+		}
+		if got := part["etag"]; got != fmt.Sprintf("etag-%d", i+1) {
+			t.Errorf("parts[%d].etag = %v", i, got)
 		}
 	}
 }
@@ -400,9 +425,17 @@ func TestUpload_HappyPath_SinglePart(t *testing.T) {
 		t.Errorf("fileURL = %q", fileURL)
 	}
 
-	form := mock.completeForm()
-	if form.Get("parts[0][etag]") != "single-etag" {
-		t.Errorf("parts[0][etag] = %q (ETag quotes not stripped?)", form.Get("parts[0][etag]"))
+	body := mock.completeJSONBody()
+	parts, ok := body["parts"].([]any)
+	if !ok || len(parts) != 1 {
+		t.Fatalf("parts = %#v, want 1-element array", body["parts"])
+	}
+	part, ok := parts[0].(map[string]any)
+	if !ok {
+		t.Fatalf("parts[0] = %#v, want object", parts[0])
+	}
+	if part["etag"] != "single-etag" {
+		t.Errorf("parts[0].etag = %v (ETag quotes not stripped?)", part["etag"])
 	}
 }
 

--- a/internal/upload/upload_test.go
+++ b/internal/upload/upload_test.go
@@ -149,12 +149,6 @@ func (m *railsMock) dispatch(t *testing.T, w http.ResponseWriter, r *http.Reques
 	}
 }
 
-func (m *railsMock) completeForm() url.Values {
-	m.completeMu.Lock()
-	defer m.completeMu.Unlock()
-	return m.completeBody
-}
-
 func (m *railsMock) completeJSONBody() map[string]any {
 	m.completeMu.Lock()
 	defer m.completeMu.Unlock()


### PR DESCRIPTION
Closes #36

## What

This adds file management to `gumroad products update`.

You can now attach new files, remove existing files, or opt into full replacement with `--replace-files` and `--keep-file`, while the default behavior preserves the product's current attachments. The command prefetches the current file set, validates invalid or conflicting file ids up front, prompts before destructive removals, and keeps `--dry-run` read-only while still showing the exact request that would be sent.

This PR also carries the create-side follow-up needed to keep file uploads working end to end on current `main`. Product creation and upload completion now send JSON for array payloads, which matches what the backend expects for `files[]` and multipart completion data.

## Why

Issue #36 is about letting sellers attach files to products from the CLI without making them learn Gumroad's lower-level file semantics.

Updates are the tricky part because product files use full-replacement behavior under the API. Preserving existing files by default and making removals explicit keeps the command safe for normal use, while `--replace-files` still exposes the underlying behavior when someone needs it. Bundling the create-side JSON fix here also makes the issue complete in practice, since the earlier create PR merged before that follow-up reached `main`.

---

This PR was implemented with AI assistance using gpt‑5.4 xhigh