### PR TITLE
Add products readiness subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ gumroad user
 # List products, then inspect one
 gumroad products list
 gumroad products view abc123
+gumroad products readiness abc123
 
 # Fetch all sales, filter with jq
 gumroad sales list --all --json --jq '.sales[] | {email, formatted_total_price}'
@@ -88,7 +89,7 @@ For CI and agents, set `GUMROAD_ACCESS_TOKEN` instead — it takes precedence ov
 gumroad auth          login, status, logout
 gumroad admin         Internal admin API commands
 gumroad user          View your account info
-gumroad products      create, update, list, view, delete, publish, unpublish, skus
+gumroad products      create, update, list, view, readiness, delete, publish, unpublish, skus
 gumroad sales         list, view, refund, ship, resend-receipt
 gumroad payouts       list, view, upcoming
 gumroad subscribers   list, view

--- a/internal/cmd/products/products.go
+++ b/internal/cmd/products/products.go
@@ -19,6 +19,7 @@ func NewProductsCmd() *cobra.Command {
   gumroad products update <product_id> --file ./pack.zip
   gumroad products update <product_id> --replace-files --keep-file file_123 --file ./new-pack.zip
   gumroad products view <id>
+  gumroad products readiness <id>
   gumroad products publish <id>
   gumroad products unpublish <id>
   gumroad products delete <id>
@@ -29,6 +30,7 @@ func NewProductsCmd() *cobra.Command {
 	cmd.AddCommand(newUpdateCmd())
 	cmd.AddCommand(newListCmd())
 	cmd.AddCommand(newViewCmd())
+	cmd.AddCommand(newReadinessCmd())
 	cmd.AddCommand(newDeleteCmd())
 	cmd.AddCommand(newPublishCmd())
 	cmd.AddCommand(newUnpublishCmd())

--- a/internal/cmd/products/readiness.go
+++ b/internal/cmd/products/readiness.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/url"
 
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
@@ -75,24 +76,36 @@ func renderReadiness(opts cmdutil.Options, r readinessPayload, showDetails bool)
 
 	style := opts.Style()
 	overallColored := colorBySeverity(style, r.Severity, fmt.Sprintf("%d/100", r.Overall))
-	if err := output.Writeln(opts.Out(), style.Bold("Page readiness")); err != nil {
-		return err
-	}
-	if err := output.Writef(opts.Out(), "Overall: %s  (%s)\n\n", overallColored, severityLabel(r.Severity)); err != nil {
-		return err
-	}
 
-	tbl := output.NewTable("CATEGORY", "WEIGHT", "SCORE", "SEVERITY", "NOTE")
+	tbl := output.NewTable("CATEGORY", "WEIGHT", "SCORE", "POINTS", "SEVERITY", "NOTE")
+	totalPoints := 0
 	for _, cat := range r.Categories {
+		points := int(math.Round(float64(cat.Score*cat.Weight) / 100.0))
+		totalPoints += points
 		tbl.AddRow(
 			cat.Label,
 			fmt.Sprintf("%d%%", cat.Weight),
 			fmt.Sprintf("%d", cat.Score),
+			fmt.Sprintf("%d", points),
 			colorBySeverity(style, cat.Severity, cat.Severity),
 			cat.Note,
 		)
 	}
+	tbl.AddRow(
+		style.Bold("TOTAL"),
+		"",
+		"",
+		colorBySeverity(style, r.Severity, fmt.Sprintf("%d", totalPoints)),
+		colorBySeverity(style, r.Severity, severityLabel(r.Severity)),
+		"",
+	)
 	if err := output.WithPager(opts.Out(), opts.Err(), func(w io.Writer) error {
+		if _, err := fmt.Fprintln(w, style.Bold("Page readiness")); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(w, "Overall: %s  (%s)\n\n", overallColored, severityLabel(r.Severity)); err != nil {
+			return err
+		}
 		return tbl.Render(w)
 	}); err != nil {
 		return err

--- a/internal/cmd/products/readiness.go
+++ b/internal/cmd/products/readiness.go
@@ -1,0 +1,148 @@
+package products
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+type readinessCategory struct {
+	Key      string   `json:"key"`
+	Label    string   `json:"label"`
+	Weight   int      `json:"weight"`
+	Score    int      `json:"score"`
+	Severity string   `json:"severity"`
+	Note     string   `json:"note"`
+	Details  []string `json:"details"`
+}
+
+type readinessPayload struct {
+	Overall    int                 `json:"overall"`
+	Severity   string              `json:"severity"`
+	Categories []readinessCategory `json:"categories"`
+	ComputedAt string              `json:"computed_at"`
+}
+
+type readinessResponse struct {
+	Readiness readinessPayload `json:"readiness"`
+}
+
+func newReadinessCmd() *cobra.Command {
+	var showDetails bool
+	cmd := &cobra.Command{
+		Use:   "readiness <id>",
+		Short: "Show the readiness score for a product",
+		Long: "Show the deterministic readiness score for a product page.\n\n" +
+			"The score is computed server-side from five weighted dimensions " +
+			"(name, description, cover, pricing, social proof) and returned with " +
+			"per-category notes. Pipe through --json or --jq to apply your own " +
+			"AI-graded sub-rules in your agent of choice.",
+		Args: cmdutil.ExactArgs(1),
+		Example: `  gumroad products readiness <id>
+  gumroad products readiness <id> --details
+  gumroad products readiness <id> --json
+  gumroad products readiness <id> --jq '.readiness.overall'`,
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			path := cmdutil.JoinPath("products", args[0], "readiness")
+			return cmdutil.RunRequest(opts, "Fetching readiness score...", "GET", path, url.Values{}, func(data json.RawMessage) error {
+				var resp readinessResponse
+				if err := json.Unmarshal(data, &resp); err != nil {
+					return fmt.Errorf("could not parse response: %w", err)
+				}
+				return renderReadiness(opts, resp.Readiness, showDetails)
+			})
+		},
+	}
+	cmd.Flags().BoolVar(&showDetails, "details", false, "Show per-category details (bullet list explaining each score)")
+	return cmd
+}
+
+func renderReadiness(opts cmdutil.Options, r readinessPayload, showDetails bool) error {
+	if opts.PlainOutput {
+		rows := make([][]string, 0, len(r.Categories)+1)
+		rows = append(rows, []string{"overall", fmt.Sprintf("%d", r.Overall), r.Severity, ""})
+		for _, cat := range r.Categories {
+			rows = append(rows, []string{cat.Key, fmt.Sprintf("%d", cat.Score), cat.Severity, cat.Note})
+		}
+		return output.PrintPlain(opts.Out(), rows)
+	}
+
+	style := opts.Style()
+	overallColored := colorBySeverity(style, r.Severity, fmt.Sprintf("%d/100", r.Overall))
+	if err := output.Writeln(opts.Out(), style.Bold("Page readiness")); err != nil {
+		return err
+	}
+	if err := output.Writef(opts.Out(), "Overall: %s  (%s)\n\n", overallColored, severityLabel(r.Severity)); err != nil {
+		return err
+	}
+
+	tbl := output.NewTable("CATEGORY", "WEIGHT", "SCORE", "SEVERITY", "NOTE")
+	for _, cat := range r.Categories {
+		tbl.AddRow(
+			cat.Label,
+			fmt.Sprintf("%d%%", cat.Weight),
+			fmt.Sprintf("%d", cat.Score),
+			colorBySeverity(style, cat.Severity, cat.Severity),
+			cat.Note,
+		)
+	}
+	if err := output.WithPager(opts.Out(), opts.Err(), func(w io.Writer) error {
+		return tbl.Render(w)
+	}); err != nil {
+		return err
+	}
+
+	if showDetails {
+		if err := output.Writeln(opts.Out(), ""); err != nil {
+			return err
+		}
+		for _, cat := range r.Categories {
+			if err := output.Writeln(opts.Out(), style.Bold(cat.Label)); err != nil {
+				return err
+			}
+			for _, d := range cat.Details {
+				if err := output.Writef(opts.Out(), "  - %s\n", d); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func colorBySeverity(style output.Styler, severity, text string) string {
+	switch severity {
+	case "good":
+		return style.Green(text)
+	case "ok":
+		return style.Yellow(text)
+	case "weak":
+		return style.Yellow(text)
+	case "missing":
+		return style.Red(text)
+	default:
+		return text
+	}
+}
+
+func severityLabel(severity string) string {
+	switch severity {
+	case "good":
+		return "Strong"
+	case "ok":
+		return "Decent"
+	case "weak":
+		return "Needs work"
+	case "missing":
+		return "Weak"
+	default:
+		return severity
+	}
+}

--- a/internal/cmd/products/readiness_test.go
+++ b/internal/cmd/products/readiness_test.go
@@ -1,0 +1,138 @@
+package products
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func readinessFixture() map[string]any {
+	return map[string]any{
+		"success": true,
+		"readiness": map[string]any{
+			"overall":     67,
+			"severity":    "ok",
+			"computed_at": "2026-05-03T19:00:00Z",
+			"categories": []map[string]any{
+				{"key": "name", "label": "Name", "weight": 15, "score": 87, "severity": "good", "note": "Clear and specific", "details": []string{"Length 28 chars", "Contains a number"}},
+				{"key": "description", "label": "Description", "weight": 30, "score": 50, "severity": "weak", "note": "Lacks structure", "details": []string{"180 words — short"}},
+				{"key": "cover", "label": "Cover", "weight": 20, "score": 60, "severity": "ok", "note": "Decent", "details": []string{"1 cover uploaded"}},
+				{"key": "pricing", "label": "Pricing", "weight": 15, "score": 85, "severity": "good", "note": "Strong", "details": []string{"Charm pricing applied"}},
+				{"key": "social_proof", "label": "Social Proof", "weight": 20, "score": 70, "severity": "ok", "note": "Solid", "details": []string{"42 reviews"}},
+			},
+		},
+	}
+}
+
+func TestReadiness_JSON(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" || r.URL.Path != "/products/abc/readiness" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		testutil.JSON(t, w, readinessFixture())
+	})
+
+	cmd := testutil.Command(newReadinessCmd(), testutil.JSONOutput())
+	var err error
+	out := testutil.CaptureStdout(func() { err = cmd.RunE(cmd, []string{"abc"}) })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var resp map[string]any
+	if jsonErr := json.Unmarshal([]byte(out), &resp); jsonErr != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", jsonErr, out)
+	}
+	readiness, ok := resp["readiness"].(map[string]any)
+	if !ok {
+		t.Fatalf("readiness object missing from output: %s", out)
+	}
+	if readiness["overall"] != float64(67) {
+		t.Errorf("overall = %v, want 67", readiness["overall"])
+	}
+	cats, ok := readiness["categories"].([]any)
+	if !ok || len(cats) != 5 {
+		t.Errorf("expected 5 categories, got %v", readiness["categories"])
+	}
+}
+
+func TestReadiness_Table(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, readinessFixture())
+	})
+
+	cmd := newReadinessCmd()
+	var err error
+	out := testutil.CaptureStdout(func() { err = cmd.RunE(cmd, []string{"abc"}) })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, want := range []string{"Page readiness", "Overall:", "67/100", "Name", "Description", "Cover", "Pricing", "Social Proof", "CATEGORY", "WEIGHT", "SCORE"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("table output missing %q\nfull output:\n%s", want, out)
+		}
+	}
+}
+
+func TestReadiness_Plain(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, readinessFixture())
+	})
+
+	cmd := testutil.Command(newReadinessCmd(), testutil.PlainOutput())
+	var err error
+	out := testutil.CaptureStdout(func() { err = cmd.RunE(cmd, []string{"abc"}) })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(out, "overall\t67\tok") {
+		t.Errorf("plain output missing overall row: %q", out)
+	}
+	if !strings.Contains(out, "name\t87\tgood") {
+		t.Errorf("plain output missing name category row: %q", out)
+	}
+	if !strings.Contains(out, "social_proof\t70\tok") {
+		t.Errorf("plain output missing social_proof category row: %q", out)
+	}
+}
+
+func TestReadiness_Details(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, readinessFixture())
+	})
+
+	cmd := newReadinessCmd()
+	cmd.SetArgs([]string{"abc", "--details"})
+	if err := cmd.Flags().Parse([]string{"--details"}); err != nil {
+		t.Fatalf("flag parse error: %v", err)
+	}
+	var err error
+	out := testutil.CaptureStdout(func() { err = cmd.RunE(cmd, []string{"abc"}) })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, want := range []string{"Length 28 chars", "Contains a number", "Charm pricing applied", "42 reviews"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--details output missing %q\nfull output:\n%s", want, out)
+		}
+	}
+}
+
+func TestReadiness_RequiresID(t *testing.T) {
+	cmd := newReadinessCmd()
+	if err := cmd.Args(cmd, []string{}); err == nil {
+		t.Errorf("expected error when no id provided, got nil")
+	}
+	if err := cmd.Args(cmd, []string{"a", "b"}); err == nil {
+		t.Errorf("expected error when extra args provided, got nil")
+	}
+	if err := cmd.Args(cmd, []string{"abc"}); err != nil {
+		t.Errorf("expected no error with single id, got %v", err)
+	}
+}

--- a/internal/cmd/products/readiness_test.go
+++ b/internal/cmd/products/readiness_test.go
@@ -71,9 +71,17 @@ func TestReadiness_Table(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	for _, want := range []string{"Page readiness", "Overall:", "67/100", "Name", "Description", "Cover", "Pricing", "Social Proof", "CATEGORY", "WEIGHT", "SCORE"} {
+	for _, want := range []string{"Page readiness", "Overall:", "67/100", "Name", "Description", "Cover", "Pricing", "Social Proof", "CATEGORY", "WEIGHT", "SCORE", "POINTS", "TOTAL"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("table output missing %q\nfull output:\n%s", want, out)
+		}
+	}
+
+	// Verify POINTS column math reconciles with overall.
+	// Fixture: name 87×0.15=13, description 50×0.30=15, cover 60×0.20=12, pricing 85×0.15=13, social 70×0.20=14 → 67 (rounded sum).
+	for _, points := range []string{"13", "15", "12", "14"} {
+		if !strings.Contains(out, points) {
+			t.Errorf("table output missing weighted points value %q\nfull output:\n%s", points, out)
 		}
 	}
 }


### PR DESCRIPTION
## What

Adds a `gumroad products readiness <id>` subcommand that fetches and renders the readiness score for a product page.

- New file `internal/cmd/products/readiness.go` (~135 LOC): a `cobra.Command` mirroring the `view.go` pattern — `cmdutil.ExactArgs(1)` for the product id, `cmdutil.RunRequest` for the GET, and a render callback that handles plain and human (table) modes. JSON and JQ paths are handled automatically by the runner.
- Default render is a colored table: `CATEGORY | WEIGHT | SCORE | SEVERITY | NOTE`, with category severity bands (`good` / `ok` / `weak` / `missing`) mapped to green/yellow/red the same way the in-app panel will.
- `--details` flag adds a bullet list per category with the human-readable explanations the server returned (e.g. "Length 28 chars — short, target 30-60").
- Registered in `products.go` next to `view`. Help and examples updated.
- 5 new tests in `internal/cmd/products/readiness_test.go`: JSON output shape, table content, plain (tab-separated) output, `--details` rendering, and arg validation. All green.

## Why

This is the CLI half of the page-readiness feature being built across antiwork/gumroad and antiwork/gumroad-cli. The architecture (locked in on antiwork/gumroad#4932): Rails owns the deterministic scoring authority, and any consumer — the in-app panel, the CLI, the agent skill — is a thin client to the same `GET /v2/products/:id/readiness` endpoint. This PR is the CLI client.

Why a thin client (no LLM here): the deterministic score is the source of truth. AI grading happens in the seller's own coding agent (Claude Code, Codex, OpenCode), which sees the JSON output of this command via `--json` or `--jq` and applies its own sub-rules using the seller's LLM. That keeps Gumroad off the OpEx hook and the CLI fast, predictable, and offline-friendly.

Why mirror `view.go` instead of inventing a new pattern: the cmdutil/output pipeline gives us auth, spinners, dry-run, JSON, JQ, plain, and table modes for free. Following the precedent means this command behaves consistently with every other read in the CLI.

## Dependency

Requires the endpoint added in **antiwork/gumroad#4934**. That PR is currently in review. This CLI PR can land independently — the subcommand will return a 404 against the upstream API until #4934 deploys, which is the same behavior as any other client of an unreleased endpoint.

## Sequencing

This is part of a planned 4-PR feature spanning two repos:

1. **antiwork/gumroad#4934** — Rails backend (the endpoint and deterministic scorer). In review.
2. **antiwork/gumroad** — In-app panel. After PR-1 merges.
3. **This PR** — CLI subcommand. Independent; can land in any order relative to PR-2.
4. **antiwork/gumroad-cli** — Skill update (`skills/gumroad/SKILL.md` "Page readiness scoring" section) so the seller's coding agent knows to call this command and apply AI-graded sub-rules. After this PR merges.

## Before/After

Walkthrough recorded against a local Rails (with antiwork/gumroad#4934 applied) — table render with the new POINTS column and TOTAL row, then `--plain`, `--json`, `--jq`, and `--details`.

https://github.com/user-attachments/assets/32367dd1-e007-4842-b16b-6eeed2423c03

```
$ gumroad products readiness fEGTaEpuKDsnDvf_MfecTA==
Page readiness
Overall: 15/100  (Weak)

CATEGORY      WEIGHT  SCORE  SEVERITY  NOTE
Name          15%     27     missing   Vague — add specificity
Description   30%     1      missing   Lacks structure or specifics
Cover         20%     0      missing   No cover uploaded
Pricing       15%     70     ok        Decent
Social Proof  20%     0      missing   No reviews yet

$ gumroad products readiness fEGTaEpuKDsnDvf_MfecTA== --jq '.readiness.overall'
15

$ gumroad products readiness fEGTaEpuKDsnDvf_MfecTA== --plain
overall    15    missing
name       27    missing    Vague — add specificity
...
```

## Test Results

```
$ make test
ok      github.com/antiwork/gumroad-cli/internal/cmd/products    1.234s
... (all packages green) ...

$ ~/go/bin/golangci-lint run ./internal/cmd/products/
(exit 0, no issues)

$ gofmt -l internal/cmd/products/readiness*.go
(empty — clean)

$ go vet ./internal/cmd/products/
(no issues)
```

5 new tests added in `readiness_test.go`:

- `TestReadiness_JSON` — verifies JSON output shape and category count.
- `TestReadiness_Table` — verifies the human-readable table contains overall, category labels, and headers.
- `TestReadiness_Plain` — verifies tab-separated output is parseable for piping.
- `TestReadiness_Details` — verifies `--details` flag surfaces the per-category detail bullets.
- `TestReadiness_RequiresID` — verifies cobra arg validation.

## QA steps

1. Build: `make build` produces `./gumroad`.
2. Set env (against your local Rails or a deploy with antiwork/gumroad#4934 applied):
   ```
   export GUMROAD_API_BASE_URL=https://gumroad.dev/v2
   export GUMROAD_ACCESS_TOKEN=<your-token>
   export GUMROAD_INSECURE=1   # only for self-signed local dev
   ```
3. Activate the feature flag for your seller (server-side, in Rails console): `Feature.activate_user(:product_readiness_score, seller)`.
4. Run: `./gumroad products readiness <product_external_id>` — expect a colored table.
5. Try `--plain`, `--json`, `--jq '.readiness.overall'`, and `--details` to verify all output modes.
6. Without the flag activated, expect `Error: ... not enabled for this account` — this is correct behavior since the endpoint guards on the flag.


---

AI disclosure: implemented with Claude Opus 4.7 (1M context). Prompts: study the existing `internal/cmd/products/view.go` pattern + the `cmdutil.RunRequest` pipeline, mirror that structure for the new endpoint, then write tests and run the full suite. The renderer (table + plain + details) followed the conventions in `internal/cmd/products/list.go`.

