### PR TITLE
Add admin payouts edge-case commands: issue, scheduled list/execute/cancel

### DIFF
--- a/internal/cmd/admin/payouts/issue.go
+++ b/internal/cmd/admin/payouts/issue.go
@@ -1,0 +1,205 @@
+package payouts
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/antiwork/gumroad-cli/internal/adminapi"
+	"github.com/antiwork/gumroad-cli/internal/admincmd"
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+type issueRequest struct {
+	Email                string `json:"email"`
+	PayoutProcessor      string `json:"payout_processor"`
+	PayoutPeriodEndDate  string `json:"payout_period_end_date"`
+	ShouldSplitTheAmount bool   `json:"should_split_the_amount,omitempty"`
+}
+
+type issueResponse struct {
+	Success bool        `json:"success"`
+	Message string      `json:"message"`
+	Payout  issuePayout `json:"payout"`
+}
+
+type issuePayout struct {
+	ExternalID  string      `json:"external_id"`
+	AmountCents api.JSONInt `json:"amount_cents"`
+	Currency    string      `json:"currency"`
+	State       string      `json:"state"`
+	Processor   string      `json:"processor"`
+}
+
+func newIssueCmd() *cobra.Command {
+	var (
+		email     string
+		through   string
+		processor string
+		split     bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "issue",
+		Short: "Issue a manual payout for a seller",
+		Long: `Issue a manual payout for a seller through Stripe or PayPal.
+
+The --through date is the payout period end date and must be in the past
+(YYYY-MM-DD). --split is only valid with --processor paypal and asks the
+server to split the payout amount across multiple PayPal transfers.
+
+This moves money. --yes is required.`,
+		Example: `  gumroad admin payouts issue --email seller@example.com --through 2026-04-30 --processor stripe --yes
+  gumroad admin payouts issue --email seller@example.com --through 2026-04-30 --processor paypal --split --yes`,
+		Args: cmdutil.ExactArgs(0),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			if email == "" {
+				return cmdutil.MissingFlagError(c, "--email")
+			}
+			if through == "" {
+				return cmdutil.MissingFlagError(c, "--through")
+			}
+			if processor == "" {
+				return cmdutil.MissingFlagError(c, "--processor")
+			}
+			if err := cmdutil.RequireDateFlag(c, "through", through); err != nil {
+				return err
+			}
+			normalizedProcessor := strings.ToLower(strings.TrimSpace(processor))
+			if normalizedProcessor != "stripe" && normalizedProcessor != "paypal" {
+				return cmdutil.UsageErrorf(c, "--processor must be one of: stripe, paypal")
+			}
+			if split && normalizedProcessor != "paypal" {
+				return cmdutil.UsageErrorf(c, "--split requires --processor paypal")
+			}
+			if t, err := time.Parse("2006-01-02", through); err == nil {
+				if !t.Before(time.Now().UTC().Truncate(24 * time.Hour)) {
+					return cmdutil.UsageErrorf(c, "--through must be a date in the past")
+				}
+			}
+
+			req := issueRequest{
+				Email:                email,
+				PayoutProcessor:      normalizedProcessor,
+				PayoutPeriodEndDate:  through,
+				ShouldSplitTheAmount: split,
+			}
+
+			confirmMsg := "Issue manual " + normalizedProcessor + " payout for " + email + " through " + through + "? This moves money."
+			ok, err := cmdutil.ConfirmAction(opts, confirmMsg)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return cmdutil.PrintCancelledAction(opts, "issue payout for "+email, email)
+			}
+
+			path := "payouts/issue"
+
+			if opts.DryRun {
+				return cmdutil.PrintDryRunRequest(opts, http.MethodPost, adminapi.AdminPath(path), issueDryRunParams(req))
+			}
+
+			data, err := admincmd.FetchPostJSON(opts, "Issuing payout...", path, req)
+			if err != nil {
+				return err
+			}
+
+			if opts.UsesJSONOutput() {
+				return cmdutil.PrintJSONResponse(opts, data)
+			}
+
+			decoded, err := cmdutil.DecodeJSON[issueResponse](data)
+			if err != nil {
+				return err
+			}
+			return renderIssue(opts, email, decoded)
+		},
+	}
+
+	cmd.Flags().StringVar(&email, "email", "", "Seller email (required)")
+	cmd.Flags().StringVar(&through, "through", "", "Payout period end date in YYYY-MM-DD (required, must be in the past)")
+	cmd.Flags().StringVar(&processor, "processor", "", "Payout processor: stripe or paypal (required)")
+	cmd.Flags().BoolVar(&split, "split", false, "Split the amount across multiple PayPal transfers (paypal only)")
+
+	return cmd
+}
+
+func issueDryRunParams(req issueRequest) url.Values {
+	params := url.Values{}
+	params.Set("email", req.Email)
+	params.Set("payout_processor", req.PayoutProcessor)
+	params.Set("payout_period_end_date", req.PayoutPeriodEndDate)
+	if req.ShouldSplitTheAmount {
+		params.Set("should_split_the_amount", "true")
+	}
+	return params
+}
+
+func renderIssue(opts cmdutil.Options, email string, resp issueResponse) error {
+	headline := fallbackStr(resp.Message, "Issued payout for "+email)
+
+	if opts.PlainOutput {
+		return output.PrintPlain(opts.Out(), [][]string{{
+			"true",
+			headline,
+			email,
+			resp.Payout.ExternalID,
+			formatIssueAmount(resp.Payout),
+			resp.Payout.State,
+			resp.Payout.Processor,
+		}})
+	}
+
+	if opts.Quiet {
+		return nil
+	}
+
+	style := opts.Style()
+	if err := output.Writeln(opts.Out(), style.Green(headline)); err != nil {
+		return err
+	}
+	if resp.Payout.ExternalID != "" {
+		if err := output.Writef(opts.Out(), "Payout ID: %s\n", resp.Payout.ExternalID); err != nil {
+			return err
+		}
+	}
+	if amount := formatIssueAmount(resp.Payout); amount != "" {
+		if err := output.Writef(opts.Out(), "Amount: %s\n", amount); err != nil {
+			return err
+		}
+	}
+	if resp.Payout.State != "" {
+		if err := output.Writef(opts.Out(), "State: %s\n", resp.Payout.State); err != nil {
+			return err
+		}
+	}
+	if resp.Payout.Processor != "" {
+		return output.Writef(opts.Out(), "Processor: %s\n", resp.Payout.Processor)
+	}
+	return nil
+}
+
+func formatIssueAmount(p issuePayout) string {
+	if p.AmountCents == 0 && p.Currency == "" {
+		return ""
+	}
+	currency := strings.TrimSpace(p.Currency)
+	if currency == "" {
+		return fmt.Sprintf("%d cents", p.AmountCents)
+	}
+	return fmt.Sprintf("%d %s cents", p.AmountCents, strings.ToUpper(currency))
+}
+
+func fallbackStr(value, alt string) string {
+	if value == "" {
+		return alt
+	}
+	return value
+}

--- a/internal/cmd/admin/payouts/issue_test.go
+++ b/internal/cmd/admin/payouts/issue_test.go
@@ -192,6 +192,60 @@ func TestIssue_JSONPreservesResponse(t *testing.T) {
 	}
 }
 
+func TestIssue_PlainOutput(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"success": true,
+			"payout": map[string]any{
+				"external_id":  "pay_abc",
+				"amount_cents": 5000,
+				"currency":     "usd",
+				"state":        "processing",
+				"processor":    "stripe",
+			},
+		})
+	})
+
+	cmd := testutil.Command(newIssueCmd(), testutil.Yes(true), testutil.PlainOutput())
+	cmd.SetArgs([]string{"--email", "seller@example.com", "--through", "2020-01-01", "--processor", "stripe"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "pay_abc") || !strings.Contains(out, "5000 USD cents") || !strings.Contains(out, "processing") {
+		t.Errorf("unexpected plain output: %q", out)
+	}
+}
+
+func TestIssue_RendersAmountWithoutCurrency(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"success": true,
+			"payout":  map[string]any{"external_id": "pay_abc", "amount_cents": 5000, "state": "processing"},
+		})
+	})
+
+	cmd := testutil.Command(newIssueCmd(), testutil.Yes(true), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--email", "seller@example.com", "--through", "2020-01-01", "--processor", "stripe"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "5000 cents") {
+		t.Errorf("expected currency-less amount formatting: %q", out)
+	}
+}
+
+func TestIssue_CancelledByUser(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not POST when user declines")
+	})
+
+	cmd := testutil.Command(newIssueCmd(), testutil.NoInput(true), testutil.DryRun(false))
+	cmd.SetArgs([]string{"--email", "seller@example.com", "--through", "2020-01-01", "--processor", "stripe"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected confirmation-required error without --yes")
+	}
+}
+
 func TestIssue_DryRunDoesNotContactEndpoint(t *testing.T) {
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
 		t.Error("dry-run must not POST to the issue endpoint")

--- a/internal/cmd/admin/payouts/issue_test.go
+++ b/internal/cmd/admin/payouts/issue_test.go
@@ -1,0 +1,209 @@
+package payouts
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestIssue_RequiresEmail(t *testing.T) {
+	cmd := newIssueCmd()
+	cmd.SetArgs([]string{"--through", "2020-01-01", "--processor", "stripe"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected missing email error")
+	}
+	if !strings.Contains(err.Error(), "missing required flag: --email") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestIssue_RequiresThrough(t *testing.T) {
+	cmd := newIssueCmd()
+	cmd.SetArgs([]string{"--email", "seller@example.com", "--processor", "stripe"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--through") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestIssue_RequiresProcessor(t *testing.T) {
+	cmd := newIssueCmd()
+	cmd.SetArgs([]string{"--email", "seller@example.com", "--through", "2020-01-01"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--processor") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestIssue_RejectsInvalidProcessor(t *testing.T) {
+	cmd := newIssueCmd()
+	cmd.SetArgs([]string{"--email", "seller@example.com", "--through", "2020-01-01", "--processor", "wire"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "stripe") {
+		t.Fatalf("expected processor validation error, got %v", err)
+	}
+}
+
+func TestIssue_SplitRequiresPaypal(t *testing.T) {
+	cmd := newIssueCmd()
+	cmd.SetArgs([]string{"--email", "seller@example.com", "--through", "2020-01-01", "--processor", "stripe", "--split"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected --split + stripe to fail client-side")
+	}
+	if !strings.Contains(err.Error(), "--split requires --processor paypal") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestIssue_RejectsFutureThrough(t *testing.T) {
+	cmd := newIssueCmd()
+	cmd.SetArgs([]string{"--email", "seller@example.com", "--through", "2099-01-01", "--processor", "stripe"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "past") {
+		t.Fatalf("expected past-date error, got %v", err)
+	}
+}
+
+func TestIssue_RejectsBadDateFormat(t *testing.T) {
+	cmd := newIssueCmd()
+	cmd.SetArgs([]string{"--email", "seller@example.com", "--through", "04/30/2026", "--processor", "stripe"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "YYYY-MM-DD") {
+		t.Fatalf("expected date format error, got %v", err)
+	}
+}
+
+func TestIssue_RequiresConfirmation(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API without confirmation")
+	})
+
+	cmd := testutil.Command(newIssueCmd(), testutil.NoInput(true))
+	cmd.SetArgs([]string{"--email", "seller@example.com", "--through", "2020-01-01", "--processor", "stripe"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error without --yes and --no-input")
+	}
+	if !strings.Contains(err.Error(), "--yes") {
+		t.Errorf("error should mention --yes: %v", err)
+	}
+}
+
+func TestIssue_SendsRequestAndShowsResult(t *testing.T) {
+	var gotMethod, gotPath, gotAuth string
+	var body issueRequest
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if err := json.Unmarshal(raw, &body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		testutil.JSON(t, w, map[string]any{
+			"success": true,
+			"payout": map[string]any{
+				"external_id":  "pay_abc",
+				"amount_cents": 5000,
+				"currency":     "usd",
+				"state":        "processing",
+				"processor":    "PAYPAL",
+			},
+		})
+	})
+
+	cmd := testutil.Command(newIssueCmd(), testutil.Yes(true), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--email", "seller@example.com", "--through", "2020-01-01", "--processor", "PayPal", "--split"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != "POST" || gotPath != "/internal/admin/payouts/issue" {
+		t.Fatalf("got %s %s, want POST /internal/admin/payouts/issue", gotMethod, gotPath)
+	}
+	if gotAuth != "Bearer admin-token" {
+		t.Fatalf("got auth %q, want Bearer admin-token", gotAuth)
+	}
+	if body.Email != "seller@example.com" || body.PayoutProcessor != "paypal" || body.PayoutPeriodEndDate != "2020-01-01" || !body.ShouldSplitTheAmount {
+		t.Fatalf("unexpected body: %+v", body)
+	}
+	for _, want := range []string{"pay_abc", "5000 USD cents", "processing"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in output: %q", want, out)
+		}
+	}
+}
+
+func TestIssue_ServerErrorSurfacesMessageAndNonZeroExit(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"success": false,
+			"message": "No payment was created",
+		})
+	})
+
+	cmd := testutil.Command(newIssueCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"--email", "seller@example.com", "--through", "2020-01-01", "--processor", "stripe"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected server error to surface")
+	}
+	if !strings.Contains(err.Error(), "No payment was created") {
+		t.Errorf("missing underlying message: %v", err)
+	}
+}
+
+func TestIssue_JSONPreservesResponse(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"success": true,
+			"payout":  map[string]any{"external_id": "pay_abc", "amount_cents": 5000},
+		})
+	})
+
+	cmd := testutil.Command(newIssueCmd(), testutil.Yes(true), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--email", "seller@example.com", "--through", "2020-01-01", "--processor", "stripe"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp issueResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if !resp.Success || resp.Payout.ExternalID != "pay_abc" {
+		t.Fatalf("unexpected JSON payload: %s", out)
+	}
+}
+
+func TestIssue_DryRunDoesNotContactEndpoint(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("dry-run must not POST to the issue endpoint")
+	})
+
+	cmd := testutil.Command(newIssueCmd(), testutil.DryRun(true), testutil.NoInput(true))
+	cmd.SetArgs([]string{"--email", "seller@example.com", "--through", "2020-01-01", "--processor", "paypal", "--split"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	for _, want := range []string{"POST", "/internal/admin/payouts/issue", "email: seller@example.com", "payout_processor: paypal", "payout_period_end_date: 2020-01-01", "should_split_the_amount: true"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("dry-run output missing %q: %q", want, out)
+		}
+	}
+}

--- a/internal/cmd/admin/payouts/payouts.go
+++ b/internal/cmd/admin/payouts/payouts.go
@@ -9,12 +9,16 @@ func NewPayoutsCmd() *cobra.Command {
 		Example: `  gumroad admin payouts list --email seller@example.com
   gumroad admin payouts list --email seller@example.com --json
   gumroad admin payouts pause --email seller@example.com --reason "Verification pending"
-  gumroad admin payouts resume --email seller@example.com`,
+  gumroad admin payouts resume --email seller@example.com
+  gumroad admin payouts issue --email seller@example.com --through 2026-04-30 --processor stripe --yes
+  gumroad admin payouts scheduled list --status flagged`,
 	}
 
 	cmd.AddCommand(newListCmd())
 	cmd.AddCommand(newPauseCmd())
 	cmd.AddCommand(newResumeCmd())
+	cmd.AddCommand(newIssueCmd())
+	cmd.AddCommand(newScheduledCmd())
 
 	return cmd
 }

--- a/internal/cmd/admin/payouts/payouts_test.go
+++ b/internal/cmd/admin/payouts/payouts_test.go
@@ -150,7 +150,7 @@ func TestNewPayoutsCmdWiresAllSubcommands(t *testing.T) {
 	if cmd.Use != "payouts" {
 		t.Fatalf("Use = %q, want payouts", cmd.Use)
 	}
-	want := map[string]bool{"list": false, "pause": false, "resume": false}
+	want := map[string]bool{"list": false, "pause": false, "resume": false, "issue": false, "scheduled": false}
 	for _, sub := range cmd.Commands() {
 		if _, ok := want[sub.Use]; !ok {
 			t.Fatalf("unexpected subcommand %q", sub.Use)

--- a/internal/cmd/admin/payouts/scheduled.go
+++ b/internal/cmd/admin/payouts/scheduled.go
@@ -1,0 +1,28 @@
+package payouts
+
+import "github.com/spf13/cobra"
+
+func newScheduledCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "scheduled",
+		Short: "Inspect and act on ScheduledPayout records",
+		Example: `  gumroad admin payouts scheduled list
+  gumroad admin payouts scheduled list --status flagged
+  gumroad admin payouts scheduled execute pay_abc123 --yes
+  gumroad admin payouts scheduled cancel pay_abc123`,
+	}
+
+	cmd.AddCommand(newScheduledListCmd())
+	cmd.AddCommand(newScheduledExecuteCmd())
+	cmd.AddCommand(newScheduledCancelCmd())
+
+	return cmd
+}
+
+var validScheduledStatuses = map[string]struct{}{
+	"pending":   {},
+	"executed":  {},
+	"cancelled": {},
+	"flagged":   {},
+	"held":      {},
+}

--- a/internal/cmd/admin/payouts/scheduled_cancel.go
+++ b/internal/cmd/admin/payouts/scheduled_cancel.go
@@ -1,0 +1,86 @@
+package payouts
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/antiwork/gumroad-cli/internal/adminapi"
+	"github.com/antiwork/gumroad-cli/internal/admincmd"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+type scheduledCancelResponse struct {
+	Success         bool            `json:"success"`
+	Message         string          `json:"message"`
+	ScheduledPayout scheduledPayout `json:"scheduled_payout"`
+}
+
+func newScheduledCancelCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cancel <external_id>",
+		Short: "Cancel a scheduled payout",
+		Example: `  gumroad admin payouts scheduled cancel pay_abc123
+  gumroad admin payouts scheduled cancel pay_abc123 --yes`,
+		Args: cmdutil.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			id := args[0]
+
+			path := cmdutil.JoinPath("payouts", id, "scheduled_cancel")
+
+			ok, err := cmdutil.ConfirmAction(opts, "Cancel scheduled payout "+id+"?")
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return cmdutil.PrintCancelledAction(opts, "cancel scheduled payout "+id, id)
+			}
+
+			if opts.DryRun {
+				return cmdutil.PrintDryRunRequest(opts, http.MethodPost, adminapi.AdminPath(path), url.Values{})
+			}
+
+			data, err := admincmd.FetchPostJSON(opts, "Cancelling scheduled payout...", path, struct{}{})
+			if err != nil {
+				return err
+			}
+
+			if opts.UsesJSONOutput() {
+				return cmdutil.PrintJSONResponse(opts, data)
+			}
+
+			decoded, err := cmdutil.DecodeJSON[scheduledCancelResponse](data)
+			if err != nil {
+				return err
+			}
+			return renderScheduledCancel(opts, id, decoded)
+		},
+	}
+
+	return cmd
+}
+
+func renderScheduledCancel(opts cmdutil.Options, id string, resp scheduledCancelResponse) error {
+	headline := fallbackStr(resp.Message, "Cancelled scheduled payout "+id)
+
+	if opts.PlainOutput {
+		return output.PrintPlain(opts.Out(), [][]string{{
+			"true", headline, id, resp.ScheduledPayout.Status,
+		}})
+	}
+
+	if opts.Quiet {
+		return nil
+	}
+
+	style := opts.Style()
+	if err := output.Writeln(opts.Out(), style.Green(headline)); err != nil {
+		return err
+	}
+	if resp.ScheduledPayout.Status != "" {
+		return output.Writef(opts.Out(), "Status: %s\n", resp.ScheduledPayout.Status)
+	}
+	return nil
+}

--- a/internal/cmd/admin/payouts/scheduled_execute.go
+++ b/internal/cmd/admin/payouts/scheduled_execute.go
@@ -1,0 +1,96 @@
+package payouts
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/antiwork/gumroad-cli/internal/adminapi"
+	"github.com/antiwork/gumroad-cli/internal/admincmd"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+type scheduledExecuteResponse struct {
+	Success         bool            `json:"success"`
+	Result          string          `json:"result"`
+	Message         string          `json:"message"`
+	ScheduledPayout scheduledPayout `json:"scheduled_payout"`
+}
+
+func newScheduledExecuteCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "execute <external_id>",
+		Short: "Execute a pending or flagged scheduled payout",
+		Long: `Execute a ScheduledPayout by its external id. Only pending or flagged rows
+can be executed. The server may return a result of executed, held, or flagged.
+
+This moves money. --yes is required.`,
+		Example: `  gumroad admin payouts scheduled execute pay_abc123 --yes
+  gumroad admin payouts scheduled execute pay_abc123 --yes --json`,
+		Args: cmdutil.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			id := args[0]
+
+			path := cmdutil.JoinPath("payouts", id, "scheduled_execute")
+
+			ok, err := cmdutil.ConfirmAction(opts, "Execute scheduled payout "+id+"? This moves money.")
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return cmdutil.PrintCancelledAction(opts, "execute scheduled payout "+id, id)
+			}
+
+			if opts.DryRun {
+				return cmdutil.PrintDryRunRequest(opts, http.MethodPost, adminapi.AdminPath(path), url.Values{})
+			}
+
+			data, err := admincmd.FetchPostJSON(opts, "Executing scheduled payout...", path, struct{}{})
+			if err != nil {
+				return err
+			}
+
+			if opts.UsesJSONOutput() {
+				return cmdutil.PrintJSONResponse(opts, data)
+			}
+
+			decoded, err := cmdutil.DecodeJSON[scheduledExecuteResponse](data)
+			if err != nil {
+				return err
+			}
+			return renderScheduledExecute(opts, id, decoded)
+		},
+	}
+
+	return cmd
+}
+
+func renderScheduledExecute(opts cmdutil.Options, id string, resp scheduledExecuteResponse) error {
+	headline := fallbackStr(resp.Message, "Executed scheduled payout "+id)
+
+	if opts.PlainOutput {
+		return output.PrintPlain(opts.Out(), [][]string{{
+			"true", headline, id, resp.Result, resp.ScheduledPayout.Status,
+		}})
+	}
+
+	if opts.Quiet {
+		return nil
+	}
+
+	style := opts.Style()
+	if err := output.Writeln(opts.Out(), style.Green(headline)); err != nil {
+		return err
+	}
+	if resp.Result != "" {
+		if err := output.Writef(opts.Out(), "Result: %s\n", resp.Result); err != nil {
+			return err
+		}
+	}
+	if resp.ScheduledPayout.Status != "" {
+		return output.Writef(opts.Out(), "Status: %s\n", resp.ScheduledPayout.Status)
+	}
+	return nil
+}

--- a/internal/cmd/admin/payouts/scheduled_list.go
+++ b/internal/cmd/admin/payouts/scheduled_list.go
@@ -19,14 +19,25 @@ type scheduledListRequest struct {
 }
 
 type scheduledPayout struct {
-	ExternalID  string      `json:"external_id"`
-	Email       string      `json:"email"`
-	AmountCents api.JSONInt `json:"amount_cents"`
-	Currency    string      `json:"currency"`
-	Status      string      `json:"status"`
-	Processor   string      `json:"processor"`
-	ScheduledAt string      `json:"scheduled_at"`
-	CreatedAt   string      `json:"created_at"`
+	ExternalID  string                 `json:"external_id"`
+	User        scheduledPayoutUser    `json:"user"`
+	AmountCents api.JSONInt            `json:"payout_amount_cents"`
+	Status      string                 `json:"status"`
+	Action      string                 `json:"action"`
+	ScheduledAt string                 `json:"scheduled_at"`
+	ExecutedAt  string                 `json:"executed_at"`
+	CreatedAt   string                 `json:"created_at"`
+	CreatedBy   scheduledPayoutCreator `json:"created_by"`
+}
+
+type scheduledPayoutUser struct {
+	Email      string `json:"email"`
+	ExternalID string `json:"external_id"`
+	Name       string `json:"name"`
+}
+
+type scheduledPayoutCreator struct {
+	Name string `json:"name"`
 }
 
 type scheduledListResponse struct {
@@ -93,7 +104,7 @@ func renderScheduledList(opts cmdutil.Options, status string, resp scheduledList
 		rows := make([][]string, 0, len(resp.ScheduledPayouts))
 		for _, p := range resp.ScheduledPayouts {
 			rows = append(rows, []string{
-				p.ExternalID, p.Email, formatScheduledAmount(p), p.Status, p.Processor, p.ScheduledAt, p.CreatedAt,
+				p.ExternalID, p.User.Email, formatScheduledAmount(p), p.Status, p.Action, p.ScheduledAt, p.CreatedAt,
 			})
 		}
 		return output.PrintPlain(opts.Out(), rows)
@@ -123,18 +134,14 @@ func renderScheduledList(opts cmdutil.Options, status string, resp scheduledList
 			return err
 		}
 
-		tbl := output.NewStyledTable(style, "ID", "EMAIL", "AMOUNT", "STATUS", "PROCESSOR", "SCHEDULED")
+		tbl := output.NewStyledTable(style, "ID", "EMAIL", "AMOUNT", "STATUS", "ACTION", "SCHEDULED")
 		for _, p := range resp.ScheduledPayouts {
-			tbl.AddRow(p.ExternalID, p.Email, formatScheduledAmount(p), p.Status, p.Processor, p.ScheduledAt)
+			tbl.AddRow(p.ExternalID, p.User.Email, formatScheduledAmount(p), p.Status, p.Action, p.ScheduledAt)
 		}
 		return tbl.Render(w)
 	})
 }
 
 func formatScheduledAmount(p scheduledPayout) string {
-	currency := strings.TrimSpace(p.Currency)
-	if currency == "" {
-		return fmt.Sprintf("%d cents", p.AmountCents)
-	}
-	return fmt.Sprintf("%d %s cents", p.AmountCents, strings.ToUpper(currency))
+	return fmt.Sprintf("%d cents", p.AmountCents)
 }

--- a/internal/cmd/admin/payouts/scheduled_list.go
+++ b/internal/cmd/admin/payouts/scheduled_list.go
@@ -1,0 +1,140 @@
+package payouts
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/antiwork/gumroad-cli/internal/admincmd"
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+type scheduledListRequest struct {
+	Status string `json:"status,omitempty"`
+	Limit  int    `json:"limit,omitempty"`
+}
+
+type scheduledPayout struct {
+	ExternalID  string      `json:"external_id"`
+	Email       string      `json:"email"`
+	AmountCents api.JSONInt `json:"amount_cents"`
+	Currency    string      `json:"currency"`
+	Status      string      `json:"status"`
+	Processor   string      `json:"processor"`
+	ScheduledAt string      `json:"scheduled_at"`
+	CreatedAt   string      `json:"created_at"`
+}
+
+type scheduledListResponse struct {
+	ScheduledPayouts []scheduledPayout `json:"scheduled_payouts"`
+	Limit            api.JSONInt       `json:"limit"`
+}
+
+func newScheduledListCmd() *cobra.Command {
+	var (
+		status string
+		limit  int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List ScheduledPayout rows",
+		Long: `List ScheduledPayout rows. Filter by --status (pending, executed,
+cancelled, flagged, held). Default limit is 20, capped server-side at 50.`,
+		Example: `  gumroad admin payouts scheduled list
+  gumroad admin payouts scheduled list --status flagged
+  gumroad admin payouts scheduled list --status pending --limit 50 --json`,
+		Args: cmdutil.ExactArgs(0),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+
+			req := scheduledListRequest{}
+			if c.Flags().Changed("status") {
+				normalized := strings.ToLower(strings.TrimSpace(status))
+				if _, ok := validScheduledStatuses[normalized]; !ok {
+					return cmdutil.UsageErrorf(c, "--status must be one of: %s", validStatusesList())
+				}
+				req.Status = normalized
+			}
+			if c.Flags().Changed("limit") {
+				if err := cmdutil.RequirePositiveIntFlag(c, "limit", limit); err != nil {
+					return err
+				}
+				req.Limit = limit
+			}
+
+			return admincmd.RunPostJSONDecoded[scheduledListResponse](opts, "Fetching scheduled payouts...", "/payouts/scheduled_list", req, func(resp scheduledListResponse) error {
+				return renderScheduledList(opts, req.Status, resp)
+			})
+		},
+	}
+
+	cmd.Flags().StringVar(&status, "status", "", "Filter by status: pending, executed, cancelled, flagged, held")
+	cmd.Flags().IntVar(&limit, "limit", 0, "Maximum results to return (default 20, capped at 50)")
+
+	return cmd
+}
+
+func validStatusesList() string {
+	keys := make([]string, 0, len(validScheduledStatuses))
+	for k := range validScheduledStatuses {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return strings.Join(keys, ", ")
+}
+
+func renderScheduledList(opts cmdutil.Options, status string, resp scheduledListResponse) error {
+	if opts.PlainOutput {
+		rows := make([][]string, 0, len(resp.ScheduledPayouts))
+		for _, p := range resp.ScheduledPayouts {
+			rows = append(rows, []string{
+				p.ExternalID, p.Email, formatScheduledAmount(p), p.Status, p.Processor, p.ScheduledAt, p.CreatedAt,
+			})
+		}
+		return output.PrintPlain(opts.Out(), rows)
+	}
+
+	if opts.Quiet {
+		return nil
+	}
+
+	style := opts.Style()
+	return output.WithPager(opts.Out(), opts.Err(), func(w io.Writer) error {
+		if len(resp.ScheduledPayouts) == 0 {
+			if status != "" {
+				return output.Writef(w, "No scheduled payouts found for status %q.\n", status)
+			}
+			return output.Writeln(w, "No scheduled payouts found.")
+		}
+
+		headline := fmt.Sprintf("%d scheduled payout(s)", len(resp.ScheduledPayouts))
+		if status != "" {
+			headline = fmt.Sprintf("%d scheduled payout(s) with status %s", len(resp.ScheduledPayouts), status)
+		}
+		if err := output.Writeln(w, style.Bold(headline)); err != nil {
+			return err
+		}
+		if err := output.Writeln(w, ""); err != nil {
+			return err
+		}
+
+		tbl := output.NewStyledTable(style, "ID", "EMAIL", "AMOUNT", "STATUS", "PROCESSOR", "SCHEDULED")
+		for _, p := range resp.ScheduledPayouts {
+			tbl.AddRow(p.ExternalID, p.Email, formatScheduledAmount(p), p.Status, p.Processor, p.ScheduledAt)
+		}
+		return tbl.Render(w)
+	})
+}
+
+func formatScheduledAmount(p scheduledPayout) string {
+	currency := strings.TrimSpace(p.Currency)
+	if currency == "" {
+		return fmt.Sprintf("%d cents", p.AmountCents)
+	}
+	return fmt.Sprintf("%d %s cents", p.AmountCents, strings.ToUpper(currency))
+}

--- a/internal/cmd/admin/payouts/scheduled_test.go
+++ b/internal/cmd/admin/payouts/scheduled_test.go
@@ -1,0 +1,228 @@
+package payouts
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestScheduledList_Default(t *testing.T) {
+	var gotMethod, gotPath string
+	var body scheduledListRequest
+	var bodyKeys map[string]json.RawMessage
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if err := json.Unmarshal(raw, &body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if err := json.Unmarshal(raw, &bodyKeys); err != nil {
+			t.Fatalf("decode keys: %v", err)
+		}
+		testutil.JSON(t, w, map[string]any{
+			"scheduled_payouts": []map[string]any{
+				{"external_id": "pay_1", "email": "seller@example.com", "amount_cents": 1000, "currency": "usd", "status": "flagged", "processor": "stripe", "scheduled_at": "2026-05-01"},
+			},
+			"limit": 20,
+		})
+	})
+
+	cmd := testutil.Command(newScheduledListCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != "POST" || gotPath != "/internal/admin/payouts/scheduled_list" {
+		t.Fatalf("got %s %s, want POST /internal/admin/payouts/scheduled_list", gotMethod, gotPath)
+	}
+	if _, hasStatus := bodyKeys["status"]; hasStatus {
+		t.Errorf("status must be omitted when not provided, got: %v", bodyKeys)
+	}
+	if _, hasLimit := bodyKeys["limit"]; hasLimit {
+		t.Errorf("limit must be omitted when not provided, got: %v", bodyKeys)
+	}
+	for _, want := range []string{"pay_1", "flagged", "1000 USD cents"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestScheduledList_PassesStatusAndLimit(t *testing.T) {
+	var body scheduledListRequest
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		testutil.JSON(t, w, map[string]any{"scheduled_payouts": []any{}, "limit": 50})
+	})
+
+	cmd := testutil.Command(newScheduledListCmd())
+	cmd.SetArgs([]string{"--status", "FLAGGED", "--limit", "50"})
+	testutil.MustExecute(t, cmd)
+
+	if body.Status != "flagged" || body.Limit != 50 {
+		t.Fatalf("got body=%+v, want status=flagged limit=50", body)
+	}
+}
+
+func TestScheduledList_RejectsBadStatus(t *testing.T) {
+	cmd := newScheduledListCmd()
+	cmd.SetArgs([]string{"--status", "bogus"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--status must be one of") {
+		t.Fatalf("expected status validation error, got %v", err)
+	}
+}
+
+func TestScheduledList_RejectsZeroLimit(t *testing.T) {
+	cmd := newScheduledListCmd()
+	cmd.SetArgs([]string{"--limit", "0"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--limit must be greater than 0") {
+		t.Fatalf("expected limit validation error, got %v", err)
+	}
+}
+
+func TestScheduledList_EmptyStateMessage(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{"scheduled_payouts": []any{}, "limit": 20})
+	})
+
+	cmd := testutil.Command(newScheduledListCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--status", "flagged"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "No scheduled payouts found") {
+		t.Errorf("expected empty-state message, got: %q", out)
+	}
+}
+
+func TestScheduledExecute_RequiresConfirmation(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API without confirmation")
+	})
+
+	cmd := testutil.Command(newScheduledExecuteCmd(), testutil.NoInput(true))
+	cmd.SetArgs([]string{"pay_abc"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--yes") {
+		t.Fatalf("expected --yes error, got %v", err)
+	}
+}
+
+func TestScheduledExecute_HappyPath(t *testing.T) {
+	var gotMethod, gotPath string
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		testutil.JSON(t, w, map[string]any{
+			"success":          true,
+			"result":           "executed",
+			"message":          "Scheduled payout pay_abc executed",
+			"scheduled_payout": map[string]any{"external_id": "pay_abc", "status": "executed"},
+		})
+	})
+
+	cmd := testutil.Command(newScheduledExecuteCmd(), testutil.Yes(true), testutil.Quiet(false))
+	cmd.SetArgs([]string{"pay_abc"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != "POST" || gotPath != "/internal/admin/payouts/pay_abc/scheduled_execute" {
+		t.Fatalf("got %s %s", gotMethod, gotPath)
+	}
+	for _, want := range []string{"Scheduled payout pay_abc executed", "Result: executed", "Status: executed"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestScheduledExecute_ServerErrorSurfacesMessage(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"success": false,
+			"message": "Scheduled payout already executed",
+		})
+	})
+
+	cmd := testutil.Command(newScheduledExecuteCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"pay_abc"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error from 422")
+	}
+	if !strings.Contains(err.Error(), "Scheduled payout already executed") {
+		t.Errorf("missing underlying message: %v", err)
+	}
+}
+
+func TestScheduledCancel_HappyPath(t *testing.T) {
+	var gotPath string
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		testutil.JSON(t, w, map[string]any{
+			"success":          true,
+			"message":          "Cancelled",
+			"scheduled_payout": map[string]any{"external_id": "pay_abc", "status": "cancelled"},
+		})
+	})
+
+	cmd := testutil.Command(newScheduledCancelCmd(), testutil.Yes(true), testutil.Quiet(false))
+	cmd.SetArgs([]string{"pay_abc"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotPath != "/internal/admin/payouts/pay_abc/scheduled_cancel" {
+		t.Fatalf("got path %q", gotPath)
+	}
+	for _, want := range []string{"Cancelled", "Status: cancelled"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestScheduledCancel_ServerError(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"success": false,
+			"message": "Cannot cancel an executed payout",
+		})
+	})
+
+	cmd := testutil.Command(newScheduledCancelCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"pay_abc"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "Cannot cancel an executed payout") {
+		t.Fatalf("expected server message in error, got %v", err)
+	}
+}
+
+func TestScheduledCmdWiresChildren(t *testing.T) {
+	cmd := newScheduledCmd()
+	want := map[string]bool{"list": false, "execute <external_id>": false, "cancel <external_id>": false}
+	for _, sub := range cmd.Commands() {
+		if _, ok := want[sub.Use]; ok {
+			want[sub.Use] = true
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("missing subcommand %q", name)
+		}
+	}
+}

--- a/internal/cmd/admin/payouts/scheduled_test.go
+++ b/internal/cmd/admin/payouts/scheduled_test.go
@@ -30,7 +30,7 @@ func TestScheduledList_Default(t *testing.T) {
 		}
 		testutil.JSON(t, w, map[string]any{
 			"scheduled_payouts": []map[string]any{
-				{"external_id": "pay_1", "email": "seller@example.com", "amount_cents": 1000, "currency": "usd", "status": "flagged", "processor": "stripe", "scheduled_at": "2026-05-01"},
+				{"external_id": "pay_1", "user": map[string]any{"email": "seller@example.com"}, "payout_amount_cents": 1000, "status": "flagged", "action": "payout", "scheduled_at": "2026-05-01"},
 			},
 			"limit": 20,
 		})
@@ -49,7 +49,7 @@ func TestScheduledList_Default(t *testing.T) {
 	if _, hasLimit := bodyKeys["limit"]; hasLimit {
 		t.Errorf("limit must be omitted when not provided, got: %v", bodyKeys)
 	}
-	for _, want := range []string{"pay_1", "flagged", "1000 USD cents"} {
+	for _, want := range []string{"pay_1", "flagged", "1000 cents"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("output missing %q: %q", want, out)
 		}
@@ -216,7 +216,7 @@ func TestScheduledList_PlainOutput(t *testing.T) {
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
 		testutil.JSON(t, w, map[string]any{
 			"scheduled_payouts": []map[string]any{
-				{"external_id": "pay_1", "email": "seller@example.com", "amount_cents": 1000, "status": "flagged", "processor": "stripe", "scheduled_at": "2026-05-01", "created_at": "2026-04-30"},
+				{"external_id": "pay_1", "user": map[string]any{"email": "seller@example.com"}, "payout_amount_cents": 1000, "status": "flagged", "action": "payout", "scheduled_at": "2026-05-01", "created_at": "2026-04-30"},
 			},
 		})
 	})
@@ -225,7 +225,7 @@ func TestScheduledList_PlainOutput(t *testing.T) {
 	cmd.SetArgs([]string{})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	want := "pay_1\tseller@example.com\t1000 cents\tflagged\tstripe\t2026-05-01\t2026-04-30"
+	want := "pay_1\tseller@example.com\t1000 cents\tflagged\tpayout\t2026-05-01\t2026-04-30"
 	if strings.TrimSpace(out) != want {
 		t.Fatalf("unexpected plain output: %q", out)
 	}

--- a/internal/cmd/admin/payouts/scheduled_test.go
+++ b/internal/cmd/admin/payouts/scheduled_test.go
@@ -212,6 +212,151 @@ func TestScheduledCancel_ServerError(t *testing.T) {
 	}
 }
 
+func TestScheduledList_PlainOutput(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"scheduled_payouts": []map[string]any{
+				{"external_id": "pay_1", "email": "seller@example.com", "amount_cents": 1000, "status": "flagged", "processor": "stripe", "scheduled_at": "2026-05-01", "created_at": "2026-04-30"},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newScheduledListCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	want := "pay_1\tseller@example.com\t1000 cents\tflagged\tstripe\t2026-05-01\t2026-04-30"
+	if strings.TrimSpace(out) != want {
+		t.Fatalf("unexpected plain output: %q", out)
+	}
+}
+
+func TestScheduledList_JSONPreservesResponse(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"scheduled_payouts": []map[string]any{{"external_id": "pay_1"}},
+			"limit":             20,
+		})
+	})
+
+	cmd := testutil.Command(newScheduledListCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp scheduledListResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if len(resp.ScheduledPayouts) != 1 || resp.ScheduledPayouts[0].ExternalID != "pay_1" {
+		t.Fatalf("unexpected JSON: %s", out)
+	}
+}
+
+func TestScheduledList_EmptyDefaultMessage(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{"scheduled_payouts": []any{}})
+	})
+
+	cmd := testutil.Command(newScheduledListCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "No scheduled payouts found.") {
+		t.Errorf("expected default empty-state, got %q", out)
+	}
+}
+
+func TestScheduledExecute_DryRun(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("dry-run must not POST")
+	})
+
+	cmd := testutil.Command(newScheduledExecuteCmd(), testutil.DryRun(true), testutil.NoInput(true))
+	cmd.SetArgs([]string{"pay_abc"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "POST") || !strings.Contains(out, "/internal/admin/payouts/pay_abc/scheduled_execute") {
+		t.Errorf("dry-run output unexpected: %q", out)
+	}
+}
+
+func TestScheduledExecute_PlainAndJSON(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"success":          true,
+			"result":           "executed",
+			"message":          "Done",
+			"scheduled_payout": map[string]any{"external_id": "pay_abc", "status": "executed"},
+		})
+	}
+
+	testutil.SetupAdmin(t, handler)
+	plain := testutil.Command(newScheduledExecuteCmd(), testutil.Yes(true), testutil.PlainOutput())
+	plain.SetArgs([]string{"pay_abc"})
+	plainOut := testutil.CaptureStdout(func() { testutil.MustExecute(t, plain) })
+	if !strings.Contains(plainOut, "true\tDone\tpay_abc\texecuted\texecuted") {
+		t.Errorf("unexpected plain: %q", plainOut)
+	}
+
+	testutil.SetupAdmin(t, handler)
+	js := testutil.Command(newScheduledExecuteCmd(), testutil.Yes(true), testutil.JSONOutput())
+	js.SetArgs([]string{"pay_abc"})
+	jsOut := testutil.CaptureStdout(func() { testutil.MustExecute(t, js) })
+	var resp scheduledExecuteResponse
+	if err := json.Unmarshal([]byte(jsOut), &resp); err != nil {
+		t.Fatalf("not JSON: %v\n%s", err, jsOut)
+	}
+	if !resp.Success || resp.Result != "executed" {
+		t.Fatalf("unexpected JSON: %s", jsOut)
+	}
+}
+
+func TestScheduledCancel_DryRun(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("dry-run must not POST")
+	})
+
+	cmd := testutil.Command(newScheduledCancelCmd(), testutil.DryRun(true), testutil.NoInput(true))
+	cmd.SetArgs([]string{"pay_abc"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "POST") || !strings.Contains(out, "/internal/admin/payouts/pay_abc/scheduled_cancel") {
+		t.Errorf("dry-run output unexpected: %q", out)
+	}
+}
+
+func TestScheduledCancel_RequiresConfirmation(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API without confirmation")
+	})
+
+	cmd := testutil.Command(newScheduledCancelCmd(), testutil.NoInput(true))
+	cmd.SetArgs([]string{"pay_abc"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--yes") {
+		t.Fatalf("expected --yes error, got %v", err)
+	}
+}
+
+func TestScheduledCancel_PlainOutput(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"success":          true,
+			"message":          "Cancelled",
+			"scheduled_payout": map[string]any{"external_id": "pay_abc", "status": "cancelled"},
+		})
+	})
+
+	cmd := testutil.Command(newScheduledCancelCmd(), testutil.Yes(true), testutil.PlainOutput())
+	cmd.SetArgs([]string{"pay_abc"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "true\tCancelled\tpay_abc\tcancelled") {
+		t.Errorf("unexpected plain: %q", out)
+	}
+}
+
 func TestScheduledCmdWiresChildren(t *testing.T) {
 	cmd := newScheduledCmd()
 	want := map[string]bool{"list": false, "execute <external_id>": false, "cancel <external_id>": false}


### PR DESCRIPTION
## What

Adds four operator-driven admin payout commands that consume the new `/internal/admin/payouts` endpoints from antiwork/gumroad#4938:

- `gumroad admin payouts issue --email <e> --through <YYYY-MM-DD> --processor stripe|paypal [--split] --yes`
- `gumroad admin payouts scheduled list [--status pending|executed|cancelled|flagged|held] [--limit N]`
- `gumroad admin payouts scheduled execute <external_id> --yes`
- `gumroad admin payouts scheduled cancel <external_id>`

All four reuse the existing admin client, auth, and config plumbing. JSON output and `--jq` work out of the box. `issue` and `scheduled execute` require `--yes` because they move money. `--split` is rejected client-side unless `--processor paypal`. `--through` is validated as strict `YYYY-MM-DD` and as a past date before any request is sent. Server `{ success: false, message }` envelopes are surfaced as a non-zero exit with the message on stderr; the raw JSON is only printed when `--json` is set.

## Why

PR 12 in the admin CLI rollout plan from antiwork/gumroad#4677. These are the edge-case payout actions that previously required hopping into the admin web UI (manual payouts, executing flagged scheduled payouts, cancelling stuck ones). Operators now get the same actions in their shell with audit trails on the server side.


---

Built with Claude Opus 4.7