### PR TITLE
Add admin user risk commands

### DIFF
--- a/internal/cmd/admin/users/mark_compliant.go
+++ b/internal/cmd/admin/users/mark_compliant.go
@@ -1,0 +1,85 @@
+package users
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/antiwork/gumroad-cli/internal/adminapi"
+	"github.com/antiwork/gumroad-cli/internal/admincmd"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+type markCompliantRequest struct {
+	Email string `json:"email"`
+	Note  string `json:"note,omitempty"`
+}
+
+func newMarkCompliantCmd() *cobra.Command {
+	var (
+		email string
+		note  string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "mark-compliant",
+		Short: "Mark a user compliant as an admin",
+		Long:  "Mark a user compliant through the internal admin API.",
+		Example: `  gumroad admin users mark-compliant --email seller@example.com
+  gumroad admin users mark-compliant --email seller@example.com --note "Cleared after review"`,
+		Args: cmdutil.ExactArgs(0),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+
+			if email == "" {
+				return cmdutil.MissingFlagError(c, "--email")
+			}
+
+			ok, err := cmdutil.ConfirmAction(opts, "Mark user "+email+" compliant?")
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return cmdutil.PrintCancelledAction(opts, "mark user "+email+" compliant", email)
+			}
+
+			req := markCompliantRequest{
+				Email: email,
+				Note:  note,
+			}
+			path := "users/mark_compliant"
+
+			if opts.DryRun {
+				return cmdutil.PrintDryRunRequest(opts, http.MethodPost, adminapi.AdminPath(path), markCompliantDryRunParams(req))
+			}
+
+			data, err := admincmd.FetchPostJSON(opts, "Marking user compliant...", path, req)
+			if err != nil {
+				return err
+			}
+			if opts.UsesJSONOutput() {
+				return cmdutil.PrintJSONResponse(opts, data)
+			}
+
+			decoded, err := cmdutil.DecodeJSON[riskActionResponse](data)
+			if err != nil {
+				return err
+			}
+			return renderRiskAction(opts, email, decoded)
+		},
+	}
+
+	cmd.Flags().StringVar(&email, "email", "", "User email (required)")
+	cmd.Flags().StringVar(&note, "note", "", "Optional admin note")
+
+	return cmd
+}
+
+func markCompliantDryRunParams(req markCompliantRequest) url.Values {
+	params := url.Values{}
+	params.Set("email", req.Email)
+	if req.Note != "" {
+		params.Set("note", req.Note)
+	}
+	return params
+}

--- a/internal/cmd/admin/users/mark_compliant_test.go
+++ b/internal/cmd/admin/users/mark_compliant_test.go
@@ -1,0 +1,144 @@
+package users
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestMarkCompliantRequiresEmail(t *testing.T) {
+	cmd := newMarkCompliantCmd()
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected missing email error")
+	}
+	if !strings.Contains(err.Error(), "missing required flag: --email") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestMarkCompliantRequiresConfirmation(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API without confirmation")
+	})
+
+	cmd := testutil.Command(newMarkCompliantCmd(), testutil.NoInput(true))
+	cmd.SetArgs([]string{"--email", "seller@example.com"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error without --yes and --no-input")
+	}
+	if !strings.Contains(err.Error(), "--yes") {
+		t.Errorf("error should mention --yes: %v", err)
+	}
+}
+
+func TestMarkCompliantSendsEmailAndNote(t *testing.T) {
+	var gotMethod, gotPath, gotQuery, gotAuth string
+	var body markCompliantRequest
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		gotAuth = r.Header.Get("Authorization")
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if err := json.Unmarshal(raw, &body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		testutil.JSON(t, w, map[string]any{
+			"success": true,
+			"status":  "marked_compliant",
+			"message": "User marked compliant",
+		})
+	})
+
+	cmd := testutil.Command(newMarkCompliantCmd(), testutil.Yes(true), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--email", "seller@example.com", "--note", "Cleared after review"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != "POST" || gotPath != "/internal/admin/users/mark_compliant" {
+		t.Fatalf("got %s %s, want POST /internal/admin/users/mark_compliant", gotMethod, gotPath)
+	}
+	if gotQuery != "" {
+		t.Fatalf("email/note must not appear in query string, got %q", gotQuery)
+	}
+	if gotAuth != "Bearer admin-token" {
+		t.Fatalf("got auth %q, want Bearer admin-token", gotAuth)
+	}
+	if body.Email != "seller@example.com" || body.Note != "Cleared after review" {
+		t.Fatalf("unexpected request body: %#v", body)
+	}
+	for _, want := range []string{"User marked compliant", "Email: seller@example.com", "Status: marked_compliant"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestMarkCompliantDryRunDoesNotContactEndpoint(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("dry-run must not POST to the mark_compliant endpoint")
+	})
+
+	cmd := testutil.Command(newMarkCompliantCmd(), testutil.DryRun(true), testutil.NoInput(true))
+	cmd.SetArgs([]string{"--email", "seller@example.com", "--note", "Retry"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "POST") || !strings.Contains(out, "/internal/admin/users/mark_compliant") {
+		t.Errorf("expected dry-run preview to mention POST and the mark_compliant path, got: %q", out)
+	}
+	if !strings.Contains(out, "email: seller@example.com") || !strings.Contains(out, "note: Retry") {
+		t.Errorf("expected dry-run preview to include email and note, got: %q", out)
+	}
+}
+
+func TestMarkCompliantJSONPreservesResponse(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"success": true,
+			"status":  "already_compliant",
+			"message": "User is already compliant",
+		})
+	})
+
+	cmd := testutil.Command(newMarkCompliantCmd(), testutil.Yes(true), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--email", "seller@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp riskActionResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if !resp.Success || resp.Status != "already_compliant" || resp.Message != "User is already compliant" {
+		t.Fatalf("unexpected JSON payload: %s", out)
+	}
+}
+
+func TestMarkCompliantPlainOutput(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"status":  "marked_compliant",
+			"message": "User marked compliant",
+		})
+	})
+
+	cmd := testutil.Command(newMarkCompliantCmd(), testutil.Yes(true), testutil.PlainOutput())
+	cmd.SetArgs([]string{"--email", "seller@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	want := "true\tUser marked compliant\tseller@example.com\tmarked_compliant"
+	if strings.TrimSpace(out) != want {
+		t.Fatalf("unexpected plain output: %q", out)
+	}
+}

--- a/internal/cmd/admin/users/risk_action.go
+++ b/internal/cmd/admin/users/risk_action.go
@@ -1,0 +1,43 @@
+package users
+
+import (
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+)
+
+type riskActionResponse struct {
+	Success bool   `json:"success"`
+	Status  string `json:"status"`
+	Message string `json:"message"`
+}
+
+func renderRiskAction(opts cmdutil.Options, email string, resp riskActionResponse) error {
+	message := resp.Message
+	if message == "" {
+		message = resp.Status
+	}
+
+	if opts.PlainOutput {
+		return output.PrintPlain(opts.Out(), [][]string{
+			{"true", message, email, resp.Status},
+		})
+	}
+
+	if opts.Quiet {
+		return nil
+	}
+
+	style := opts.Style()
+	if err := output.Writeln(opts.Out(), style.Green(message)); err != nil {
+		return err
+	}
+	if email != "" {
+		if err := output.Writef(opts.Out(), "Email: %s\n", email); err != nil {
+			return err
+		}
+	}
+	if resp.Status != "" {
+		return output.Writef(opts.Out(), "Status: %s\n", resp.Status)
+	}
+	return nil
+}

--- a/internal/cmd/admin/users/suspend.go
+++ b/internal/cmd/admin/users/suspend.go
@@ -1,0 +1,88 @@
+package users
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/antiwork/gumroad-cli/internal/adminapi"
+	"github.com/antiwork/gumroad-cli/internal/admincmd"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+const suspendConfirmationMessage = "Suspend user %s for fraud? This freezes payouts and disables the seller's products."
+
+type suspendRequest struct {
+	Email          string `json:"email"`
+	SuspensionNote string `json:"suspension_note,omitempty"`
+}
+
+func newSuspendCmd() *cobra.Command {
+	var (
+		email string
+		note  string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "suspend",
+		Short: "Suspend a user for fraud as an admin",
+		Long:  "Suspend a user for fraud through the internal admin API.",
+		Example: `  gumroad admin users suspend --email seller@example.com
+  gumroad admin users suspend --email seller@example.com --note "Chargeback risk confirmed"`,
+		Args: cmdutil.ExactArgs(0),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+
+			if email == "" {
+				return cmdutil.MissingFlagError(c, "--email")
+			}
+
+			ok, err := cmdutil.ConfirmAction(opts, fmt.Sprintf(suspendConfirmationMessage, email))
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return cmdutil.PrintCancelledAction(opts, "suspend user "+email+" for fraud", email)
+			}
+
+			req := suspendRequest{
+				Email:          email,
+				SuspensionNote: note,
+			}
+			path := "users/suspend_for_fraud"
+
+			if opts.DryRun {
+				return cmdutil.PrintDryRunRequest(opts, http.MethodPost, adminapi.AdminPath(path), suspendDryRunParams(req))
+			}
+
+			data, err := admincmd.FetchPostJSON(opts, "Suspending user...", path, req)
+			if err != nil {
+				return err
+			}
+			if opts.UsesJSONOutput() {
+				return cmdutil.PrintJSONResponse(opts, data)
+			}
+
+			decoded, err := cmdutil.DecodeJSON[riskActionResponse](data)
+			if err != nil {
+				return err
+			}
+			return renderRiskAction(opts, email, decoded)
+		},
+	}
+
+	cmd.Flags().StringVar(&email, "email", "", "User email (required)")
+	cmd.Flags().StringVar(&note, "note", "", "Optional suspension note")
+
+	return cmd
+}
+
+func suspendDryRunParams(req suspendRequest) url.Values {
+	params := url.Values{}
+	params.Set("email", req.Email)
+	if req.SuspensionNote != "" {
+		params.Set("suspension_note", req.SuspensionNote)
+	}
+	return params
+}

--- a/internal/cmd/admin/users/suspend_test.go
+++ b/internal/cmd/admin/users/suspend_test.go
@@ -1,0 +1,145 @@
+package users
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestSuspendRequiresEmail(t *testing.T) {
+	cmd := newSuspendCmd()
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected missing email error")
+	}
+	if !strings.Contains(err.Error(), "missing required flag: --email") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSuspendRequiresConfirmation(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API without confirmation")
+	})
+
+	cmd := testutil.Command(newSuspendCmd(), testutil.NoInput(true))
+	cmd.SetArgs([]string{"--email", "seller@example.com"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error without --yes and --no-input")
+	}
+	if !strings.Contains(err.Error(), "--yes") {
+		t.Errorf("error should mention --yes: %v", err)
+	}
+}
+
+func TestSuspendSendsEmailAndSuspensionNote(t *testing.T) {
+	var gotMethod, gotPath, gotQuery, gotAuth string
+	var body suspendRequest
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		gotAuth = r.Header.Get("Authorization")
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if err := json.Unmarshal(raw, &body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		testutil.JSON(t, w, map[string]any{
+			"success": true,
+			"status":  "suspended_for_fraud",
+			"message": "User suspended for fraud",
+		})
+	})
+
+	cmd := testutil.Command(newSuspendCmd(), testutil.Yes(true), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--email", "seller@example.com", "--note", "Chargeback risk confirmed"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != "POST" || gotPath != "/internal/admin/users/suspend_for_fraud" {
+		t.Fatalf("got %s %s, want POST /internal/admin/users/suspend_for_fraud", gotMethod, gotPath)
+	}
+	if gotQuery != "" {
+		t.Fatalf("email/note must not appear in query string, got %q", gotQuery)
+	}
+	if gotAuth != "Bearer admin-token" {
+		t.Fatalf("got auth %q, want Bearer admin-token", gotAuth)
+	}
+	if body.Email != "seller@example.com" || body.SuspensionNote != "Chargeback risk confirmed" {
+		t.Fatalf("unexpected request body: %#v", body)
+	}
+	for _, want := range []string{"User suspended for fraud", "Email: seller@example.com", "Status: suspended_for_fraud"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestSuspendDryRunDoesNotContactEndpoint(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("dry-run must not POST to the suspend_for_fraud endpoint")
+	})
+
+	cmd := testutil.Command(newSuspendCmd(), testutil.DryRun(true), testutil.NoInput(true))
+	cmd.SetArgs([]string{"--email", "seller@example.com", "--note", "Chargeback risk confirmed"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "POST") || !strings.Contains(out, "/internal/admin/users/suspend_for_fraud") {
+		t.Errorf("expected dry-run preview to mention POST and the suspend_for_fraud path, got: %q", out)
+	}
+	if !strings.Contains(out, "email: seller@example.com") || !strings.Contains(out, "suspension_note: Chargeback risk confirmed") {
+		t.Errorf("expected dry-run preview to include email and suspension_note, got: %q", out)
+	}
+}
+
+func TestSuspendJSONPreservesResponse(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"success": true,
+			"status":  "already_suspended",
+			"message": "User is already suspended for fraud",
+		})
+	})
+
+	cmd := testutil.Command(newSuspendCmd(), testutil.Yes(true), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--email", "seller@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp riskActionResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if !resp.Success || resp.Status != "already_suspended" || resp.Message != "User is already suspended for fraud" {
+		t.Fatalf("unexpected JSON payload: %s", out)
+	}
+}
+
+func TestSuspendPlainOutput(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"success": true,
+			"status":  "suspended_for_fraud",
+			"message": "User suspended for fraud",
+		})
+	})
+
+	cmd := testutil.Command(newSuspendCmd(), testutil.Yes(true), testutil.PlainOutput())
+	cmd.SetArgs([]string{"--email", "seller@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	want := "true\tUser suspended for fraud\tseller@example.com\tsuspended_for_fraud"
+	if strings.TrimSpace(out) != want {
+		t.Fatalf("unexpected plain output: %q", out)
+	}
+}

--- a/internal/cmd/admin/users/users.go
+++ b/internal/cmd/admin/users/users.go
@@ -5,12 +5,16 @@ import "github.com/spf13/cobra"
 func NewUsersCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "users",
-		Short: "Read admin user records",
+		Short: "Read and update admin user records",
 		Example: `  gumroad admin users suspension --email user@example.com
-  gumroad admin users suspension --email user@example.com --json`,
+  gumroad admin users suspension --email user@example.com --json
+  gumroad admin users mark-compliant --email user@example.com
+  gumroad admin users suspend --email user@example.com --note "Chargeback risk confirmed"`,
 	}
 
 	cmd.AddCommand(newSuspensionCmd())
+	cmd.AddCommand(newMarkCompliantCmd())
+	cmd.AddCommand(newSuspendCmd())
 
 	return cmd
 }

--- a/internal/cmd/admin/users/users_test.go
+++ b/internal/cmd/admin/users/users_test.go
@@ -136,7 +136,14 @@ func TestNewUsersCmdWiresSuspension(t *testing.T) {
 	if cmd.Use != "users" {
 		t.Fatalf("Use = %q, want users", cmd.Use)
 	}
-	if got := cmd.Commands(); len(got) != 1 || got[0].Use != "suspension" {
-		t.Fatalf("unexpected subcommands: %#v", got)
+
+	uses := map[string]bool{}
+	for _, child := range cmd.Commands() {
+		uses[child.Use] = true
+	}
+	for _, want := range []string{"suspension", "mark-compliant", "suspend"} {
+		if !uses[want] {
+			t.Fatalf("missing %q subcommand; got %#v", want, cmd.Commands())
+		}
 	}
 }


### PR DESCRIPTION
Ref antiwork/gumroad/issues/4677

## What

Adds CLI commands for the new internal admin user risk actions:

`gumroad admin users suspend --email <email> [--note <text>]`

`gumroad admin users mark-compliant --email <email> [--note <text>]`

Both commands support confirmation, `--yes`, `--no-input`, `--dry-run`, `--json`, `--plain`, and `--quiet`. Suspend includes the payout and product impact directly in the confirmation prompt because the backend fraud-suspension action freezes payouts and disables the seller's products.

## Why

We are prioritizing suspend and mark-compliant as the next admin CLI actions. This exposes the narrow server contract from antiwork/gumroad/pull/4882 without depending on the still-open Phase 1 CLI work, so the risk actions can be used from the CLI as soon as the backend is available.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh.