### PR TITLE
Document products readiness in the gumroad skill

### DIFF
--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -10,7 +10,10 @@ description: >
   "refund a sale", "create a product", "upload a file", "attach a file to a product",
   "finish a failed upload", "abort an upload", "manage webhooks",
   "check my earnings", "see my revenue", "who subscribed", "manage my store",
-  "discount code", "coupon", "shipping status", "payout schedule", or any
+  "discount code", "coupon", "shipping status", "payout schedule",
+  "improve my product page", "review my listing", "score my product",
+  "make my product convert better", "get feedback on a product",
+  "rate my product page", "is my product page good", or any
   request to query or act on Gumroad data — even if the user doesn't say
   "Gumroad" explicitly but is clearly referring to their creator store or
   digital product sales.
@@ -84,6 +87,10 @@ gumroad products list --json --no-input
 
 # View a product
 gumroad products view <id> --json --no-input
+
+# Score a product page across 5 weighted dimensions (deterministic, no LLM)
+gumroad products readiness <id> --json --no-input
+gumroad products readiness <id> --jq '.readiness | {overall, weak: [.categories[] | select(.score < 60) | .key]}' --no-input
 
 # Create a product (created as draft)
 gumroad products create --name "Art Pack" --price 10.00 --json --no-input
@@ -273,6 +280,39 @@ gumroad webhooks create --resource sale --url https://example.com/hook --json --
 # Delete
 gumroad webhooks delete <id> --yes --json --no-input
 ```
+
+## Page readiness scoring
+
+When the user asks to **improve a product page**, **review their listing**, **make their product convert better**, **get feedback on a product**, or anything similar, run `gumroad products readiness <id> --json` first. The endpoint returns a deterministic score across five weighted dimensions:
+
+| Category | Weight | Server-side rubric |
+|---|---:|---|
+| `name` | 15% | Length 30-60 chars, has digit, contains action verb |
+| `description` | 30% | Word count 200-800, has list, has heading, FAQ, "for X who Y" phrasing |
+| `cover` | 20% | At least one cover, multiple covers bonus, video preview bonus |
+| `pricing` | 15% | Priced (not free), 2+ variants, charm pricing ($X.99/$X.97/$X9) |
+| `social_proof` | 20% | log10-scaled review count + bucketed avg rating, ×0.7 if hidden |
+
+The deterministic score is your floor. **Layer your own AI judgment on top** for the categories that benefit from it — name, description, and cover — using the seller's product data:
+
+```sh
+# Get the deterministic score
+gumroad products readiness <id> --json --no-input > /tmp/readiness.json
+
+# Get the underlying product data
+gumroad products view <id> --json --no-input > /tmp/product.json
+```
+
+Then apply these sub-rubrics with your LLM judgment:
+
+- **Name** (when score < 80): is the name evocative, specific, and outcome-oriented? Generic names like "Photoshop course" score lower than "Master Lightroom in 14 days for first-time wedding photographers" even at the same length.
+- **Description** (when score < 80): does it lead with a clear value proposition, name the audience, and include concrete deliverables? Length and structure are deterministic; voice and clarity need LLM judgment.
+- **Cover** (when score < 80): the deterministic check only knows count and presence of video. You can't grade image content from the JSON — suggest the seller upload a higher-contrast cover, or call out if the existing cover URL would benefit from a redesign.
+- **Pricing**, **social_proof**: skip LLM grading. The deterministic score captures everything useful.
+
+Surface results as **prioritized actions**, not raw scores. Pick the 2-3 lowest-scoring categories and propose concrete, specific changes the seller can make in `gumroad products update` or in the dashboard. Always show the current score next to each suggestion so the seller sees the gap.
+
+Don't run readiness against products the user hasn't asked about, and don't auto-apply rewrites — propose changes and let the seller approve before calling `gumroad products update`.
 
 ## Tips
 


### PR DESCRIPTION
## What

Extends `skills/gumroad/SKILL.md` so coding agents (Claude Code, Codex, OpenCode, anything reading the skill) know about the new `gumroad products readiness <id>` subcommand and can layer their own AI-graded sub-rules on top of the deterministic score.

Three changes in one file (~41 lines added):

1. **Frontmatter trigger phrases** — adds page-readiness phrasings (\"improve my product page\", \"review my listing\", \"score my product\", \"make my product convert better\", \"get feedback on a product\", \"rate my product page\", \"is my product page good\") so the skill activates on intent rather than requiring the user to know the subcommand exists.

2. **`products` section** — adds a one-liner for `gumroad products readiness <id>` next to `view`, plus a typical agent-facing `--jq` filter that picks out categories scoring below the \"ok\" threshold.

3. **New `## Page readiness scoring` section** — documents the deterministic rubric (5 weighted dimensions with point allocations) and tells the agent exactly how to layer its own LLM judgment on top:
   - For `name`, `description`, `cover` (when score < 80): apply LLM critique on top of the deterministic check (specific to what each category benefits from)
   - For `pricing`, `social_proof`: skip LLM grading, the deterministic check captures everything useful
   - Surface results as **prioritized actions**, not raw scores
   - Don't auto-apply rewrites — propose, then call `gumroad products update` only after seller approval

## Why

The page-readiness feature is being shipped across a few PRs (see #62 for the CLI subcommand, antiwork/gumroad#4934 for the Rails endpoint). The CLI subcommand prints a deterministic score across 5 weighted dimensions, but the deterministic score is only the floor — the higher-leverage feedback (\"is the description voicy and audience-targeted?\", \"does the name evoke a specific outcome?\") needs a language model.

Rather than build that LLM grading server-side and pay the OpEx, the architecture (decided in antiwork/gumroad#4932) keeps AI judgment on the seller's side: the seller's coding agent has its own LLM credentials, sees the deterministic score via the CLI, and applies its own sub-rubric. This skill update is what teaches the agent how to do that.

The skill update ships via the existing `gumroad skill` install flow — once a seller updates their gumroad-cli binary and re-runs `gumroad skill`, every supported agent harness (Claude Code, Codex, OpenCode, plus the universal `~/.agents/` location) picks up the new content automatically. No new distribution channel.

## Dependency

The skill references `gumroad products readiness <id>`, which is added in **#62** (the CLI subcommand PR). This skill PR is mechanically independent — git-wise it touches only `skills/gumroad/SKILL.md` and #62 touches only `internal/cmd/products/*` + `README.md` — but logically it depends on #62 landing first. Until #62 merges, the skill content is accurate but the subcommand it references won't exist on a binary built from main.

Suggested merge order: **#62 first, then this PR**. Reviewers can also approve in parallel since the diffs don't conflict.

## Before/After

Walkthrough recorded against a local Rails (with antiwork/gumroad#4934 + #62 applied). Shows a fresh Claude Code session triggering the new `## Page readiness scoring` section on intent ("improve my product page for…"), running `gumroad products readiness <id>` + `gumroad products view <id>`, then surfacing prioritized actions with concrete `gumroad products update` commands ready for the seller to approve.

https://github.com/user-attachments/assets/b5834223-399a-4e76-831a-03bd6d598d56


## Test Results

```
$ go test ./...
... (all packages green) ...

$ ~/go/bin/golangci-lint run
(exit 0, no issues)

$ gofmt -l skills/
(empty — clean)
```

The change is markdown-only, so no Go tests directly exercise it. `make test` continues to pass since the `skills/` package only embeds the file; the embed test verifies the file is non-empty and parseable, which it remains.

## QA steps

1. Build: `make build` produces `./gumroad`.
2. Install the skill to your agent's location:
   ```sh
   gumroad skill > ~/.claude/skills/gumroad/SKILL.md
   # or for OpenCode:
   gumroad skill > ~/.opencode/skills/gumroad/SKILL.md
   # or for Codex:
   gumroad skill > ~/.codex/skills/gumroad/SKILL.md
   ```
3. Start a fresh Claude Code (or Codex / OpenCode) session.
4. Ask: \"improve my product page for <product_name>\" or \"score my product page\".
5. Verify the agent: (a) recognizes the intent, (b) calls `gumroad products readiness <id> --json --no-input`, (c) calls `gumroad products view <id>` for context, (d) returns prioritized actions with concrete `gumroad products update` commands ready for the seller to approve, (e) does NOT auto-apply rewrites.

---

AI disclosure: implemented with Claude Opus 4.7 (1M context). Prompts: extend the existing skill format with a Page readiness scoring section that mirrors the rest of the file's conventions; add trigger phrases that surface the skill on intent; tell the agent which categories benefit from LLM judgment vs. which to skip. Tested by triggering the skill end-to-end against a local Rails — the agent correctly fetched the score, applied the sub-rubric for description and name, and surfaced prioritized actions.
