### PR TITLE
Add InteractiveTUIAllowed gate and --no-tui flag

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -93,6 +93,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&opts.DryRun, "dry-run", false, "Preview mutating requests without executing them")
 	cmd.PersistentFlags().BoolVar(&opts.NoColor, "no-color", false, "Disable color output")
 	cmd.PersistentFlags().BoolVar(&opts.NoInput, "no-input", false, "Disable interactive prompts")
+	cmd.PersistentFlags().BoolVar(&opts.NoTUI, "no-tui", false, "Disable interactive full-screen views; print scriptable output instead")
 	cmd.PersistentFlags().BoolVar(&opts.Yes, "yes", false, "Skip confirmation prompts")
 	cmd.PersistentFlags().BoolVar(&opts.NoImage, "no-image", false, "Disable image rendering")
 	cmd.PersistentFlags().DurationVar(&opts.PageDelay, "page-delay", 0, "Wait between paginated --all requests (e.g. 200ms, 1s)")

--- a/internal/cmdutil/options.go
+++ b/internal/cmdutil/options.go
@@ -26,6 +26,7 @@ type Options struct {
 	DryRun      bool
 	NoColor     bool
 	NoInput     bool
+	NoTUI       bool
 	Yes         bool
 	NoImage     bool
 	PageDelay   time.Duration
@@ -98,4 +99,46 @@ func (o Options) UsesJSONOutput() bool {
 // DebugEnabled reports whether debug logging should be enabled.
 func (o Options) DebugEnabled() bool {
 	return o.Debug || os.Getenv("GUMROAD_DEBUG") == "1"
+}
+
+func (o Options) InteractiveTUIAllowed() bool {
+	if o.NoTUI {
+		return false
+	}
+	if o.UsesJSONOutput() {
+		return false
+	}
+	if o.PlainOutput {
+		return false
+	}
+	if o.NoInput {
+		return false
+	}
+	if o.Quiet {
+		return false
+	}
+	if !o.Style().Enabled() {
+		return false
+	}
+	if !output.IsTTY() {
+		return false
+	}
+	if !stdinIsTerminal(o.In()) {
+		return false
+	}
+	if v := os.Getenv("GUMROAD_TUI"); v == "0" || v == "false" {
+		return false
+	}
+	if os.Getenv("CI") != "" {
+		return false
+	}
+	return true
+}
+
+var stdinIsTerminal = func(r io.Reader) bool {
+	f, ok := r.(*os.File)
+	if !ok {
+		return false
+	}
+	return output.IsFileTerminal(f)
 }

--- a/internal/cmdutil/tui_test.go
+++ b/internal/cmdutil/tui_test.go
@@ -1,0 +1,187 @@
+package cmdutil
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/output"
+)
+
+func withFakeTTYBoth(t *testing.T) {
+	t.Helper()
+	output.SetStdoutIsTerminalForTesting(true)
+	output.SetColorEnabledForTesting(true)
+	origStdin := stdinIsTerminal
+	stdinIsTerminal = func(io.Reader) bool { return true }
+	t.Cleanup(func() {
+		output.ResetStdoutIsTerminalForTesting()
+		output.ResetColorEnabledForTesting()
+		stdinIsTerminal = origStdin
+	})
+}
+
+func baseOpts() Options {
+	o := DefaultOptions()
+	o.Stdout = os.Stdout
+	o.Stdin = os.Stdin
+	return o
+}
+
+func TestInteractiveTUIAllowed_GreenPath(t *testing.T) {
+	t.Setenv("CI", "")
+	t.Setenv("GUMROAD_TUI", "")
+	t.Setenv("NO_COLOR", "")
+	t.Setenv("TERM", "xterm-256color")
+	withFakeTTYBoth(t)
+
+	if !baseOpts().InteractiveTUIAllowed() {
+		t.Fatal("expected TUI to be allowed when every gate passes")
+	}
+}
+
+func TestInteractiveTUIAllowed_BlocksJSON(t *testing.T) {
+	t.Setenv("CI", "")
+	t.Setenv("GUMROAD_TUI", "")
+	t.Setenv("TERM", "xterm-256color")
+	withFakeTTYBoth(t)
+
+	o := baseOpts()
+	o.JSONOutput = true
+	if o.InteractiveTUIAllowed() {
+		t.Fatal("expected --json to block TUI")
+	}
+}
+
+func TestInteractiveTUIAllowed_BlocksJQ(t *testing.T) {
+	t.Setenv("CI", "")
+	t.Setenv("TERM", "xterm-256color")
+	withFakeTTYBoth(t)
+
+	o := baseOpts()
+	o.JQExpr = ".sales[0].id"
+	if o.InteractiveTUIAllowed() {
+		t.Fatal("expected --jq to block TUI")
+	}
+}
+
+func TestInteractiveTUIAllowed_BlocksPlain(t *testing.T) {
+	t.Setenv("CI", "")
+	t.Setenv("TERM", "xterm-256color")
+	withFakeTTYBoth(t)
+
+	o := baseOpts()
+	o.PlainOutput = true
+	if o.InteractiveTUIAllowed() {
+		t.Fatal("expected --plain to block TUI")
+	}
+}
+
+func TestInteractiveTUIAllowed_BlocksNoInput(t *testing.T) {
+	t.Setenv("CI", "")
+	t.Setenv("TERM", "xterm-256color")
+	withFakeTTYBoth(t)
+
+	o := baseOpts()
+	o.NoInput = true
+	if o.InteractiveTUIAllowed() {
+		t.Fatal("expected --no-input to block TUI")
+	}
+}
+
+func TestInteractiveTUIAllowed_BlocksNoTUIFlag(t *testing.T) {
+	t.Setenv("CI", "")
+	t.Setenv("TERM", "xterm-256color")
+	withFakeTTYBoth(t)
+
+	o := baseOpts()
+	o.NoTUI = true
+	if o.InteractiveTUIAllowed() {
+		t.Fatal("expected --no-tui to block TUI")
+	}
+}
+
+func TestInteractiveTUIAllowed_BlocksQuiet(t *testing.T) {
+	t.Setenv("CI", "")
+	t.Setenv("TERM", "xterm-256color")
+	withFakeTTYBoth(t)
+
+	o := baseOpts()
+	o.Quiet = true
+	if o.InteractiveTUIAllowed() {
+		t.Fatal("expected --quiet to block TUI")
+	}
+}
+
+func TestInteractiveTUIAllowed_BlocksNonTTYStdout(t *testing.T) {
+	t.Setenv("CI", "")
+	t.Setenv("TERM", "xterm-256color")
+	output.SetColorEnabledForTesting(true)
+	output.SetStdoutIsTerminalForTesting(false)
+	t.Cleanup(output.ResetColorEnabledForTesting)
+	t.Cleanup(output.ResetStdoutIsTerminalForTesting)
+	origStdin := stdinIsTerminal
+	stdinIsTerminal = func(io.Reader) bool { return true }
+	t.Cleanup(func() { stdinIsTerminal = origStdin })
+
+	if baseOpts().InteractiveTUIAllowed() {
+		t.Fatal("expected non-TTY stdout to block TUI")
+	}
+}
+
+func TestInteractiveTUIAllowed_BlocksNonTTYStdin(t *testing.T) {
+	t.Setenv("CI", "")
+	t.Setenv("TERM", "xterm-256color")
+	withFakeTTYBoth(t)
+	stdinIsTerminal = func(io.Reader) bool { return false }
+
+	if baseOpts().InteractiveTUIAllowed() {
+		t.Fatal("expected piped stdin to block TUI")
+	}
+}
+
+func TestInteractiveTUIAllowed_BlocksNoColor(t *testing.T) {
+	t.Setenv("CI", "")
+	t.Setenv("TERM", "xterm-256color")
+	output.SetStdoutIsTerminalForTesting(true)
+	output.SetColorEnabledForTesting(false)
+	t.Cleanup(output.ResetColorEnabledForTesting)
+	t.Cleanup(output.ResetStdoutIsTerminalForTesting)
+	origStdin := stdinIsTerminal
+	stdinIsTerminal = func(io.Reader) bool { return true }
+	t.Cleanup(func() { stdinIsTerminal = origStdin })
+
+	if baseOpts().InteractiveTUIAllowed() {
+		t.Fatal("expected NO_COLOR / disabled color to block TUI")
+	}
+}
+
+func TestInteractiveTUIAllowed_BlocksOnCI(t *testing.T) {
+	withFakeTTYBoth(t)
+	t.Setenv("CI", "true")
+
+	if baseOpts().InteractiveTUIAllowed() {
+		t.Fatal("expected CI=true to block TUI")
+	}
+}
+
+func TestInteractiveTUIAllowed_BlocksOnGumroadTUIZero(t *testing.T) {
+	withFakeTTYBoth(t)
+	t.Setenv("CI", "")
+	t.Setenv("GUMROAD_TUI", "0")
+
+	if baseOpts().InteractiveTUIAllowed() {
+		t.Fatal("expected GUMROAD_TUI=0 to block TUI")
+	}
+
+	t.Setenv("GUMROAD_TUI", "false")
+	if baseOpts().InteractiveTUIAllowed() {
+		t.Fatal("expected GUMROAD_TUI=false to block TUI")
+	}
+}
+
+func TestStdinIsTerminal_NonFileReturnsFalse(t *testing.T) {
+	if stdinIsTerminal(io.NopCloser(nil)) {
+		t.Fatal("non-file reader must not register as a terminal")
+	}
+}

--- a/internal/output/color.go
+++ b/internal/output/color.go
@@ -32,6 +32,13 @@ func IsTTY() bool {
 	return stdoutIsTerminal()
 }
 
+func IsFileTerminal(f *os.File) bool {
+	if f == nil {
+		return false
+	}
+	return term.IsTerminal(int(f.Fd()))
+}
+
 func NewStyler(noColor bool) Styler {
 	return NewStylerForWriter(os.Stdout, noColor)
 }


### PR DESCRIPTION
## What

Adds `cmdutil.Options.InteractiveTUIAllowed()` and a `--no-tui` persistent flag so commands can decide whether to launch a TUI or fall through to the existing scriptable output.

The gate denies TUI rendering whenever any of these hold:
- `--no-tui` is set
- output is `--json`, `--jq`, or `--plain`
- `--no-input` or `--quiet` is set
- color is disabled
- stdout or stdin is not a terminal
- `GUMROAD_TUI=0` or `GUMROAD_TUI=false`
- `CI` is set

Also adds `output.IsFileTerminal` so the gate can check stdin's TTY state via the same `term` package already used for stdout.

This is PR 1 of 3 splitting the original sales TUI branch. The gate has no consumers here — it gets used by the sales TUI in #57 and wired into `sales list` in #58.

## Why

Auto-launching a TUI in pipelines, CI jobs, or under `--json` would silently break automation. Centralizing every "should I be interactive?" decision behind one method keeps the answer consistent across the CLI and gives users an explicit kill switch via `--no-tui` for cases the heuristic misses (terminal multiplexers, tmux-in-CI, weird `$TERM` values).

Splitting this out keeps ~240 lines of gate logic and tests reviewable in isolation, separate from ~1.1k lines of view code in #57.

## Before / After

Not user-facing on its own — the `--no-tui` flag is inert until the sales TUI lands. Walkthrough video: in PR #58.

## Test Results

`make test-cover` and `make lint` clean. `internal/cmdutil` coverage 93.4% against the 90% gate. 

Screenshot: 

<img width="2504" height="1732" alt="CleanShot 2026-04-30 at 05 47 40@2x" src="https://github.com/user-attachments/assets/adbcb8db-6a50-423a-9960-1e69701a0e84" />

---

Built with Claude Opus 4.7 (1M context) via Claude Code.

Conversation History: https://isolated.tech/share/bNiaICzZ