### PR TITLE
Add buy command using POST /v2/orders directly (no pre-lookup)

### DIFF
--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -73,10 +73,11 @@ func rewriteError(statusCode int, msg string) (message, hint string) {
 	case 401:
 		return "Not authenticated.", HintRunAuthLogin
 	case 403:
+		hint := "Check that your token has the required scope (e.g. create_purchases for buy, edit_products for product mutations)."
 		if msg != "" {
-			return fmt.Sprintf("Access denied: %s", msg), "Check that your token has the required scope."
+			return fmt.Sprintf("Access denied: %s", msg), hint
 		}
-		return "Access denied.", "Check that your token has the required scope."
+		return "Access denied.", hint
 	case 404:
 		if msg != "" {
 			return msg, "Check the resource ID and try again."

--- a/internal/api/errors_test.go
+++ b/internal/api/errors_test.go
@@ -152,7 +152,7 @@ func TestAPIError_Hints(t *testing.T) {
 		wantHint   string
 	}{
 		{"401", 401, `{"success":false}`, HintRunAuthLogin},
-		{"403", 403, `{"success":false}`, "Check that your token has the required scope."},
+		{"403", 403, `{"success":false}`, "Check that your token has the required scope (e.g. create_purchases for buy, edit_products for product mutations)."},
 		{"404", 404, `{"success":false}`, "Check the resource ID and try again."},
 		{"429", 429, `{"success":false,"message":"Rate limited"}`, "Wait a moment and retry."},
 		{"500", 500, `{"success":false}`, ""},

--- a/internal/cmd/buy/buy.go
+++ b/internal/cmd/buy/buy.go
@@ -1,0 +1,301 @@
+package buy
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/config"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+const (
+	defaultLineItemUID = "li-0"
+	ordersPath         = "/orders"
+)
+
+type buyLineItemResult struct {
+	UID             string `json:"uid"`
+	Success         bool   `json:"success"`
+	ErrorMessage    string `json:"error_message"`
+	Name            string `json:"name"`
+	Permalink       string `json:"permalink"`
+	ContentURL      string `json:"content_url"`
+	RedirectToken   string `json:"redirect_token"`
+	RequiresAction  bool   `json:"requires_action"`
+	ClientSecret    string `json:"client_secret"`
+	ConfirmationURL string `json:"confirmation_url"`
+}
+
+type buyResponse struct {
+	Success   bool                         `json:"success"`
+	Message   string                       `json:"message"`
+	LineItems map[string]buyLineItemResult `json:"line_items"`
+}
+
+func NewBuyCmd() *cobra.Command {
+	var paymentMethodID, customerID, email, variant, offerCode string
+	var quantity, priceCents, tipCents int
+
+	cmd := &cobra.Command{
+		Use:   "buy <permalink>",
+		Short: "Buy a product as the authenticated user",
+		Long: "Buy a product on Gumroad as the authenticated user.\n\n" +
+			"Pre-mint a Stripe PaymentMethod (pm_xxx) on Gumroad's Stripe platform " +
+			"and pass it via --payment-method-id. 3DS / SCA challenges cannot be " +
+			"completed in a CLI; when one is required, the command prints a " +
+			"confirmation URL and exits non-zero so you can finish in a browser.\n\n" +
+			"Requires an OAuth token with the create_purchases scope.",
+		Example: `  gumroad buy abc123 --payment-method-id pm_card_visa --price-cents 500 --yes
+  gumroad buy abc123 --pm pm_card_visa --price-cents 500 --yes
+  gumroad buy abc123 --pm pm_card_visa --price-cents 500 --quantity 2 --offer-code SAVE10 --yes`,
+		Args: cmdutil.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			flags := c.Flags()
+			permalink := args[0]
+
+			if paymentMethodID == "" {
+				return cmdutil.MissingFlagError(c, "--payment-method-id")
+			}
+			if !flags.Changed("price-cents") {
+				return cmdutil.MissingFlagError(c, "--price-cents")
+			}
+
+			if flags.Changed("quantity") {
+				if err := cmdutil.RequirePositiveIntFlag(c, "quantity", quantity); err != nil {
+					return err
+				}
+			}
+			if err := cmdutil.RequireNonNegativeIntFlag(c, "price-cents", priceCents); err != nil {
+				return err
+			}
+			if flags.Changed("tip-cents") {
+				if err := cmdutil.RequireNonNegativeIntFlag(c, "tip-cents", tipCents); err != nil {
+					return err
+				}
+			}
+
+			body := buildOrderBody(orderBodyInput{
+				PaymentMethodID: paymentMethodID,
+				CustomerID:      customerID,
+				CustomerIDSet:   flags.Changed("customer-id"),
+				Email:           email,
+				EmailSet:        flags.Changed("email"),
+				Permalink:       permalink,
+				PerceivedCents:  priceCents,
+				Quantity:        quantity,
+				Variant:         variant,
+				VariantSet:      flags.Changed("variant"),
+				OfferCode:       offerCode,
+				OfferCodeSet:    flags.Changed("offer-code"),
+				TipCents:        tipCents,
+				TipCentsSet:     flags.Changed("tip-cents"),
+			})
+
+			if opts.DryRun {
+				return renderDryRun(opts, body)
+			}
+
+			summary := buildBuySummary(permalink, paymentMethodID, priceCents, quantity)
+			ok, err := cmdutil.ConfirmAction(opts, "Buy "+summary+"?")
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return cmdutil.PrintCancelledAction(opts, "buy "+permalink, permalink)
+			}
+
+			token, err := config.Token()
+			if err != nil {
+				return err
+			}
+
+			data, err := cmdutil.RunWithTokenData(opts, token, "Purchasing...",
+				func(client *api.Client) (json.RawMessage, error) {
+					return client.PostJSON(ordersPath, body)
+				})
+			if err != nil {
+				return err
+			}
+			if opts.UsesJSONOutput() {
+				return cmdutil.PrintJSONResponse(opts, data)
+			}
+			resp, err := cmdutil.DecodeJSON[buyResponse](data)
+			if err != nil {
+				return err
+			}
+			return renderBuyResult(opts, resp)
+		},
+	}
+
+	cmd.Flags().StringVar(&paymentMethodID, "payment-method-id", "", "Stripe PaymentMethod ID (pm_xxx) on Gumroad's platform (required)")
+	cmd.Flags().StringVar(&paymentMethodID, "pm", "", "Alias for --payment-method-id")
+	cmd.Flags().StringVar(&customerID, "customer-id", "", "Stripe customer (cus_xxx) for saved-card flows")
+	cmd.Flags().StringVar(&email, "email", "", "Override receipt email (default: the OAuth user's email)")
+	cmd.Flags().IntVar(&quantity, "quantity", 1, "Quantity to purchase")
+	cmd.Flags().IntVar(&priceCents, "price-cents", 0, "Perceived price in cents; the server validates this against the product's listed price (required)")
+	cmd.Flags().StringVar(&variant, "variant", "", "Variant external id")
+	cmd.Flags().StringVar(&offerCode, "offer-code", "", "Discount code")
+	cmd.Flags().IntVar(&tipCents, "tip-cents", 0, "Optional tip in cents")
+
+	return cmd
+}
+
+type orderBodyInput struct {
+	PaymentMethodID string
+	CustomerID      string
+	CustomerIDSet   bool
+	Email           string
+	EmailSet        bool
+	Permalink       string
+	PerceivedCents  int
+	Quantity        int
+	Variant         string
+	VariantSet      bool
+	OfferCode       string
+	OfferCodeSet    bool
+	TipCents        int
+	TipCentsSet     bool
+}
+
+func buildOrderBody(in orderBodyInput) map[string]any {
+	lineItem := map[string]any{
+		"uid":                   defaultLineItemUID,
+		"permalink":             in.Permalink,
+		"perceived_price_cents": in.PerceivedCents,
+		"quantity":              in.Quantity,
+	}
+	if in.VariantSet && in.Variant != "" {
+		lineItem["variants"] = []string{in.Variant}
+	}
+	if in.OfferCodeSet && in.OfferCode != "" {
+		lineItem["discount_code"] = in.OfferCode
+	}
+	if in.TipCentsSet {
+		lineItem["tip_cents"] = in.TipCents
+	}
+
+	body := map[string]any{
+		"stripe_payment_method_id": in.PaymentMethodID,
+		"line_items":               []map[string]any{lineItem},
+	}
+	if in.CustomerIDSet && in.CustomerID != "" {
+		body["stripe_customer_id"] = in.CustomerID
+	}
+	if in.EmailSet && in.Email != "" {
+		body["email"] = in.Email
+	}
+	return body
+}
+
+func buildBuySummary(permalink, paymentMethodID string, perceivedCents, quantity int) string {
+	priceLabel := cmdutil.FormatMoney(perceivedCents, "")
+	totalLabel := cmdutil.FormatMoney(perceivedCents*quantity, "")
+	return fmt.Sprintf("%s, %s × %d = %s, paid with %s",
+		permalink, priceLabel, quantity, totalLabel, paymentMethodID)
+}
+
+func renderDryRun(opts cmdutil.Options, body map[string]any) error {
+	if opts.UsesJSONOutput() {
+		payload := map[string]any{
+			"dry_run": true,
+			"request": map[string]any{
+				"method": "POST",
+				"path":   ordersPath,
+				"body":   body,
+			},
+		}
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("could not encode dry-run output: %w", err)
+		}
+		return output.PrintJSON(opts.Out(), data, opts.JQExpr)
+	}
+
+	if opts.PlainOutput {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("could not encode dry-run output: %w", err)
+		}
+		return output.PrintPlain(opts.Out(), [][]string{{"POST", ordersPath, string(data)}})
+	}
+
+	style := opts.Style()
+	if err := output.Writeln(opts.Out(), style.Yellow("Dry run")+": POST "+ordersPath); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(body, "", "  ")
+	if err != nil {
+		return fmt.Errorf("could not encode dry-run output: %w", err)
+	}
+	return output.Writeln(opts.Out(), string(data))
+}
+
+func renderBuyResult(opts cmdutil.Options, resp buyResponse) error {
+	item, ok := resp.LineItems[defaultLineItemUID]
+	if !ok {
+		for _, value := range resp.LineItems {
+			item = value
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return errors.New("purchase response missing line items")
+	}
+
+	style := opts.Style()
+
+	if item.RequiresAction {
+		if err := output.Writeln(opts.Err(), style.Yellow("3DS verification required.")); err != nil {
+			return err
+		}
+		if item.ConfirmationURL != "" {
+			if err := output.Writef(opts.Err(), "Complete in browser: %s\n", item.ConfirmationURL); err != nil {
+				return err
+			}
+		}
+		return errors.New("3DS verification required; complete in browser to finish the purchase")
+	}
+
+	if !item.Success {
+		message := item.ErrorMessage
+		if message == "" {
+			message = "purchase failed"
+		}
+		if err := output.Writeln(opts.Err(), style.Red(message)); err != nil {
+			return err
+		}
+		return errors.New(message)
+	}
+
+	if opts.PlainOutput {
+		return output.PrintPlain(opts.Out(), [][]string{{
+			item.Permalink, item.Name, item.ContentURL, item.RedirectToken,
+		}})
+	}
+
+	if opts.Quiet {
+		return nil
+	}
+
+	heading := "Purchased " + item.Name
+	if err := output.Writeln(opts.Out(), style.Bold(heading)); err != nil {
+		return err
+	}
+	if item.ContentURL != "" {
+		if err := output.Writef(opts.Out(), "%s %s\n", style.Dim("Content:"), item.ContentURL); err != nil {
+			return err
+		}
+	}
+	if item.RedirectToken != "" {
+		if err := output.Writef(opts.Out(), "%s %s\n", style.Dim("Redirect token:"), item.RedirectToken); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/cmd/buy/buy_test.go
+++ b/internal/cmd/buy/buy_test.go
@@ -1,0 +1,586 @@
+package buy
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func decodeOrderBody(t *testing.T, r *http.Request) map[string]any {
+	t.Helper()
+	raw, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	return body
+}
+
+func rejectGET(t *testing.T) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected GET %s — buy must POST /orders directly without any pre-lookup", r.URL.Path)
+		http.Error(w, "no GETs allowed in buy tests", http.StatusInternalServerError)
+	}
+}
+
+func ordersHandler(t *testing.T, body map[string]any) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			rejectGET(t)(w, r)
+			return
+		}
+		if r.URL.Path != "/orders" {
+			t.Errorf("unexpected request to %s; want /orders", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		testutil.JSON(t, w, body)
+	}
+}
+
+func TestBuy_RequiresPermalinkArg(t *testing.T) {
+	cmd := testutil.Command(NewBuyCmd())
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when permalink missing")
+	}
+	if !strings.Contains(err.Error(), "missing required argument") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBuy_RequiresPaymentMethod(t *testing.T) {
+	cmd := testutil.Command(NewBuyCmd())
+	cmd.SetArgs([]string{"abc123", "--price-cents", "500"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when --payment-method-id missing")
+	}
+	if !strings.Contains(err.Error(), "--payment-method-id") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var usageErr *cmdutil.UsageError
+	if !errors.As(err, &usageErr) {
+		t.Fatalf("expected *cmdutil.UsageError, got %T", err)
+	}
+}
+
+func TestBuy_RequiresPriceCents(t *testing.T) {
+	cmd := testutil.Command(NewBuyCmd())
+	cmd.SetArgs([]string{"abc123", "--pm", "pm_card_visa"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when --price-cents missing")
+	}
+	if !strings.Contains(err.Error(), "--price-cents") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var usageErr *cmdutil.UsageError
+	if !errors.As(err, &usageErr) {
+		t.Fatalf("expected *cmdutil.UsageError, got %T", err)
+	}
+}
+
+func TestBuy_DryRunPrintsBodyAndSkipsPost(t *testing.T) {
+	var sawAnyRequest atomic.Bool
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		sawAnyRequest.Store(true)
+		t.Errorf("dry-run made unexpected %s %s — must not touch the network", r.Method, r.URL.Path)
+		http.Error(w, "dry-run should not call the API", http.StatusInternalServerError)
+	})
+
+	cmd := testutil.Command(NewBuyCmd(), testutil.DryRun(true), testutil.Quiet(false))
+	cmd.SetArgs([]string{"abc123", "--pm", "pm_card_visa", "--price-cents", "500"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if sawAnyRequest.Load() {
+		t.Fatal("dry-run must not make any HTTP request")
+	}
+	for _, want := range []string{"Dry run", "POST /orders", `"permalink": "abc123"`, `"perceived_price_cents": 500`, `"stripe_payment_method_id": "pm_card_visa"`} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("dry-run output missing %q in %q", want, out)
+		}
+	}
+}
+
+func TestBuy_DryRun_DoesNotRequireConfig(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("GUMROAD_ACCESS_TOKEN", "")
+	t.Setenv("GUMROAD_API_BASE_URL", "http://127.0.0.1:1/v2")
+
+	cmd := testutil.Command(NewBuyCmd(), testutil.DryRun(true))
+	cmd.SetArgs([]string{"abc123", "--pm", "pm_card_visa", "--price-cents", "500"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "POST /orders") {
+		t.Fatalf("dry-run output missing POST /orders; got %q", out)
+	}
+}
+
+func TestBuy_HappyPath(t *testing.T) {
+	var gotMethod, gotPath, gotContentType string
+	var gotBody map[string]any
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			rejectGET(t)(w, r)
+			return
+		}
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotContentType = r.Header.Get("Content-Type")
+		gotBody = decodeOrderBody(t, r)
+		testutil.JSON(t, w, map[string]any{
+			"line_items": map[string]any{
+				"li-0": map[string]any{
+					"uid":         "li-0",
+					"success":     true,
+					"name":        "Art Pack",
+					"permalink":   "abc123",
+					"content_url": "https://gumroad.com/library/abc123",
+				},
+			},
+		})
+	})
+
+	cmd := testutil.Command(NewBuyCmd(), testutil.Yes(true), testutil.Quiet(false))
+	cmd.SetArgs([]string{"abc123", "--pm", "pm_card_visa", "--price-cents", "500"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != "POST" || gotPath != "/orders" {
+		t.Fatalf("got %s %s, want POST /orders", gotMethod, gotPath)
+	}
+	if !strings.HasPrefix(gotContentType, "application/json") {
+		t.Fatalf("got Content-Type %q, want application/json", gotContentType)
+	}
+	if gotBody["stripe_payment_method_id"] != "pm_card_visa" {
+		t.Fatalf("got pm %v, want pm_card_visa", gotBody["stripe_payment_method_id"])
+	}
+	items, ok := gotBody["line_items"].([]any)
+	if !ok || len(items) != 1 {
+		t.Fatalf("expected 1 line item, got %v", gotBody["line_items"])
+	}
+	item := items[0].(map[string]any)
+	if item["permalink"] != "abc123" {
+		t.Fatalf("got permalink %v, want abc123", item["permalink"])
+	}
+	if int(item["perceived_price_cents"].(float64)) != 500 {
+		t.Fatalf("got perceived_price_cents %v, want 500", item["perceived_price_cents"])
+	}
+	if int(item["quantity"].(float64)) != 1 {
+		t.Fatalf("got quantity %v, want 1", item["quantity"])
+	}
+	if item["uid"] != "li-0" {
+		t.Fatalf("got uid %v, want li-0", item["uid"])
+	}
+	for _, want := range []string{"Purchased Art Pack", "https://gumroad.com/library/abc123"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q in %q", want, out)
+		}
+	}
+}
+
+func TestBuy_RequiresConfirmation(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("should not POST /orders without confirmation; got %s %s", r.Method, r.URL.Path)
+		http.Error(w, "no API call expected", http.StatusInternalServerError)
+	})
+
+	cmd := testutil.Command(NewBuyCmd(), testutil.NoInput(true))
+	cmd.SetArgs([]string{"abc123", "--pm", "pm_card_visa", "--price-cents", "500"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error without --yes and --no-input")
+	}
+}
+
+func TestBuy_CardDeclined(t *testing.T) {
+	testutil.Setup(t, ordersHandler(t, map[string]any{
+		"line_items": map[string]any{
+			"li-0": map[string]any{
+				"uid":           "li-0",
+				"success":       false,
+				"error_message": "Your card was declined.",
+			},
+		},
+	}))
+
+	var stderr strings.Builder
+	cmd := testutil.Command(NewBuyCmd(), testutil.Yes(true), testutil.Quiet(false), testutil.Stderr(&stderr))
+	cmd.SetArgs([]string{"abc123", "--pm", "pm_card_visa", "--price-cents", "500"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "Your card was declined") {
+		t.Fatalf("expected decline error, got %v", err)
+	}
+	if !strings.Contains(stderr.String(), "Your card was declined") {
+		t.Fatalf("expected decline message on stderr, got %q", stderr.String())
+	}
+}
+
+func TestBuy_RequiresAction3DS(t *testing.T) {
+	testutil.Setup(t, ordersHandler(t, map[string]any{
+		"line_items": map[string]any{
+			"li-0": map[string]any{
+				"uid":              "li-0",
+				"requires_action":  true,
+				"client_secret":    "pi_xxx_secret_yyy",
+				"confirmation_url": "https://gumroad.com/l/abc123",
+			},
+		},
+	}))
+
+	var stderr strings.Builder
+	cmd := testutil.Command(NewBuyCmd(), testutil.Yes(true), testutil.Quiet(false), testutil.Stderr(&stderr))
+	cmd.SetArgs([]string{"abc123", "--pm", "pm_card_visa", "--price-cents", "500"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "3DS") {
+		t.Fatalf("expected 3DS error, got %v", err)
+	}
+	for _, want := range []string{"3DS verification required", "https://gumroad.com/l/abc123"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("expected %q on stderr, got %q", want, stderr.String())
+		}
+	}
+}
+
+func TestBuy_JSONOutputPreservesEnvelope(t *testing.T) {
+	testutil.Setup(t, ordersHandler(t, map[string]any{
+		"line_items": map[string]any{
+			"li-0": map[string]any{
+				"uid":         "li-0",
+				"success":     true,
+				"name":        "Art Pack",
+				"permalink":   "abc123",
+				"content_url": "https://gumroad.com/library/abc123",
+			},
+		},
+	}))
+
+	cmd := testutil.Command(NewBuyCmd(), testutil.Yes(true), testutil.JSONOutput())
+	cmd.SetArgs([]string{"abc123", "--pm", "pm_card_visa", "--price-cents", "500"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+	items, ok := resp["line_items"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected line_items in JSON envelope, got %v", resp)
+	}
+	li, ok := items["li-0"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected li-0 in JSON envelope, got %v", items)
+	}
+	if li["content_url"] != "https://gumroad.com/library/abc123" {
+		t.Fatalf("got content_url %v, want https://gumroad.com/library/abc123", li["content_url"])
+	}
+}
+
+func TestBuy_PWYWSendsPriceVerbatim(t *testing.T) {
+	var gotBody map[string]any
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			rejectGET(t)(w, r)
+			return
+		}
+		gotBody = decodeOrderBody(t, r)
+		testutil.JSON(t, w, map[string]any{
+			"line_items": map[string]any{
+				"li-0": map[string]any{
+					"uid":         "li-0",
+					"success":     true,
+					"name":        "PWYW Pack",
+					"permalink":   "pwyw1",
+					"content_url": "https://gumroad.com/library/pwyw1",
+				},
+			},
+		})
+	})
+
+	cmd := testutil.Command(NewBuyCmd(), testutil.Yes(true), testutil.Quiet(true))
+	cmd.SetArgs([]string{"pwyw1", "--pm", "pm_card_visa", "--price-cents", "1234"})
+	testutil.MustExecute(t, cmd)
+
+	items := gotBody["line_items"].([]any)
+	item := items[0].(map[string]any)
+	if int(item["perceived_price_cents"].(float64)) != 1234 {
+		t.Fatalf("got perceived_price_cents %v, want 1234 (CLI must send the flag verbatim)", item["perceived_price_cents"])
+	}
+}
+
+func TestBuy_PermalinkNotFound(t *testing.T) {
+	testutil.Setup(t, ordersHandler(t, map[string]any{
+		"line_items": map[string]any{
+			"li-0": map[string]any{
+				"uid":           "li-0",
+				"success":       false,
+				"error_message": "Product missing does not exist",
+			},
+		},
+	}))
+
+	var stderr strings.Builder
+	cmd := testutil.Command(NewBuyCmd(), testutil.Yes(true), testutil.Stderr(&stderr))
+	cmd.SetArgs([]string{"missing", "--pm", "pm_card_visa", "--price-cents", "500"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "Product missing does not exist") {
+		t.Fatalf("expected unknown-permalink error, got %v", err)
+	}
+	if !strings.Contains(stderr.String(), "Product missing does not exist") {
+		t.Fatalf("expected error on stderr, got %q", stderr.String())
+	}
+}
+
+func TestBuy_OptionalFieldsSentWhenSet(t *testing.T) {
+	var gotBody map[string]any
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			rejectGET(t)(w, r)
+			return
+		}
+		gotBody = decodeOrderBody(t, r)
+		testutil.JSON(t, w, map[string]any{
+			"line_items": map[string]any{
+				"li-0": map[string]any{"uid": "li-0", "success": true, "name": "Art Pack", "permalink": "abc123"},
+			},
+		})
+	})
+
+	cmd := testutil.Command(NewBuyCmd(), testutil.Yes(true), testutil.Quiet(true))
+	cmd.SetArgs([]string{
+		"abc123",
+		"--pm", "pm_card_visa",
+		"--price-cents", "500",
+		"--customer-id", "cus_xyz",
+		"--email", "buyer@example.com",
+		"--quantity", "2",
+		"--variant", "var_id",
+		"--offer-code", "SAVE10",
+		"--tip-cents", "100",
+	})
+	testutil.MustExecute(t, cmd)
+
+	if gotBody["stripe_customer_id"] != "cus_xyz" {
+		t.Errorf("missing stripe_customer_id, got %v", gotBody["stripe_customer_id"])
+	}
+	if gotBody["email"] != "buyer@example.com" {
+		t.Errorf("missing email, got %v", gotBody["email"])
+	}
+	item := gotBody["line_items"].([]any)[0].(map[string]any)
+	if int(item["quantity"].(float64)) != 2 {
+		t.Errorf("got quantity %v, want 2", item["quantity"])
+	}
+	variants, ok := item["variants"].([]any)
+	if !ok || len(variants) != 1 || variants[0] != "var_id" {
+		t.Errorf("got variants %v, want [var_id]", item["variants"])
+	}
+	if item["discount_code"] != "SAVE10" {
+		t.Errorf("got discount_code %v, want SAVE10", item["discount_code"])
+	}
+	if int(item["tip_cents"].(float64)) != 100 {
+		t.Errorf("got tip_cents %v, want 100", item["tip_cents"])
+	}
+}
+
+func TestBuy_DryRun_JSONOutput(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("dry-run should not POST; got %s %s", r.Method, r.URL.Path)
+		http.Error(w, "no API call expected", http.StatusInternalServerError)
+	})
+
+	cmd := testutil.Command(NewBuyCmd(), testutil.DryRun(true), testutil.JSONOutput())
+	cmd.SetArgs([]string{"abc123", "--pm", "pm_card_visa", "--price-cents", "500"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var payload struct {
+		DryRun  bool `json:"dry_run"`
+		Request struct {
+			Method string         `json:"method"`
+			Path   string         `json:"path"`
+			Body   map[string]any `json:"body"`
+		} `json:"request"`
+	}
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if !payload.DryRun || payload.Request.Method != "POST" || payload.Request.Path != "/orders" {
+		t.Fatalf("unexpected dry-run JSON envelope: %+v", payload)
+	}
+	if payload.Request.Body["stripe_payment_method_id"] != "pm_card_visa" {
+		t.Fatalf("dry-run body missing payment method, got %v", payload.Request.Body)
+	}
+}
+
+func TestBuy_DryRun_PlainOutput(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("dry-run should not POST; got %s %s", r.Method, r.URL.Path)
+		http.Error(w, "no API call expected", http.StatusInternalServerError)
+	})
+
+	cmd := testutil.Command(NewBuyCmd(), testutil.DryRun(true), testutil.PlainOutput())
+	cmd.SetArgs([]string{"abc123", "--pm", "pm_card_visa", "--price-cents", "500"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "POST\t/orders\t") {
+		t.Fatalf("expected plain dry-run row, got %q", out)
+	}
+}
+
+func TestBuy_PlainOutput_Success(t *testing.T) {
+	testutil.Setup(t, ordersHandler(t, map[string]any{
+		"line_items": map[string]any{
+			"li-0": map[string]any{
+				"uid":            "li-0",
+				"success":        true,
+				"name":           "Art Pack",
+				"permalink":      "abc123",
+				"content_url":    "https://gumroad.com/library/abc123",
+				"redirect_token": "tok-1",
+			},
+		},
+	}))
+
+	cmd := testutil.Command(NewBuyCmd(), testutil.Yes(true), testutil.PlainOutput())
+	cmd.SetArgs([]string{"abc123", "--pm", "pm_card_visa", "--price-cents", "500"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	cols := strings.Split(strings.TrimRight(out, "\n"), "\t")
+	if len(cols) != 4 {
+		t.Fatalf("expected 4 tab-separated columns, got %d: %q", len(cols), out)
+	}
+	if cols[0] != "abc123" || cols[1] != "Art Pack" || cols[2] != "https://gumroad.com/library/abc123" || cols[3] != "tok-1" {
+		t.Fatalf("unexpected plain row %v", cols)
+	}
+}
+
+func TestBuy_QuietSuppressesOutput(t *testing.T) {
+	testutil.Setup(t, ordersHandler(t, map[string]any{
+		"line_items": map[string]any{
+			"li-0": map[string]any{"uid": "li-0", "success": true, "name": "Art Pack", "permalink": "abc123"},
+		},
+	}))
+
+	cmd := testutil.Command(NewBuyCmd(), testutil.Yes(true), testutil.Quiet(true))
+	cmd.SetArgs([]string{"abc123", "--pm", "pm_card_visa", "--price-cents", "500"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if strings.TrimSpace(out) != "" {
+		t.Fatalf("expected no output in quiet mode, got %q", out)
+	}
+}
+
+func TestBuy_FallsBackToFirstLineItem(t *testing.T) {
+	testutil.Setup(t, ordersHandler(t, map[string]any{
+		"line_items": map[string]any{
+			"other-uid": map[string]any{
+				"uid": "other-uid", "success": true, "name": "Art Pack", "permalink": "abc123",
+			},
+		},
+	}))
+
+	cmd := testutil.Command(NewBuyCmd(), testutil.Yes(true), testutil.Quiet(false))
+	cmd.SetArgs([]string{"abc123", "--pm", "pm_card_visa", "--price-cents", "500"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "Purchased Art Pack") {
+		t.Fatalf("expected success render from fallback line item, got %q", out)
+	}
+}
+
+func TestBuy_EmptyLineItemsErrors(t *testing.T) {
+	testutil.Setup(t, ordersHandler(t, map[string]any{"line_items": map[string]any{}}))
+
+	cmd := testutil.Command(NewBuyCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"abc123", "--pm", "pm_card_visa", "--price-cents", "500"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "missing line items") {
+		t.Fatalf("expected missing line items error, got %v", err)
+	}
+}
+
+func TestBuy_QuantityRejectsZero(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API with invalid --quantity")
+	})
+
+	cmd := testutil.Command(NewBuyCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"abc123", "--pm", "pm_card_visa", "--price-cents", "500", "--quantity", "0"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--quantity must be greater than 0") {
+		t.Fatalf("expected quantity error, got %v", err)
+	}
+}
+
+func TestBuy_TipCentsRejectsNegative(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API with negative --tip-cents")
+	})
+
+	cmd := testutil.Command(NewBuyCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"abc123", "--pm", "pm_card_visa", "--price-cents", "500", "--tip-cents", "-1"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--tip-cents cannot be negative") {
+		t.Fatalf("expected tip-cents error, got %v", err)
+	}
+}
+
+func TestBuy_DeclineWithoutMessage(t *testing.T) {
+	testutil.Setup(t, ordersHandler(t, map[string]any{
+		"line_items": map[string]any{
+			"li-0": map[string]any{"uid": "li-0", "success": false},
+		},
+	}))
+
+	var stderr strings.Builder
+	cmd := testutil.Command(NewBuyCmd(), testutil.Yes(true), testutil.Stderr(&stderr))
+	cmd.SetArgs([]string{"abc123", "--pm", "pm_card_visa", "--price-cents", "500"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "purchase failed") {
+		t.Fatalf("expected fallback purchase failed error, got %v", err)
+	}
+}
+
+func TestBuy_OptionalFieldsOmittedWhenUnset(t *testing.T) {
+	var gotBody map[string]any
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			rejectGET(t)(w, r)
+			return
+		}
+		gotBody = decodeOrderBody(t, r)
+		testutil.JSON(t, w, map[string]any{
+			"line_items": map[string]any{
+				"li-0": map[string]any{"uid": "li-0", "success": true, "name": "Art Pack", "permalink": "abc123"},
+			},
+		})
+	})
+
+	cmd := testutil.Command(NewBuyCmd(), testutil.Yes(true), testutil.Quiet(true))
+	cmd.SetArgs([]string{"abc123", "--pm", "pm_card_visa", "--price-cents", "500"})
+	testutil.MustExecute(t, cmd)
+
+	for _, key := range []string{"stripe_customer_id", "email"} {
+		if _, ok := gotBody[key]; ok {
+			t.Errorf("expected %s omitted when unset, got %v", key, gotBody[key])
+		}
+	}
+	item := gotBody["line_items"].([]any)[0].(map[string]any)
+	for _, key := range []string{"variants", "discount_code", "tip_cents"} {
+		if _, ok := item[key]; ok {
+			t.Errorf("expected line item %s omitted when unset, got %v", key, item[key])
+		}
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/antiwork/gumroad-cli/internal/cmd/admin"
 	"github.com/antiwork/gumroad-cli/internal/cmd/auth"
+	"github.com/antiwork/gumroad-cli/internal/cmd/buy"
 	"github.com/antiwork/gumroad-cli/internal/cmd/categories"
 	"github.com/antiwork/gumroad-cli/internal/cmd/completion"
 	"github.com/antiwork/gumroad-cli/internal/cmd/customfields"
@@ -115,6 +116,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(webhooks.NewWebhooksCmd())
 	cmd.AddCommand(completion.NewCompletionCmd())
 	cmd.AddCommand(skill.NewSkillCmd())
+	cmd.AddCommand(buy.NewBuyCmd())
 	cmdutil.PropagateExamples(cmd)
 
 	return cmd


### PR DESCRIPTION
## What

Adds the `gumroad buy` command. Calls `POST /v2/orders` with the permalink and a Stripe PaymentMethod, with no pre-lookup step. Improves the 403 error hint to name the relevant scopes (`create_purchases`, `edit_products`).

```
gumroad buy <permalink> --pm pm_xxx --price-cents N [--quantity N] [--variant ...] [--offer-code ...] [--tip-cents N] [--customer-id cus_xxx] [--email ...] --yes
```

Test changes in `internal/cmd/buy/buy_test.go`:
- Mock errors on any GET — there is no lookup endpoint.
- `TestBuy_PermalinkNotFound` exercises the real not-found path: orders endpoint returns `success: false` with a server-side `error_message`.
- `TestBuy_PWYWSendsPriceVerbatim` asserts the CLI forwards `--price-cents` verbatim with no client-side branching on `customizable_price`.
- `TestBuy_DryRun_DoesNotRequireConfig` pins the dry-run gate above `config.Token()`.

## Why

The earlier draft of this command called `GET /v2/products/search.json` first to resolve the permalink to a product, but that route does not exist. Requests fell through to the resource controller and got back `200 {success: false, message: \"The product was not found.\"}` — so every `gumroad buy` invocation failed before reaching the orders endpoint, with a misleading message. Even the legacy `/products/search.json` (`Api::V1::LinksController#search`) is scoped to the OAuth user's own products, so a buyer cannot use it to look up a seller's listing in the first place.

`POST /v2/orders` accepts the permalink directly and returns the product name, content URL, and redirect token in the line-item response. Skipping the lookup also fixes three downstream bugs that the QA report flagged separately:

- **Dry-run actually dry**. The dry-run gate now runs before any network call or token resolution, so `--dry-run` produces the request preview offline.
- **Scope errors visible**. `POST /v2/orders` returns 403 cleanly when the token lacks `create_purchases`. The CLI now surfaces this with a hint naming the scope, instead of masking it as \"product not found\".
- **--price-cents required up front**. With no lookup to fall back on, the buyer's intended price has to come from the flag — required for PWYW, validated by the server for fixed-price products.

The 403 hint update lives in `internal/api/errors.go` so other commands benefit too. The hint now reads: _\"Check that your token has the required scope (e.g. create_purchases for buy, edit_products for product mutations).\"_

## Before/After

Verified end-to-end against a local Rails server (`http://api.gumroad.dev:3000/v2`):

| Scenario | Before | After |
| --- | --- | --- |
| Happy path | `Error: The product was not found.` (exit 1) | `Purchased QA Art Pack`, content URL, exit 0; Purchase id=15, ch_3TSzIGIBOqvOFDrf1n5fDSd8 |
| Card declined | (never reached) | `Your card was declined.` exit 1 |
| 3DS required | (never reached) | `3DS verification required.` + confirmation URL on stderr, exit 1 |
| `--dry-run` | makes a `GET` before the gate | exits 0 with no HTTP attempt (verified with `GUMROAD_API_BASE_URL=http://127.0.0.1:1/v2`) |
| Wrong scope | `Error: The product was not found.` | `Error: Access denied. Hint: Check that your token has the required scope (e.g. create_purchases for buy, edit_products for product mutations).` |

I'll attach a terminal recording showing the five scenarios above.

## Test Results

```
make test-cover  →  internal/cmd/buy 86.8%, internal/api 93.8% (gates: 85% cmd, 90% infra) ✓
make lint        →  golangci-lint clean ✓
make build && ./gumroad buy --help  →  ✓
```

I also confirmed the regression test fails when the fix is reverted (per CONTRIBUTING.md): removing the `--price-cents required` check trips `TestBuy_RequiresPriceCents` with `unexpected error: confirmation required but stdin is not interactive`.

---

🤖 AI disclosure: implementation drafted with Claude Opus 4.7 (1M context). Prompts: \"Implement the fix for gumroad-cli-hy4 (P0) and the test rewrite for gumroad-cli-g64 (P1)\" with the full QA context (root cause analysis, ticket text, server contract docs, and live-server verification recipe). The agent was instructed to trace code paths against the live Rails server and confirm a real Purchase row was created before claiming done.