### PR TITLE
Fix admin purchase plain output to include receipt URLs

### DIFF
--- a/internal/cmd/admin/purchases/purchases_test.go
+++ b/internal/cmd/admin/purchases/purchases_test.go
@@ -74,6 +74,7 @@ func TestViewPlainOutputUsesFallbackFields(t *testing.T) {
 				"price_cents":    5000,
 				"purchase_state": "successful",
 				"created_at":     "2026-04-24T12:00:00Z",
+				"receipt_url":    "https://gumroad.com/receipts/123",
 			},
 		})
 	})
@@ -82,7 +83,7 @@ func TestViewPlainOutputUsesFallbackFields(t *testing.T) {
 	cmd.SetArgs([]string{"123"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	want := "123\tbuyer@example.com\tseller@example.com\tprod_123\t5000 cents\tsuccessful\t2026-04-24T12:00:00Z"
+	want := "123\tbuyer@example.com\tseller@example.com\tprod_123\t5000 cents\tsuccessful\t2026-04-24T12:00:00Z\thttps://gumroad.com/receipts/123"
 	if strings.TrimSpace(out) != want {
 		t.Fatalf("unexpected plain output: %q", out)
 	}

--- a/internal/cmd/admin/purchases/view.go
+++ b/internal/cmd/admin/purchases/view.go
@@ -69,7 +69,7 @@ func renderPurchase(opts cmdutil.Options, p purchase) error {
 
 	if opts.PlainOutput {
 		return output.PrintPlain(opts.Out(), [][]string{
-			{p.ID, p.Email, p.SellerEmail, product, amount, status, p.CreatedAt},
+			{p.ID, p.Email, p.SellerEmail, product, amount, status, p.CreatedAt, p.ReceiptURL},
 		})
 	}
 


### PR DESCRIPTION
Ref antiwork/gumroad/issues/4677

## What

- Adds `receipt_url` to the plain-text output for admin purchase lookups.
- Keeps the human and JSON output behavior unchanged.
- Covers the new output shape with a regression test.

## Why

- Admins using `--plain` should not lose a useful purchase field that is already available in the other output modes.
- The receipt URL is a practical scripting field, so keeping it in plain output makes the command more consistent and easier to use.

---

This PR was implemented with AI assistance using gpt-5.5 xhigh.