### PR TITLE
add affiliate management commands

### DIFF
--- a/internal/cmd/affiliates/affiliates.go
+++ b/internal/cmd/affiliates/affiliates.go
@@ -1,0 +1,18 @@
+package affiliates
+
+import (
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+func NewAffiliatesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "affiliates",
+		Short: "Manage affiliates",
+	}
+
+	cmd.AddCommand(newListCmd())
+	cmd.AddCommand(newCreateCmd())
+
+	return cmdutil.PropagateExamples(cmd)
+}

--- a/internal/cmd/affiliates/affiliates_test.go
+++ b/internal/cmd/affiliates/affiliates_test.go
@@ -1,0 +1,87 @@
+package affiliates
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestList_JSON(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" || r.URL.Path != "/affiliates" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		testutil.JSON(t, w, map[string]any{
+			"affiliates": []map[string]any{
+				{"id": "a1", "email": "partner1@example.com", "commission_percentage": 20},
+				{"id": "a2", "email": "partner2@example.com", "commission_percentage": 50},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newListCmd(), testutil.JSONOutput())
+	var err error
+	out := testutil.CaptureStdout(func() { err = cmd.RunE(cmd, []string{}) })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var resp map[string]any
+	if jsonErr := json.Unmarshal([]byte(out), &resp); jsonErr != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", jsonErr, out)
+	}
+	affiliates := resp["affiliates"].([]any)
+	if len(affiliates) != 2 {
+		t.Errorf("got %d affiliates, want 2", len(affiliates))
+	}
+}
+
+func TestList_Table(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"affiliates": []map[string]any{
+				{"id": "a1", "email": "partner@example.com", "commission_percentage": 20},
+			},
+		})
+	})
+
+	cmd := newListCmd()
+	out := testutil.CaptureStdout(func() { _ = cmd.RunE(cmd, []string{}) })
+	if !strings.Contains(out, "a1") || !strings.Contains(out, "partner@example.com") || !strings.Contains(out, "20%") {
+		t.Errorf("table output missing affiliate data: %q", out)
+	}
+}
+
+func TestCreate_Success(t *testing.T) {
+	var gotMethod, gotPath string
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		testutil.JSON(t, w, map[string]any{})
+	})
+
+	cmd := testutil.Command(newCreateCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--email", "new@example.com", "--commission", "30"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != "POST" {
+		t.Errorf("got method %q, want POST", gotMethod)
+	}
+	if gotPath != "/affiliates" {
+		t.Errorf("got path %q, want /affiliates", gotPath)
+	}
+	if !strings.Contains(out, "created successfully") {
+		t.Errorf("expected success message, got: %q", out)
+	}
+}
+
+func TestCreate_MissingEmail(t *testing.T) {
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--commission", "30"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "required flag(s) \"email\" not set") {
+		t.Errorf("expected missing email error, got: %v", err)
+	}
+}

--- a/internal/cmd/affiliates/create.go
+++ b/internal/cmd/affiliates/create.go
@@ -1,0 +1,45 @@
+package affiliates
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+type createOptions struct {
+	Email                string
+	CommissionPercentage int
+}
+
+func newCreateCmd() *cobra.Command {
+	var co createOptions
+
+	cmd := &cobra.Command{
+		Use:     "create",
+		Short:   "Create an affiliate",
+		Args:    cmdutil.ExactArgs(0),
+		Example: `  gumroad affiliates create --email partner@example.com --commission 20`,
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+
+			params := url.Values{}
+			params.Set("email", co.Email)
+			if co.CommissionPercentage > 0 {
+				params.Set("commission_percentage", fmt.Sprintf("%d", co.CommissionPercentage))
+			}
+
+			return cmdutil.RunRequest(opts, "Creating affiliate...", "POST", "/affiliates", params, func(data []byte) error {
+				return cmdutil.PrintSuccess(opts, "Affiliate created successfully.")
+			})
+		},
+	}
+
+	cmd.Flags().StringVar(&co.Email, "email", "", "Email of the affiliate")
+	cmd.Flags().IntVar(&co.CommissionPercentage, "commission", 0, "Commission percentage (0-100)")
+
+	_ = cmd.MarkFlagRequired("email")
+
+	return cmd
+}

--- a/internal/cmd/affiliates/list.go
+++ b/internal/cmd/affiliates/list.go
@@ -1,0 +1,54 @@
+package affiliates
+
+import (
+	"io"
+	"net/url"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+type affiliateListItem struct {
+	ID                   string `json:"id"`
+	Email                string `json:"email"`
+	CommissionPercentage int    `json:"commission_percentage"`
+}
+
+type affiliatesListResponse struct {
+	Affiliates []affiliateListItem `json:"affiliates"`
+}
+
+func newListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "list",
+		Short:   "List affiliates",
+		Args:    cmdutil.ExactArgs(0),
+		Example: `  gumroad affiliates list`,
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			return cmdutil.RunRequestDecoded[affiliatesListResponse](opts, "Fetching affiliates...", "GET", "/affiliates", url.Values{}, func(resp affiliatesListResponse) error {
+				if len(resp.Affiliates) == 0 {
+					return cmdutil.PrintInfo(opts, "No affiliates found.")
+				}
+
+				if opts.PlainOutput {
+					var rows [][]string
+					for _, a := range resp.Affiliates {
+						rows = append(rows, []string{a.ID, a.Email, cmdutil.FormatInt(a.CommissionPercentage) + "%"})
+					}
+					return output.PrintPlain(opts.Out(), rows)
+				}
+
+				style := opts.Style()
+				tbl := output.NewStyledTable(style, "ID", "EMAIL", "COMMISSION")
+				for _, a := range resp.Affiliates {
+					tbl.AddRow(a.ID, a.Email, cmdutil.FormatInt(a.CommissionPercentage)+"%")
+				}
+				return output.WithPager(opts.Out(), opts.Err(), func(w io.Writer) error {
+					return tbl.Render(w)
+				})
+			})
+		},
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/antiwork/gumroad-cli/internal/cmd/affiliates"
 	"github.com/antiwork/gumroad-cli/internal/cmd/auth"
 	"github.com/antiwork/gumroad-cli/internal/cmd/categories"
 	"github.com/antiwork/gumroad-cli/internal/cmd/completion"
@@ -98,6 +99,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&opts.Debug, "debug", false, "Enable debug logging to stderr")
 
 	// Subcommands
+	cmd.AddCommand(affiliates.NewAffiliatesCmd())
 	cmd.AddCommand(auth.NewAuthCmd())
 	cmd.AddCommand(user.NewUserCmd())
 	cmd.AddCommand(products.NewProductsCmd())


### PR DESCRIPTION
- gumroad affiliates list: displays a styled table of all affiliates and supports --json, --jq, and --plain output modes
- gumroad affiliates create: adds a new affiliate with required --email and optional --commission percentage

as affiliate management is supported by the gumroad api but was missing from the cli 
adding these commands makes the cli more complete for creators who want to manage their partner programs from the terminal or via automated scripts

- created a new package internal/cmd/affiliates to maintain isolation
- used cmdutil.RunRequestDecoded for optimized API interaction and automatic JSON/JQ handling
- implemented unit tests with mocking to ensure the logic remains correct even without a live API token