### PR TITLE
Add admin CLI foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ For CI and agents, set `GUMROAD_ACCESS_TOKEN` instead — it takes precedence ov
 
 ```
 gumroad auth          login, status, logout
+gumroad admin         Internal admin API commands
 gumroad user          View your account info
 gumroad products      create, update, list, view, delete, publish, unpublish, skus
 gumroad sales         list, view, refund, ship, resend-receipt
@@ -103,6 +104,8 @@ gumroad completion    bash, zsh, fish, powershell
 ```
 
 Run `gumroad <command> --help` for usage details and examples.
+
+Admin commands use a separate internal token. For non-interactive use, set `GUMROAD_ADMIN_ACCESS_TOKEN`; for local testing, set `GUMROAD_ADMIN_API_BASE_URL`.
 
 ## File attachments
 

--- a/internal/adminapi/client.go
+++ b/internal/adminapi/client.go
@@ -1,0 +1,106 @@
+package adminapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/antiwork/gumroad-cli/internal/adminconfig"
+	"github.com/antiwork/gumroad-cli/internal/api"
+)
+
+const (
+	EnvAPIBaseURL      = "GUMROAD_ADMIN_API_BASE_URL"
+	defaultAPIBaseURL  = "https://api.gumroad.com"
+	adminAPIPathPrefix = "/internal/admin"
+)
+
+type Client struct {
+	api *api.Client
+}
+
+func NewClientWithContext(ctx context.Context, token, version string, debug bool) *Client {
+	return NewClientWithBaseURL(ctx, token, version, debug, defaultBaseURL())
+}
+
+func NewClientWithBaseURL(ctx context.Context, token, version string, debug bool, baseURL string) *Client {
+	return &Client{api: api.NewClientWithBaseURL(ctx, token, version, debug, baseURL)}
+}
+
+func (c *Client) SetDebugWriter(w io.Writer) {
+	if c == nil || c.api == nil {
+		return
+	}
+	c.api.SetDebugWriter(w)
+}
+
+func (c *Client) Get(path string, params url.Values) (json.RawMessage, error) {
+	data, err := c.api.Get(adminPath(path), params)
+	return data, rewriteAdminError(err)
+}
+
+func (c *Client) Post(path string, params url.Values) (json.RawMessage, error) {
+	data, err := c.api.Post(adminPath(path), params)
+	return data, rewriteAdminError(err)
+}
+
+func (c *Client) PostJSON(path string, payload any) (json.RawMessage, error) {
+	data, err := c.api.PostJSON(adminPath(path), payload)
+	return data, rewriteAdminError(err)
+}
+
+func (c *Client) Put(path string, params url.Values) (json.RawMessage, error) {
+	data, err := c.api.Put(adminPath(path), params)
+	return data, rewriteAdminError(err)
+}
+
+func (c *Client) PutJSON(path string, payload any) (json.RawMessage, error) {
+	data, err := c.api.PutJSON(adminPath(path), payload)
+	return data, rewriteAdminError(err)
+}
+
+func (c *Client) Delete(path string, params url.Values) (json.RawMessage, error) {
+	data, err := c.api.Delete(adminPath(path), params)
+	return data, rewriteAdminError(err)
+}
+
+func defaultBaseURL() string {
+	if v := strings.TrimRight(os.Getenv(EnvAPIBaseURL), "/"); v != "" {
+		return v
+	}
+	return defaultAPIBaseURL
+}
+
+func adminPath(path string) string {
+	if path == "" || path == "/" {
+		return adminAPIPathPrefix
+	}
+	if strings.HasPrefix(path, "/") {
+		return adminAPIPathPrefix + path
+	}
+	return adminAPIPathPrefix + "/" + path
+}
+
+func rewriteAdminError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var apiErr *api.APIError
+	if !errors.As(err, &apiErr) {
+		return err
+	}
+
+	replacement := *apiErr
+	switch apiErr.StatusCode {
+	case 401:
+		replacement.Hint = adminconfig.HintSetAdminToken
+	case 403:
+		replacement.Hint = "Check that your admin token has internal admin access."
+	}
+	return &replacement
+}

--- a/internal/adminapi/client_test.go
+++ b/internal/adminapi/client_test.go
@@ -1,0 +1,108 @@
+package adminapi
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/adminconfig"
+	"github.com/antiwork/gumroad-cli/internal/api"
+)
+
+func TestClientPrefixesInternalAdminPath(t *testing.T) {
+	var gotPath string
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		if err := json.NewEncoder(w).Encode(map[string]any{"success": true}); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := NewClientWithBaseURL(t.Context(), "admin-token", "test", false, srv.URL)
+	if _, err := client.Get("/purchases/123", nil); err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+
+	if gotPath != "/internal/admin/purchases/123" {
+		t.Fatalf("got path %q, want /internal/admin/purchases/123", gotPath)
+	}
+	if gotAuth != "Bearer admin-token" {
+		t.Fatalf("got auth %q, want Bearer admin-token", gotAuth)
+	}
+}
+
+func TestClientUsesAdminBaseURLEnv(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		if err := json.NewEncoder(w).Encode(map[string]any{"success": true}); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv(EnvAPIBaseURL, srv.URL+"/")
+
+	client := NewClientWithContext(t.Context(), "tok", "test", false)
+	if _, err := client.Get("/users/suspension", nil); err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if gotPath != "/internal/admin/users/suspension" {
+		t.Fatalf("got path %q, want /internal/admin/users/suspension", gotPath)
+	}
+}
+
+func TestClientRedactsQueryValuesInDebug(t *testing.T) {
+	var debug strings.Builder
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewEncoder(w).Encode(map[string]any{"success": true}); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := NewClientWithBaseURL(t.Context(), "admin-token", "test", true, srv.URL)
+	client.SetDebugWriter(&debug)
+
+	params := url.Values{"license_key": {"SECRET-LICENSE"}}
+	if _, err := client.Get("/licenses/lookup", params); err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+
+	if strings.Contains(debug.String(), "SECRET-LICENSE") {
+		t.Fatalf("debug output leaked query value: %q", debug.String())
+	}
+	if !strings.Contains(debug.String(), "license_key=REDACTED") {
+		t.Fatalf("debug output should show redacted query, got %q", debug.String())
+	}
+}
+
+func TestClientRewritesAdminAuthHint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		if err := json.NewEncoder(w).Encode(map[string]any{"success": false, "message": "Nope"}); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := NewClientWithBaseURL(t.Context(), "bad-token", "test", false, srv.URL)
+	_, err := client.Get("/purchases/123", nil)
+	if err == nil {
+		t.Fatal("expected auth error")
+	}
+
+	var apiErr *api.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected APIError, got %T", err)
+	}
+	if apiErr.GetHint() != adminconfig.HintSetAdminToken {
+		t.Fatalf("got hint %q, want %q", apiErr.GetHint(), adminconfig.HintSetAdminToken)
+	}
+}

--- a/internal/admincmd/read.go
+++ b/internal/admincmd/read.go
@@ -1,0 +1,81 @@
+package admincmd
+
+import (
+	"encoding/json"
+	"net/url"
+
+	"github.com/antiwork/gumroad-cli/internal/adminapi"
+	"github.com/antiwork/gumroad-cli/internal/adminconfig"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+)
+
+type ClientRunner func(*adminapi.Client) (json.RawMessage, error)
+
+func NewAPIClient(opts cmdutil.Options, token string) *adminapi.Client {
+	client := adminapi.NewClientWithContext(opts.Context, token, opts.Version, opts.DebugEnabled())
+	client.SetDebugWriter(opts.Err())
+	return client
+}
+
+func Run(opts cmdutil.Options, spinnerMessage string, run ClientRunner, render func(json.RawMessage) error) error {
+	data, err := runAuthenticatedData(opts, spinnerMessage, run)
+	if err != nil {
+		return err
+	}
+	if opts.UsesJSONOutput() {
+		return cmdutil.PrintJSONResponse(opts, data)
+	}
+	return render(data)
+}
+
+func RunDecoded[T any](opts cmdutil.Options, spinnerMessage string, run ClientRunner, render func(T) error) error {
+	data, err := runAuthenticatedData(opts, spinnerMessage, run)
+	if err != nil {
+		return err
+	}
+	if opts.UsesJSONOutput() {
+		return cmdutil.PrintJSONResponse(opts, data)
+	}
+
+	decoded, err := cmdutil.DecodeJSON[T](data)
+	if err != nil {
+		return err
+	}
+	return render(decoded)
+}
+
+func RunGet(opts cmdutil.Options, spinnerMessage, path string, params url.Values, render func(json.RawMessage) error) error {
+	return Run(opts, spinnerMessage, func(client *adminapi.Client) (json.RawMessage, error) {
+		return client.Get(path, params)
+	}, render)
+}
+
+func RunGetDecoded[T any](opts cmdutil.Options, spinnerMessage, path string, params url.Values, render func(T) error) error {
+	return RunDecoded[T](opts, spinnerMessage, func(client *adminapi.Client) (json.RawMessage, error) {
+		return client.Get(path, params)
+	}, render)
+}
+
+func runAuthenticatedData(opts cmdutil.Options, spinnerMessage string, run ClientRunner) (json.RawMessage, error) {
+	token, err := adminconfig.Token()
+	if err != nil {
+		return nil, err
+	}
+	return runWithTokenData(opts, token, spinnerMessage, run)
+}
+
+func runWithTokenData(opts cmdutil.Options, token, spinnerMessage string, run ClientRunner) (json.RawMessage, error) {
+	if cmdutil.ShouldShowSpinner(opts) {
+		sp := output.NewSpinnerTo(spinnerMessage, opts.Err())
+		sp.Start()
+		defer sp.Stop()
+	}
+
+	client := NewAPIClient(opts, token)
+	data, err := run(client)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}

--- a/internal/adminconfig/config.go
+++ b/internal/adminconfig/config.go
@@ -1,0 +1,203 @@
+package adminconfig
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/antiwork/gumroad-cli/internal/config"
+)
+
+type Config struct {
+	AccessToken string `json:"access_token"`
+}
+
+const (
+	EnvAccessToken        = "GUMROAD_ADMIN_ACCESS_TOKEN"
+	HintSetAdminToken     = "Set GUMROAD_ADMIN_ACCESS_TOKEN."
+	adminConfigFile       = "admin.json"
+	adminConfigTempPrefix = "admin.json.tmp-*"
+)
+
+var (
+	ErrNotAuthenticated = errors.New("not authenticated")
+	goos                = runtime.GOOS
+)
+
+type TokenSource string
+
+const (
+	TokenSourceEnv    TokenSource = "env"
+	TokenSourceConfig TokenSource = "config"
+)
+
+type TokenInfo struct {
+	Value  string
+	Source TokenSource
+}
+
+func Dir() (string, error) {
+	return config.Dir()
+}
+
+func Path() (string, error) {
+	dir, err := Dir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, adminConfigFile), nil
+}
+
+func Load() (*Config, error) {
+	p, err := Path()
+	if err != nil {
+		return nil, err
+	}
+	info, err := os.Stat(p)
+	if err != nil {
+		if os.IsNotExist(err) {
+			if goos == "windows" {
+				if recoverErr := recoverBackup(p); recoverErr == nil {
+					info, err = os.Stat(p)
+				}
+			}
+			if err != nil {
+				return &Config{}, nil
+			}
+		} else {
+			return nil, fmt.Errorf("could not read admin config: %w", err)
+		}
+	}
+	if err := validateConfigPermissions(p, info.Mode()); err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return nil, fmt.Errorf("could not read admin config: %w", err)
+	}
+	var cfg Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("could not parse admin config: %w", err)
+	}
+	return &cfg, nil
+}
+
+func Save(cfg *Config) error {
+	p, err := Path()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0700); err != nil {
+		return fmt.Errorf("could not create config directory: %w", err)
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("could not marshal admin config: %w", err)
+	}
+	if err := writeConfigAtomically(p, data); err != nil {
+		return fmt.Errorf("could not write admin config: %w", err)
+	}
+	return nil
+}
+
+func Delete() error {
+	p, err := Path()
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("could not delete admin config: %w", err)
+	}
+	if err := os.Remove(p + ".bak"); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("could not delete admin config backup: %w", err)
+	}
+	return nil
+}
+
+func ResolveToken() (TokenInfo, error) {
+	if token := strings.TrimSpace(os.Getenv(EnvAccessToken)); token != "" {
+		return TokenInfo{Value: token, Source: TokenSourceEnv}, nil
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		return TokenInfo{}, err
+	}
+	if cfg.AccessToken == "" {
+		return TokenInfo{}, fmt.Errorf("%w. %s", ErrNotAuthenticated, HintSetAdminToken)
+	}
+	return TokenInfo{Value: cfg.AccessToken, Source: TokenSourceConfig}, nil
+}
+
+func Token() (string, error) {
+	info, err := ResolveToken()
+	if err != nil {
+		return "", err
+	}
+	return info.Value, nil
+}
+
+func writeConfigAtomically(path string, data []byte) (err error) {
+	tmp, err := os.CreateTemp(filepath.Dir(path), adminConfigTempPrefix)
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		if err != nil {
+			_ = tmp.Close()
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if err = tmp.Chmod(0600); err != nil {
+		return err
+	}
+	if _, err = tmp.Write(data); err != nil {
+		return err
+	}
+	if err = tmp.Sync(); err != nil {
+		return err
+	}
+	if err = tmp.Close(); err != nil {
+		return err
+	}
+	return replaceFile(tmpPath, path)
+}
+
+func replaceFile(tmpPath, path string) error {
+	if goos != "windows" {
+		return os.Rename(tmpPath, path)
+	}
+	backupPath := path + ".bak"
+	_ = os.Remove(backupPath)
+	if err := os.Rename(path, backupPath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Rename(backupPath, path)
+		return err
+	}
+	_ = os.Remove(backupPath)
+	return nil
+}
+
+func recoverBackup(path string) error {
+	return os.Rename(path+".bak", path)
+}
+
+func validateConfigPermissions(path string, mode os.FileMode) error {
+	if goos == "windows" {
+		return nil
+	}
+
+	perm := mode.Perm()
+	if perm&0077 != 0 {
+		return fmt.Errorf("could not read admin config: config file %s has insecure permissions %04o; run chmod 600 %s", path, perm, path)
+	}
+	return nil
+}

--- a/internal/adminconfig/config.go
+++ b/internal/adminconfig/config.go
@@ -17,8 +17,8 @@ type Config struct {
 }
 
 const (
-	EnvAccessToken        = "GUMROAD_ADMIN_ACCESS_TOKEN"
-	HintSetAdminToken     = "Set GUMROAD_ADMIN_ACCESS_TOKEN."
+	EnvAccessToken        = "GUMROAD_ADMIN_ACCESS_TOKEN"      //nolint:gosec // G101: env var name, not a credential.
+	HintSetAdminToken     = "Set GUMROAD_ADMIN_ACCESS_TOKEN." //nolint:gosec // G101: remediation text, not a credential.
 	adminConfigFile       = "admin.json"
 	adminConfigTempPrefix = "admin.json.tmp-*"
 )

--- a/internal/adminconfig/config_test.go
+++ b/internal/adminconfig/config_test.go
@@ -1,0 +1,147 @@
+package adminconfig
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/config"
+)
+
+func TestSaveLoadAndDelete(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	if err := Save(&Config{AccessToken: "admin-token"}); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	loaded, err := Load()
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if loaded.AccessToken != "admin-token" {
+		t.Fatalf("got token %q, want admin-token", loaded.AccessToken)
+	}
+
+	if err := Delete(); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+	loaded, err = Load()
+	if err != nil {
+		t.Fatalf("Load after Delete failed: %v", err)
+	}
+	if loaded.AccessToken != "" {
+		t.Fatalf("expected empty token after Delete, got %q", loaded.AccessToken)
+	}
+}
+
+func TestPathUsesSeparateAdminConfigFile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	adminPath, err := Path()
+	if err != nil {
+		t.Fatalf("Path failed: %v", err)
+	}
+	publicPath, err := config.Path()
+	if err != nil {
+		t.Fatalf("config.Path failed: %v", err)
+	}
+
+	if adminPath == publicPath {
+		t.Fatalf("admin config should not share public config path %q", adminPath)
+	}
+	if filepath.Base(adminPath) != "admin.json" {
+		t.Fatalf("got admin path %q, want admin.json file", adminPath)
+	}
+}
+
+func TestTokenUsesEnvAccessToken(t *testing.T) {
+	t.Setenv(EnvAccessToken, "env-admin-token")
+
+	info, err := ResolveToken()
+	if err != nil {
+		t.Fatalf("ResolveToken failed: %v", err)
+	}
+	if info.Value != "env-admin-token" {
+		t.Fatalf("got token %q, want env-admin-token", info.Value)
+	}
+	if info.Source != TokenSourceEnv {
+		t.Fatalf("got source %q, want %q", info.Source, TokenSourceEnv)
+	}
+}
+
+func TestTokenEnvTakesPrecedenceOverAdminConfig(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv(EnvAccessToken, "env-admin-token")
+
+	if err := Save(&Config{AccessToken: "file-admin-token"}); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	info, err := ResolveToken()
+	if err != nil {
+		t.Fatalf("ResolveToken failed: %v", err)
+	}
+	if info.Value != "env-admin-token" {
+		t.Fatalf("got token %q, want env-admin-token", info.Value)
+	}
+	if info.Source != TokenSourceEnv {
+		t.Fatalf("got source %q, want %q", info.Source, TokenSourceEnv)
+	}
+}
+
+func TestTokenDoesNotUsePublicConfig(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv(EnvAccessToken, "")
+
+	if err := config.Save(&config.Config{AccessToken: "public-token"}); err != nil {
+		t.Fatalf("public config Save failed: %v", err)
+	}
+
+	_, err := Token()
+	if err == nil {
+		t.Fatal("expected missing admin token error")
+	}
+	if !errors.Is(err, ErrNotAuthenticated) {
+		t.Fatalf("expected ErrNotAuthenticated, got %v", err)
+	}
+	if !strings.Contains(err.Error(), EnvAccessToken) {
+		t.Fatalf("expected error to mention %s, got %v", EnvAccessToken, err)
+	}
+}
+
+func TestLoadInsecurePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission checks do not apply on Windows")
+	}
+
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	dir, err := Dir()
+	if err != nil {
+		t.Fatalf("Dir failed: %v", err)
+	}
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+	path := filepath.Join(dir, "admin.json")
+	if err := os.WriteFile(path, []byte(`{"access_token":"tok"}`), 0644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	_, err = Load()
+	if err == nil {
+		t.Fatal("expected insecure-permissions error")
+	}
+	if !strings.Contains(err.Error(), "insecure permissions 0644") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/adminconfig/config_test.go
+++ b/internal/adminconfig/config_test.go
@@ -133,7 +133,7 @@ func TestLoadInsecurePermissions(t *testing.T) {
 		t.Fatalf("MkdirAll failed: %v", err)
 	}
 	path := filepath.Join(dir, "admin.json")
-	if err := os.WriteFile(path, []byte(`{"access_token":"tok"}`), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(`{"access_token":"tok"}`), 0644); err != nil { //nolint:gosec // G306: intentionally insecure permissions for validation test.
 		t.Fatalf("WriteFile failed: %v", err)
 	}
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 )
@@ -61,6 +62,14 @@ func NewClientWithContext(ctx context.Context, token, version string, debug bool
 		debugWriter: os.Stderr,
 		sleep:       sleepContext,
 	}
+}
+
+func NewClientWithBaseURL(ctx context.Context, token, version string, debug bool, baseURL string) *Client {
+	client := NewClientWithContext(ctx, token, version, debug)
+	if baseURL != "" {
+		client.baseURL = strings.TrimRight(baseURL, "/")
+	}
+	return client
 }
 
 func (c *Client) SetDebugWriter(w io.Writer) {

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -77,6 +77,13 @@ func TestNewClient(t *testing.T) {
 	}
 }
 
+func TestNewClientWithBaseURL(t *testing.T) {
+	c := NewClientWithBaseURL(context.Background(), "tok-123", "1.0.0", false, "http://example.test/")
+	if c.baseURL != "http://example.test" {
+		t.Fatalf("got baseURL %q, want http://example.test", c.baseURL)
+	}
+}
+
 func TestClient_BearerHeader(t *testing.T) {
 	var gotAuth string
 	srv := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {

--- a/internal/cmd/admin/admin.go
+++ b/internal/cmd/admin/admin.go
@@ -1,0 +1,14 @@
+package admin
+
+import "github.com/spf13/cobra"
+
+func NewAdminCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "admin",
+		Short:   "Run Gumroad admin commands",
+		Long:    "Run internal Gumroad admin API commands with a separate admin token.",
+		Example: "  gumroad admin --help",
+	}
+
+	return cmd
+}

--- a/internal/cmd/errors.go
+++ b/internal/cmd/errors.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/antiwork/gumroad-cli/internal/adminconfig"
 	"github.com/antiwork/gumroad-cli/internal/api"
 	"github.com/antiwork/gumroad-cli/internal/cmd/files"
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
@@ -173,6 +174,17 @@ func classifyPrimaryCause(err error) commandErrorDetail {
 			Message:    apiErr.Error(),
 			Hint:       apiErr.GetHint(),
 			StatusCode: apiErr.StatusCode,
+		}
+	case errors.Is(err, adminconfig.ErrNotAuthenticated):
+		hint := adminconfig.HintSetAdminToken
+		if strings.Contains(err.Error(), adminconfig.EnvAccessToken) {
+			hint = ""
+		}
+		return commandErrorDetail{
+			Type:    "auth_error",
+			Code:    "not_authenticated",
+			Message: err.Error(),
+			Hint:    hint,
 		}
 	case errors.Is(err, config.ErrNotAuthenticated), errors.Is(err, api.ErrNotAuthenticated):
 		hint := api.HintRunAuthLogin

--- a/internal/cmd/errors_test.go
+++ b/internal/cmd/errors_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/antiwork/gumroad-cli/internal/adminconfig"
 	"github.com/antiwork/gumroad-cli/internal/api"
 	"github.com/antiwork/gumroad-cli/internal/cmd/files"
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
@@ -94,6 +95,17 @@ func TestClassifyCommandError_WrappedConfigAuth(t *testing.T) {
 func TestClassifyCommandError_ConfigAuthWithRemediationInMessage(t *testing.T) {
 	// Simulates the real error from config.ResolveToken which already embeds remediation.
 	wrapped := fmt.Errorf("%w. Run `gumroad auth login` first or set `GUMROAD_ACCESS_TOKEN`", config.ErrNotAuthenticated)
+	detail := classifyCommandError(wrapped)
+	if detail.Type != "auth_error" || detail.Code != "not_authenticated" {
+		t.Fatalf("unexpected detail: %+v", detail)
+	}
+	if detail.Hint != "" {
+		t.Errorf("expected empty hint when message already contains remediation, got %q", detail.Hint)
+	}
+}
+
+func TestClassifyCommandError_AdminAuthWithRemediationInMessage(t *testing.T) {
+	wrapped := fmt.Errorf("%w. %s", adminconfig.ErrNotAuthenticated, adminconfig.HintSetAdminToken)
 	detail := classifyCommandError(wrapped)
 	if detail.Type != "auth_error" || detail.Code != "not_authenticated" {
 		t.Fatalf("unexpected detail: %+v", detail)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/antiwork/gumroad-cli/internal/cmd/admin"
 	"github.com/antiwork/gumroad-cli/internal/cmd/auth"
 	"github.com/antiwork/gumroad-cli/internal/cmd/categories"
 	"github.com/antiwork/gumroad-cli/internal/cmd/completion"
@@ -98,6 +99,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&opts.Debug, "debug", false, "Enable debug logging to stderr")
 
 	// Subcommands
+	cmd.AddCommand(admin.NewAdminCmd())
 	cmd.AddCommand(auth.NewAuthCmd())
 	cmd.AddCommand(user.NewUserCmd())
 	cmd.AddCommand(products.NewProductsCmd())

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -166,7 +166,7 @@ func TestHelp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("help failed: %v\n%s", err, out)
 	}
-	for _, cmd := range []string{"auth", "user", "products", "sales", "payouts", "subscribers", "licenses", "offer-codes", "webhooks", "completion"} {
+	for _, cmd := range []string{"admin", "auth", "user", "products", "sales", "payouts", "subscribers", "licenses", "offer-codes", "webhooks", "completion"} {
 		if !strings.Contains(out, cmd) {
 			t.Errorf("help missing command %q", cmd)
 		}


### PR DESCRIPTION
Ref antiwork/gumroad/issues/4677

## What

Adds the foundation for a new `gumroad admin` command group that talks to Gumroad's internal admin API. No admin subcommands ship in this PR. it only lays down the foundation so later PRs can add read/write commands on top.

Specifically:

- New top-level `gumroad admin` cobra command (parent only, no subcommands yet).
- New `internal/adminconfig` package: separate `admin.json` config file, separate `GUMROAD_ADMIN_ACCESS_TOKEN` env var, atomic writes, 0600 permission enforcement, and Windows-safe replace with backup recovery.
- New `internal/adminapi` package: a thin wrapper around `internal/api.Client` that auto-prepends the `/internal/admin` path prefix, supports a separate `GUMROAD_ADMIN_API_BASE_URL` override, and rewrites 401/403 hints to point at the admin token env var.
- New `internal/admincmd` package: shared runners (`Run`, `RunDecoded`, `RunGet`, `RunGetDecoded`) that resolve the admin token, handle the spinner, and route through the standard JSON output pipeline — mirroring the `cmdutil` helpers that regular commands already use.
- Small extensions to shared code: `api.NewClientWithBaseURL` so the admin client can reuse the base HTTP client, and a new branch in `classifyPrimaryCause` so admin-auth errors produce the right hint.

## Why

Admin access is a different privilege level from the regular Gumroad API. Tokens, base URL, and error hints all need to be kept separate so a user's regular `GUMROAD_ACCESS_TOKEN` is never sent to an admin endpoint (and vice versa). Splitting this into a foundation PR keeps the follow-up PR focused purely on commands.

The admin client intentionally wraps `internal/api.Client` rather than duplicating HTTP logic, so retries, debug logging, error parsing, and the 200-OK-with-`success:false` handling stay in one place. The `/internal/admin` prefix is centralized in the admin client so subcommands only specify their own endpoint paths.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh