### PR TITLE
Add admin purchases refund command

### DIFF
--- a/internal/adminapi/client.go
+++ b/internal/adminapi/client.go
@@ -39,32 +39,32 @@ func (c *Client) SetDebugWriter(w io.Writer) {
 }
 
 func (c *Client) Get(path string, params url.Values) (json.RawMessage, error) {
-	data, err := c.api.Get(adminPath(path), params)
+	data, err := c.api.Get(AdminPath(path), params)
 	return data, rewriteAdminError(err)
 }
 
 func (c *Client) Post(path string, params url.Values) (json.RawMessage, error) {
-	data, err := c.api.Post(adminPath(path), params)
+	data, err := c.api.Post(AdminPath(path), params)
 	return data, rewriteAdminError(err)
 }
 
 func (c *Client) PostJSON(path string, payload any) (json.RawMessage, error) {
-	data, err := c.api.PostJSON(adminPath(path), payload)
+	data, err := c.api.PostJSON(AdminPath(path), payload)
 	return data, rewriteAdminError(err)
 }
 
 func (c *Client) Put(path string, params url.Values) (json.RawMessage, error) {
-	data, err := c.api.Put(adminPath(path), params)
+	data, err := c.api.Put(AdminPath(path), params)
 	return data, rewriteAdminError(err)
 }
 
 func (c *Client) PutJSON(path string, payload any) (json.RawMessage, error) {
-	data, err := c.api.PutJSON(adminPath(path), payload)
+	data, err := c.api.PutJSON(AdminPath(path), payload)
 	return data, rewriteAdminError(err)
 }
 
 func (c *Client) Delete(path string, params url.Values) (json.RawMessage, error) {
-	data, err := c.api.Delete(adminPath(path), params)
+	data, err := c.api.Delete(AdminPath(path), params)
 	return data, rewriteAdminError(err)
 }
 
@@ -75,7 +75,8 @@ func defaultBaseURL() string {
 	return defaultAPIBaseURL
 }
 
-func adminPath(path string) string {
+// AdminPath returns the absolute admin-prefixed path for path.
+func AdminPath(path string) string {
 	if path == "" || path == "/" {
 		return adminAPIPathPrefix
 	}

--- a/internal/admincmd/read.go
+++ b/internal/admincmd/read.go
@@ -76,6 +76,16 @@ func RunPostJSONDecoded[T any](opts cmdutil.Options, spinnerMessage, path string
 	}, render)
 }
 
+// FetchPostJSON posts a JSON payload and returns the raw response without
+// rendering it. Use this when the caller needs to keep transport-level
+// failures distinguishable from post-success render/decode errors (e.g. so
+// only the POST failure gets a "request failed" wrapper).
+func FetchPostJSON(opts cmdutil.Options, spinnerMessage, path string, payload any) (json.RawMessage, error) {
+	return runAuthenticatedData(opts, spinnerMessage, func(client *adminapi.Client) (json.RawMessage, error) {
+		return client.PostJSON(path, payload)
+	})
+}
+
 func runAuthenticatedData(opts cmdutil.Options, spinnerMessage string, run ClientRunner) (json.RawMessage, error) {
 	token, err := adminconfig.Token()
 	if err != nil {

--- a/internal/admincmd/read.go
+++ b/internal/admincmd/read.go
@@ -57,6 +57,19 @@ func RunGetDecoded[T any](opts cmdutil.Options, spinnerMessage, path string, par
 	}, render)
 }
 
+// FetchGetDecoded fetches a GET endpoint and decodes the response without
+// rendering it. Use it when chaining requests where only the data is needed.
+func FetchGetDecoded[T any](opts cmdutil.Options, spinnerMessage, path string, params url.Values) (T, error) {
+	var zero T
+	data, err := runAuthenticatedData(opts, spinnerMessage, func(client *adminapi.Client) (json.RawMessage, error) {
+		return client.Get(path, params)
+	})
+	if err != nil {
+		return zero, err
+	}
+	return cmdutil.DecodeJSON[T](data)
+}
+
 func RunPostJSONDecoded[T any](opts cmdutil.Options, spinnerMessage, path string, payload any, render func(T) error) error {
 	return RunDecoded[T](opts, spinnerMessage, func(client *adminapi.Client) (json.RawMessage, error) {
 		return client.PostJSON(path, payload)

--- a/internal/cmd/admin/admin.go
+++ b/internal/cmd/admin/admin.go
@@ -14,6 +14,7 @@ func NewAdminCmd() *cobra.Command {
 		Short: "Run Gumroad admin commands",
 		Long:  "Run internal Gumroad admin API commands with a separate admin token.",
 		Example: `  gumroad admin purchases view <purchase-id>
+  gumroad admin purchases refund <purchase-id> --email <email>
   gumroad admin licenses lookup --key <license-key>
   gumroad admin users suspension --email <email>
   gumroad admin payouts list --email <email>`,

--- a/internal/cmd/admin/purchases/purchases.go
+++ b/internal/cmd/admin/purchases/purchases.go
@@ -5,12 +5,14 @@ import "github.com/spf13/cobra"
 func NewPurchasesCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "purchases",
-		Short: "Read admin purchase records",
+		Short: "Read and manage admin purchase records",
 		Example: `  gumroad admin purchases view <purchase-id>
-  gumroad admin purchases view <purchase-id> --json`,
+  gumroad admin purchases view <purchase-id> --json
+  gumroad admin purchases refund <purchase-id> --email buyer@example.com`,
 	}
 
 	cmd.AddCommand(newViewCmd())
+	cmd.AddCommand(newRefundCmd())
 
 	return cmd
 }

--- a/internal/cmd/admin/purchases/purchases_test.go
+++ b/internal/cmd/admin/purchases/purchases_test.go
@@ -150,12 +150,24 @@ func TestViewHumanOutputUsesFormattedTotalAndReceipt(t *testing.T) {
 	}
 }
 
-func TestNewPurchasesCmdWiresView(t *testing.T) {
+func TestNewPurchasesCmdWiresSubcommands(t *testing.T) {
 	cmd := NewPurchasesCmd()
 	if cmd.Use != "purchases" {
 		t.Fatalf("Use = %q, want purchases", cmd.Use)
 	}
-	if got := cmd.Commands(); len(got) != 1 || got[0].Use != "view <purchase-id>" {
-		t.Fatalf("unexpected subcommands: %#v", got)
+
+	got := cmd.Commands()
+	if len(got) != 2 {
+		t.Fatalf("expected 2 subcommands, got %d: %#v", len(got), got)
+	}
+
+	names := map[string]bool{}
+	for _, sub := range got {
+		names[sub.Use] = true
+	}
+	for _, want := range []string{"view <purchase-id>", "refund <purchase-id>"} {
+		if !names[want] {
+			t.Errorf("missing subcommand %q in %v", want, names)
+		}
 	}
 }

--- a/internal/cmd/admin/purchases/refund.go
+++ b/internal/cmd/admin/purchases/refund.go
@@ -1,0 +1,170 @@
+package purchases
+
+import (
+	"fmt"
+
+	"github.com/antiwork/gumroad-cli/internal/admincmd"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+type refundRequest struct {
+	Email              string `json:"email"`
+	AmountCents        int    `json:"amount_cents,omitempty"`
+	Force              bool   `json:"force,omitempty"`
+	CancelSubscription bool   `json:"cancel_subscription,omitempty"`
+}
+
+type refundResponse struct {
+	Message                 string   `json:"message"`
+	Purchase                purchase `json:"purchase"`
+	SubscriptionCancelled   bool     `json:"subscription_cancelled"`
+	SubscriptionCancelError string   `json:"subscription_cancel_error"`
+}
+
+func newRefundCmd() *cobra.Command {
+	var (
+		email              string
+		amount             string
+		force              bool
+		cancelSubscription bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "refund <purchase-id>",
+		Short: "Refund a purchase as an admin",
+		Long: `Refund a specific purchase end-to-end without going through the admin web UI.
+
+The buyer email is required as a sanity check against the purchase. Without --amount,
+the entire purchase is refunded. --force bypasses the refund-policy timeframe and
+fine-print guards (the active-chargeback guard still applies). --cancel-subscription
+cancels the linked subscription after a successful refund.`,
+		Example: `  gumroad admin purchases refund 12345 --email buyer@example.com
+  gumroad admin purchases refund 12345 --email buyer@example.com --amount 5.00
+  gumroad admin purchases refund 12345 --email buyer@example.com --force
+  gumroad admin purchases refund 12345 --email buyer@example.com --cancel-subscription`,
+		Args: cmdutil.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+
+			if email == "" {
+				return cmdutil.MissingFlagError(c, "--email")
+			}
+
+			var cents int
+			if c.Flags().Changed("amount") {
+				parsed, err := cmdutil.ParseMoney("amount", amount, "amount", "")
+				if err != nil {
+					return cmdutil.UsageErrorf(c, "%s", err.Error())
+				}
+				if parsed <= 0 {
+					return cmdutil.UsageErrorf(c, "--amount must be greater than 0")
+				}
+				cents = parsed
+			}
+
+			isPartial := cents > 0
+			amountDesc := cmdutil.FormatMoney(cents, "")
+
+			msg := "Refund purchase " + args[0] + "?"
+			if isPartial {
+				msg = fmt.Sprintf("Refund %s on purchase %s?", amountDesc, args[0])
+			}
+			if cancelSubscription {
+				msg += " (will also cancel the linked subscription)"
+			}
+			if force {
+				msg += " (forcing past refund-policy guards)"
+			}
+
+			ok, err := cmdutil.ConfirmAction(opts, msg)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				action := "refund purchase " + args[0]
+				if isPartial {
+					action = fmt.Sprintf("refund %s on purchase %s", amountDesc, args[0])
+				}
+				return cmdutil.PrintCancelledAction(opts, action, args[0])
+			}
+
+			req := refundRequest{
+				Email:              email,
+				AmountCents:        cents,
+				Force:              force,
+				CancelSubscription: cancelSubscription,
+			}
+
+			path := cmdutil.JoinPath("purchases", args[0], "refund")
+			return admincmd.RunPostJSONDecoded[refundResponse](opts, "Refunding purchase...", path, req, func(resp refundResponse) error {
+				return renderRefund(opts, args[0], resp)
+			})
+		},
+	}
+
+	cmd.Flags().StringVar(&email, "email", "", "Buyer email (required)")
+	cmd.Flags().StringVar(&amount, "amount", "", "Partial refund amount in displayed currency (e.g. 5, 5.00); omit for full refund")
+	cmd.Flags().BoolVar(&force, "force", false, "Bypass refund-policy timeframe and fine-print guards")
+	cmd.Flags().BoolVar(&cancelSubscription, "cancel-subscription", false, "Cancel the linked subscription after the refund succeeds")
+
+	return cmd
+}
+
+func renderRefund(opts cmdutil.Options, purchaseID string, resp refundResponse) error {
+	subscriptionStatus := subscriptionStatusLabel(resp)
+
+	if opts.PlainOutput {
+		row := []string{
+			"true",
+			fallback(resp.Message, "Refunded purchase "+purchaseID),
+			fallback(resp.Purchase.ID, purchaseID),
+			subscriptionStatus,
+			resp.SubscriptionCancelError,
+		}
+		return output.PrintPlain(opts.Out(), [][]string{row})
+	}
+
+	if opts.Quiet {
+		return nil
+	}
+
+	style := opts.Style()
+	headline := fallback(resp.Message, "Refunded purchase "+purchaseID)
+	if err := output.Writeln(opts.Out(), style.Green(headline)); err != nil {
+		return err
+	}
+
+	if resp.Purchase.ID != "" {
+		if err := renderPurchase(opts, resp.Purchase); err != nil {
+			return err
+		}
+	}
+
+	if resp.SubscriptionCancelled {
+		return output.Writeln(opts.Out(), "Subscription: cancelled")
+	}
+	if resp.SubscriptionCancelError != "" {
+		return output.Writef(opts.Out(), "Subscription cancel failed: %s\n", resp.SubscriptionCancelError)
+	}
+	return nil
+}
+
+func subscriptionStatusLabel(resp refundResponse) string {
+	switch {
+	case resp.SubscriptionCancelled:
+		return "cancelled"
+	case resp.SubscriptionCancelError != "":
+		return "cancel_failed"
+	default:
+		return "not_cancelled"
+	}
+}
+
+func fallback(value, alt string) string {
+	if value == "" {
+		return alt
+	}
+	return value
+}

--- a/internal/cmd/admin/purchases/refund.go
+++ b/internal/cmd/admin/purchases/refund.go
@@ -70,6 +70,9 @@ cancels the linked subscription after a successful refund.`,
 					return err
 				}
 				currency = lookup.Purchase.CurrencyType
+				if currency == "" {
+					return fmt.Errorf("could not determine purchase currency from admin lookup; refusing --amount to avoid mis-scaled refund (re-run without --amount for a full refund, or upgrade the server to expose currency_type)")
+				}
 				if lookup.Purchase.AmountRefundableCents > 0 {
 					refundableCents = int(lookup.Purchase.AmountRefundableCents)
 					haveRefundable = true

--- a/internal/cmd/admin/purchases/refund.go
+++ b/internal/cmd/admin/purchases/refund.go
@@ -73,7 +73,7 @@ cancels the linked subscription after a successful refund.`,
 				}
 				currency = lookup.Purchase.CurrencyType
 				if currency == "" {
-					return fmt.Errorf("could not determine purchase currency from admin lookup; refusing --amount to avoid mis-scaled refund (re-run without --amount for a full refund, or upgrade the server to expose currency_type)")
+					return cmdutil.UsageErrorf(c, "could not determine purchase currency from admin lookup; refusing --amount to avoid mis-scaled refund (re-run without --amount for a full refund, or upgrade the server to expose currency_type)")
 				}
 				if lookup.Purchase.AmountRefundableCentsInCurrency > 0 {
 					refundableCents = int(lookup.Purchase.AmountRefundableCentsInCurrency)

--- a/internal/cmd/admin/purchases/refund.go
+++ b/internal/cmd/admin/purchases/refund.go
@@ -1,6 +1,7 @@
 package purchases
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/antiwork/gumroad-cli/internal/adminapi"
 	"github.com/antiwork/gumroad-cli/internal/admincmd"
+	"github.com/antiwork/gumroad-cli/internal/api"
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
@@ -150,7 +152,24 @@ cancels the linked subscription after a successful refund.`,
 // wrapRefundError adds an explicit verification hint to refund POST failures.
 // Unlike list/lookup commands, a failed refund could still have partially
 // landed server-side, so the operator should confirm state before retrying.
+//
+// For api.APIError causes, we re-wrap as a new APIError so the structured
+// JSON error path (cmd.classifyPrimaryCause) reads the wrapped message and
+// hint via apiErr.Error() / apiErr.GetHint(). A plain fmt.Errorf wrap is
+// invisible to that classifier — it walks the chain past wrappers — and the
+// safety hint silently disappears in --json mode.
 func wrapRefundError(purchaseID string, err error) error {
+	var apiErr *api.APIError
+	if errors.As(err, &apiErr) {
+		return &api.APIError{
+			StatusCode: apiErr.StatusCode,
+			Message: fmt.Sprintf(
+				"refund request failed: %s. Verify status with 'gumroad admin purchases view %s' before retrying to avoid duplicate refunds",
+				apiErr.Message, purchaseID,
+			),
+			Hint: apiErr.Hint,
+		}
+	}
 	return fmt.Errorf("refund request failed: %w. Verify status with 'gumroad admin purchases view %s' before retrying to avoid duplicate refunds", err, purchaseID)
 }
 

--- a/internal/cmd/admin/purchases/refund.go
+++ b/internal/cmd/admin/purchases/refund.go
@@ -73,8 +73,8 @@ cancels the linked subscription after a successful refund.`,
 				if currency == "" {
 					return fmt.Errorf("could not determine purchase currency from admin lookup; refusing --amount to avoid mis-scaled refund (re-run without --amount for a full refund, or upgrade the server to expose currency_type)")
 				}
-				if lookup.Purchase.AmountRefundableCents > 0 {
-					refundableCents = int(lookup.Purchase.AmountRefundableCents)
+				if lookup.Purchase.AmountRefundableCentsInCurrency > 0 {
+					refundableCents = int(lookup.Purchase.AmountRefundableCentsInCurrency)
 					haveRefundable = true
 				}
 

--- a/internal/cmd/admin/purchases/refund.go
+++ b/internal/cmd/admin/purchases/refund.go
@@ -131,13 +131,20 @@ cancels the linked subscription after a successful refund.`,
 				return cmdutil.PrintDryRunRequest(opts, http.MethodPost, adminapi.AdminPath(refundPath), refundDryRunParams(req))
 			}
 
-			err = admincmd.RunPostJSONDecoded[refundResponse](opts, "Refunding purchase...", refundPath, req, func(resp refundResponse) error {
-				return renderRefund(opts, args[0], resp)
-			})
+			data, err := admincmd.FetchPostJSON(opts, "Refunding purchase...", refundPath, req)
 			if err != nil {
 				return wrapRefundError(args[0], err)
 			}
-			return nil
+
+			if opts.UsesJSONOutput() {
+				return cmdutil.PrintJSONResponse(opts, data)
+			}
+
+			decoded, err := cmdutil.DecodeJSON[refundResponse](data)
+			if err != nil {
+				return err
+			}
+			return renderRefund(opts, args[0], decoded)
 		},
 	}
 

--- a/internal/cmd/admin/purchases/refund.go
+++ b/internal/cmd/admin/purchases/refund.go
@@ -2,7 +2,11 @@ package purchases
 
 import (
 	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
 
+	"github.com/antiwork/gumroad-cli/internal/adminapi"
 	"github.com/antiwork/gumroad-cli/internal/admincmd"
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/output"
@@ -52,20 +56,41 @@ cancels the linked subscription after a successful refund.`,
 				return cmdutil.MissingFlagError(c, "--email")
 			}
 
-			var cents int
+			refundPath := cmdutil.JoinPath("purchases", args[0], "refund")
+
+			var (
+				cents           int
+				currency        string
+				refundableCents int
+				haveRefundable  bool
+			)
 			if c.Flags().Changed("amount") {
-				parsed, err := cmdutil.ParseMoney("amount", amount, "amount", "")
+				lookup, err := admincmd.FetchGetDecoded[purchaseResponse](opts, "Looking up purchase...", cmdutil.JoinPath("purchases", args[0]), url.Values{})
+				if err != nil {
+					return err
+				}
+				currency = lookup.Purchase.CurrencyType
+				if lookup.Purchase.AmountRefundableCents > 0 {
+					refundableCents = int(lookup.Purchase.AmountRefundableCents)
+					haveRefundable = true
+				}
+
+				parsed, err := cmdutil.ParseMoney("amount", amount, "amount", currency)
 				if err != nil {
 					return cmdutil.UsageErrorf(c, "%s", err.Error())
 				}
 				if parsed <= 0 {
 					return cmdutil.UsageErrorf(c, "--amount must be greater than 0")
 				}
+				if haveRefundable && parsed > refundableCents {
+					return cmdutil.UsageErrorf(c, "--amount %s exceeds the refundable balance of %s",
+						cmdutil.FormatMoney(parsed, currency), cmdutil.FormatMoney(refundableCents, currency))
+				}
 				cents = parsed
 			}
 
 			isPartial := cents > 0
-			amountDesc := cmdutil.FormatMoney(cents, "")
+			amountDesc := cmdutil.FormatMoney(cents, currency)
 
 			msg := "Refund purchase " + args[0] + "?"
 			if isPartial {
@@ -97,10 +122,17 @@ cancels the linked subscription after a successful refund.`,
 				CancelSubscription: cancelSubscription,
 			}
 
-			path := cmdutil.JoinPath("purchases", args[0], "refund")
-			return admincmd.RunPostJSONDecoded[refundResponse](opts, "Refunding purchase...", path, req, func(resp refundResponse) error {
+			if opts.DryRun {
+				return cmdutil.PrintDryRunRequest(opts, http.MethodPost, adminapi.AdminPath(refundPath), refundDryRunParams(req))
+			}
+
+			err = admincmd.RunPostJSONDecoded[refundResponse](opts, "Refunding purchase...", refundPath, req, func(resp refundResponse) error {
 				return renderRefund(opts, args[0], resp)
 			})
+			if err != nil {
+				return wrapRefundError(args[0], err)
+			}
+			return nil
 		},
 	}
 
@@ -110,6 +142,28 @@ cancels the linked subscription after a successful refund.`,
 	cmd.Flags().BoolVar(&cancelSubscription, "cancel-subscription", false, "Cancel the linked subscription after the refund succeeds")
 
 	return cmd
+}
+
+// wrapRefundError adds an explicit verification hint to refund POST failures.
+// Unlike list/lookup commands, a failed refund could still have partially
+// landed server-side, so the operator should confirm state before retrying.
+func wrapRefundError(purchaseID string, err error) error {
+	return fmt.Errorf("refund request failed: %w. Verify status with 'gumroad admin purchases view %s' before retrying to avoid duplicate refunds", err, purchaseID)
+}
+
+func refundDryRunParams(req refundRequest) url.Values {
+	params := url.Values{}
+	params.Set("email", req.Email)
+	if req.AmountCents > 0 {
+		params.Set("amount_cents", strconv.Itoa(req.AmountCents))
+	}
+	if req.Force {
+		params.Set("force", "true")
+	}
+	if req.CancelSubscription {
+		params.Set("cancel_subscription", "true")
+	}
+	return params
 }
 
 func renderRefund(opts cmdutil.Options, purchaseID string, resp refundResponse) error {

--- a/internal/cmd/admin/purchases/refund_test.go
+++ b/internal/cmd/admin/purchases/refund_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/testutil"
 )
 
@@ -233,6 +234,10 @@ func TestRefund_RejectsMissingCurrencyTypeFromLookup(t *testing.T) {
 	if strings.Contains(err.Error(), "Verify status") {
 		t.Errorf("guard fires before the POST so it must not include the verify-state hint: %v", err)
 	}
+	var usageErr *cmdutil.UsageError
+	if !errors.As(err, &usageErr) {
+		t.Errorf("guard must be a *cmdutil.UsageError so --json classifies it as usage_error like its sibling pre-flight guards, got %T", err)
+	}
 }
 
 func TestRefund_RejectsEmptyCurrencyTypeFromLookup(t *testing.T) {
@@ -256,6 +261,10 @@ func TestRefund_RejectsEmptyCurrencyTypeFromLookup(t *testing.T) {
 	err := cmd.Execute()
 	if err == nil || !strings.Contains(err.Error(), "could not determine purchase currency") {
 		t.Fatalf("expected currency-empty guard, got: %v", err)
+	}
+	var usageErr *cmdutil.UsageError
+	if !errors.As(err, &usageErr) {
+		t.Errorf("guard must be a *cmdutil.UsageError, got %T", err)
 	}
 }
 

--- a/internal/cmd/admin/purchases/refund_test.go
+++ b/internal/cmd/admin/purchases/refund_test.go
@@ -1,0 +1,299 @@
+package purchases
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestRefund_RequiresEmail(t *testing.T) {
+	cmd := newRefundCmd()
+	cmd.SetArgs([]string{"123"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected missing email error")
+	}
+	if !strings.Contains(err.Error(), "missing required flag: --email") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRefund_RequiresConfirmation(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API without confirmation")
+	})
+
+	cmd := testutil.Command(newRefundCmd(), testutil.NoInput(true))
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error without --yes and --no-input")
+	}
+	if !strings.Contains(err.Error(), "--yes") {
+		t.Errorf("error should mention --yes: %v", err)
+	}
+}
+
+func TestRefund_FullSendsEmailAndOmitsAmountCents(t *testing.T) {
+	var gotMethod, gotPath, gotAuth, gotQuery string
+	var body refundRequest
+	var bodyKeys map[string]json.RawMessage
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotQuery = r.URL.RawQuery
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if err := json.Unmarshal(raw, &body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if err := json.Unmarshal(raw, &bodyKeys); err != nil {
+			t.Fatalf("decode body keys: %v", err)
+		}
+		testutil.JSON(t, w, map[string]any{
+			"message": "Successfully refunded purchase number 123",
+			"purchase": map[string]any{
+				"id":             "123",
+				"email":          "buyer@example.com",
+				"refund_status":  "refunded",
+				"purchase_state": "successful",
+			},
+			"subscription_cancelled": false,
+		})
+	})
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true), testutil.Quiet(false))
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != "POST" || gotPath != "/internal/admin/purchases/123/refund" {
+		t.Fatalf("got %s %s, want POST /internal/admin/purchases/123/refund", gotMethod, gotPath)
+	}
+	if gotAuth != "Bearer admin-token" {
+		t.Fatalf("got auth %q, want Bearer admin-token", gotAuth)
+	}
+	if gotQuery != "" {
+		t.Fatalf("email/amount must not appear in query string, got %q", gotQuery)
+	}
+	if body.Email != "buyer@example.com" {
+		t.Fatalf("got email %q, want buyer@example.com", body.Email)
+	}
+	if _, present := bodyKeys["amount_cents"]; present {
+		t.Errorf("amount_cents must be omitted on full refund, got body keys: %v", bodyKeys)
+	}
+	if _, present := bodyKeys["force"]; present {
+		t.Errorf("force should be omitted when not set, got body keys: %v", bodyKeys)
+	}
+	if _, present := bodyKeys["cancel_subscription"]; present {
+		t.Errorf("cancel_subscription should be omitted when not set, got body keys: %v", bodyKeys)
+	}
+	if !strings.Contains(out, "Successfully refunded purchase number 123") {
+		t.Errorf("expected success message in output: %q", out)
+	}
+}
+
+func TestRefund_PartialSendsAmountCents(t *testing.T) {
+	var body refundRequest
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		testutil.JSON(t, w, map[string]any{
+			"message":                "Successfully refunded purchase number 123",
+			"purchase":               map[string]any{"id": "123"},
+			"subscription_cancelled": false,
+		})
+	})
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true), testutil.Quiet(false))
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "5.00"})
+	testutil.MustExecute(t, cmd)
+
+	if body.AmountCents != 500 {
+		t.Errorf("got amount_cents=%d, want 500", body.AmountCents)
+	}
+}
+
+func TestRefund_RejectsInvalidAmount(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API")
+	})
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "abc"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "not a valid amount") {
+		t.Fatalf("expected validation error, got: %v", err)
+	}
+}
+
+func TestRefund_RejectsZeroAmount(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API")
+	})
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "0"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--amount must be greater than 0") {
+		t.Fatalf("expected zero-amount error, got: %v", err)
+	}
+}
+
+func TestRefund_ForwardsForceAndCancelSubscription(t *testing.T) {
+	var body refundRequest
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		testutil.JSON(t, w, map[string]any{
+			"message":                "Successfully refunded purchase number 123",
+			"purchase":               map[string]any{"id": "123"},
+			"subscription_cancelled": true,
+		})
+	})
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true), testutil.Quiet(false))
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--force", "--cancel-subscription"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !body.Force {
+		t.Errorf("expected force=true in body, got %#v", body)
+	}
+	if !body.CancelSubscription {
+		t.Errorf("expected cancel_subscription=true in body, got %#v", body)
+	}
+	if !strings.Contains(out, "Subscription: cancelled") {
+		t.Errorf("expected subscription cancelled message: %q", out)
+	}
+}
+
+func TestRefund_ShowsSubscriptionCancelError(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"message":                   "Successfully refunded purchase number 123",
+			"purchase":                  map[string]any{"id": "123"},
+			"subscription_cancelled":    false,
+			"subscription_cancel_error": "stripe blew up",
+		})
+	})
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true), testutil.Quiet(false))
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--cancel-subscription"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "Subscription cancel failed: stripe blew up") {
+		t.Errorf("expected cancel failure message: %q", out)
+	}
+}
+
+func TestRefund_DryRunSkipsConfirmation(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		// Admin commands today do not short-circuit on dry-run, so the call
+		// still hits the API. We just want to confirm dry-run doesn't trip
+		// the confirmation prompt under --no-input.
+		testutil.JSON(t, w, map[string]any{
+			"message":                "Successfully refunded purchase number 123",
+			"purchase":               map[string]any{"id": "123"},
+			"subscription_cancelled": false,
+		})
+	})
+
+	cmd := testutil.Command(newRefundCmd(), testutil.DryRun(true), testutil.NoInput(true))
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("expected dry-run to bypass confirmation, got %v", err)
+	}
+}
+
+func TestRefund_CancelledByPromptDeclineNotReached(t *testing.T) {
+	// With NoInput(true) and no --yes the prompt errors before we reach the API.
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API when confirmation is refused")
+	})
+
+	cmd := testutil.Command(newRefundCmd(), testutil.NoInput(true))
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com"})
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected confirmation error")
+	}
+}
+
+func TestRefund_JSONPreservesResponse(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"message":                "Successfully refunded purchase number 123",
+			"purchase":               map[string]any{"id": "123"},
+			"subscription_cancelled": true,
+		})
+	})
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true), testutil.JSONOutput())
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--cancel-subscription"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp struct {
+		Success               bool           `json:"success"`
+		Message               string         `json:"message"`
+		Purchase              map[string]any `json:"purchase"`
+		SubscriptionCancelled bool           `json:"subscription_cancelled"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if !resp.Success || resp.Purchase["id"] != "123" || !resp.SubscriptionCancelled {
+		t.Fatalf("unexpected JSON payload: %s", out)
+	}
+}
+
+func TestRefund_PlainOutput(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"message":                "Successfully refunded purchase number 123",
+			"purchase":               map[string]any{"id": "123"},
+			"subscription_cancelled": true,
+		})
+	})
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true), testutil.PlainOutput())
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--cancel-subscription"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	want := "true\tSuccessfully refunded purchase number 123\t123\tcancelled\t"
+	if strings.TrimSpace(out) != strings.TrimSpace(want) {
+		t.Fatalf("unexpected plain output: %q", out)
+	}
+}
+
+func TestRefund_APIErrorSurfacesMessage(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"success": false,
+			"message": "Refund amount cannot be greater than the purchase price.",
+		})
+	})
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "50.00"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "Refund amount cannot be greater") {
+		t.Fatalf("expected API error message, got: %v", err)
+	}
+}

--- a/internal/cmd/admin/purchases/refund_test.go
+++ b/internal/cmd/admin/purchases/refund_test.go
@@ -207,6 +207,56 @@ func TestRefund_PartialUsesPurchaseCurrencyForJPY(t *testing.T) {
 	}
 }
 
+func TestRefund_RejectsMissingCurrencyTypeFromLookup(t *testing.T) {
+	testutil.SetupAdmin(t, adminRefundHandler(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"purchase": map[string]any{"id": "123", "email": "buyer@example.com"},
+			})
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			t.Error("refund POST must not fire when currency cannot be determined")
+		}))
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "500"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when currency_type is missing from lookup")
+	}
+	if !strings.Contains(err.Error(), "could not determine purchase currency") {
+		t.Errorf("expected currency-missing guard, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "Verify status") {
+		t.Errorf("guard fires before the POST so it must not include the verify-state hint: %v", err)
+	}
+}
+
+func TestRefund_RejectsEmptyCurrencyTypeFromLookup(t *testing.T) {
+	testutil.SetupAdmin(t, adminRefundHandler(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"purchase": map[string]any{
+					"id":            "123",
+					"email":         "buyer@example.com",
+					"currency_type": "",
+				},
+			})
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			t.Error("refund POST must not fire when currency is empty")
+		}))
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "500"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "could not determine purchase currency") {
+		t.Fatalf("expected currency-empty guard, got: %v", err)
+	}
+}
+
 func TestRefund_RejectsDecimalAmountForJPY(t *testing.T) {
 	testutil.SetupAdmin(t, adminRefundHandler(t,
 		purchaseLookupResponder("jpy"),

--- a/internal/cmd/admin/purchases/refund_test.go
+++ b/internal/cmd/admin/purchases/refund_test.go
@@ -44,7 +44,7 @@ func purchaseLookupResponderWithRefundable(currency string, refundableCents int)
 			"currency_type": currency,
 		}
 		if refundableCents > 0 {
-			payload["amount_refundable_cents"] = refundableCents
+			payload["amount_refundable_cents_in_currency"] = refundableCents
 		}
 		_ = json.NewEncoder(w).Encode(map[string]any{"purchase": payload})
 	}

--- a/internal/cmd/admin/purchases/refund_test.go
+++ b/internal/cmd/admin/purchases/refund_test.go
@@ -551,6 +551,30 @@ func TestRefund_JSONIncludesVerifyStateHint(t *testing.T) {
 	}
 }
 
+func TestRefund_MalformedSuccessResponseIsNotWrappedAsRequestFailed(t *testing.T) {
+	testutil.SetupAdmin(t, adminRefundHandler(t, nil, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("not json"))
+	}))
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected decode error to surface")
+	}
+	if !strings.Contains(err.Error(), "could not parse response") {
+		t.Errorf("expected decode-error message: %v", err)
+	}
+	if strings.Contains(err.Error(), "refund request failed:") {
+		t.Errorf("post-POST decode error must not be wrapped as a transport failure: %v", err)
+	}
+	if strings.Contains(err.Error(), "Verify status") {
+		t.Errorf("post-POST decode error must not advertise duplicate-refund risk — the refund already landed: %v", err)
+	}
+}
+
 func TestRefund_FullyRefundedPurchaseDefersToServer(t *testing.T) {
 	var postHits int
 

--- a/internal/cmd/admin/purchases/refund_test.go
+++ b/internal/cmd/admin/purchases/refund_test.go
@@ -10,6 +10,46 @@ import (
 	"github.com/antiwork/gumroad-cli/internal/testutil"
 )
 
+func adminRefundHandler(t *testing.T, lookup, refund http.HandlerFunc) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/refund"):
+			t.Fatalf("unexpected GET to %s", r.URL.Path)
+		case r.Method == http.MethodGet:
+			if lookup == nil {
+				t.Fatalf("unexpected lookup GET to %s", r.URL.Path)
+			}
+			lookup(w, r)
+		case r.Method == http.MethodPost:
+			if refund == nil {
+				t.Fatalf("unexpected POST to %s", r.URL.Path)
+			}
+			refund(w, r)
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}
+}
+
+func purchaseLookupResponder(currency string) http.HandlerFunc {
+	return purchaseLookupResponderWithRefundable(currency, 0)
+}
+
+func purchaseLookupResponderWithRefundable(currency string, refundableCents int) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		payload := map[string]any{
+			"id":            "123",
+			"email":         "buyer@example.com",
+			"currency_type": currency,
+		}
+		if refundableCents > 0 {
+			payload["amount_refundable_cents"] = refundableCents
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"purchase": payload})
+	}
+}
+
 func TestRefund_RequiresEmail(t *testing.T) {
 	cmd := newRefundCmd()
 	cmd.SetArgs([]string{"123"})
@@ -45,7 +85,7 @@ func TestRefund_FullSendsEmailAndOmitsAmountCents(t *testing.T) {
 	var body refundRequest
 	var bodyKeys map[string]json.RawMessage
 
-	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+	testutil.SetupAdmin(t, adminRefundHandler(t, nil, func(w http.ResponseWriter, r *http.Request) {
 		gotMethod = r.Method
 		gotPath = r.URL.Path
 		gotAuth = r.Header.Get("Authorization")
@@ -70,7 +110,7 @@ func TestRefund_FullSendsEmailAndOmitsAmountCents(t *testing.T) {
 			},
 			"subscription_cancelled": false,
 		})
-	})
+	}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true), testutil.Quiet(false))
 	cmd.SetArgs([]string{"123", "--email", "buyer@example.com"})
@@ -102,33 +142,93 @@ func TestRefund_FullSendsEmailAndOmitsAmountCents(t *testing.T) {
 	}
 }
 
-func TestRefund_PartialSendsAmountCents(t *testing.T) {
+func TestRefund_PartialLooksUpPurchaseAndConvertsUSD(t *testing.T) {
+	var lookupHits int
 	var body refundRequest
+	var refundPath string
 
-	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("decode body: %v", err)
-		}
-		testutil.JSON(t, w, map[string]any{
-			"message":                "Successfully refunded purchase number 123",
-			"purchase":               map[string]any{"id": "123"},
-			"subscription_cancelled": false,
-		})
-	})
+	testutil.SetupAdmin(t, adminRefundHandler(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			lookupHits++
+			if r.URL.Path != "/internal/admin/purchases/123" {
+				t.Fatalf("unexpected lookup path %q", r.URL.Path)
+			}
+			purchaseLookupResponder("usd")(w, r)
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			refundPath = r.URL.Path
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			testutil.JSON(t, w, map[string]any{
+				"message":                "Successfully refunded purchase number 123",
+				"purchase":               map[string]any{"id": "123"},
+				"subscription_cancelled": false,
+			})
+		}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true), testutil.Quiet(false))
 	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "5.00"})
 	testutil.MustExecute(t, cmd)
 
+	if lookupHits != 1 {
+		t.Fatalf("expected one lookup, got %d", lookupHits)
+	}
+	if refundPath != "/internal/admin/purchases/123/refund" {
+		t.Fatalf("unexpected refund path %q", refundPath)
+	}
 	if body.AmountCents != 500 {
-		t.Errorf("got amount_cents=%d, want 500", body.AmountCents)
+		t.Errorf("got amount_cents=%d, want 500 for $5.00 USD", body.AmountCents)
+	}
+}
+
+func TestRefund_PartialUsesPurchaseCurrencyForJPY(t *testing.T) {
+	var body refundRequest
+
+	testutil.SetupAdmin(t, adminRefundHandler(t,
+		purchaseLookupResponder("jpy"),
+		func(w http.ResponseWriter, r *http.Request) {
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			testutil.JSON(t, w, map[string]any{
+				"message":                "Successfully refunded purchase number 123",
+				"purchase":               map[string]any{"id": "123"},
+				"subscription_cancelled": false,
+			})
+		}))
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true), testutil.Quiet(false))
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "500"})
+	testutil.MustExecute(t, cmd)
+
+	if body.AmountCents != 500 {
+		t.Errorf("got amount_cents=%d, want 500 for ¥500 JPY (single-unit currency)", body.AmountCents)
+	}
+}
+
+func TestRefund_RejectsDecimalAmountForJPY(t *testing.T) {
+	testutil.SetupAdmin(t, adminRefundHandler(t,
+		purchaseLookupResponder("jpy"),
+		func(w http.ResponseWriter, r *http.Request) {
+			t.Error("should not reach refund API for invalid amount")
+		}))
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "5.00"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "JPY") {
+		t.Fatalf("expected JPY decimal-rejection error, got: %v", err)
 	}
 }
 
 func TestRefund_RejectsInvalidAmount(t *testing.T) {
-	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
-		t.Error("should not reach API")
-	})
+	testutil.SetupAdmin(t, adminRefundHandler(t,
+		purchaseLookupResponder("usd"),
+		func(w http.ResponseWriter, r *http.Request) {
+			t.Error("should not reach refund API")
+		}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
 	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "abc"})
@@ -140,9 +240,11 @@ func TestRefund_RejectsInvalidAmount(t *testing.T) {
 }
 
 func TestRefund_RejectsZeroAmount(t *testing.T) {
-	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
-		t.Error("should not reach API")
-	})
+	testutil.SetupAdmin(t, adminRefundHandler(t,
+		purchaseLookupResponder("usd"),
+		func(w http.ResponseWriter, r *http.Request) {
+			t.Error("should not reach refund API")
+		}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
 	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "0"})
@@ -156,7 +258,7 @@ func TestRefund_RejectsZeroAmount(t *testing.T) {
 func TestRefund_ForwardsForceAndCancelSubscription(t *testing.T) {
 	var body refundRequest
 
-	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+	testutil.SetupAdmin(t, adminRefundHandler(t, nil, func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			t.Fatalf("decode body: %v", err)
 		}
@@ -165,7 +267,7 @@ func TestRefund_ForwardsForceAndCancelSubscription(t *testing.T) {
 			"purchase":               map[string]any{"id": "123"},
 			"subscription_cancelled": true,
 		})
-	})
+	}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true), testutil.Quiet(false))
 	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--force", "--cancel-subscription"})
@@ -183,14 +285,14 @@ func TestRefund_ForwardsForceAndCancelSubscription(t *testing.T) {
 }
 
 func TestRefund_ShowsSubscriptionCancelError(t *testing.T) {
-	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+	testutil.SetupAdmin(t, adminRefundHandler(t, nil, func(w http.ResponseWriter, r *http.Request) {
 		testutil.JSON(t, w, map[string]any{
 			"message":                   "Successfully refunded purchase number 123",
 			"purchase":                  map[string]any{"id": "123"},
 			"subscription_cancelled":    false,
 			"subscription_cancel_error": "stripe blew up",
 		})
-	})
+	}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true), testutil.Quiet(false))
 	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--cancel-subscription"})
@@ -201,30 +303,51 @@ func TestRefund_ShowsSubscriptionCancelError(t *testing.T) {
 	}
 }
 
-func TestRefund_DryRunSkipsConfirmation(t *testing.T) {
-	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
-		// Admin commands today do not short-circuit on dry-run, so the call
-		// still hits the API. We just want to confirm dry-run doesn't trip
-		// the confirmation prompt under --no-input.
-		testutil.JSON(t, w, map[string]any{
-			"message":                "Successfully refunded purchase number 123",
-			"purchase":               map[string]any{"id": "123"},
-			"subscription_cancelled": false,
-		})
-	})
+func TestRefund_DryRunDoesNotContactRefundEndpoint(t *testing.T) {
+	testutil.SetupAdmin(t, adminRefundHandler(t, nil, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("dry-run must not POST to the refund endpoint")
+	}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.DryRun(true), testutil.NoInput(true))
 	cmd.SetArgs([]string{"123", "--email", "buyer@example.com"})
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("expected dry-run to bypass confirmation, got %v", err)
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "POST") || !strings.Contains(out, "/internal/admin/purchases/123/refund") {
+		t.Errorf("expected dry-run preview to mention POST and the refund path, got: %q", out)
+	}
+	if !strings.Contains(out, "email: buyer@example.com") {
+		t.Errorf("expected dry-run preview to include email, got: %q", out)
+	}
+}
+
+func TestRefund_DryRunWithPartialAmountLooksUpButDoesNotRefund(t *testing.T) {
+	var lookupHits int
+
+	testutil.SetupAdmin(t, adminRefundHandler(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			lookupHits++
+			purchaseLookupResponder("jpy")(w, r)
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			t.Error("dry-run must not POST to the refund endpoint")
+		}))
+
+	cmd := testutil.Command(newRefundCmd(), testutil.DryRun(true), testutil.NoInput(true))
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "500"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if lookupHits != 1 {
+		t.Fatalf("expected one lookup to derive currency, got %d", lookupHits)
+	}
+	if !strings.Contains(out, "amount_cents: 500") {
+		t.Errorf("expected dry-run preview to show amount_cents=500 (JPY-aware), got: %q", out)
 	}
 }
 
 func TestRefund_CancelledByPromptDeclineNotReached(t *testing.T) {
-	// With NoInput(true) and no --yes the prompt errors before we reach the API.
-	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+	testutil.SetupAdmin(t, adminRefundHandler(t, nil, func(w http.ResponseWriter, r *http.Request) {
 		t.Error("should not reach API when confirmation is refused")
-	})
+	}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.NoInput(true))
 	cmd.SetArgs([]string{"123", "--email", "buyer@example.com"})
@@ -235,13 +358,13 @@ func TestRefund_CancelledByPromptDeclineNotReached(t *testing.T) {
 }
 
 func TestRefund_JSONPreservesResponse(t *testing.T) {
-	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+	testutil.SetupAdmin(t, adminRefundHandler(t, nil, func(w http.ResponseWriter, r *http.Request) {
 		testutil.JSON(t, w, map[string]any{
 			"message":                "Successfully refunded purchase number 123",
 			"purchase":               map[string]any{"id": "123"},
 			"subscription_cancelled": true,
 		})
-	})
+	}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true), testutil.JSONOutput())
 	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--cancel-subscription"})
@@ -262,13 +385,13 @@ func TestRefund_JSONPreservesResponse(t *testing.T) {
 }
 
 func TestRefund_PlainOutput(t *testing.T) {
-	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+	testutil.SetupAdmin(t, adminRefundHandler(t, nil, func(w http.ResponseWriter, r *http.Request) {
 		testutil.JSON(t, w, map[string]any{
 			"message":                "Successfully refunded purchase number 123",
 			"purchase":               map[string]any{"id": "123"},
 			"subscription_cancelled": true,
 		})
-	})
+	}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true), testutil.PlainOutput())
 	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--cancel-subscription"})
@@ -280,20 +403,92 @@ func TestRefund_PlainOutput(t *testing.T) {
 	}
 }
 
-func TestRefund_APIErrorSurfacesMessage(t *testing.T) {
-	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+func TestRefund_RejectsAmountAboveRefundableBalance(t *testing.T) {
+	testutil.SetupAdmin(t, adminRefundHandler(t,
+		purchaseLookupResponderWithRefundable("usd", 500),
+		func(w http.ResponseWriter, r *http.Request) {
+			t.Error("should not reach refund API when amount exceeds refundable balance")
+		}))
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "10.00"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "exceeds the refundable balance") {
+		t.Fatalf("expected refundable-balance error, got: %v", err)
+	}
+}
+
+func TestRefund_AcceptsAmountAtRefundableBalance(t *testing.T) {
+	var body refundRequest
+	testutil.SetupAdmin(t, adminRefundHandler(t,
+		purchaseLookupResponderWithRefundable("usd", 500),
+		func(w http.ResponseWriter, r *http.Request) {
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			testutil.JSON(t, w, map[string]any{
+				"message":                "Successfully refunded purchase number 123",
+				"purchase":               map[string]any{"id": "123"},
+				"subscription_cancelled": false,
+			})
+		}))
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "5.00"})
+	testutil.MustExecute(t, cmd)
+
+	if body.AmountCents != 500 {
+		t.Errorf("got amount_cents=%d, want 500", body.AmountCents)
+	}
+}
+
+func TestRefund_PurchaseHasNoChargeSurfacesMessage(t *testing.T) {
+	testutil.SetupAdmin(t, adminRefundHandler(t, nil, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnprocessableEntity)
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"success": false,
-			"message": "Refund amount cannot be greater than the purchase price.",
+			"message": "Purchase has no charge to refund",
 		})
-	})
+	}))
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected no-charge error to surface")
+	}
+	if !strings.Contains(err.Error(), "Purchase has no charge to refund") {
+		t.Errorf("missing underlying message: %v", err)
+	}
+	if !strings.Contains(err.Error(), "gumroad admin purchases view 123") {
+		t.Errorf("expected verify-state hint pointing at purchase 123: %v", err)
+	}
+}
+
+func TestRefund_APIErrorSurfacesMessage(t *testing.T) {
+	testutil.SetupAdmin(t, adminRefundHandler(t,
+		purchaseLookupResponder("usd"),
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"success": false,
+				"message": "Refund amount cannot be greater than the purchase price.",
+			})
+		}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
 	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "50.00"})
 
 	err := cmd.Execute()
-	if err == nil || !strings.Contains(err.Error(), "Refund amount cannot be greater") {
-		t.Fatalf("expected API error message, got: %v", err)
+	if err == nil {
+		t.Fatal("expected API error to surface")
+	}
+	if !strings.Contains(err.Error(), "Refund amount cannot be greater") {
+		t.Errorf("missing underlying message: %v", err)
+	}
+	if !strings.Contains(err.Error(), "Verify status with 'gumroad admin purchases view 123'") {
+		t.Errorf("expected verify-state hint: %v", err)
 	}
 }

--- a/internal/cmd/admin/purchases/refund_test.go
+++ b/internal/cmd/admin/purchases/refund_test.go
@@ -2,11 +2,13 @@ package purchases
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
 
+	"github.com/antiwork/gumroad-cli/internal/api"
 	"github.com/antiwork/gumroad-cli/internal/testutil"
 )
 
@@ -514,6 +516,67 @@ func TestRefund_PurchaseHasNoChargeSurfacesMessage(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "gumroad admin purchases view 123") {
 		t.Errorf("expected verify-state hint pointing at purchase 123: %v", err)
+	}
+}
+
+func TestRefund_JSONIncludesVerifyStateHint(t *testing.T) {
+	testutil.SetupAdmin(t, adminRefundHandler(t, nil, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"success": false,
+			"message": "Purchase has no charge to refund",
+		})
+	}))
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true), testutil.JSONOutput())
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected refund error to surface")
+	}
+
+	var apiErr *api.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected wrap to keep an *api.APIError on the chain so JSON classification reads the verify hint, got %T: %v", err, err)
+	}
+	if !strings.Contains(apiErr.Error(), "refund request failed:") {
+		t.Errorf("APIError.Message must carry the wrap prefix for JSON output: %q", apiErr.Error())
+	}
+	if !strings.Contains(apiErr.Error(), "Verify status with 'gumroad admin purchases view 123'") {
+		t.Errorf("APIError.Message must carry the verify-state guidance for JSON output: %q", apiErr.Error())
+	}
+	if apiErr.StatusCode != http.StatusUnprocessableEntity {
+		t.Errorf("status code lost across the wrap: got %d, want 422", apiErr.StatusCode)
+	}
+}
+
+func TestRefund_FullyRefundedPurchaseDefersToServer(t *testing.T) {
+	var postHits int
+
+	testutil.SetupAdmin(t, adminRefundHandler(t,
+		purchaseLookupResponderWithRefundable("usd", 0),
+		func(w http.ResponseWriter, r *http.Request) {
+			postHits++
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"success": false,
+				"message": "Refund amount cannot be greater than the purchase price.",
+			})
+		}))
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "5.00"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected the server-side rejection to surface")
+	}
+	if postHits != 1 {
+		t.Errorf("AmountRefundableCentsInCurrency=0 currently defers to the server; expected one refund POST, got %d", postHits)
+	}
+	if !strings.Contains(err.Error(), "Refund amount cannot be greater") {
+		t.Errorf("expected the server's 422 message to surface: %v", err)
 	}
 }
 

--- a/internal/cmd/admin/purchases/view.go
+++ b/internal/cmd/admin/purchases/view.go
@@ -16,20 +16,20 @@ type purchaseResponse struct {
 }
 
 type purchase struct {
-	ID                    string      `json:"id"`
-	Email                 string      `json:"email"`
-	SellerEmail           string      `json:"seller_email"`
-	ProductName           string      `json:"product_name"`
-	ProductAlias          string      `json:"link_name"`
-	ProductID             string      `json:"product_id"`
-	FormattedTotalPrice   string      `json:"formatted_total_price"`
-	PriceCents            api.JSONInt `json:"price_cents"`
-	CurrencyType          string      `json:"currency_type"`
-	AmountRefundableCents api.JSONInt `json:"amount_refundable_cents"`
-	PurchaseState         string      `json:"purchase_state"`
-	RefundStatus          string      `json:"refund_status"`
-	CreatedAt             string      `json:"created_at"`
-	ReceiptURL            string      `json:"receipt_url"`
+	ID                              string      `json:"id"`
+	Email                           string      `json:"email"`
+	SellerEmail                     string      `json:"seller_email"`
+	ProductName                     string      `json:"product_name"`
+	ProductAlias                    string      `json:"link_name"`
+	ProductID                       string      `json:"product_id"`
+	FormattedTotalPrice             string      `json:"formatted_total_price"`
+	PriceCents                      api.JSONInt `json:"price_cents"`
+	CurrencyType                    string      `json:"currency_type"`
+	AmountRefundableCentsInCurrency api.JSONInt `json:"amount_refundable_cents_in_currency"`
+	PurchaseState                   string      `json:"purchase_state"`
+	RefundStatus                    string      `json:"refund_status"`
+	CreatedAt                       string      `json:"created_at"`
+	ReceiptURL                      string      `json:"receipt_url"`
 }
 
 func newViewCmd() *cobra.Command {

--- a/internal/cmd/admin/purchases/view.go
+++ b/internal/cmd/admin/purchases/view.go
@@ -16,18 +16,20 @@ type purchaseResponse struct {
 }
 
 type purchase struct {
-	ID                  string      `json:"id"`
-	Email               string      `json:"email"`
-	SellerEmail         string      `json:"seller_email"`
-	ProductName         string      `json:"product_name"`
-	ProductAlias        string      `json:"link_name"`
-	ProductID           string      `json:"product_id"`
-	FormattedTotalPrice string      `json:"formatted_total_price"`
-	PriceCents          api.JSONInt `json:"price_cents"`
-	PurchaseState       string      `json:"purchase_state"`
-	RefundStatus        string      `json:"refund_status"`
-	CreatedAt           string      `json:"created_at"`
-	ReceiptURL          string      `json:"receipt_url"`
+	ID                    string      `json:"id"`
+	Email                 string      `json:"email"`
+	SellerEmail           string      `json:"seller_email"`
+	ProductName           string      `json:"product_name"`
+	ProductAlias          string      `json:"link_name"`
+	ProductID             string      `json:"product_id"`
+	FormattedTotalPrice   string      `json:"formatted_total_price"`
+	PriceCents            api.JSONInt `json:"price_cents"`
+	CurrencyType          string      `json:"currency_type"`
+	AmountRefundableCents api.JSONInt `json:"amount_refundable_cents"`
+	PurchaseState         string      `json:"purchase_state"`
+	RefundStatus          string      `json:"refund_status"`
+	CreatedAt             string      `json:"created_at"`
+	ReceiptURL            string      `json:"receipt_url"`
 }
 
 func newViewCmd() *cobra.Command {


### PR DESCRIPTION
Part of antiwork/gumroad#4677. Pairs with antiwork/gumroad#4825.

## What

Adds `gumroad admin purchases refund <purchase-id>` so admins (and Gumclaw, via the CLI) can refund a specific purchase end-to-end without the admin web UI.

```
Refund a purchase as an admin

Usage:
  gumroad admin purchases refund <purchase-id> [flags]

Flags:
      --amount string         Partial refund amount in displayed currency (e.g. 5, 5.00); omit for full refund
      --cancel-subscription   Cancel the linked subscription after the refund succeeds
      --email string          Buyer email (required)
      --force                 Bypass refund-policy timeframe and fine-print guards
```

The command:

- Sends `email` (required), `amount_cents`, `force`, and `cancel_subscription` in the JSON body — sensitive identifiers stay out of the URL, matching the contract rule from the rollout plan.
- Confirms before mutating, with `--yes` to skip and `--no-input` to fail loudly (same pattern as `gumroad sales refund`).
- Renders the post-refund purchase summary plus a separate line for `Subscription: cancelled` / `Subscription cancel failed: <err>` so the three states the endpoint exposes — not attempted, cancelled, and tried-and-failed — are visually distinct.
- Supports `--json` (raw response pass-through), `--plain` (TSV), and `--debug`.

## Why

This is the CLI half of the admin rollout plan from antiwork/gumroad#4677. Refunds are one of the highest-volume admin actions still missing from the CLI, and pairing this with antiwork/gumroad#4825 unlocks the first end-to-end Gumclaw refund path without admin web UI.

The flag shape was chosen to mirror the API parameters one-for-one rather than invent a new vocabulary — `--amount` is the one ergonomic exception, taking displayed-currency major units and converting to `amount_cents` via the existing `cmdutil.ParseMoney` (matches the seller-side `gumroad sales refund` pattern). Confirmation lives at the CLI layer because the API has no idempotency guard; `--yes` is the documented escape hatch for Gumclaw to use non-interactively.

https://github.com/user-attachments/assets/971b44aa-5e70-4577-a4d3-150c1d01a156

---

This PR was implemented with AI assistance using Claude Opus 4.7