### PR TITLE
Add admin read commands: purchases, licenses, users, payouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ For CI and agents, set `GUMROAD_ACCESS_TOKEN` instead — it takes precedence ov
 
 ```
 gumroad auth          login, status, logout
-gumroad admin         internal reads for purchases, licenses, users, payouts
+gumroad admin         Internal admin API commands
 gumroad user          View your account info
 gumroad products      create, update, list, view, delete, publish, unpublish, skus
 gumroad sales         list, view, refund, ship, resend-receipt

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ For CI and agents, set `GUMROAD_ACCESS_TOKEN` instead — it takes precedence ov
 
 ```
 gumroad auth          login, status, logout
-gumroad admin         Internal admin API commands
+gumroad admin         internal reads for purchases, licenses, users, payouts
 gumroad user          View your account info
 gumroad products      create, update, list, view, delete, publish, unpublish, skus
 gumroad sales         list, view, refund, ship, resend-receipt

--- a/internal/admincmd/read.go
+++ b/internal/admincmd/read.go
@@ -57,6 +57,12 @@ func RunGetDecoded[T any](opts cmdutil.Options, spinnerMessage, path string, par
 	}, render)
 }
 
+func RunPostJSONDecoded[T any](opts cmdutil.Options, spinnerMessage, path string, payload any, render func(T) error) error {
+	return RunDecoded[T](opts, spinnerMessage, func(client *adminapi.Client) (json.RawMessage, error) {
+		return client.PostJSON(path, payload)
+	}, render)
+}
+
 func runAuthenticatedData(opts cmdutil.Options, spinnerMessage string, run ClientRunner) (json.RawMessage, error) {
 	token, err := adminconfig.Token()
 	if err != nil {

--- a/internal/cmd/admin/admin.go
+++ b/internal/cmd/admin/admin.go
@@ -1,14 +1,28 @@
 package admin
 
-import "github.com/spf13/cobra"
+import (
+	adminlicenses "github.com/antiwork/gumroad-cli/internal/cmd/admin/licenses"
+	adminpayouts "github.com/antiwork/gumroad-cli/internal/cmd/admin/payouts"
+	adminpurchases "github.com/antiwork/gumroad-cli/internal/cmd/admin/purchases"
+	adminusers "github.com/antiwork/gumroad-cli/internal/cmd/admin/users"
+	"github.com/spf13/cobra"
+)
 
 func NewAdminCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "admin",
-		Short:   "Run Gumroad admin commands",
-		Long:    "Run internal Gumroad admin API commands with a separate admin token.",
-		Example: "  gumroad admin --help",
+		Use:   "admin",
+		Short: "Run Gumroad admin commands",
+		Long:  "Run internal Gumroad admin API commands with a separate admin token.",
+		Example: `  gumroad admin purchases view <purchase-id>
+  gumroad admin licenses lookup --key <license-key>
+  gumroad admin users suspension --email <email>
+  gumroad admin payouts list --email <email>`,
 	}
+
+	cmd.AddCommand(adminpurchases.NewPurchasesCmd())
+	cmd.AddCommand(adminlicenses.NewLicensesCmd())
+	cmd.AddCommand(adminusers.NewUsersCmd())
+	cmd.AddCommand(adminpayouts.NewPayoutsCmd())
 
 	return cmd
 }

--- a/internal/cmd/admin/licenses/licenses.go
+++ b/internal/cmd/admin/licenses/licenses.go
@@ -1,0 +1,16 @@
+package licenses
+
+import "github.com/spf13/cobra"
+
+func NewLicensesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "licenses",
+		Short: "Read admin license records",
+		Example: `  echo "$LICENSE_KEY" | gumroad admin licenses lookup
+  gumroad admin licenses lookup --key <license-key> --json`,
+	}
+
+	cmd.AddCommand(newLookupCmd())
+
+	return cmd
+}

--- a/internal/cmd/admin/licenses/licenses_test.go
+++ b/internal/cmd/admin/licenses/licenses_test.go
@@ -1,0 +1,102 @@
+package licenses
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestLookupUsesInternalAdminEndpoint(t *testing.T) {
+	var gotMethod, gotPath, gotKey, gotAuth string
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotKey = r.URL.Query().Get("license_key")
+		gotAuth = r.Header.Get("Authorization")
+		testutil.JSON(t, w, map[string]any{
+			"license": map[string]any{
+				"email": "buyer@example.com", "product_name": "Course", "purchase_id": "123",
+				"uses": 2, "enabled": true,
+			},
+		})
+	})
+
+	cmd := testutil.Command(newLookupCmd())
+	cmd.SetArgs([]string{"--key", "ABC-123"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != "GET" || gotPath != "/internal/admin/licenses/lookup" {
+		t.Fatalf("got %s %s, want GET /internal/admin/licenses/lookup", gotMethod, gotPath)
+	}
+	if gotKey != "ABC-123" {
+		t.Fatalf("got license_key %q, want ABC-123", gotKey)
+	}
+	if gotAuth != "Bearer admin-token" {
+		t.Fatalf("got auth %q, want Bearer admin-token", gotAuth)
+	}
+	for _, want := range []string{"Course", "Purchase ID: 123", "Buyer: buyer@example.com", "Uses: 2", "Status: enabled"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q: %q", want, out)
+		}
+	}
+	if strings.Contains(out, "ABC-123") {
+		t.Fatalf("human output should not echo license key: %q", out)
+	}
+}
+
+func TestLookupReadsLicenseKeyFromStdin(t *testing.T) {
+	var gotKey string
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotKey = r.URL.Query().Get("license_key")
+		testutil.JSON(t, w, map[string]any{
+			"purchase": map[string]any{"email": "buyer@example.com", "product_id": "prod_123"},
+			"uses":     1,
+		})
+	})
+
+	cmd := testutil.Command(newLookupCmd(), testutil.Stdin(strings.NewReader("PIPE-KEY\n")))
+	cmd.SetArgs([]string{})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotKey != "PIPE-KEY" {
+		t.Fatalf("got license_key %q, want PIPE-KEY", gotKey)
+	}
+}
+
+func TestLookupJSONPreservesResponse(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"license": map[string]any{"purchase_id": "123", "uses": 2},
+		})
+	})
+
+	cmd := testutil.Command(newLookupCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--key", "ABC-123"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp struct {
+		License map[string]any `json:"license"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if resp.License["purchase_id"] != "123" {
+		t.Fatalf("unexpected JSON payload: %s", out)
+	}
+}
+
+func TestLookupRejectsEmptyKeyFlag(t *testing.T) {
+	cmd := newLookupCmd()
+	cmd.SetArgs([]string{"--key", ""})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected empty key error")
+	}
+	if !strings.Contains(err.Error(), "--key cannot be empty") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/cmd/admin/licenses/licenses_test.go
+++ b/internal/cmd/admin/licenses/licenses_test.go
@@ -103,6 +103,22 @@ func TestLookupJSONPreservesResponse(t *testing.T) {
 	}
 }
 
+func TestLookupPlainOutput(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"purchase": map[string]any{"id": "123", "email": "buyer@example.com", "link_name": "Course", "uses": 3},
+		})
+	})
+
+	cmd := testutil.Command(newLookupCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{"--key", "ABC-123"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if strings.TrimSpace(out) != "123\tbuyer@example.com\tCourse\t3" {
+		t.Fatalf("unexpected plain output: %q", out)
+	}
+}
+
 func TestLookupRejectsEmptyKeyFlag(t *testing.T) {
 	cmd := newLookupCmd()
 	cmd.SetArgs([]string{"--key", ""})
@@ -113,5 +129,39 @@ func TestLookupRejectsEmptyKeyFlag(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "--key cannot be empty") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNewLicensesCmdWiresLookup(t *testing.T) {
+	cmd := NewLicensesCmd()
+	if cmd.Use != "licenses" {
+		t.Fatalf("Use = %q, want licenses", cmd.Use)
+	}
+	if got := cmd.Commands(); len(got) != 1 || got[0].Use != "lookup" {
+		t.Fatalf("unexpected subcommands: %#v", got)
+	}
+}
+
+func TestLicenseStatusVariants(t *testing.T) {
+	enabled := true
+	disabled := true
+	falseValue := false
+
+	for _, tc := range []struct {
+		name string
+		in   license
+		want string
+	}{
+		{name: "enabled", in: license{Enabled: &enabled}, want: "enabled"},
+		{name: "explicit disabled", in: license{Disabled: &disabled}, want: "disabled"},
+		{name: "enabled false", in: license{Enabled: &falseValue}, want: "disabled"},
+		{name: "disabled false", in: license{Disabled: &falseValue}, want: "enabled"},
+		{name: "unknown", in: license{}, want: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := licenseStatus(tc.in); got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/cmd/admin/licenses/licenses_test.go
+++ b/internal/cmd/admin/licenses/licenses_test.go
@@ -10,12 +10,17 @@ import (
 )
 
 func TestLookupUsesInternalAdminEndpoint(t *testing.T) {
-	var gotMethod, gotPath, gotKey, gotAuth string
+	var gotMethod, gotPath, gotQuery, gotKey, gotAuth string
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
 		gotMethod = r.Method
 		gotPath = r.URL.Path
-		gotKey = r.URL.Query().Get("license_key")
+		gotQuery = r.URL.RawQuery
 		gotAuth = r.Header.Get("Authorization")
+		var payload lookupRequest
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		gotKey = payload.LicenseKey
 		testutil.JSON(t, w, map[string]any{
 			"license": map[string]any{
 				"email": "buyer@example.com", "product_name": "Course", "purchase_id": "123",
@@ -28,8 +33,11 @@ func TestLookupUsesInternalAdminEndpoint(t *testing.T) {
 	cmd.SetArgs([]string{"--key", "ABC-123"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	if gotMethod != "GET" || gotPath != "/internal/admin/licenses/lookup" {
-		t.Fatalf("got %s %s, want GET /internal/admin/licenses/lookup", gotMethod, gotPath)
+	if gotMethod != "POST" || gotPath != "/internal/admin/licenses/lookup" {
+		t.Fatalf("got %s %s, want POST /internal/admin/licenses/lookup", gotMethod, gotPath)
+	}
+	if gotQuery != "" {
+		t.Fatalf("license key should not be sent in query string, got %q", gotQuery)
 	}
 	if gotKey != "ABC-123" {
 		t.Fatalf("got license_key %q, want ABC-123", gotKey)
@@ -50,7 +58,14 @@ func TestLookupUsesInternalAdminEndpoint(t *testing.T) {
 func TestLookupReadsLicenseKeyFromStdin(t *testing.T) {
 	var gotKey string
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
-		gotKey = r.URL.Query().Get("license_key")
+		if r.URL.RawQuery != "" {
+			t.Fatalf("license key should not be sent in query string, got %q", r.URL.RawQuery)
+		}
+		var payload lookupRequest
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		gotKey = payload.LicenseKey
 		testutil.JSON(t, w, map[string]any{
 			"purchase": map[string]any{"email": "buyer@example.com", "product_id": "prod_123"},
 			"uses":     1,

--- a/internal/cmd/admin/licenses/licenses_test.go
+++ b/internal/cmd/admin/licenses/licenses_test.go
@@ -130,8 +130,8 @@ func TestLookupHumanOutputShowsZeroUses(t *testing.T) {
 	cmd.SetArgs([]string{"--key", "ABC-123"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	if !strings.Contains(out, "Uses: 0") {
-		t.Fatalf("output missing zero uses: %q", out)
+	if strings.TrimSpace(out) != "123\nUses: 0" {
+		t.Fatalf("unexpected human output: %q", out)
 	}
 }
 

--- a/internal/cmd/admin/licenses/licenses_test.go
+++ b/internal/cmd/admin/licenses/licenses_test.go
@@ -119,6 +119,22 @@ func TestLookupPlainOutput(t *testing.T) {
 	}
 }
 
+func TestLookupHumanOutputShowsZeroUses(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"license": map[string]any{"purchase_id": "123", "uses": 0},
+		})
+	})
+
+	cmd := testutil.Command(newLookupCmd())
+	cmd.SetArgs([]string{"--key", "ABC-123"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "Uses: 0") {
+		t.Fatalf("output missing zero uses: %q", out)
+	}
+}
+
 func TestLookupRejectsEmptyKeyFlag(t *testing.T) {
 	cmd := newLookupCmd()
 	cmd.SetArgs([]string{"--key", ""})

--- a/internal/cmd/admin/licenses/lookup.go
+++ b/internal/cmd/admin/licenses/lookup.go
@@ -1,0 +1,166 @@
+package licenses
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/antiwork/gumroad-cli/internal/admincmd"
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/prompt"
+	"github.com/spf13/cobra"
+)
+
+const (
+	licenseKeyPrompt = "license key"
+	licenseKeyHint   = "Pipe it via stdin or pass --key."
+)
+
+type licenseResponse struct {
+	License  license     `json:"license"`
+	Purchase purchase    `json:"purchase"`
+	Uses     api.JSONInt `json:"uses"`
+}
+
+type license struct {
+	Email       string      `json:"email"`
+	ProductID   string      `json:"product_id"`
+	ProductName string      `json:"product_name"`
+	PurchaseID  string      `json:"purchase_id"`
+	Uses        api.JSONInt `json:"uses"`
+	Enabled     *bool       `json:"enabled"`
+	Disabled    *bool       `json:"disabled"`
+	CreatedAt   string      `json:"created_at"`
+}
+
+type purchase struct {
+	ID          string      `json:"id"`
+	Email       string      `json:"email"`
+	ProductID   string      `json:"product_id"`
+	ProductName string      `json:"product_name"`
+	LinkName    string      `json:"link_name"`
+	Uses        api.JSONInt `json:"uses"`
+}
+
+func newLookupCmd() *cobra.Command {
+	var key string
+
+	cmd := &cobra.Command{
+		Use:   "lookup",
+		Short: "Look up a license key",
+		Args:  cmdutil.ExactArgs(0),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			resolvedKey, err := resolveLicenseKey(c, opts, key)
+			if err != nil {
+				return err
+			}
+
+			params := url.Values{}
+			params.Set("license_key", resolvedKey)
+			return admincmd.RunGetDecoded[licenseResponse](opts, "Fetching license...", "/licenses/lookup", params, func(resp licenseResponse) error {
+				return renderLicense(opts, resp)
+			})
+		},
+	}
+
+	cmd.Flags().StringVar(&key, "key", "", "License key")
+
+	return cmd
+}
+
+func resolveLicenseKey(cmd *cobra.Command, opts cmdutil.Options, key string) (string, error) {
+	if cmd != nil && cmd.Flags().Changed("key") {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return "", cmdutil.UsageErrorf(cmd, "--key cannot be empty")
+		}
+		return key, nil
+	}
+
+	key, err := prompt.SecretInput(licenseKeyPrompt, licenseKeyPrompt, opts.In(), opts.Err(), opts.NoInput, licenseKeyHint)
+	if err != nil {
+		return "", err
+	}
+	if key == "" {
+		return "", cmdutil.UsageErrorf(cmd, "license key cannot be empty. %s", licenseKeyHint)
+	}
+	return key, nil
+}
+
+func renderLicense(opts cmdutil.Options, resp licenseResponse) error {
+	email := firstNonEmpty(resp.License.Email, resp.Purchase.Email)
+	product := firstNonEmpty(resp.License.ProductName, resp.Purchase.ProductName, resp.Purchase.LinkName, resp.License.ProductID, resp.Purchase.ProductID)
+	purchaseID := firstNonEmpty(resp.License.PurchaseID, resp.Purchase.ID)
+	uses := resp.License.Uses
+	if uses == 0 {
+		uses = resp.Purchase.Uses
+	}
+	if uses == 0 {
+		uses = resp.Uses
+	}
+	status := licenseStatus(resp.License)
+
+	if opts.PlainOutput {
+		return output.PrintPlain(opts.Out(), [][]string{
+			{purchaseID, email, product, fmt.Sprintf("%d", uses), status},
+		})
+	}
+
+	style := opts.Style()
+	headline := product
+	if headline == "" {
+		headline = purchaseID
+	}
+	if headline == "" {
+		headline = "License"
+	}
+	if err := output.Writeln(opts.Out(), style.Bold(headline)); err != nil {
+		return err
+	}
+	if purchaseID != "" {
+		if err := output.Writef(opts.Out(), "Purchase ID: %s\n", purchaseID); err != nil {
+			return err
+		}
+	}
+	if email != "" {
+		if err := output.Writef(opts.Out(), "Buyer: %s\n", email); err != nil {
+			return err
+		}
+	}
+	if uses != 0 {
+		if err := output.Writef(opts.Out(), "Uses: %d\n", uses); err != nil {
+			return err
+		}
+	}
+	if status != "" {
+		return output.Writef(opts.Out(), "Status: %s\n", status)
+	}
+	return nil
+}
+
+func licenseStatus(l license) string {
+	switch {
+	case l.Enabled != nil && *l.Enabled:
+		return "enabled"
+	case l.Disabled != nil && *l.Disabled:
+		return "disabled"
+	case l.Enabled != nil:
+		return "disabled"
+	case l.Disabled != nil:
+		return "enabled"
+	default:
+		return ""
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/cmd/admin/licenses/lookup.go
+++ b/internal/cmd/admin/licenses/lookup.go
@@ -111,9 +111,11 @@ func renderLicense(opts cmdutil.Options, resp licenseResponse) error {
 	}
 
 	style := opts.Style()
+	headlineFromPurchaseID := false
 	headline := product
-	if headline == "" {
+	if headline == "" && purchaseID != "" {
 		headline = purchaseID
+		headlineFromPurchaseID = true
 	}
 	if headline == "" {
 		headline = "License"
@@ -121,7 +123,7 @@ func renderLicense(opts cmdutil.Options, resp licenseResponse) error {
 	if err := output.Writeln(opts.Out(), style.Bold(headline)); err != nil {
 		return err
 	}
-	if purchaseID != "" {
+	if purchaseID != "" && !headlineFromPurchaseID {
 		if err := output.Writef(opts.Out(), "Purchase ID: %s\n", purchaseID); err != nil {
 			return err
 		}

--- a/internal/cmd/admin/licenses/lookup.go
+++ b/internal/cmd/admin/licenses/lookup.go
@@ -2,7 +2,6 @@ package licenses
 
 import (
 	"fmt"
-	"net/url"
 	"strings"
 
 	"github.com/antiwork/gumroad-cli/internal/admincmd"
@@ -44,6 +43,10 @@ type purchase struct {
 	Uses        api.JSONInt `json:"uses"`
 }
 
+type lookupRequest struct {
+	LicenseKey string `json:"license_key"`
+}
+
 func newLookupCmd() *cobra.Command {
 	var key string
 
@@ -58,9 +61,7 @@ func newLookupCmd() *cobra.Command {
 				return err
 			}
 
-			params := url.Values{}
-			params.Set("license_key", resolvedKey)
-			return admincmd.RunGetDecoded[licenseResponse](opts, "Fetching license...", "/licenses/lookup", params, func(resp licenseResponse) error {
+			return admincmd.RunPostJSONDecoded[licenseResponse](opts, "Fetching license...", "/licenses/lookup", lookupRequest{LicenseKey: resolvedKey}, func(resp licenseResponse) error {
 				return renderLicense(opts, resp)
 			})
 		},

--- a/internal/cmd/admin/licenses/lookup.go
+++ b/internal/cmd/admin/licenses/lookup.go
@@ -35,12 +35,12 @@ type license struct {
 }
 
 type purchase struct {
-	ID          string      `json:"id"`
-	Email       string      `json:"email"`
-	ProductID   string      `json:"product_id"`
-	ProductName string      `json:"product_name"`
-	LinkName    string      `json:"link_name"`
-	Uses        api.JSONInt `json:"uses"`
+	ID           string      `json:"id"`
+	Email        string      `json:"email"`
+	ProductID    string      `json:"product_id"`
+	ProductName  string      `json:"product_name"`
+	ProductAlias string      `json:"link_name"`
+	Uses         api.JSONInt `json:"uses"`
 }
 
 type lookupRequest struct {
@@ -93,7 +93,7 @@ func resolveLicenseKey(cmd *cobra.Command, opts cmdutil.Options, key string) (st
 
 func renderLicense(opts cmdutil.Options, resp licenseResponse) error {
 	email := firstNonEmpty(resp.License.Email, resp.Purchase.Email)
-	product := firstNonEmpty(resp.License.ProductName, resp.Purchase.ProductName, resp.Purchase.LinkName, resp.License.ProductID, resp.Purchase.ProductID)
+	product := firstNonEmpty(resp.License.ProductName, resp.Purchase.ProductName, resp.Purchase.ProductAlias, resp.License.ProductID, resp.Purchase.ProductID)
 	purchaseID := firstNonEmpty(resp.License.PurchaseID, resp.Purchase.ID)
 	uses := resp.License.Uses
 	if uses == 0 {
@@ -131,10 +131,8 @@ func renderLicense(opts cmdutil.Options, resp licenseResponse) error {
 			return err
 		}
 	}
-	if uses != 0 {
-		if err := output.Writef(opts.Out(), "Uses: %d\n", uses); err != nil {
-			return err
-		}
+	if err := output.Writef(opts.Out(), "Uses: %d\n", uses); err != nil {
+		return err
 	}
 	if status != "" {
 		return output.Writef(opts.Out(), "Status: %s\n", status)

--- a/internal/cmd/admin/payouts/list.go
+++ b/internal/cmd/admin/payouts/list.go
@@ -125,10 +125,11 @@ func writePayoutsTable(w io.Writer, style output.Styler, payouts []payout) error
 }
 
 func formatAmount(p payout) string {
-	if p.Currency == "" {
+	currency := strings.TrimSpace(p.Currency)
+	if currency == "" {
 		return fmt.Sprintf("%d cents", p.AmountCents)
 	}
-	return strings.TrimSpace(fmt.Sprintf("%d %s cents", p.AmountCents, strings.ToUpper(p.Currency)))
+	return fmt.Sprintf("%d %s cents", p.AmountCents, strings.ToUpper(currency))
 }
 
 func payoutDestination(p payout) string {

--- a/internal/cmd/admin/payouts/list.go
+++ b/internal/cmd/admin/payouts/list.go
@@ -1,0 +1,135 @@
+package payouts
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"strings"
+
+	"github.com/antiwork/gumroad-cli/internal/admincmd"
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+type payoutsResponse struct {
+	LastPayouts          []payout `json:"last_payouts"`
+	NextPayoutDate       string   `json:"next_payout_date"`
+	BalanceForNextPayout string   `json:"balance_for_next_payout"`
+	PayoutNote           string   `json:"payout_note"`
+}
+
+type payout struct {
+	ExternalID        string      `json:"external_id"`
+	AmountCents       api.JSONInt `json:"amount_cents"`
+	Currency          string      `json:"currency"`
+	State             string      `json:"state"`
+	CreatedAt         string      `json:"created_at"`
+	Processor         string      `json:"processor"`
+	BankAccountVisual string      `json:"bank_account_visual"`
+	PaypalEmail       string      `json:"paypal_email"`
+}
+
+func newListCmd() *cobra.Command {
+	var email string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List recent payouts for a user",
+		Args:  cmdutil.ExactArgs(0),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			if email == "" {
+				return cmdutil.MissingFlagError(c, "--email")
+			}
+
+			params := url.Values{}
+			params.Set("email", email)
+			return admincmd.RunGetDecoded[payoutsResponse](opts, "Fetching payouts...", "/payouts", params, func(resp payoutsResponse) error {
+				return renderPayouts(opts, email, resp)
+			})
+		},
+	}
+
+	cmd.Flags().StringVar(&email, "email", "", "User email (required)")
+
+	return cmd
+}
+
+func renderPayouts(opts cmdutil.Options, email string, resp payoutsResponse) error {
+	if opts.PlainOutput {
+		return writePayoutsPlain(opts.Out(), email, resp)
+	}
+
+	style := opts.Style()
+	return output.WithPager(opts.Out(), opts.Err(), func(w io.Writer) error {
+		if err := output.Writeln(w, style.Bold(email)); err != nil {
+			return err
+		}
+		if resp.NextPayoutDate != "" {
+			if err := output.Writef(w, "Next payout: %s\n", resp.NextPayoutDate); err != nil {
+				return err
+			}
+		}
+		if resp.BalanceForNextPayout != "" {
+			if err := output.Writef(w, "Balance for next payout: %s\n", resp.BalanceForNextPayout); err != nil {
+				return err
+			}
+		}
+		if resp.PayoutNote != "" {
+			if err := output.Writef(w, "Payout note: %s\n", resp.PayoutNote); err != nil {
+				return err
+			}
+		}
+		if len(resp.LastPayouts) == 0 {
+			return output.Writeln(w, "No recent payouts found.")
+		}
+		if err := output.Writeln(w, ""); err != nil {
+			return err
+		}
+		return writePayoutsTable(w, style, resp.LastPayouts)
+	})
+}
+
+func writePayoutsPlain(w io.Writer, email string, resp payoutsResponse) error {
+	if len(resp.LastPayouts) == 0 {
+		return output.PrintPlain(w, [][]string{{email, "", "", "", "", resp.NextPayoutDate, resp.BalanceForNextPayout, resp.PayoutNote}})
+	}
+
+	rows := make([][]string, 0, len(resp.LastPayouts))
+	for _, p := range resp.LastPayouts {
+		rows = append(rows, []string{
+			email,
+			p.ExternalID,
+			formatAmount(p),
+			p.State,
+			p.CreatedAt,
+			p.Processor,
+			payoutDestination(p),
+		})
+	}
+	return output.PrintPlain(w, rows)
+}
+
+func writePayoutsTable(w io.Writer, style output.Styler, payouts []payout) error {
+	tbl := output.NewStyledTable(style, "ID", "AMOUNT", "STATE", "DATE", "PROCESSOR", "DESTINATION")
+	for _, p := range payouts {
+		tbl.AddRow(p.ExternalID, formatAmount(p), p.State, p.CreatedAt, p.Processor, payoutDestination(p))
+	}
+	return tbl.Render(w)
+}
+
+func formatAmount(p payout) string {
+	if p.Currency == "" {
+		return fmt.Sprintf("%d cents", p.AmountCents)
+	}
+	return strings.TrimSpace(fmt.Sprintf("%d %s cents", p.AmountCents, strings.ToUpper(p.Currency)))
+}
+
+func payoutDestination(p payout) string {
+	if p.BankAccountVisual != "" {
+		return p.BankAccountVisual
+	}
+	return p.PaypalEmail
+}

--- a/internal/cmd/admin/payouts/list.go
+++ b/internal/cmd/admin/payouts/list.go
@@ -3,7 +3,6 @@ package payouts
 import (
 	"fmt"
 	"io"
-	"net/url"
 	"strings"
 
 	"github.com/antiwork/gumroad-cli/internal/admincmd"
@@ -31,6 +30,10 @@ type payout struct {
 	PaypalEmail       string      `json:"paypal_email"`
 }
 
+type listRequest struct {
+	Email string `json:"email"`
+}
+
 func newListCmd() *cobra.Command {
 	var email string
 
@@ -44,9 +47,7 @@ func newListCmd() *cobra.Command {
 				return cmdutil.MissingFlagError(c, "--email")
 			}
 
-			params := url.Values{}
-			params.Set("email", email)
-			return admincmd.RunGetDecoded[payoutsResponse](opts, "Fetching payouts...", "/payouts", params, func(resp payoutsResponse) error {
+			return admincmd.RunPostJSONDecoded[payoutsResponse](opts, "Fetching payouts...", "/payouts/list", listRequest{Email: email}, func(resp payoutsResponse) error {
 				return renderPayouts(opts, email, resp)
 			})
 		},

--- a/internal/cmd/admin/payouts/list.go
+++ b/internal/cmd/admin/payouts/list.go
@@ -95,7 +95,7 @@ func renderPayouts(opts cmdutil.Options, email string, resp payoutsResponse) err
 
 func writePayoutsPlain(w io.Writer, email string, resp payoutsResponse) error {
 	if len(resp.LastPayouts) == 0 {
-		return output.PrintPlain(w, [][]string{{email, "", "", "", "", resp.NextPayoutDate, resp.BalanceForNextPayout, resp.PayoutNote}})
+		return output.PrintPlain(w, [][]string{{email, "", "", "", "", "", "", resp.NextPayoutDate, resp.BalanceForNextPayout, resp.PayoutNote}})
 	}
 
 	rows := make([][]string, 0, len(resp.LastPayouts))
@@ -108,6 +108,9 @@ func writePayoutsPlain(w io.Writer, email string, resp payoutsResponse) error {
 			p.CreatedAt,
 			p.Processor,
 			payoutDestination(p),
+			resp.NextPayoutDate,
+			resp.BalanceForNextPayout,
+			resp.PayoutNote,
 		})
 	}
 	return output.PrintPlain(w, rows)

--- a/internal/cmd/admin/payouts/payouts.go
+++ b/internal/cmd/admin/payouts/payouts.go
@@ -1,0 +1,16 @@
+package payouts
+
+import "github.com/spf13/cobra"
+
+func NewPayoutsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "payouts",
+		Short: "Read admin payout records",
+		Example: `  gumroad admin payouts list --email seller@example.com
+  gumroad admin payouts list --email seller@example.com --json`,
+	}
+
+	cmd.AddCommand(newListCmd())
+
+	return cmd
+}

--- a/internal/cmd/admin/payouts/payouts_test.go
+++ b/internal/cmd/admin/payouts/payouts_test.go
@@ -1,0 +1,86 @@
+package payouts
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestListUsesInternalAdminEndpoint(t *testing.T) {
+	var gotMethod, gotPath, gotEmail, gotAuth string
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotEmail = r.URL.Query().Get("email")
+		gotAuth = r.Header.Get("Authorization")
+		testutil.JSON(t, w, map[string]any{
+			"last_payouts": []map[string]any{
+				{
+					"external_id": "pay_123", "amount_cents": 5000, "currency": "usd",
+					"state": "completed", "created_at": "2026-04-24T12:00:00Z",
+					"processor": "stripe", "bank_account_visual": "****1234",
+				},
+			},
+			"next_payout_date":        "2026-04-30",
+			"balance_for_next_payout": "$25.00",
+			"payout_note":             "Manual review",
+		})
+	})
+
+	cmd := testutil.Command(newListCmd())
+	cmd.SetArgs([]string{"--email", "seller@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != "GET" || gotPath != "/internal/admin/payouts" {
+		t.Fatalf("got %s %s, want GET /internal/admin/payouts", gotMethod, gotPath)
+	}
+	if gotEmail != "seller@example.com" {
+		t.Fatalf("got email %q, want seller@example.com", gotEmail)
+	}
+	if gotAuth != "Bearer admin-token" {
+		t.Fatalf("got auth %q, want Bearer admin-token", gotAuth)
+	}
+	for _, want := range []string{"seller@example.com", "Next payout: 2026-04-30", "$25.00", "Manual review", "pay_123", "5000 USD cents"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestListRequiresEmail(t *testing.T) {
+	cmd := newListCmd()
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected missing email error")
+	}
+	if !strings.Contains(err.Error(), "missing required flag: --email") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestListJSONPreservesResponse(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"last_payouts": []map[string]any{{"external_id": "pay_123"}},
+		})
+	})
+
+	cmd := testutil.Command(newListCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--email", "seller@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp struct {
+		LastPayouts []map[string]any `json:"last_payouts"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if len(resp.LastPayouts) != 1 || resp.LastPayouts[0]["external_id"] != "pay_123" {
+		t.Fatalf("unexpected JSON payload: %s", out)
+	}
+}

--- a/internal/cmd/admin/payouts/payouts_test.go
+++ b/internal/cmd/admin/payouts/payouts_test.go
@@ -10,12 +10,17 @@ import (
 )
 
 func TestListUsesInternalAdminEndpoint(t *testing.T) {
-	var gotMethod, gotPath, gotEmail, gotAuth string
+	var gotMethod, gotPath, gotQuery, gotEmail, gotAuth string
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
 		gotMethod = r.Method
 		gotPath = r.URL.Path
-		gotEmail = r.URL.Query().Get("email")
+		gotQuery = r.URL.RawQuery
 		gotAuth = r.Header.Get("Authorization")
+		var payload listRequest
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		gotEmail = payload.Email
 		testutil.JSON(t, w, map[string]any{
 			"last_payouts": []map[string]any{
 				{
@@ -34,8 +39,11 @@ func TestListUsesInternalAdminEndpoint(t *testing.T) {
 	cmd.SetArgs([]string{"--email", "seller@example.com"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	if gotMethod != "GET" || gotPath != "/internal/admin/payouts" {
-		t.Fatalf("got %s %s, want GET /internal/admin/payouts", gotMethod, gotPath)
+	if gotMethod != "POST" || gotPath != "/internal/admin/payouts/list" {
+		t.Fatalf("got %s %s, want POST /internal/admin/payouts/list", gotMethod, gotPath)
+	}
+	if gotQuery != "" {
+		t.Fatalf("email should not be sent in query string, got %q", gotQuery)
 	}
 	if gotEmail != "seller@example.com" {
 		t.Fatalf("got email %q, want seller@example.com", gotEmail)

--- a/internal/cmd/admin/payouts/payouts_test.go
+++ b/internal/cmd/admin/payouts/payouts_test.go
@@ -92,3 +92,55 @@ func TestListJSONPreservesResponse(t *testing.T) {
 		t.Fatalf("unexpected JSON payload: %s", out)
 	}
 }
+
+func TestListPlainOutputWithPaypalDestination(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"last_payouts": []map[string]any{
+				{
+					"external_id": "pay_123", "amount_cents": 5000,
+					"state": "completed", "created_at": "2026-04-24T12:00:00Z",
+					"processor": "paypal", "paypal_email": "seller@example.com",
+				},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newListCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{"--email", "seller@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	want := "seller@example.com\tpay_123\t5000 cents\tcompleted\t2026-04-24T12:00:00Z\tpaypal\tseller@example.com"
+	if strings.TrimSpace(out) != want {
+		t.Fatalf("unexpected plain output: %q", out)
+	}
+}
+
+func TestListPlainOutputWithNoPayouts(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"next_payout_date":        "2026-04-30",
+			"balance_for_next_payout": "$25.00",
+			"payout_note":             "Manual review",
+		})
+	})
+
+	cmd := testutil.Command(newListCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{"--email", "seller@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	want := "seller@example.com\t\t\t\t\t2026-04-30\t$25.00\tManual review"
+	if strings.TrimSpace(out) != want {
+		t.Fatalf("unexpected plain output: %q", out)
+	}
+}
+
+func TestNewPayoutsCmdWiresList(t *testing.T) {
+	cmd := NewPayoutsCmd()
+	if cmd.Use != "payouts" {
+		t.Fatalf("Use = %q, want payouts", cmd.Use)
+	}
+	if got := cmd.Commands(); len(got) != 1 || got[0].Use != "list" {
+		t.Fatalf("unexpected subcommands: %#v", got)
+	}
+}

--- a/internal/cmd/admin/payouts/payouts_test.go
+++ b/internal/cmd/admin/payouts/payouts_test.go
@@ -138,6 +138,13 @@ func TestListPlainOutputWithNoPayouts(t *testing.T) {
 	}
 }
 
+func TestFormatAmountTrimsCurrency(t *testing.T) {
+	p := payout{AmountCents: 5000, Currency: " usd "}
+	if got := formatAmount(p); got != "5000 USD cents" {
+		t.Fatalf("got %q, want 5000 USD cents", got)
+	}
+}
+
 func TestNewPayoutsCmdWiresList(t *testing.T) {
 	cmd := NewPayoutsCmd()
 	if cmd.Use != "payouts" {

--- a/internal/cmd/admin/payouts/payouts_test.go
+++ b/internal/cmd/admin/payouts/payouts_test.go
@@ -103,6 +103,9 @@ func TestListPlainOutputWithPaypalDestination(t *testing.T) {
 					"processor": "paypal", "paypal_email": "seller@example.com",
 				},
 			},
+			"next_payout_date":        "2026-04-30",
+			"balance_for_next_payout": "$25.00",
+			"payout_note":             "Manual review",
 		})
 	})
 
@@ -110,7 +113,7 @@ func TestListPlainOutputWithPaypalDestination(t *testing.T) {
 	cmd.SetArgs([]string{"--email", "seller@example.com"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	want := "seller@example.com\tpay_123\t5000 cents\tcompleted\t2026-04-24T12:00:00Z\tpaypal\tseller@example.com"
+	want := "seller@example.com\tpay_123\t5000 cents\tcompleted\t2026-04-24T12:00:00Z\tpaypal\tseller@example.com\t2026-04-30\t$25.00\tManual review"
 	if strings.TrimSpace(out) != want {
 		t.Fatalf("unexpected plain output: %q", out)
 	}
@@ -129,7 +132,7 @@ func TestListPlainOutputWithNoPayouts(t *testing.T) {
 	cmd.SetArgs([]string{"--email", "seller@example.com"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	want := "seller@example.com\t\t\t\t\t2026-04-30\t$25.00\tManual review"
+	want := "seller@example.com\t\t\t\t\t\t\t2026-04-30\t$25.00\tManual review"
 	if strings.TrimSpace(out) != want {
 		t.Fatalf("unexpected plain output: %q", out)
 	}

--- a/internal/cmd/admin/purchases/purchases.go
+++ b/internal/cmd/admin/purchases/purchases.go
@@ -1,0 +1,16 @@
+package purchases
+
+import "github.com/spf13/cobra"
+
+func NewPurchasesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "purchases",
+		Short: "Read admin purchase records",
+		Example: `  gumroad admin purchases view <purchase-id>
+  gumroad admin purchases view <purchase-id> --json`,
+	}
+
+	cmd.AddCommand(newViewCmd())
+
+	return cmd
+}

--- a/internal/cmd/admin/purchases/purchases_test.go
+++ b/internal/cmd/admin/purchases/purchases_test.go
@@ -1,0 +1,64 @@
+package purchases
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestViewUsesInternalAdminEndpoint(t *testing.T) {
+	var gotMethod, gotPath, gotAuth string
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		testutil.JSON(t, w, map[string]any{
+			"purchase": map[string]any{
+				"id": "123", "email": "buyer@example.com", "seller_email": "seller@example.com",
+				"link_name": "Course", "price_cents": 1200, "purchase_state": "successful",
+				"created_at": "2026-04-24T12:00:00Z",
+			},
+		})
+	})
+
+	cmd := testutil.Command(newViewCmd())
+	cmd.SetArgs([]string{"123"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != "GET" || gotPath != "/internal/admin/purchases/123" {
+		t.Fatalf("got %s %s, want GET /internal/admin/purchases/123", gotMethod, gotPath)
+	}
+	if gotAuth != "Bearer admin-token" {
+		t.Fatalf("got auth %q, want Bearer admin-token", gotAuth)
+	}
+	for _, want := range []string{"Course", "Purchase ID: 123", "Buyer: buyer@example.com", "Seller: seller@example.com"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestViewJSONPreservesResponse(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"purchase": map[string]any{"id": "123", "email": "buyer@example.com"},
+		})
+	})
+
+	cmd := testutil.Command(newViewCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"123"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp struct {
+		Purchase map[string]any `json:"purchase"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if resp.Purchase["id"] != "123" {
+		t.Fatalf("unexpected JSON payload: %s", out)
+	}
+}

--- a/internal/cmd/admin/purchases/purchases_test.go
+++ b/internal/cmd/admin/purchases/purchases_test.go
@@ -99,7 +99,7 @@ func TestViewHumanOutputOmitsEmptyOptionalFields(t *testing.T) {
 	cmd.SetArgs([]string{"123"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	if strings.TrimSpace(out) != "123\nPurchase ID: 123" {
+	if strings.TrimSpace(out) != "123" {
 		t.Fatalf("unexpected human output: %q", out)
 	}
 }

--- a/internal/cmd/admin/purchases/purchases_test.go
+++ b/internal/cmd/admin/purchases/purchases_test.go
@@ -62,3 +62,83 @@ func TestViewJSONPreservesResponse(t *testing.T) {
 		t.Fatalf("unexpected JSON payload: %s", out)
 	}
 }
+
+func TestViewPlainOutputUsesFallbackFields(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"purchase": map[string]any{
+				"id":             "123",
+				"email":          "buyer@example.com",
+				"seller_email":   "seller@example.com",
+				"product_id":     "prod_123",
+				"price_cents":    5000,
+				"purchase_state": "successful",
+				"created_at":     "2026-04-24T12:00:00Z",
+			},
+		})
+	})
+
+	cmd := testutil.Command(newViewCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{"123"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	want := "123\tbuyer@example.com\tseller@example.com\tprod_123\t5000 cents\tsuccessful\t2026-04-24T12:00:00Z"
+	if strings.TrimSpace(out) != want {
+		t.Fatalf("unexpected plain output: %q", out)
+	}
+}
+
+func TestViewHumanOutputOmitsEmptyOptionalFields(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"purchase": map[string]any{"id": "123"},
+		})
+	})
+
+	cmd := testutil.Command(newViewCmd())
+	cmd.SetArgs([]string{"123"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if strings.TrimSpace(out) != "123\nPurchase ID: 123" {
+		t.Fatalf("unexpected human output: %q", out)
+	}
+}
+
+func TestViewHumanOutputUsesFormattedTotalAndReceipt(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"purchase": map[string]any{
+				"id":                    "123",
+				"product_name":          "Course",
+				"formatted_total_price": "$12",
+				"purchase_state":        "successful",
+				"refund_status":         "partially_refunded",
+				"receipt_url":           "https://gumroad.com/receipts/123",
+			},
+		})
+	})
+
+	cmd := testutil.Command(newViewCmd())
+	cmd.SetArgs([]string{"123"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	for _, want := range []string{
+		"Course  $12",
+		"Status: successful, partially_refunded",
+		"Receipt: https://gumroad.com/receipts/123",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestNewPurchasesCmdWiresView(t *testing.T) {
+	cmd := NewPurchasesCmd()
+	if cmd.Use != "purchases" {
+		t.Fatalf("Use = %q, want purchases", cmd.Use)
+	}
+	if got := cmd.Commands(); len(got) != 1 || got[0].Use != "view <purchase-id>" {
+		t.Fatalf("unexpected subcommands: %#v", got)
+	}
+}

--- a/internal/cmd/admin/purchases/purchases_test.go
+++ b/internal/cmd/admin/purchases/purchases_test.go
@@ -104,6 +104,22 @@ func TestViewHumanOutputOmitsEmptyOptionalFields(t *testing.T) {
 	}
 }
 
+func TestViewHumanOutputAvoidsDuplicateIDWithAmountFallback(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"purchase": map[string]any{"id": "123", "formatted_total_price": "$12"},
+		})
+	})
+
+	cmd := testutil.Command(newViewCmd())
+	cmd.SetArgs([]string{"123"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if strings.TrimSpace(out) != "123  $12" {
+		t.Fatalf("unexpected human output: %q", out)
+	}
+}
+
 func TestViewHumanOutputUsesFormattedTotalAndReceipt(t *testing.T) {
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
 		testutil.JSON(t, w, map[string]any{

--- a/internal/cmd/admin/purchases/view.go
+++ b/internal/cmd/admin/purchases/view.go
@@ -74,9 +74,11 @@ func renderPurchase(opts cmdutil.Options, p purchase) error {
 	}
 
 	style := opts.Style()
+	headlineFromID := false
 	headline := product
 	if headline == "" {
 		headline = p.ID
+		headlineFromID = true
 	}
 	if amount != "" {
 		headline += "  " + amount
@@ -84,7 +86,7 @@ func renderPurchase(opts cmdutil.Options, p purchase) error {
 	if err := output.Writeln(opts.Out(), style.Bold(headline)); err != nil {
 		return err
 	}
-	if headline != p.ID {
+	if !headlineFromID {
 		if err := output.Writef(opts.Out(), "Purchase ID: %s\n", p.ID); err != nil {
 			return err
 		}

--- a/internal/cmd/admin/purchases/view.go
+++ b/internal/cmd/admin/purchases/view.go
@@ -1,0 +1,114 @@
+package purchases
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/antiwork/gumroad-cli/internal/admincmd"
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+type purchaseResponse struct {
+	Purchase purchase `json:"purchase"`
+}
+
+type purchase struct {
+	ID                  string      `json:"id"`
+	Email               string      `json:"email"`
+	SellerEmail         string      `json:"seller_email"`
+	ProductName         string      `json:"product_name"`
+	LinkName            string      `json:"link_name"`
+	ProductID           string      `json:"product_id"`
+	FormattedTotalPrice string      `json:"formatted_total_price"`
+	PriceCents          api.JSONInt `json:"price_cents"`
+	PurchaseState       string      `json:"purchase_state"`
+	RefundStatus        string      `json:"refund_status"`
+	CreatedAt           string      `json:"created_at"`
+	ReceiptURL          string      `json:"receipt_url"`
+}
+
+func newViewCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "view <purchase-id>",
+		Short: "View an admin purchase record",
+		Args:  cmdutil.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			path := cmdutil.JoinPath("purchases", args[0])
+			return admincmd.RunGetDecoded[purchaseResponse](opts, "Fetching purchase...", path, url.Values{}, func(resp purchaseResponse) error {
+				return renderPurchase(opts, resp.Purchase)
+			})
+		},
+	}
+}
+
+func renderPurchase(opts cmdutil.Options, p purchase) error {
+	product := p.ProductName
+	if product == "" {
+		product = p.LinkName
+	}
+	if product == "" {
+		product = p.ProductID
+	}
+
+	amount := p.FormattedTotalPrice
+	if amount == "" && p.PriceCents != 0 {
+		amount = fmt.Sprintf("%d cents", p.PriceCents)
+	}
+
+	status := p.PurchaseState
+	if p.RefundStatus != "" {
+		if status != "" {
+			status += ", "
+		}
+		status += p.RefundStatus
+	}
+
+	if opts.PlainOutput {
+		return output.PrintPlain(opts.Out(), [][]string{
+			{p.ID, p.Email, p.SellerEmail, product, amount, status, p.CreatedAt},
+		})
+	}
+
+	style := opts.Style()
+	headline := product
+	if headline == "" {
+		headline = p.ID
+	}
+	if amount != "" {
+		headline += "  " + amount
+	}
+	if err := output.Writeln(opts.Out(), style.Bold(headline)); err != nil {
+		return err
+	}
+	if err := output.Writef(opts.Out(), "Purchase ID: %s\n", p.ID); err != nil {
+		return err
+	}
+	if p.Email != "" {
+		if err := output.Writef(opts.Out(), "Buyer: %s\n", p.Email); err != nil {
+			return err
+		}
+	}
+	if p.SellerEmail != "" {
+		if err := output.Writef(opts.Out(), "Seller: %s\n", p.SellerEmail); err != nil {
+			return err
+		}
+	}
+	if status != "" {
+		if err := output.Writef(opts.Out(), "Status: %s\n", status); err != nil {
+			return err
+		}
+	}
+	if p.CreatedAt != "" {
+		if err := output.Writef(opts.Out(), "Date: %s\n", p.CreatedAt); err != nil {
+			return err
+		}
+	}
+	if p.ReceiptURL != "" {
+		return output.Writef(opts.Out(), "Receipt: %s\n", p.ReceiptURL)
+	}
+	return nil
+}

--- a/internal/cmd/admin/purchases/view.go
+++ b/internal/cmd/admin/purchases/view.go
@@ -20,7 +20,7 @@ type purchase struct {
 	Email               string      `json:"email"`
 	SellerEmail         string      `json:"seller_email"`
 	ProductName         string      `json:"product_name"`
-	LinkName            string      `json:"link_name"`
+	ProductAlias        string      `json:"link_name"`
 	ProductID           string      `json:"product_id"`
 	FormattedTotalPrice string      `json:"formatted_total_price"`
 	PriceCents          api.JSONInt `json:"price_cents"`
@@ -48,7 +48,7 @@ func newViewCmd() *cobra.Command {
 func renderPurchase(opts cmdutil.Options, p purchase) error {
 	product := p.ProductName
 	if product == "" {
-		product = p.LinkName
+		product = p.ProductAlias
 	}
 	if product == "" {
 		product = p.ProductID
@@ -84,8 +84,10 @@ func renderPurchase(opts cmdutil.Options, p purchase) error {
 	if err := output.Writeln(opts.Out(), style.Bold(headline)); err != nil {
 		return err
 	}
-	if err := output.Writef(opts.Out(), "Purchase ID: %s\n", p.ID); err != nil {
-		return err
+	if headline != p.ID {
+		if err := output.Writef(opts.Out(), "Purchase ID: %s\n", p.ID); err != nil {
+			return err
+		}
 	}
 	if p.Email != "" {
 		if err := output.Writef(opts.Out(), "Buyer: %s\n", p.Email); err != nil {

--- a/internal/cmd/admin/users/suspension.go
+++ b/internal/cmd/admin/users/suspension.go
@@ -1,0 +1,67 @@
+package users
+
+import (
+	"net/url"
+
+	"github.com/antiwork/gumroad-cli/internal/admincmd"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+type suspensionResponse struct {
+	Status    string `json:"status"`
+	UpdatedAt string `json:"updated_at"`
+	AppealURL string `json:"appeal_url"`
+}
+
+func newSuspensionCmd() *cobra.Command {
+	var email string
+
+	cmd := &cobra.Command{
+		Use:   "suspension",
+		Short: "View a user's suspension status",
+		Args:  cmdutil.ExactArgs(0),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			if email == "" {
+				return cmdutil.MissingFlagError(c, "--email")
+			}
+
+			params := url.Values{}
+			params.Set("email", email)
+			return admincmd.RunGetDecoded[suspensionResponse](opts, "Fetching suspension info...", "/users/suspension", params, func(resp suspensionResponse) error {
+				return renderSuspension(opts, email, resp)
+			})
+		},
+	}
+
+	cmd.Flags().StringVar(&email, "email", "", "User email (required)")
+
+	return cmd
+}
+
+func renderSuspension(opts cmdutil.Options, email string, resp suspensionResponse) error {
+	if opts.PlainOutput {
+		return output.PrintPlain(opts.Out(), [][]string{
+			{email, resp.Status, resp.UpdatedAt, resp.AppealURL},
+		})
+	}
+
+	style := opts.Style()
+	if err := output.Writeln(opts.Out(), style.Bold(email)); err != nil {
+		return err
+	}
+	if err := output.Writef(opts.Out(), "Status: %s\n", resp.Status); err != nil {
+		return err
+	}
+	if resp.UpdatedAt != "" {
+		if err := output.Writef(opts.Out(), "Updated: %s\n", resp.UpdatedAt); err != nil {
+			return err
+		}
+	}
+	if resp.AppealURL != "" {
+		return output.Writef(opts.Out(), "Appeal: %s\n", resp.AppealURL)
+	}
+	return nil
+}

--- a/internal/cmd/admin/users/suspension.go
+++ b/internal/cmd/admin/users/suspension.go
@@ -1,8 +1,6 @@
 package users
 
 import (
-	"net/url"
-
 	"github.com/antiwork/gumroad-cli/internal/admincmd"
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/output"
@@ -13,6 +11,10 @@ type suspensionResponse struct {
 	Status    string `json:"status"`
 	UpdatedAt string `json:"updated_at"`
 	AppealURL string `json:"appeal_url"`
+}
+
+type suspensionRequest struct {
+	Email string `json:"email"`
 }
 
 func newSuspensionCmd() *cobra.Command {
@@ -28,9 +30,7 @@ func newSuspensionCmd() *cobra.Command {
 				return cmdutil.MissingFlagError(c, "--email")
 			}
 
-			params := url.Values{}
-			params.Set("email", email)
-			return admincmd.RunGetDecoded[suspensionResponse](opts, "Fetching suspension info...", "/users/suspension", params, func(resp suspensionResponse) error {
+			return admincmd.RunPostJSONDecoded[suspensionResponse](opts, "Fetching suspension info...", "/users/suspension", suspensionRequest{Email: email}, func(resp suspensionResponse) error {
 				return renderSuspension(opts, email, resp)
 			})
 		},

--- a/internal/cmd/admin/users/suspension.go
+++ b/internal/cmd/admin/users/suspension.go
@@ -52,8 +52,10 @@ func renderSuspension(opts cmdutil.Options, email string, resp suspensionRespons
 	if err := output.Writeln(opts.Out(), style.Bold(email)); err != nil {
 		return err
 	}
-	if err := output.Writef(opts.Out(), "Status: %s\n", resp.Status); err != nil {
-		return err
+	if resp.Status != "" {
+		if err := output.Writef(opts.Out(), "Status: %s\n", resp.Status); err != nil {
+			return err
+		}
 	}
 	if resp.UpdatedAt != "" {
 		if err := output.Writef(opts.Out(), "Updated: %s\n", resp.UpdatedAt); err != nil {

--- a/internal/cmd/admin/users/users.go
+++ b/internal/cmd/admin/users/users.go
@@ -1,0 +1,16 @@
+package users
+
+import "github.com/spf13/cobra"
+
+func NewUsersCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "users",
+		Short: "Read admin user records",
+		Example: `  gumroad admin users suspension --email user@example.com
+  gumroad admin users suspension --email user@example.com --json`,
+	}
+
+	cmd.AddCommand(newSuspensionCmd())
+
+	return cmd
+}

--- a/internal/cmd/admin/users/users_test.go
+++ b/internal/cmd/admin/users/users_test.go
@@ -10,12 +10,17 @@ import (
 )
 
 func TestSuspensionUsesInternalAdminEndpoint(t *testing.T) {
-	var gotMethod, gotPath, gotEmail, gotAuth string
+	var gotMethod, gotPath, gotQuery, gotEmail, gotAuth string
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
 		gotMethod = r.Method
 		gotPath = r.URL.Path
-		gotEmail = r.URL.Query().Get("email")
+		gotQuery = r.URL.RawQuery
 		gotAuth = r.Header.Get("Authorization")
+		var payload suspensionRequest
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		gotEmail = payload.Email
 		testutil.JSON(t, w, map[string]any{
 			"status":     "Suspended",
 			"updated_at": "2026-04-24T12:00:00Z",
@@ -27,8 +32,11 @@ func TestSuspensionUsesInternalAdminEndpoint(t *testing.T) {
 	cmd.SetArgs([]string{"--email", "user@example.com"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	if gotMethod != "GET" || gotPath != "/internal/admin/users/suspension" {
-		t.Fatalf("got %s %s, want GET /internal/admin/users/suspension", gotMethod, gotPath)
+	if gotMethod != "POST" || gotPath != "/internal/admin/users/suspension" {
+		t.Fatalf("got %s %s, want POST /internal/admin/users/suspension", gotMethod, gotPath)
+	}
+	if gotQuery != "" {
+		t.Fatalf("email should not be sent in query string, got %q", gotQuery)
 	}
 	if gotEmail != "user@example.com" {
 		t.Fatalf("got email %q, want user@example.com", gotEmail)

--- a/internal/cmd/admin/users/users_test.go
+++ b/internal/cmd/admin/users/users_test.go
@@ -117,6 +117,20 @@ func TestSuspensionHumanOutputOmitsEmptyOptionalFields(t *testing.T) {
 	}
 }
 
+func TestSuspensionHumanOutputOmitsEmptyStatus(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{})
+	})
+
+	cmd := testutil.Command(newSuspensionCmd())
+	cmd.SetArgs([]string{"--email", "user@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if strings.TrimSpace(out) != "user@example.com" {
+		t.Fatalf("unexpected human output: %q", out)
+	}
+}
+
 func TestNewUsersCmdWiresSuspension(t *testing.T) {
 	cmd := NewUsersCmd()
 	if cmd.Use != "users" {

--- a/internal/cmd/admin/users/users_test.go
+++ b/internal/cmd/admin/users/users_test.go
@@ -83,3 +83,46 @@ func TestSuspensionJSONPreservesResponse(t *testing.T) {
 		t.Fatalf("unexpected JSON payload: %s", out)
 	}
 }
+
+func TestSuspensionPlainOutput(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"status":     "Flagged",
+			"updated_at": "2026-04-24T12:00:00Z",
+			"appeal_url": "https://gumroad.com/appeal",
+		})
+	})
+
+	cmd := testutil.Command(newSuspensionCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{"--email", "user@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	want := "user@example.com\tFlagged\t2026-04-24T12:00:00Z\thttps://gumroad.com/appeal"
+	if strings.TrimSpace(out) != want {
+		t.Fatalf("unexpected plain output: %q", out)
+	}
+}
+
+func TestSuspensionHumanOutputOmitsEmptyOptionalFields(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{"status": "Compliant"})
+	})
+
+	cmd := testutil.Command(newSuspensionCmd())
+	cmd.SetArgs([]string{"--email", "user@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if strings.TrimSpace(out) != "user@example.com\nStatus: Compliant" {
+		t.Fatalf("unexpected human output: %q", out)
+	}
+}
+
+func TestNewUsersCmdWiresSuspension(t *testing.T) {
+	cmd := NewUsersCmd()
+	if cmd.Use != "users" {
+		t.Fatalf("Use = %q, want users", cmd.Use)
+	}
+	if got := cmd.Commands(); len(got) != 1 || got[0].Use != "suspension" {
+		t.Fatalf("unexpected subcommands: %#v", got)
+	}
+}

--- a/internal/cmd/admin/users/users_test.go
+++ b/internal/cmd/admin/users/users_test.go
@@ -1,0 +1,77 @@
+package users
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestSuspensionUsesInternalAdminEndpoint(t *testing.T) {
+	var gotMethod, gotPath, gotEmail, gotAuth string
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotEmail = r.URL.Query().Get("email")
+		gotAuth = r.Header.Get("Authorization")
+		testutil.JSON(t, w, map[string]any{
+			"status":     "Suspended",
+			"updated_at": "2026-04-24T12:00:00Z",
+			"appeal_url": "https://gumroad.com/appeal",
+		})
+	})
+
+	cmd := testutil.Command(newSuspensionCmd())
+	cmd.SetArgs([]string{"--email", "user@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != "GET" || gotPath != "/internal/admin/users/suspension" {
+		t.Fatalf("got %s %s, want GET /internal/admin/users/suspension", gotMethod, gotPath)
+	}
+	if gotEmail != "user@example.com" {
+		t.Fatalf("got email %q, want user@example.com", gotEmail)
+	}
+	if gotAuth != "Bearer admin-token" {
+		t.Fatalf("got auth %q, want Bearer admin-token", gotAuth)
+	}
+	for _, want := range []string{"user@example.com", "Status: Suspended", "Updated: 2026-04-24T12:00:00Z", "Appeal: https://gumroad.com/appeal"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestSuspensionRequiresEmail(t *testing.T) {
+	cmd := newSuspensionCmd()
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected missing email error")
+	}
+	if !strings.Contains(err.Error(), "missing required flag: --email") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSuspensionJSONPreservesResponse(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{"status": "Compliant"})
+	})
+
+	cmd := testutil.Command(newSuspensionCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--email", "user@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp struct {
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if resp.Status != "Compliant" {
+		t.Fatalf("unexpected JSON payload: %s", out)
+	}
+}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/antiwork/gumroad-cli/internal/adminapi"
+	"github.com/antiwork/gumroad-cli/internal/adminconfig"
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/config"
 	"github.com/antiwork/gumroad-cli/internal/output"
@@ -37,6 +39,26 @@ func Setup(t *testing.T, handler http.HandlerFunc) *httptest.Server {
 
 	srv := httptest.NewServer(handler)
 	t.Setenv("GUMROAD_API_BASE_URL", srv.URL)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// SetupAdmin creates a mock admin HTTP server and temp admin config for
+// command tests. Cleanup is automatic via t.Cleanup.
+func SetupAdmin(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+
+	cfgDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+	t.Setenv(config.EnvAccessToken, "")
+	t.Setenv(adminconfig.EnvAccessToken, "")
+
+	if err := adminconfig.Save(&adminconfig.Config{AccessToken: "admin-token"}); err != nil {
+		t.Fatalf("Save admin config failed: %v", err)
+	}
+
+	srv := httptest.NewServer(handler)
+	t.Setenv(adminapi.EnvAPIBaseURL, srv.URL)
 	t.Cleanup(srv.Close)
 	return srv
 }


### PR DESCRIPTION
Ref: antiwork/gumroad/issues/4677

## What

Four read-only admin commands on top of the foundation:

- `gumroad admin purchases view <purchase-id>`
- `gumroad admin licenses lookup --key <license-key>` (also accepts the key on stdin)
- `gumroad admin users suspension --email <email>`
- `gumroad admin payouts list --email <email>`

Plus `admincmd.RunPostJSONDecoded[T]` for read-style POSTs and `testutil.SetupAdmin` for admin command tests.

## Why

This is the minimum useful surface on top of [#48](https://github.com/antiwork/gumroad-cli/pull/48) and doubles as the base branch for @nyomanjyotisa's Phase 1 writes (refunds, resends, reassigns). Keeping this PR read-only means we don't need the destructive-op logic yet.

The three lookup commands use `POST` with a JSON body instead of `GET` with query params so license keys and emails don't end up in URLs, access logs, or proxy logs. `licenses lookup` also accepts stdin for cases where we want to avoid putting the license key in shell history.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh