### PR TITLE
Split memberships from products in `products list` output

### DIFF
--- a/internal/cmd/products/list.go
+++ b/internal/cmd/products/list.go
@@ -12,11 +12,12 @@ import (
 )
 
 type productListItem struct {
-	ID             string      `json:"id"`
-	Name           string      `json:"name"`
-	Published      bool        `json:"published"`
-	FormattedPrice string      `json:"formatted_price"`
-	SalesCount     api.JSONInt `json:"sales_count"`
+	ID                 string      `json:"id"`
+	Name               string      `json:"name"`
+	Published          bool        `json:"published"`
+	FormattedPrice     string      `json:"formatted_price"`
+	SalesCount         api.JSONInt `json:"sales_count"`
+	IsTieredMembership bool        `json:"is_tiered_membership"`
 }
 
 type productsListResponse struct {
@@ -49,17 +50,52 @@ func newListCmd() *cobra.Command {
 				}
 
 				style := opts.Style()
-				tbl := output.NewStyledTable(style, "ID", "NAME", "STATUS", "PRICE", "SALES")
+				var memberships, standard []productListItem
 				for _, p := range resp.Products {
-					status := style.Yellow("draft")
-					if p.Published {
-						status = style.Green("published")
+					if p.IsTieredMembership {
+						memberships = append(memberships, p)
+					} else {
+						standard = append(standard, p)
 					}
-					tbl.AddRow(p.ID, p.Name, status, p.FormattedPrice, fmt.Sprintf("%d", p.SalesCount))
 				}
+
+				buildTable := func(items []productListItem, countHeader string) *output.Table {
+					tbl := output.NewStyledTable(style, "ID", "NAME", "STATUS", "PRICE", countHeader)
+					for _, p := range items {
+						status := style.Yellow("draft")
+						if p.Published {
+							status = style.Green("published")
+						}
+						tbl.AddRow(p.ID, p.Name, status, p.FormattedPrice, fmt.Sprintf("%d", p.SalesCount))
+					}
+					return tbl
+				}
+
 				return output.WithPager(opts.Out(), opts.Err(), func(w io.Writer) error {
-					if err := tbl.Render(w); err != nil {
-						return err
+					split := len(memberships) > 0 && len(standard) > 0
+					if split {
+						if err := output.Writeln(w, style.Bold("Memberships")); err != nil {
+							return err
+						}
+						if err := buildTable(memberships, "MEMBERS").Render(w); err != nil {
+							return err
+						}
+						if err := output.Writeln(w, "\n"+style.Bold("Products")); err != nil {
+							return err
+						}
+						if err := buildTable(standard, "SALES").Render(w); err != nil {
+							return err
+						}
+					} else {
+						items := standard
+						header := "SALES"
+						if len(memberships) > 0 {
+							items = memberships
+							header = "MEMBERS"
+						}
+						if err := buildTable(items, header).Render(w); err != nil {
+							return err
+						}
 					}
 					if !opts.Quiet {
 						return output.Writeln(w, style.Dim("\nTip: view a product with  gumroad products view <id>"))

--- a/internal/cmd/products/products_test.go
+++ b/internal/cmd/products/products_test.go
@@ -344,8 +344,11 @@ func TestView_SalesCountFloat(t *testing.T) {
 
 	cmd := newViewCmd()
 	out := testutil.CaptureStdout(func() { _ = cmd.RunE(cmd, []string{"p1"}) })
-	if !strings.Contains(out, "Sales: 3 ($15.00)") {
+	if !strings.Contains(out, "Sales: 3") {
 		t.Errorf("output missing integer-like float sales count: %q", out)
+	}
+	if !strings.Contains(out, "Revenue: $15.00") {
+		t.Errorf("output missing revenue line: %q", out)
 	}
 }
 
@@ -367,6 +370,9 @@ func TestView_MembershipUsesMembersLabel(t *testing.T) {
 	}
 	if strings.Contains(out, "Sales: 7") {
 		t.Errorf("expected membership to not use Sales label, got: %q", out)
+	}
+	if !strings.Contains(out, "Revenue: $35.00") {
+		t.Errorf("expected revenue line, got: %q", out)
 	}
 }
 

--- a/internal/cmd/products/products_test.go
+++ b/internal/cmd/products/products_test.go
@@ -92,6 +92,132 @@ func TestList_Empty(t *testing.T) {
 	}
 }
 
+func TestList_MixedTypes_SplitsTables(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"products": []map[string]any{
+				{"id": "m1", "name": "Club", "published": true, "formatted_price": "$5 a month", "sales_count": 7, "is_tiered_membership": true},
+				{"id": "p1", "name": "Art Pack", "published": true, "formatted_price": "$10", "sales_count": 42, "is_tiered_membership": false},
+			},
+		})
+	})
+
+	cmd := newListCmd()
+	out := testutil.CaptureStdout(func() { _ = cmd.RunE(cmd, []string{}) })
+
+	if !strings.Contains(out, "Memberships") || !strings.Contains(out, "Products") {
+		t.Errorf("expected both section headers, got: %q", out)
+	}
+	if !strings.Contains(out, "MEMBERS") {
+		t.Errorf("expected MEMBERS column header for memberships, got: %q", out)
+	}
+	if !strings.Contains(out, "SALES") {
+		t.Errorf("expected SALES column header for products, got: %q", out)
+	}
+	membersIdx := strings.Index(out, "Memberships")
+	productsIdx := strings.Index(out, "\nProducts")
+	if membersIdx < 0 || productsIdx < 0 || membersIdx > productsIdx {
+		t.Errorf("expected Memberships section before Products section, got: %q", out)
+	}
+	if strings.Index(out, "m1") > strings.Index(out, "p1") {
+		t.Errorf("expected membership row before product row, got: %q", out)
+	}
+}
+
+func TestList_OnlyMemberships_UsesMembersHeader(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"products": []map[string]any{
+				{"id": "m1", "name": "Club", "published": true, "formatted_price": "$5 a month", "sales_count": 7, "is_tiered_membership": true},
+			},
+		})
+	})
+
+	cmd := newListCmd()
+	out := testutil.CaptureStdout(func() { _ = cmd.RunE(cmd, []string{}) })
+
+	if !strings.Contains(out, "MEMBERS") {
+		t.Errorf("expected MEMBERS column header, got: %q", out)
+	}
+	if strings.Contains(out, "SALES") {
+		t.Errorf("expected no SALES column when only memberships present, got: %q", out)
+	}
+	if strings.Contains(out, "\nProducts\n") || strings.Contains(out, "Memberships\n") && strings.Contains(out, "Products") {
+		// Section headers only appear when both types exist.
+		t.Errorf("expected no section headers when only memberships present, got: %q", out)
+	}
+}
+
+func TestList_OnlyProducts_UsesSalesHeader(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"products": []map[string]any{
+				{"id": "p1", "name": "Art Pack", "published": true, "formatted_price": "$10", "sales_count": 42, "is_tiered_membership": false},
+			},
+		})
+	})
+
+	cmd := newListCmd()
+	out := testutil.CaptureStdout(func() { _ = cmd.RunE(cmd, []string{}) })
+
+	if !strings.Contains(out, "SALES") {
+		t.Errorf("expected SALES column header, got: %q", out)
+	}
+	if strings.Contains(out, "MEMBERS") {
+		t.Errorf("expected no MEMBERS column when only products present, got: %q", out)
+	}
+	if strings.Contains(out, "Memberships") || strings.Contains(out, "\nProducts\n") {
+		t.Errorf("expected no section headers when only products present, got: %q", out)
+	}
+}
+
+func TestList_JSON_PreservesFlatShape(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"products": []map[string]any{
+				{"id": "m1", "name": "Club", "published": true, "formatted_price": "$5 a month", "sales_count": 7, "is_tiered_membership": true},
+				{"id": "p1", "name": "Art Pack", "published": true, "formatted_price": "$10", "sales_count": 42, "is_tiered_membership": false},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newListCmd(), testutil.JSONOutput())
+	out := testutil.CaptureStdout(func() { _ = cmd.RunE(cmd, []string{}) })
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+	products := resp["products"].([]any)
+	if len(products) != 2 {
+		t.Fatalf("got %d products, want 2 (flat)", len(products))
+	}
+	if strings.Contains(out, "Memberships") || strings.Contains(out, "\nProducts\n") {
+		t.Errorf("JSON output should not contain section headers, got: %q", out)
+	}
+}
+
+func TestList_Plain_PreservesFlatShape(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"products": []map[string]any{
+				{"id": "m1", "name": "Club", "published": true, "formatted_price": "$5 a month", "sales_count": 7, "is_tiered_membership": true},
+				{"id": "p1", "name": "Art Pack", "published": true, "formatted_price": "$10", "sales_count": 42, "is_tiered_membership": false},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newListCmd(), testutil.PlainOutput())
+	out := testutil.CaptureStdout(func() { _ = cmd.RunE(cmd, []string{}) })
+
+	if strings.Contains(out, "Memberships") || strings.Contains(out, "Products\n") {
+		t.Errorf("plain output should not contain section headers, got: %q", out)
+	}
+	if !strings.Contains(out, "m1\t") || !strings.Contains(out, "p1\t") {
+		t.Errorf("plain output missing tab-separated rows: %q", out)
+	}
+}
+
 func TestView_CorrectEndpoint(t *testing.T) {
 	var gotPath string
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {

--- a/internal/cmd/products/products_test.go
+++ b/internal/cmd/products/products_test.go
@@ -349,6 +349,27 @@ func TestView_SalesCountFloat(t *testing.T) {
 	}
 }
 
+func TestView_MembershipUsesMembersLabel(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"product": map[string]any{
+				"id": "m1", "name": "Club", "published": true,
+				"formatted_price": "$5 a month", "sales_count": 7, "sales_usd_cents": 3500,
+				"is_tiered_membership": true,
+			},
+		})
+	})
+
+	cmd := newViewCmd()
+	out := testutil.CaptureStdout(func() { _ = cmd.RunE(cmd, []string{"m1"}) })
+	if !strings.Contains(out, "Members: 7") {
+		t.Errorf("expected membership to use Members label, got: %q", out)
+	}
+	if strings.Contains(out, "Sales: 7") {
+		t.Errorf("expected membership to not use Sales label, got: %q", out)
+	}
+}
+
 func TestList_SalesCountFloat(t *testing.T) {
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
 		testutil.RawJSON(t, w, `{

--- a/internal/cmd/products/view.go
+++ b/internal/cmd/products/view.go
@@ -92,7 +92,10 @@ func newViewCmd() *cobra.Command {
 				if p.IsTieredMembership {
 					countLabel = "Members"
 				}
-				if err := output.Writef(opts.Out(), "%s: %d ($%.2f)\n", countLabel, p.SalesCount, p.SalesUSDCents/100); err != nil {
+				if err := output.Writef(opts.Out(), "%s: %d\n", countLabel, p.SalesCount); err != nil {
+					return err
+				}
+				if err := output.Writef(opts.Out(), "Revenue: $%.2f\n", p.SalesUSDCents/100); err != nil {
 					return err
 				}
 				if p.URL != "" {

--- a/internal/cmd/products/view.go
+++ b/internal/cmd/products/view.go
@@ -45,16 +45,17 @@ func newViewCmd() *cobra.Command {
 			return cmdutil.RunRequest(opts, "Fetching product...", "GET", cmdutil.JoinPath("products", args[0]), url.Values{}, func(data json.RawMessage) error {
 				var resp struct {
 					Product struct {
-						ID             string      `json:"id"`
-						Name           string      `json:"name"`
-						Published      bool        `json:"published"`
-						Description    string      `json:"description"`
-						FormattedPrice string      `json:"formatted_price"`
-						SalesCount     api.JSONInt `json:"sales_count"`
-						SalesUSDCents  float64     `json:"sales_usd_cents"`
-						URL            string      `json:"short_url"`
-						ThumbnailURL   *string     `json:"thumbnail_url"`
-						PreviewURL     *string     `json:"preview_url"`
+						ID                 string      `json:"id"`
+						Name               string      `json:"name"`
+						Published          bool        `json:"published"`
+						Description        string      `json:"description"`
+						FormattedPrice     string      `json:"formatted_price"`
+						SalesCount         api.JSONInt `json:"sales_count"`
+						SalesUSDCents      float64     `json:"sales_usd_cents"`
+						URL                string      `json:"short_url"`
+						ThumbnailURL       *string     `json:"thumbnail_url"`
+						PreviewURL         *string     `json:"preview_url"`
+						IsTieredMembership bool        `json:"is_tiered_membership"`
 					} `json:"product"`
 				}
 				if err := json.Unmarshal(data, &resp); err != nil {
@@ -87,7 +88,11 @@ func newViewCmd() *cobra.Command {
 				if err := output.Writef(opts.Out(), "ID: %s  Status: %s  Price: %s\n", p.ID, status, p.FormattedPrice); err != nil {
 					return err
 				}
-				if err := output.Writef(opts.Out(), "Sales: %d ($%.2f)\n", p.SalesCount, p.SalesUSDCents/100); err != nil {
+				countLabel := "Sales"
+				if p.IsTieredMembership {
+					countLabel = "Members"
+				}
+				if err := output.Writef(opts.Out(), "%s: %d ($%.2f)\n", countLabel, p.SalesCount, p.SalesUSDCents/100); err != nil {
 					return err
 				}
 				if p.URL != "" {


### PR DESCRIPTION
## What

`gumroad products list` now splits memberships and one-time products into two tables when both are present, and renames the count column to `MEMBERS` for memberships. When the account has only one type, a single table is rendered with the appropriate column header.

## Why

For memberships the value is actually the active member count, not sales, so the label was misleading

## Before
<img width="2172" height="338" alt="image" src="https://github.com/user-attachments/assets/7812bd06-d809-46dd-9657-2056f134db01" />


## After
<img width="1026" height="208" alt="image" src="https://github.com/user-attachments/assets/0542e584-9d91-4136-9dc2-1857e367e868" />

---

AI disclosure: implemented with Claude Opus 4.7