### PR TITLE
Fix user agent to use gumroad-cli

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -191,7 +191,7 @@ func (c *Client) doPreparedWithContext(
 		}
 
 		req.Header.Set("Authorization", "Bearer "+c.token)
-		req.Header.Set("User-Agent", "gumroad/"+c.version)
+		req.Header.Set("User-Agent", "gumroad-cli/"+c.version)
 		if contentType != "" {
 			req.Header.Set("Content-Type", contentType)
 		}

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -107,8 +107,8 @@ func TestClient_UserAgent(t *testing.T) {
 	c := &Client{token: "tok", httpClient: srv.Client(), baseURL: srv.URL, version: "1.2.3"}
 
 	_, _ = c.Get("/user", nil)
-	if gotUA != "gumroad/1.2.3" {
-		t.Errorf("got User-Agent=%q, want %q", gotUA, "gumroad/1.2.3")
+	if gotUA != "gumroad-cli/1.2.3" {
+		t.Errorf("got User-Agent=%q, want %q", gotUA, "gumroad-cli/1.2.3")
 	}
 }
 


### PR DESCRIPTION
## What
- Change the CLI user agent string from `gumroad/<version>` to `gumroad-cli/<version>`.
- Update the unit test to match the new header value.

## Why
- Makes the client identity clearer in API logs and server-side diagnostics.
- Keeps the user agent aligned with the product name.