### PR TITLE
Split auth login to store seller and admin tokens from one browser approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,18 +69,18 @@ gumroad sales refund abc123 --amount 5.00 --dry-run
 
 ## Authentication
 
-`gumroad auth login` opens your browser for OAuth authorization. After you approve, the CLI stores the token locally and you're done.
+`gumroad auth login` opens your browser for OAuth authorization. After you approve, the CLI stores the seller token locally. Team members can also check the admin box in the same browser approval; that stores a separate admin token in `admin.token`.
 
 ```sh
 gumroad auth login          # Browser-based OAuth (default)
 gumroad auth login --web    # Force browser OAuth, no fallback
-gumroad auth status         # Check who you're logged in as
-gumroad auth logout         # Remove stored token
+gumroad auth status         # Check seller auth and stored admin auth
+gumroad auth logout         # Revoke/delete stored tokens
 ```
 
 When a browser isn't available (SSH, containers), the CLI falls back to a manual flow: it prints the authorize URL and you paste the redirect URL back.
 
-For CI and agents, set `GUMROAD_ACCESS_TOKEN` instead — it takes precedence over stored config and needs no interactive login. Piped stdin also works: `echo $TOKEN | gumroad auth login`.
+For CI and agents, set `GUMROAD_ACCESS_TOKEN` instead — it takes precedence over stored seller config and needs no interactive login. Piped stdin also works: `echo $TOKEN | gumroad auth login`.
 
 ## Commands
 
@@ -105,7 +105,7 @@ gumroad completion    bash, zsh, fish, powershell
 
 Run `gumroad <command> --help` for usage details and examples.
 
-Admin commands use a separate internal token. For non-interactive use, set `GUMROAD_ADMIN_ACCESS_TOKEN`; for local testing, set `GUMROAD_ADMIN_API_BASE_URL`.
+Admin commands use a separate internal token. Run `gumroad auth login` and check the admin box to store one locally, or set `GUMROAD_ADMIN_ACCESS_TOKEN` for CI and agents. For local testing, set `GUMROAD_ADMIN_API_BASE_URL`.
 
 ## File attachments
 
@@ -146,7 +146,7 @@ Paginated commands (`sales list`, `payouts list`, `subscribers list`) accept `--
 
 ## AI agents
 
-`gumroad` is built to work with AI agents. The `--json`, `--jq`, and `--no-input` flags make it easy to query Gumroad data programmatically, and `GUMROAD_ACCESS_TOKEN` gives agents a no-persistence auth path.
+`gumroad` is built to work with AI agents. The `--json`, `--jq`, and `--no-input` flags make it easy to query Gumroad data programmatically, and `GUMROAD_ACCESS_TOKEN` gives agents a no-persistence seller auth path.
 
 A [Claude Code skill](skills/gumroad/SKILL.md) is included. Run `gumroad skill` to install or refresh it.
 

--- a/internal/adminapi/client.go
+++ b/internal/adminapi/client.go
@@ -23,6 +23,24 @@ type Client struct {
 	api *api.Client
 }
 
+type AdminToken struct {
+	Token           string            `json:"token"`
+	TokenExternalID string            `json:"token_external_id"`
+	Actor           adminconfig.Actor `json:"actor"`
+	ExpiresAt       string            `json:"expires_at"`
+}
+
+type WhoamiResponse struct {
+	Actor  adminconfig.Actor `json:"actor"`
+	Token  TokenMetadata     `json:"token"`
+	Scopes []string          `json:"scopes"`
+}
+
+type TokenMetadata struct {
+	ExternalID string `json:"external_id"`
+	ExpiresAt  string `json:"expires_at"`
+}
+
 func NewClientWithContext(ctx context.Context, token, version string, debug bool) *Client {
 	return NewClientWithBaseURL(ctx, token, version, debug, defaultBaseURL())
 }
@@ -68,11 +86,52 @@ func (c *Client) Delete(path string, params url.Values) (json.RawMessage, error)
 	return data, rewriteAdminError(err)
 }
 
+func (c *Client) Whoami() (WhoamiResponse, error) {
+	data, err := c.Get("/whoami", url.Values{})
+	if err != nil {
+		return WhoamiResponse{}, err
+	}
+	var resp WhoamiResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return WhoamiResponse{}, err
+	}
+	return resp, nil
+}
+
+func (c *Client) RevokeSelf() error {
+	_, err := c.PostJSON("/auth/revoke", struct{}{})
+	return err
+}
+
+func ExchangeAuthorizationCode(ctx context.Context, code, codeVerifier, version string, debug bool) (AdminToken, error) {
+	client := NewClientWithContext(ctx, "", version, debug)
+	data, err := client.PostJSON("/auth/exchange", map[string]string{
+		"code":          code,
+		"code_verifier": codeVerifier,
+	})
+	if err != nil {
+		return AdminToken{}, err
+	}
+	var token AdminToken
+	if err := json.Unmarshal(data, &token); err != nil {
+		return AdminToken{}, err
+	}
+	return token, nil
+}
+
 func defaultBaseURL() string {
 	if v := strings.TrimRight(os.Getenv(EnvAPIBaseURL), "/"); v != "" {
 		return v
 	}
 	return defaultAPIBaseURL
+}
+
+func AdminTokensURL() string {
+	base := defaultBaseURL()
+	if strings.Contains(base, "://api.gumroad.com") {
+		base = strings.Replace(base, "://api.gumroad.com", "://app.gumroad.com", 1)
+	}
+	return strings.TrimRight(base, "/") + "/admin/cli/tokens"
 }
 
 // AdminPath returns the absolute admin-prefixed path for path.

--- a/internal/adminapi/client.go
+++ b/internal/adminapi/client.go
@@ -128,9 +128,7 @@ func defaultBaseURL() string {
 
 func AdminTokensURL() string {
 	base := defaultBaseURL()
-	if strings.Contains(base, "://api.gumroad.com") {
-		base = strings.Replace(base, "://api.gumroad.com", "://app.gumroad.com", 1)
-	}
+	base = strings.Replace(base, "://api.gumroad.com", "://app.gumroad.com", 1)
 	return strings.TrimRight(base, "/") + "/admin/cli/tokens"
 }
 

--- a/internal/adminconfig/config.go
+++ b/internal/adminconfig/config.go
@@ -29,8 +29,8 @@ type Config struct {
 }
 
 const (
-	EnvAccessToken    = "GUMROAD_ADMIN_ACCESS_TOKEN" //nolint:gosec // G101: env var name, not a credential.
-	HintSetAdminToken = "Run `gumroad auth login` and check the admin box, or set GUMROAD_ADMIN_ACCESS_TOKEN."
+	EnvAccessToken    = "GUMROAD_ADMIN_ACCESS_TOKEN"                                                           //nolint:gosec // G101: env var name, not a credential.
+	HintSetAdminToken = "Run `gumroad auth login` and check the admin box, or set GUMROAD_ADMIN_ACCESS_TOKEN." //nolint:gosec // G101: remediation text, not a credential.
 
 	adminConfigFile       = "admin.token"
 	legacyAdminConfigFile = "admin.json"

--- a/internal/adminconfig/config.go
+++ b/internal/adminconfig/config.go
@@ -23,8 +23,6 @@ type Config struct {
 	Actor           Actor  `json:"actor,omitempty"`
 	ExpiresAt       string `json:"expires_at,omitempty"`
 
-	// AccessToken is the legacy admin.json field. Load accepts it so older
-	// local configs still work, but Save writes the PR11B admin.token shape.
 	AccessToken string `json:"access_token,omitempty"`
 }
 
@@ -143,6 +141,9 @@ func Save(cfg *Config) error {
 	if err := writeConfigAtomically(p, data); err != nil {
 		return fmt.Errorf("could not write admin config: %w", err)
 	}
+	if err := deleteLegacyConfigFiles(); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -157,6 +158,10 @@ func Delete() error {
 	if err := os.Remove(p + ".bak"); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("could not delete admin config backup: %w", err)
 	}
+	return deleteLegacyConfigFiles()
+}
+
+func deleteLegacyConfigFiles() error {
 	legacyPath, err := LegacyPath()
 	if err != nil {
 		return err

--- a/internal/adminconfig/config.go
+++ b/internal/adminconfig/config.go
@@ -12,15 +12,29 @@ import (
 	"github.com/antiwork/gumroad-cli/internal/config"
 )
 
+type Actor struct {
+	Name  string `json:"name,omitempty"`
+	Email string `json:"email,omitempty"`
+}
+
 type Config struct {
-	AccessToken string `json:"access_token"`
+	Token           string `json:"token,omitempty"`
+	TokenExternalID string `json:"token_external_id,omitempty"`
+	Actor           Actor  `json:"actor,omitempty"`
+	ExpiresAt       string `json:"expires_at,omitempty"`
+
+	// AccessToken is the legacy admin.json field. Load accepts it so older
+	// local configs still work, but Save writes the PR11B admin.token shape.
+	AccessToken string `json:"access_token,omitempty"`
 }
 
 const (
-	EnvAccessToken        = "GUMROAD_ADMIN_ACCESS_TOKEN"      //nolint:gosec // G101: env var name, not a credential.
-	HintSetAdminToken     = "Set GUMROAD_ADMIN_ACCESS_TOKEN." //nolint:gosec // G101: remediation text, not a credential.
-	adminConfigFile       = "admin.json"
-	adminConfigTempPrefix = "admin.json.tmp-*"
+	EnvAccessToken    = "GUMROAD_ADMIN_ACCESS_TOKEN" //nolint:gosec // G101: env var name, not a credential.
+	HintSetAdminToken = "Run `gumroad auth login` and check the admin box, or set GUMROAD_ADMIN_ACCESS_TOKEN."
+
+	adminConfigFile       = "admin.token"
+	legacyAdminConfigFile = "admin.json"
+	adminConfigTempPrefix = "admin.token.tmp-*"
 )
 
 var (
@@ -36,8 +50,11 @@ const (
 )
 
 type TokenInfo struct {
-	Value  string
-	Source TokenSource
+	Value           string
+	Source          TokenSource
+	TokenExternalID string
+	Actor           Actor
+	ExpiresAt       string
 }
 
 func Dir() (string, error) {
@@ -52,11 +69,36 @@ func Path() (string, error) {
 	return filepath.Join(dir, adminConfigFile), nil
 }
 
+func LegacyPath() (string, error) {
+	dir, err := Dir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, legacyAdminConfigFile), nil
+}
+
 func Load() (*Config, error) {
 	p, err := Path()
 	if err != nil {
 		return nil, err
 	}
+	cfg, found, err := loadConfigFile(p)
+	if err != nil || found {
+		return cfg, err
+	}
+
+	legacyPath, err := LegacyPath()
+	if err != nil {
+		return nil, err
+	}
+	cfg, _, err = loadConfigFile(legacyPath)
+	if err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+func loadConfigFile(p string) (*Config, bool, error) {
 	info, err := os.Stat(p)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -66,24 +108,24 @@ func Load() (*Config, error) {
 				}
 			}
 			if err != nil {
-				return &Config{}, nil
+				return &Config{}, false, nil
 			}
 		} else {
-			return nil, fmt.Errorf("could not read admin config: %w", err)
+			return nil, false, fmt.Errorf("could not read admin config: %w", err)
 		}
 	}
 	if err := validateConfigPermissions(p, info.Mode()); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	data, err := os.ReadFile(p)
 	if err != nil {
-		return nil, fmt.Errorf("could not read admin config: %w", err)
+		return nil, false, fmt.Errorf("could not read admin config: %w", err)
 	}
 	var cfg Config
 	if err := json.Unmarshal(data, &cfg); err != nil {
-		return nil, fmt.Errorf("could not parse admin config: %w", err)
+		return nil, false, fmt.Errorf("could not parse admin config: %w", err)
 	}
-	return &cfg, nil
+	return &cfg, true, nil
 }
 
 func Save(cfg *Config) error {
@@ -115,6 +157,16 @@ func Delete() error {
 	if err := os.Remove(p + ".bak"); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("could not delete admin config backup: %w", err)
 	}
+	legacyPath, err := LegacyPath()
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(legacyPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("could not delete legacy admin config: %w", err)
+	}
+	if err := os.Remove(legacyPath + ".bak"); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("could not delete legacy admin config backup: %w", err)
+	}
 	return nil
 }
 
@@ -122,15 +174,18 @@ func ResolveToken() (TokenInfo, error) {
 	if token := strings.TrimSpace(os.Getenv(EnvAccessToken)); token != "" {
 		return TokenInfo{Value: token, Source: TokenSourceEnv}, nil
 	}
+	return ResolveStoredToken()
+}
 
+func ResolveStoredToken() (TokenInfo, error) {
 	cfg, err := Load()
 	if err != nil {
 		return TokenInfo{}, err
 	}
-	if cfg.AccessToken == "" {
-		return TokenInfo{}, fmt.Errorf("%w. %s", ErrNotAuthenticated, HintSetAdminToken)
+	if cfg.tokenValue() == "" {
+		return TokenInfo{}, notLoggedInError()
 	}
-	return TokenInfo{Value: cfg.AccessToken, Source: TokenSourceConfig}, nil
+	return cfg.tokenInfo(), nil
 }
 
 func Token() (string, error) {
@@ -139,6 +194,30 @@ func Token() (string, error) {
 		return "", err
 	}
 	return info.Value, nil
+}
+
+func (cfg *Config) tokenValue() string {
+	if cfg == nil {
+		return ""
+	}
+	if strings.TrimSpace(cfg.Token) != "" {
+		return strings.TrimSpace(cfg.Token)
+	}
+	return strings.TrimSpace(cfg.AccessToken)
+}
+
+func (cfg *Config) tokenInfo() TokenInfo {
+	return TokenInfo{
+		Value:           cfg.tokenValue(),
+		Source:          TokenSourceConfig,
+		TokenExternalID: cfg.TokenExternalID,
+		Actor:           cfg.Actor,
+		ExpiresAt:       cfg.ExpiresAt,
+	}
+}
+
+func notLoggedInError() error {
+	return fmt.Errorf("%w. not logged in for admin; run 'gumroad auth login' and check the admin box", ErrNotAuthenticated)
 }
 
 func writeConfigAtomically(path string, data []byte) (err error) {

--- a/internal/adminconfig/config_test.go
+++ b/internal/adminconfig/config_test.go
@@ -47,6 +47,47 @@ func TestSaveLoadAndDelete(t *testing.T) {
 	}
 }
 
+func TestSaveRemovesLegacyConfigFiles(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	dir, err := Dir()
+	if err != nil {
+		t.Fatalf("Dir failed: %v", err)
+	}
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+	legacyPath, err := LegacyPath()
+	if err != nil {
+		t.Fatalf("LegacyPath failed: %v", err)
+	}
+	if err := os.WriteFile(legacyPath, []byte(`{"access_token":"old-admin-token"}`), 0600); err != nil {
+		t.Fatalf("WriteFile legacy failed: %v", err)
+	}
+	if err := os.WriteFile(legacyPath+".bak", []byte(`{"access_token":"backup-admin-token"}`), 0600); err != nil {
+		t.Fatalf("WriteFile legacy backup failed: %v", err)
+	}
+
+	if err := Save(&Config{Token: "new-admin-token"}); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Fatalf("legacy config should be removed, got err=%v", err)
+	}
+	if _, err := os.Stat(legacyPath + ".bak"); !os.IsNotExist(err) {
+		t.Fatalf("legacy backup should be removed, got err=%v", err)
+	}
+	loaded, err := Load()
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if loaded.Token != "new-admin-token" {
+		t.Fatalf("got token %q, want new-admin-token", loaded.Token)
+	}
+}
+
 func TestPathUsesSeparateAdminConfigFile(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)

--- a/internal/adminconfig/config_test.go
+++ b/internal/adminconfig/config_test.go
@@ -15,7 +15,12 @@ func TestSaveLoadAndDelete(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)
 
-	if err := Save(&Config{AccessToken: "admin-token"}); err != nil {
+	if err := Save(&Config{
+		Token:           "admin-token",
+		TokenExternalID: "adm_123",
+		Actor:           Actor{Name: "Admin User", Email: "admin@example.com"},
+		ExpiresAt:       "2026-06-01T00:00:00Z",
+	}); err != nil {
 		t.Fatalf("Save failed: %v", err)
 	}
 
@@ -23,8 +28,11 @@ func TestSaveLoadAndDelete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load failed: %v", err)
 	}
-	if loaded.AccessToken != "admin-token" {
-		t.Fatalf("got token %q, want admin-token", loaded.AccessToken)
+	if loaded.Token != "admin-token" {
+		t.Fatalf("got token %q, want admin-token", loaded.Token)
+	}
+	if loaded.TokenExternalID != "adm_123" || loaded.Actor.Email != "admin@example.com" || loaded.ExpiresAt == "" {
+		t.Fatalf("admin metadata was not preserved: %+v", loaded)
 	}
 
 	if err := Delete(); err != nil {
@@ -34,8 +42,8 @@ func TestSaveLoadAndDelete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load after Delete failed: %v", err)
 	}
-	if loaded.AccessToken != "" {
-		t.Fatalf("expected empty token after Delete, got %q", loaded.AccessToken)
+	if loaded.Token != "" {
+		t.Fatalf("expected empty token after Delete, got %q", loaded.Token)
 	}
 }
 
@@ -55,8 +63,8 @@ func TestPathUsesSeparateAdminConfigFile(t *testing.T) {
 	if adminPath == publicPath {
 		t.Fatalf("admin config should not share public config path %q", adminPath)
 	}
-	if filepath.Base(adminPath) != "admin.json" {
-		t.Fatalf("got admin path %q, want admin.json file", adminPath)
+	if filepath.Base(adminPath) != "admin.token" {
+		t.Fatalf("got admin path %q, want admin.token file", adminPath)
 	}
 }
 
@@ -75,12 +83,12 @@ func TestTokenUsesEnvAccessToken(t *testing.T) {
 	}
 }
 
-func TestTokenEnvTakesPrecedenceOverAdminConfig(t *testing.T) {
+func TestTokenEnvTakesPrecedenceOverStoredConfig(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)
 	t.Setenv(EnvAccessToken, "env-admin-token")
 
-	if err := Save(&Config{AccessToken: "file-admin-token"}); err != nil {
+	if err := Save(&Config{Token: "file-admin-token"}); err != nil {
 		t.Fatalf("Save failed: %v", err)
 	}
 
@@ -112,8 +120,8 @@ func TestTokenDoesNotUsePublicConfig(t *testing.T) {
 	if !errors.Is(err, ErrNotAuthenticated) {
 		t.Fatalf("expected ErrNotAuthenticated, got %v", err)
 	}
-	if !strings.Contains(err.Error(), EnvAccessToken) {
-		t.Fatalf("expected error to mention %s, got %v", EnvAccessToken, err)
+	if !strings.Contains(err.Error(), "check the admin box") {
+		t.Fatalf("expected error to mention admin login, got %v", err)
 	}
 }
 

--- a/internal/cmd/auth/auth_test.go
+++ b/internal/cmd/auth/auth_test.go
@@ -423,21 +423,31 @@ func TestLoginCredentialsFromOAuthResultIgnoresEmptyAdminToken(t *testing.T) {
 	}
 }
 
-func TestLoginCredentialsFromOAuthResultWrapsAdminExchangeFailure(t *testing.T) {
+func TestLoginCredentialsFromOAuthResultWarnsAndPreservesSellerWhenAdminExchangeFails(t *testing.T) {
 	adminSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		testutil.JSON(t, w, map[string]any{"success": false, "message": "boom"})
 	}))
 	t.Cleanup(adminSrv.Close)
 	t.Setenv(adminapi.EnvAPIBaseURL, adminSrv.URL)
+	var errOut bytes.Buffer
 
-	_, err := loginCredentialsFromOAuthResult(testutil.TestOptions(), oauth.FlowResult{
+	creds, err := loginCredentialsFromOAuthResult(testutil.TestOptions(testutil.Stderr(&errOut)), oauth.FlowResult{
 		AccessToken:            "seller-token",
 		AdminAuthorizationCode: "admin-code",
 		CodeVerifier:           "verifier",
 	})
-	if err == nil || !strings.Contains(err.Error(), "could not authorize admin token") {
-		t.Fatalf("expected wrapped admin exchange error, got %v", err)
+	if err != nil {
+		t.Fatalf("loginCredentialsFromOAuthResult failed: %v", err)
+	}
+	if creds.SellerToken != "seller-token" {
+		t.Fatalf("got seller token %q, want seller-token", creds.SellerToken)
+	}
+	if creds.AdminToken != nil {
+		t.Fatalf("expected no admin token, got %+v", creds.AdminToken)
+	}
+	if !strings.Contains(errOut.String(), "warning: could not authorize admin token") {
+		t.Fatalf("expected admin exchange warning, got %q", errOut.String())
 	}
 }
 
@@ -518,6 +528,30 @@ func TestStatus_InvalidToken(t *testing.T) {
 	out := runStatus(t)
 	if !strings.Contains(out, "invalid or expired") {
 		t.Errorf("should say 'invalid or expired': %q", out)
+	}
+}
+
+func TestStatus_InvalidSellerTokenShowsStoredAdminWhoami(t *testing.T) {
+	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(401)
+		testutil.JSON(t, w, map[string]any{"success": false})
+	})
+	withConfig(t, "expired")
+	if err := adminconfig.Save(&adminconfig.Config{Token: "admin-token"}); err != nil {
+		t.Fatalf("Save admin config failed: %v", err)
+	}
+	adminSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"actor": map[string]any{"name": "Live Admin", "email": "admin@example.com"},
+			"token": map[string]any{"expires_at": "2026-06-01T00:00:00Z"},
+		})
+	}))
+	t.Cleanup(adminSrv.Close)
+	t.Setenv(adminapi.EnvAPIBaseURL, adminSrv.URL)
+
+	out := runStatus(t)
+	if !strings.Contains(out, "invalid or expired") || !strings.Contains(out, "Admin: Live Admin") {
+		t.Fatalf("expected seller failure and admin status, got %q", out)
 	}
 }
 
@@ -678,6 +712,46 @@ func TestStatus_JSONOutputShowsInvalidStoredAdminToken(t *testing.T) {
 	admin := resp["admin"].(map[string]any)
 	if admin["authenticated"] != false || admin["reason"] != statusReasonInvalidOrExpired {
 		t.Fatalf("unexpected admin status: %#v", admin)
+	}
+}
+
+func TestStatus_JSONOutputShowsUnreachableStoredAdminToken(t *testing.T) {
+	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"success": true,
+			"user":    map[string]any{"name": "Jane", "email": "jane@example.com"},
+		})
+	})
+	withConfig(t, "valid-token")
+	if err := adminconfig.Save(&adminconfig.Config{
+		Token: "admin-token",
+		Actor: adminconfig.Actor{Name: "Cached Admin"},
+	}); err != nil {
+		t.Fatalf("Save admin config failed: %v", err)
+	}
+	adminSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		testutil.JSON(t, w, map[string]any{"success": false, "message": "try later"})
+	}))
+	t.Cleanup(adminSrv.Close)
+	t.Setenv(adminapi.EnvAPIBaseURL, adminSrv.URL)
+
+	out := runStatus(t, testutil.JSONOutput())
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("status JSON output is invalid: %v\n%s", err, out)
+	}
+	if resp["authenticated"] != true {
+		t.Fatalf("seller status should still be authenticated: %#v", resp)
+	}
+	admin := resp["admin"].(map[string]any)
+	if admin["authenticated"] != false || admin["reason"] != statusReasonUnreachable {
+		t.Fatalf("unexpected admin status: %#v", admin)
+	}
+
+	textOut := runStatus(t)
+	if !strings.Contains(textOut, "Logged in as Jane") || !strings.Contains(textOut, "Could not reach the admin API") {
+		t.Fatalf("expected seller status and admin unreachable guidance, got %q", textOut)
 	}
 }
 
@@ -946,6 +1020,36 @@ func TestStatus_JSONOutput_NotLoggedInIncludesStoredAdminToken(t *testing.T) {
 	actor := admin["actor"].(map[string]any)
 	if actor["email"] != "admin@example.com" {
 		t.Fatalf("got admin actor email=%v, want admin@example.com", actor["email"])
+	}
+}
+
+func TestStatus_JSONOutput_NotLoggedInIncludesUnreachableStoredAdminToken(t *testing.T) {
+	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach seller API when not logged in")
+	})
+	cfgDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+	if err := adminconfig.Save(&adminconfig.Config{Token: "admin-token"}); err != nil {
+		t.Fatalf("Save admin config failed: %v", err)
+	}
+	adminSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		testutil.JSON(t, w, map[string]any{"success": false, "message": "try later"})
+	}))
+	t.Cleanup(adminSrv.Close)
+	t.Setenv(adminapi.EnvAPIBaseURL, adminSrv.URL)
+
+	out := runStatus(t, testutil.JSONOutput())
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("status JSON output is invalid: %v\n%s", err, out)
+	}
+	if resp["authenticated"] != false || resp["reason"] != statusReasonNotLoggedIn {
+		t.Fatalf("unexpected seller status: %#v", resp)
+	}
+	admin := resp["admin"].(map[string]any)
+	if admin["authenticated"] != false || admin["reason"] != statusReasonUnreachable {
+		t.Fatalf("unexpected admin status: %#v", admin)
 	}
 }
 

--- a/internal/cmd/auth/auth_test.go
+++ b/internal/cmd/auth/auth_test.go
@@ -231,6 +231,42 @@ func TestLogin_JSONOutput(t *testing.T) {
 	}
 }
 
+func TestLogin_JSONOutputIncludesAdminTokenFromSameApproval(t *testing.T) {
+	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.RawJSON(t, w, testutil.Fixture(t, "testdata/login_success.json"))
+	})
+	cfgDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+	var out bytes.Buffer
+	opts := testutil.TestOptions(testutil.JSONOutput(), testutil.Stdout(&out))
+	cmd := testutil.WithOptions(newLoginCmd(), opts)
+
+	if err := verifyAndSave(cmd, opts, loginCredentials{
+		SellerToken: "good-token",
+		AdminToken: &adminconfig.Config{
+			Token:           "admin-token",
+			TokenExternalID: "adm_123",
+			Actor:           adminconfig.Actor{Name: "Admin User", Email: "admin@example.com"},
+			ExpiresAt:       "2026-06-01T00:00:00Z",
+		},
+	}); err != nil {
+		t.Fatalf("verifyAndSave failed: %v", err)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(out.Bytes(), &resp); err != nil {
+		t.Fatalf("login JSON output is invalid: %v\n%s", err, out.String())
+	}
+	admin := resp["admin"].(map[string]any)
+	if admin["authenticated"] != true {
+		t.Fatalf("got admin authenticated=%v, want true", admin["authenticated"])
+	}
+	actor := admin["actor"].(map[string]any)
+	if actor["email"] != "admin@example.com" {
+		t.Fatalf("got admin actor email=%v, want admin@example.com", actor["email"])
+	}
+}
+
 func TestLogin_PlainOutput(t *testing.T) {
 	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
 		testutil.RawJSON(t, w, testutil.Fixture(t, "testdata/login_success.json"))
@@ -244,6 +280,62 @@ func TestLogin_PlainOutput(t *testing.T) {
 	}
 	if strings.TrimSpace(out.String()) != "true\tJane\tjane@example.com" {
 		t.Fatalf("unexpected plain output: %q", out.String())
+	}
+}
+
+func TestLoginCredentialsFromOAuthResultExchangesAdminCode(t *testing.T) {
+	adminSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/internal/admin/auth/exchange" {
+			t.Fatalf("got path %q, want /internal/admin/auth/exchange", r.URL.Path)
+		}
+		var body map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("Decode failed: %v", err)
+		}
+		if body["code"] != "admin-code" || body["code_verifier"] != "verifier" {
+			t.Fatalf("unexpected exchange payload: %#v", body)
+		}
+		testutil.JSON(t, w, map[string]any{
+			"token":             "admin-token-from-code",
+			"token_external_id": "adm_code",
+			"actor":             map[string]any{"name": "Code Admin", "email": "code-admin@example.com"},
+			"expires_at":        "2026-06-01T00:00:00Z",
+		})
+	}))
+	t.Cleanup(adminSrv.Close)
+	t.Setenv(adminapi.EnvAPIBaseURL, adminSrv.URL)
+
+	creds, err := loginCredentialsFromOAuthResult(testutil.TestOptions(), oauth.FlowResult{
+		AccessToken:            "seller-token",
+		AdminAuthorizationCode: "admin-code",
+		CodeVerifier:           "verifier",
+	})
+	if err != nil {
+		t.Fatalf("loginCredentialsFromOAuthResult failed: %v", err)
+	}
+	if creds.SellerToken != "seller-token" || creds.AdminToken == nil {
+		t.Fatalf("unexpected credentials: %+v", creds)
+	}
+	if creds.AdminToken.Token != "admin-token-from-code" || creds.AdminToken.Actor.Email != "code-admin@example.com" {
+		t.Fatalf("unexpected admin token: %+v", creds.AdminToken)
+	}
+}
+
+func TestLoginCredentialsFromOAuthResultWrapsAdminExchangeFailure(t *testing.T) {
+	adminSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		testutil.JSON(t, w, map[string]any{"success": false, "message": "boom"})
+	}))
+	t.Cleanup(adminSrv.Close)
+	t.Setenv(adminapi.EnvAPIBaseURL, adminSrv.URL)
+
+	_, err := loginCredentialsFromOAuthResult(testutil.TestOptions(), oauth.FlowResult{
+		AccessToken:            "seller-token",
+		AdminAuthorizationCode: "admin-code",
+		CodeVerifier:           "verifier",
+	})
+	if err == nil || !strings.Contains(err.Error(), "could not authorize admin token") {
+		t.Fatalf("expected wrapped admin exchange error, got %v", err)
 	}
 }
 
@@ -417,6 +509,104 @@ func TestStatus_ShowsStoredAdminWhoami(t *testing.T) {
 	out := runStatus(t)
 	if !strings.Contains(out, "Live Admin") || !strings.Contains(out, "2026-06-01T00:00:00Z") {
 		t.Fatalf("expected admin whoami output, got %q", out)
+	}
+}
+
+func TestStatus_JSONOutputShowsInvalidStoredAdminToken(t *testing.T) {
+	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"success": true,
+			"user":    map[string]any{"name": "Jane", "email": "jane@example.com"},
+		})
+	})
+	withConfig(t, "valid-token")
+	if err := adminconfig.Save(&adminconfig.Config{
+		Token:           "admin-token",
+		TokenExternalID: "adm_local",
+		Actor:           adminconfig.Actor{Email: "cached@example.com"},
+		ExpiresAt:       "cached",
+	}); err != nil {
+		t.Fatalf("Save admin config failed: %v", err)
+	}
+	adminSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		testutil.JSON(t, w, map[string]any{"success": false, "message": "revoked"})
+	}))
+	t.Cleanup(adminSrv.Close)
+	t.Setenv(adminapi.EnvAPIBaseURL, adminSrv.URL)
+
+	out := runStatus(t, testutil.JSONOutput())
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("status JSON output is invalid: %v\n%s", err, out)
+	}
+	admin := resp["admin"].(map[string]any)
+	if admin["authenticated"] != false || admin["reason"] != statusReasonInvalidOrExpired {
+		t.Fatalf("unexpected admin status: %#v", admin)
+	}
+}
+
+func TestStatus_PlainOutputIncludesStoredAdminToken(t *testing.T) {
+	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"success": true,
+			"user":    map[string]any{"name": "Jane", "email": "jane@example.com"},
+		})
+	})
+	withConfig(t, "valid-token")
+	if err := adminconfig.Save(&adminconfig.Config{Token: "admin-token"}); err != nil {
+		t.Fatalf("Save admin config failed: %v", err)
+	}
+	adminSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"actor": map[string]any{"email": "admin@example.com"},
+			"token": map[string]any{
+				"external_id": "adm_123",
+				"expires_at":  "2026-06-01T00:00:00Z",
+			},
+		})
+	}))
+	t.Cleanup(adminSrv.Close)
+	t.Setenv(adminapi.EnvAPIBaseURL, adminSrv.URL)
+
+	out := runStatus(t, testutil.PlainOutput())
+	want := "true\tJane\tjane@example.com\t\ttrue\tadmin@example.com\tadmin@example.com\t2026-06-01T00:00:00Z\t"
+	if strings.TrimSuffix(out, "\n") != want {
+		t.Fatalf("unexpected plain output: %q", out)
+	}
+}
+
+func TestStatus_StoredAdminAccessDenied(t *testing.T) {
+	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"success": true,
+			"user":    map[string]any{"name": "Jane", "email": "jane@example.com"},
+		})
+	})
+	withConfig(t, "valid-token")
+	if err := adminconfig.Save(&adminconfig.Config{
+		Token: "admin-token",
+		Actor: adminconfig.Actor{
+			Name: "Cached Admin",
+		},
+	}); err != nil {
+		t.Fatalf("Save admin config failed: %v", err)
+	}
+	adminSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		testutil.JSON(t, w, map[string]any{"success": false, "message": "forbidden"})
+	}))
+	t.Cleanup(adminSrv.Close)
+	t.Setenv(adminapi.EnvAPIBaseURL, adminSrv.URL)
+
+	out := runStatus(t, testutil.JSONOutput())
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("status JSON output is invalid: %v\n%s", err, out)
+	}
+	admin := resp["admin"].(map[string]any)
+	if admin["authenticated"] != false || admin["reason"] != statusReasonAccessDenied {
+		t.Fatalf("unexpected admin status: %#v", admin)
 	}
 }
 
@@ -747,6 +937,26 @@ func TestStatus_PlainOutput_AccessDenied(t *testing.T) {
 	}
 }
 
+func TestAdminActorNameFallbacks(t *testing.T) {
+	tests := []struct {
+		name  string
+		actor adminconfig.Actor
+		want  string
+	}{
+		{name: "name", actor: adminconfig.Actor{Name: "Admin User", Email: "admin@example.com"}, want: "Admin User"},
+		{name: "email", actor: adminconfig.Actor{Email: "admin@example.com"}, want: "admin@example.com"},
+		{name: "empty", actor: adminconfig.Actor{}, want: "admin token"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := adminActorName(tt.actor); got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 // --- Logout ---
 
 func TestLogout_WithYes(t *testing.T) {
@@ -851,6 +1061,42 @@ func TestLogout_KeepsAdminTokenWhenServerRevokeFails(t *testing.T) {
 	}
 	if _, statErr := os.Stat(adminPath); statErr != nil {
 		t.Fatalf("admin config should remain after revoke failure: %v", statErr)
+	}
+}
+
+func TestRevokeExistingAdminTokenDeletesUnauthorizedToken(t *testing.T) {
+	cfgDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+	if err := adminconfig.Save(&adminconfig.Config{Token: "stale-admin-token"}); err != nil {
+		t.Fatalf("Save admin config failed: %v", err)
+	}
+	adminPath, err := adminconfig.Path()
+	if err != nil {
+		t.Fatalf("adminconfig.Path: %v", err)
+	}
+	adminSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer stale-admin-token" {
+			t.Fatalf("got Authorization=%q, want Bearer stale-admin-token", got)
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+		testutil.JSON(t, w, map[string]any{"success": false, "message": "revoked"})
+	}))
+	t.Cleanup(adminSrv.Close)
+	t.Setenv(adminapi.EnvAPIBaseURL, adminSrv.URL)
+
+	if err := revokeExistingAdminToken(testutil.TestOptions()); err != nil {
+		t.Fatalf("revokeExistingAdminToken failed: %v", err)
+	}
+	if _, err := os.Stat(adminPath); !os.IsNotExist(err) {
+		t.Fatalf("admin config should be deleted, got err=%v", err)
+	}
+}
+
+func TestRevokeExistingAdminTokenReturnsNilWhenMissing(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	if err := revokeExistingAdminToken(testutil.TestOptions()); err != nil {
+		t.Fatalf("revokeExistingAdminToken failed: %v", err)
 	}
 }
 

--- a/internal/cmd/auth/auth_test.go
+++ b/internal/cmd/auth/auth_test.go
@@ -351,6 +351,9 @@ func TestLogin_SavesSellerAndAdminWhenPreviousAdminRevokeFails(t *testing.T) {
 	if !strings.Contains(errOut.String(), "warning: could not revoke previous admin token") {
 		t.Fatalf("expected admin revoke warning, got %q", errOut.String())
 	}
+	if !strings.Contains(errOut.String(), adminapi.AdminTokensURL()) {
+		t.Fatalf("expected admin tokens URL in warning, got %q", errOut.String())
+	}
 }
 
 func TestLogin_PlainOutput(t *testing.T) {

--- a/internal/cmd/auth/auth_test.go
+++ b/internal/cmd/auth/auth_test.go
@@ -14,6 +14,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/antiwork/gumroad-cli/internal/adminapi"
+	"github.com/antiwork/gumroad-cli/internal/adminconfig"
 	"github.com/antiwork/gumroad-cli/internal/config"
 	"github.com/antiwork/gumroad-cli/internal/oauth"
 	"github.com/antiwork/gumroad-cli/internal/testutil"
@@ -376,6 +378,48 @@ func TestStatus_ValidToken(t *testing.T) {
 	}
 }
 
+func TestStatus_ShowsStoredAdminWhoami(t *testing.T) {
+	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"success": true,
+			"user":    map[string]any{"name": "Jane", "email": "jane@example.com"},
+		}); err != nil {
+			t.Fatalf("Encode failed: %v", err)
+		}
+	})
+	withConfig(t, "valid-token")
+	if err := adminconfig.Save(&adminconfig.Config{
+		Token:           "admin-token",
+		TokenExternalID: "adm_local",
+		Actor:           adminconfig.Actor{Name: "Cached Admin", Email: "cached@example.com"},
+		ExpiresAt:       "cached",
+	}); err != nil {
+		t.Fatalf("Save admin config failed: %v", err)
+	}
+	adminSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/internal/admin/whoami" {
+			t.Fatalf("got path %q, want /internal/admin/whoami", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer admin-token" {
+			t.Fatalf("got Authorization=%q, want Bearer admin-token", got)
+		}
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"actor":  map[string]any{"name": "Live Admin", "email": "admin@example.com"},
+			"token":  map[string]any{"external_id": "adm_123", "expires_at": "2026-06-01T00:00:00Z"},
+			"scopes": []string{"admin"},
+		}); err != nil {
+			t.Fatalf("Encode failed: %v", err)
+		}
+	}))
+	t.Cleanup(adminSrv.Close)
+	t.Setenv(adminapi.EnvAPIBaseURL, adminSrv.URL)
+
+	out := runStatus(t)
+	if !strings.Contains(out, "Live Admin") || !strings.Contains(out, "2026-06-01T00:00:00Z") {
+		t.Fatalf("expected admin whoami output, got %q", out)
+	}
+}
+
 func TestStatus_ValidTokenWithNameOnly(t *testing.T) {
 	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewEncoder(w).Encode(map[string]any{
@@ -730,6 +774,86 @@ func TestLogout_WithYes(t *testing.T) {
 	}
 }
 
+func TestLogout_RevokesAndDeletesStoredAdminToken(t *testing.T) {
+	cfgDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cfgDir, "gumroad"), 0700); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "gumroad", "config.json"), []byte(`{"access_token":"tok"}`), 0600); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+	if err := adminconfig.Save(&adminconfig.Config{Token: "admin-token"}); err != nil {
+		t.Fatalf("Save admin config failed: %v", err)
+	}
+	adminPath, err := adminconfig.Path()
+	if err != nil {
+		t.Fatalf("adminconfig.Path: %v", err)
+	}
+
+	var revoked bool
+	adminSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/internal/admin/auth/revoke" {
+			t.Fatalf("got path %q, want /internal/admin/auth/revoke", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer admin-token" {
+			t.Fatalf("got Authorization=%q, want Bearer admin-token", got)
+		}
+		revoked = true
+		if err := json.NewEncoder(w).Encode(map[string]any{"success": true}); err != nil {
+			t.Fatalf("Encode failed: %v", err)
+		}
+	}))
+	t.Cleanup(adminSrv.Close)
+	t.Setenv(adminapi.EnvAPIBaseURL, adminSrv.URL)
+
+	cmd := testutil.Command(newLogoutCmd(), testutil.Yes(true))
+	if err := cmd.RunE(cmd, []string{}); err != nil {
+		t.Fatalf("RunE failed: %v", err)
+	}
+	if !revoked {
+		t.Fatal("expected admin revoke request")
+	}
+	if _, err := os.Stat(adminPath); !os.IsNotExist(err) {
+		t.Fatalf("admin config should be deleted, got err=%v", err)
+	}
+}
+
+func TestLogout_KeepsAdminTokenWhenServerRevokeFails(t *testing.T) {
+	cfgDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cfgDir, "gumroad"), 0700); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "gumroad", "config.json"), []byte(`{"access_token":"tok"}`), 0600); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+	if err := adminconfig.Save(&adminconfig.Config{Token: "admin-token"}); err != nil {
+		t.Fatalf("Save admin config failed: %v", err)
+	}
+	adminPath, err := adminconfig.Path()
+	if err != nil {
+		t.Fatalf("adminconfig.Path: %v", err)
+	}
+	adminSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		if err := json.NewEncoder(w).Encode(map[string]any{"success": false, "message": "boom"}); err != nil {
+			t.Fatalf("Encode failed: %v", err)
+		}
+	}))
+	t.Cleanup(adminSrv.Close)
+	t.Setenv(adminapi.EnvAPIBaseURL, adminSrv.URL)
+
+	cmd := testutil.Command(newLogoutCmd(), testutil.Yes(true))
+	err = cmd.RunE(cmd, []string{})
+	if err == nil || !strings.Contains(err.Error(), "couldn't revoke server-side") {
+		t.Fatalf("expected revoke failure, got %v", err)
+	}
+	if _, statErr := os.Stat(adminPath); statErr != nil {
+		t.Fatalf("admin config should remain after revoke failure: %v", statErr)
+	}
+}
+
 func TestLogout_RequiresConfirmation(t *testing.T) {
 	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
 		t.Error("should not reach API")
@@ -1006,13 +1130,18 @@ func withMockBrowserFail(t *testing.T) {
 // package to use it. Returns the API server for /user verification.
 func setupOAuthTokenServer(t *testing.T) {
 	t.Helper()
+	setupOAuthTokenServerWithResponse(t, oauth.TokenResponse{
+		AccessToken: "oauth-access-token-from-server",
+		TokenType:   "bearer",
+		Scope:       "edit_products view_sales",
+	})
+}
+
+func setupOAuthTokenServerWithResponse(t *testing.T, tokenResponse oauth.TokenResponse) {
+	t.Helper()
 	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(oauth.TokenResponse{
-			AccessToken: "oauth-access-token-from-server",
-			TokenType:   "bearer",
-			Scope:       "edit_products view_sales",
-		}); err != nil {
+		if err := json.NewEncoder(w).Encode(tokenResponse); err != nil {
 			t.Errorf("encode token response: %v", err)
 		}
 	}))
@@ -1065,6 +1194,66 @@ func TestLogin_OAuth_BrowserFlow(t *testing.T) {
 	}
 	if !strings.Contains(string(data), "oauth-access-token-from-server") {
 		t.Errorf("config should contain OAuth token, got: %s", data)
+	}
+}
+
+func TestLogin_OAuth_BrowserFlowSavesAdminTokenFromSameApproval(t *testing.T) {
+	withTerminal(t, true)
+	withMockBrowser(t)
+	setupOAuthTokenServerWithResponse(t, oauth.TokenResponse{
+		AccessToken: "oauth-access-token-from-server",
+		TokenType:   "bearer",
+		Scope:       "edit_products view_sales",
+		AdminToken: &oauth.AdminTokenResponse{
+			Token:           "admin-token-from-oauth",
+			TokenExternalID: "adm_123",
+			Actor:           oauth.AdminActor{Name: "Admin User", Email: "admin@example.com"},
+			ExpiresAt:       "2026-06-01T00:00:00Z",
+		},
+	})
+	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer oauth-access-token-from-server" {
+			w.WriteHeader(401)
+			if err := json.NewEncoder(w).Encode(map[string]any{"success": false}); err != nil {
+				t.Errorf("encode response: %v", err)
+			}
+			return
+		}
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"success": true,
+			"user":    map[string]any{"name": "OAuth User", "email": "oauth@test.com"},
+		}); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
+	})
+	cfgDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+
+	cmd := testutil.Command(newLoginCmd())
+	if err := cmd.RunE(cmd, []string{}); err != nil {
+		t.Fatalf("RunE: %v", err)
+	}
+
+	publicData, err := os.ReadFile(filepath.Join(cfgDir, "gumroad", "config.json"))
+	if err != nil {
+		t.Fatalf("public config not saved: %v", err)
+	}
+	if !strings.Contains(string(publicData), "oauth-access-token-from-server") {
+		t.Fatalf("public config should contain seller OAuth token, got %s", publicData)
+	}
+
+	adminPath, err := adminconfig.Path()
+	if err != nil {
+		t.Fatalf("adminconfig.Path: %v", err)
+	}
+	adminData, err := os.ReadFile(adminPath)
+	if err != nil {
+		t.Fatalf("admin config not saved: %v", err)
+	}
+	for _, want := range []string{"admin-token-from-oauth", "adm_123", "admin@example.com", "2026-06-01T00:00:00Z"} {
+		if !strings.Contains(string(adminData), want) {
+			t.Fatalf("admin config missing %q: %s", want, adminData)
+		}
 	}
 }
 

--- a/internal/cmd/auth/auth_test.go
+++ b/internal/cmd/auth/auth_test.go
@@ -267,6 +267,92 @@ func TestLogin_JSONOutputIncludesAdminTokenFromSameApproval(t *testing.T) {
 	}
 }
 
+func TestLogin_SavesSellerTokenWhenAdminTokenIsEmpty(t *testing.T) {
+	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.RawJSON(t, w, testutil.Fixture(t, "testdata/login_success.json"))
+	})
+	cfgDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+	opts := testutil.TestOptions()
+	cmd := testutil.WithOptions(newLoginCmd(), opts)
+
+	if err := verifyAndSave(cmd, opts, loginCredentials{
+		SellerToken: "good-token",
+		AdminToken:  &adminconfig.Config{},
+	}); err != nil {
+		t.Fatalf("verifyAndSave failed: %v", err)
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load config failed: %v", err)
+	}
+	if cfg.AccessToken != "good-token" {
+		t.Fatalf("got seller token %q, want good-token", cfg.AccessToken)
+	}
+	adminCfg, err := adminconfig.Load()
+	if err != nil {
+		t.Fatalf("Load admin config failed: %v", err)
+	}
+	if adminCfg.Token != "" {
+		t.Fatalf("expected no admin token to be saved, got %q", adminCfg.Token)
+	}
+}
+
+func TestLogin_SavesSellerAndAdminWhenPreviousAdminRevokeFails(t *testing.T) {
+	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.RawJSON(t, w, testutil.Fixture(t, "testdata/login_success.json"))
+	})
+	cfgDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+	if err := adminconfig.Save(&adminconfig.Config{Token: "old-admin-token"}); err != nil {
+		t.Fatalf("Save old admin config failed: %v", err)
+	}
+	adminSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/internal/admin/auth/revoke" {
+			t.Fatalf("got path %q, want /internal/admin/auth/revoke", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer old-admin-token" {
+			t.Fatalf("got Authorization=%q, want Bearer old-admin-token", got)
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		testutil.JSON(t, w, map[string]any{"success": false, "message": "temporary failure"})
+	}))
+	t.Cleanup(adminSrv.Close)
+	t.Setenv(adminapi.EnvAPIBaseURL, adminSrv.URL)
+	var errOut bytes.Buffer
+	opts := testutil.TestOptions(testutil.Stderr(&errOut))
+	cmd := testutil.WithOptions(newLoginCmd(), opts)
+
+	if err := verifyAndSave(cmd, opts, loginCredentials{
+		SellerToken: "good-token",
+		AdminToken: &adminconfig.Config{
+			Token: "new-admin-token",
+			Actor: adminconfig.Actor{Email: "admin@example.com"},
+		},
+	}); err != nil {
+		t.Fatalf("verifyAndSave failed: %v", err)
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load config failed: %v", err)
+	}
+	if cfg.AccessToken != "good-token" {
+		t.Fatalf("got seller token %q, want good-token", cfg.AccessToken)
+	}
+	adminCfg, err := adminconfig.Load()
+	if err != nil {
+		t.Fatalf("Load admin config failed: %v", err)
+	}
+	if adminCfg.Token != "new-admin-token" {
+		t.Fatalf("got admin token %q, want new-admin-token", adminCfg.Token)
+	}
+	if !strings.Contains(errOut.String(), "warning: could not revoke previous admin token") {
+		t.Fatalf("expected admin revoke warning, got %q", errOut.String())
+	}
+}
+
 func TestLogin_PlainOutput(t *testing.T) {
 	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
 		testutil.RawJSON(t, w, testutil.Fixture(t, "testdata/login_success.json"))
@@ -318,6 +404,22 @@ func TestLoginCredentialsFromOAuthResultExchangesAdminCode(t *testing.T) {
 	}
 	if creds.AdminToken.Token != "admin-token-from-code" || creds.AdminToken.Actor.Email != "code-admin@example.com" {
 		t.Fatalf("unexpected admin token: %+v", creds.AdminToken)
+	}
+}
+
+func TestLoginCredentialsFromOAuthResultIgnoresEmptyAdminToken(t *testing.T) {
+	creds, err := loginCredentialsFromOAuthResult(testutil.TestOptions(), oauth.FlowResult{
+		AccessToken: "seller-token",
+		AdminToken:  &oauth.AdminTokenResponse{},
+	})
+	if err != nil {
+		t.Fatalf("loginCredentialsFromOAuthResult failed: %v", err)
+	}
+	if creds.SellerToken != "seller-token" {
+		t.Fatalf("got seller token %q, want seller-token", creds.SellerToken)
+	}
+	if creds.AdminToken != nil {
+		t.Fatalf("expected empty admin token to be ignored, got %+v", creds.AdminToken)
 	}
 }
 
@@ -512,6 +614,39 @@ func TestStatus_ShowsStoredAdminWhoami(t *testing.T) {
 	}
 }
 
+func TestStatus_NotLoggedInShowsStoredAdminWhoami(t *testing.T) {
+	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach seller API when not logged in")
+	})
+	cfgDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+	if err := adminconfig.Save(&adminconfig.Config{Token: "admin-token"}); err != nil {
+		t.Fatalf("Save admin config failed: %v", err)
+	}
+	adminSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/internal/admin/whoami" {
+			t.Fatalf("got path %q, want /internal/admin/whoami", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer admin-token" {
+			t.Fatalf("got Authorization=%q, want Bearer admin-token", got)
+		}
+		testutil.JSON(t, w, map[string]any{
+			"actor": map[string]any{"name": "Live Admin", "email": "admin@example.com"},
+			"token": map[string]any{
+				"external_id": "adm_123",
+				"expires_at":  "2026-06-01T00:00:00Z",
+			},
+		})
+	}))
+	t.Cleanup(adminSrv.Close)
+	t.Setenv(adminapi.EnvAPIBaseURL, adminSrv.URL)
+
+	out := runStatus(t)
+	if !strings.Contains(out, "Not logged in.") || !strings.Contains(out, "Admin: Live Admin") {
+		t.Fatalf("expected not-logged-in output with admin status, got %q", out)
+	}
+}
+
 func TestStatus_JSONOutputShowsInvalidStoredAdminToken(t *testing.T) {
 	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
 		testutil.JSON(t, w, map[string]any{
@@ -576,6 +711,34 @@ func TestStatus_PlainOutputIncludesStoredAdminToken(t *testing.T) {
 	}
 }
 
+func TestStatus_PlainOutput_NotLoggedInIncludesStoredAdminToken(t *testing.T) {
+	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach seller API when not logged in")
+	})
+	cfgDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+	if err := adminconfig.Save(&adminconfig.Config{Token: "admin-token"}); err != nil {
+		t.Fatalf("Save admin config failed: %v", err)
+	}
+	adminSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"actor": map[string]any{"email": "admin@example.com"},
+			"token": map[string]any{
+				"external_id": "adm_123",
+				"expires_at":  "2026-06-01T00:00:00Z",
+			},
+		})
+	}))
+	t.Cleanup(adminSrv.Close)
+	t.Setenv(adminapi.EnvAPIBaseURL, adminSrv.URL)
+
+	out := runStatus(t, testutil.PlainOutput())
+	want := "false\t\t\t" + statusReasonNotLoggedIn + "\ttrue\tadmin@example.com\tadmin@example.com\t2026-06-01T00:00:00Z\t"
+	if strings.TrimSuffix(out, "\n") != want {
+		t.Fatalf("unexpected plain output: %q", out)
+	}
+}
+
 func TestStatus_StoredAdminAccessDenied(t *testing.T) {
 	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
 		testutil.JSON(t, w, map[string]any{
@@ -607,6 +770,14 @@ func TestStatus_StoredAdminAccessDenied(t *testing.T) {
 	admin := resp["admin"].(map[string]any)
 	if admin["authenticated"] != false || admin["reason"] != statusReasonAccessDenied {
 		t.Fatalf("unexpected admin status: %#v", admin)
+	}
+
+	textOut := runStatus(t)
+	if !strings.Contains(textOut, "admin access is denied") {
+		t.Fatalf("expected access denied guidance, got %q", textOut)
+	}
+	if strings.Contains(textOut, "invalid or expired") {
+		t.Fatalf("access denied should not be reported as invalid or expired: %q", textOut)
 	}
 }
 
@@ -736,6 +907,45 @@ func TestStatus_JSONOutput_NotLoggedIn(t *testing.T) {
 	}
 	if resp["reason"] != statusReasonNotLoggedIn {
 		t.Errorf("got reason=%v, want %s", resp["reason"], statusReasonNotLoggedIn)
+	}
+}
+
+func TestStatus_JSONOutput_NotLoggedInIncludesStoredAdminToken(t *testing.T) {
+	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach seller API when not logged in")
+	})
+	cfgDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+	if err := adminconfig.Save(&adminconfig.Config{Token: "admin-token"}); err != nil {
+		t.Fatalf("Save admin config failed: %v", err)
+	}
+	adminSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"actor": map[string]any{"name": "Live Admin", "email": "admin@example.com"},
+			"token": map[string]any{
+				"external_id": "adm_123",
+				"expires_at":  "2026-06-01T00:00:00Z",
+			},
+		})
+	}))
+	t.Cleanup(adminSrv.Close)
+	t.Setenv(adminapi.EnvAPIBaseURL, adminSrv.URL)
+
+	out := runStatus(t, testutil.JSONOutput())
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("status JSON output is invalid: %v\n%s", err, out)
+	}
+	if resp["authenticated"] != false || resp["reason"] != statusReasonNotLoggedIn {
+		t.Fatalf("unexpected seller status: %#v", resp)
+	}
+	admin := resp["admin"].(map[string]any)
+	if admin["authenticated"] != true {
+		t.Fatalf("unexpected admin status: %#v", admin)
+	}
+	actor := admin["actor"].(map[string]any)
+	if actor["email"] != "admin@example.com" {
+		t.Fatalf("got admin actor email=%v, want admin@example.com", actor["email"])
 	}
 }
 

--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -152,7 +152,8 @@ func loginCredentialsFromOAuthResult(opts cmdutil.Options, result oauth.FlowResu
 	case result.AdminAuthorizationCode != "":
 		adminToken, err := adminapi.ExchangeAuthorizationCode(opts.Context, result.AdminAuthorizationCode, result.CodeVerifier, opts.Version, opts.DebugEnabled())
 		if err != nil {
-			return loginCredentials{}, fmt.Errorf("could not authorize admin token: %w", err)
+			warnAdminAuthorizationFailure(opts, err)
+			return creds, nil
 		}
 		creds.AdminToken = adminConfigFromExchange(adminToken)
 	}
@@ -266,6 +267,10 @@ func verifyAndSave(c *cobra.Command, opts cmdutil.Options, creds loginCredential
 
 func warnAdminRevokeFailure(opts cmdutil.Options, err error) {
 	_, _ = fmt.Fprintf(opts.Err(), "warning: %v\n", err)
+}
+
+func warnAdminAuthorizationFailure(opts cmdutil.Options, err error) {
+	_, _ = fmt.Fprintf(opts.Err(), "warning: could not authorize admin token: %v\n", err)
 }
 
 func revokeExistingAdminToken(opts cmdutil.Options) error {

--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -266,7 +266,7 @@ func verifyAndSave(c *cobra.Command, opts cmdutil.Options, creds loginCredential
 }
 
 func warnAdminRevokeFailure(opts cmdutil.Options, err error) {
-	_, _ = fmt.Fprintf(opts.Err(), "warning: %v\n", err)
+	_, _ = fmt.Fprintf(opts.Err(), "warning: %v\nThe previous admin token may still be valid server-side; revoke it at %s\n", err, adminapi.AdminTokensURL())
 }
 
 func warnAdminAuthorizationFailure(opts cmdutil.Options, err error) {

--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/antiwork/gumroad-cli/internal/adminapi"
 	"github.com/antiwork/gumroad-cli/internal/adminconfig"
@@ -159,11 +160,11 @@ func loginCredentialsFromOAuthResult(opts cmdutil.Options, result oauth.FlowResu
 }
 
 func adminConfigFromOAuth(token *oauth.AdminTokenResponse) *adminconfig.Config {
-	if token == nil {
+	if token == nil || strings.TrimSpace(token.Token) == "" {
 		return nil
 	}
 	return &adminconfig.Config{
-		Token:           token.Token,
+		Token:           strings.TrimSpace(token.Token),
 		TokenExternalID: token.TokenExternalID,
 		Actor: adminconfig.Actor{
 			Name:  token.Actor.Name,
@@ -174,8 +175,11 @@ func adminConfigFromOAuth(token *oauth.AdminTokenResponse) *adminconfig.Config {
 }
 
 func adminConfigFromExchange(token adminapi.AdminToken) *adminconfig.Config {
+	if strings.TrimSpace(token.Token) == "" {
+		return nil
+	}
 	return &adminconfig.Config{
-		Token:           token.Token,
+		Token:           strings.TrimSpace(token.Token),
 		TokenExternalID: token.TokenExternalID,
 		Actor:           token.Actor,
 		ExpiresAt:       token.ExpiresAt,
@@ -204,17 +208,16 @@ func verifyAndSave(c *cobra.Command, opts cmdutil.Options, creds loginCredential
 		return err
 	}
 
-	if creds.AdminToken != nil {
-		if creds.AdminToken.Token == "" {
-			return fmt.Errorf("admin token response did not contain a token")
-		}
-		if err := revokeExistingAdminToken(opts); err != nil {
-			return err
-		}
-	}
-
 	if err := config.Save(&config.Config{AccessToken: creds.SellerToken}); err != nil {
 		return fmt.Errorf("could not save token: %w", err)
+	}
+	if creds.AdminToken != nil {
+		creds.AdminToken.Token = strings.TrimSpace(creds.AdminToken.Token)
+		if creds.AdminToken.Token == "" {
+			creds.AdminToken = nil
+		} else if err := revokeExistingAdminToken(opts); err != nil {
+			warnAdminRevokeFailure(opts, err)
+		}
 	}
 	if creds.AdminToken != nil {
 		if err := adminconfig.Save(creds.AdminToken); err != nil {
@@ -259,6 +262,10 @@ func verifyAndSave(c *cobra.Command, opts cmdutil.Options, creds loginCredential
 		return output.Writeln(opts.Out(), opts.Style().Green("✓")+" Admin operations authorized as "+opts.Style().Bold(adminActorName(creds.AdminToken.Actor)))
 	}
 	return nil
+}
+
+func warnAdminRevokeFailure(opts cmdutil.Options, err error) {
+	_, _ = fmt.Fprintf(opts.Err(), "warning: %v\n", err)
 }
 
 func revokeExistingAdminToken(opts cmdutil.Options) error {

--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -9,6 +9,8 @@ import (
 	"net/url"
 	"os"
 
+	"github.com/antiwork/gumroad-cli/internal/adminapi"
+	"github.com/antiwork/gumroad-cli/internal/adminconfig"
 	"github.com/antiwork/gumroad-cli/internal/api"
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/config"
@@ -21,6 +23,11 @@ import (
 
 type authUserEnvelope struct {
 	User json.RawMessage `json:"user"`
+}
+
+type loginCredentials struct {
+	SellerToken string
+	AdminToken  *adminconfig.Config
 }
 
 // isTerminalFunc checks whether the reader is a terminal. Replaceable in tests.
@@ -36,7 +43,7 @@ func newLoginCmd() *cobra.Command {
 		Long: `Log in to Gumroad via browser-based OAuth or a manual API token.
 
 By default, opens your browser for OAuth authorization.
-When stdin is piped (e.g. echo $TOKEN | gumroad auth login), reads a token directly.`,
+When stdin is piped (e.g. echo $TOKEN | gumroad auth login), reads a seller token directly.`,
 		Example: `  # Browser-based OAuth login (default)
   gumroad auth login
 
@@ -51,15 +58,15 @@ When stdin is piped (e.g. echo $TOKEN | gumroad auth login), reads a token direc
 				return cmdutil.PrintDryRunAction(opts, "store API token")
 			}
 
-			token, err := resolveToken(opts, webFlag)
+			creds, err := resolveLoginCredentials(opts, webFlag)
 			if err != nil {
 				return err
 			}
-			if token == "" {
+			if creds.SellerToken == "" {
 				return cmdutil.UsageErrorf(c, "token cannot be empty")
 			}
 
-			return verifyAndSave(c, opts, token)
+			return verifyAndSave(c, opts, creds)
 		},
 	}
 
@@ -68,9 +75,10 @@ When stdin is piped (e.g. echo $TOKEN | gumroad auth login), reads a token direc
 	return cmd
 }
 
-func resolveToken(opts cmdutil.Options, webFlag bool) (string, error) {
+func resolveLoginCredentials(opts cmdutil.Options, webFlag bool) (loginCredentials, error) {
 	if !isTerminalFunc(opts.In()) {
-		return prompt.TokenInput(opts.In(), opts.Err(), opts.NoInput)
+		token, err := prompt.TokenInput(opts.In(), opts.Err(), opts.NoInput)
+		return loginCredentials{SellerToken: token}, err
 	}
 	return oauthLogin(opts, webFlag)
 }
@@ -82,33 +90,37 @@ func defaultIsTerminal(r interface{}) bool {
 	return false
 }
 
-func oauthLogin(opts cmdutil.Options, webFlag bool) (string, error) {
+func oauthLogin(opts cmdutil.Options, webFlag bool) (loginCredentials, error) {
 	cfg := oauth.DefaultFlowConfig()
 
-	token, browserErr := tryBrowserFlow(opts, cfg)
+	result, browserErr := tryBrowserFlow(opts, cfg)
 	if browserErr == nil {
-		return token, nil
+		return loginCredentialsFromOAuthResult(opts, result)
 	}
 
 	if webFlag {
-		return "", fmt.Errorf("browser login failed: %w", browserErr)
+		return loginCredentials{}, fmt.Errorf("browser login failed: %w", browserErr)
 	}
 
 	// Fall back to headless flow.
 	fmt.Fprintln(opts.Err(), "Could not open browser. Falling back to manual flow.")
 	fmt.Fprintln(opts.Err())
 
-	return oauth.HeadlessFlow(opts.Context, cfg, opts.Err(), stdinReader(opts.In()))
+	result, err := oauth.HeadlessFlowResult(opts.Context, cfg, opts.Err(), stdinReader(opts.In()))
+	if err != nil {
+		return loginCredentials{}, err
+	}
+	return loginCredentialsFromOAuthResult(opts, result)
 }
 
-func tryBrowserFlow(opts cmdutil.Options, cfg oauth.FlowConfig) (string, error) {
+func tryBrowserFlow(opts cmdutil.Options, cfg oauth.FlowConfig) (oauth.FlowResult, error) {
 	sp := output.NewSpinnerTo("Opening browser for authorization...", opts.Err())
 	if cmdutil.ShouldShowSpinner(opts) {
 		sp.Start()
 	}
 	defer sp.Stop()
 
-	return oauth.BrowserFlow(opts.Context, cfg, func(authURL string) error {
+	return oauth.BrowserFlowResult(opts.Context, cfg, func(authURL string) error {
 		sp.Stop()
 		if err := oauth.OpenBrowser(authURL); err != nil {
 			return err
@@ -131,14 +143,53 @@ func stdinReader(in io.Reader) func() (string, error) {
 	}
 }
 
-func verifyAndSave(c *cobra.Command, opts cmdutil.Options, token string) error {
+func loginCredentialsFromOAuthResult(opts cmdutil.Options, result oauth.FlowResult) (loginCredentials, error) {
+	creds := loginCredentials{SellerToken: result.AccessToken}
+	switch {
+	case result.AdminToken != nil:
+		creds.AdminToken = adminConfigFromOAuth(result.AdminToken)
+	case result.AdminAuthorizationCode != "":
+		adminToken, err := adminapi.ExchangeAuthorizationCode(opts.Context, result.AdminAuthorizationCode, result.CodeVerifier, opts.Version, opts.DebugEnabled())
+		if err != nil {
+			return loginCredentials{}, fmt.Errorf("could not authorize admin token: %w", err)
+		}
+		creds.AdminToken = adminConfigFromExchange(adminToken)
+	}
+	return creds, nil
+}
+
+func adminConfigFromOAuth(token *oauth.AdminTokenResponse) *adminconfig.Config {
+	if token == nil {
+		return nil
+	}
+	return &adminconfig.Config{
+		Token:           token.Token,
+		TokenExternalID: token.TokenExternalID,
+		Actor: adminconfig.Actor{
+			Name:  token.Actor.Name,
+			Email: token.Actor.Email,
+		},
+		ExpiresAt: token.ExpiresAt,
+	}
+}
+
+func adminConfigFromExchange(token adminapi.AdminToken) *adminconfig.Config {
+	return &adminconfig.Config{
+		Token:           token.Token,
+		TokenExternalID: token.TokenExternalID,
+		Actor:           token.Actor,
+		ExpiresAt:       token.ExpiresAt,
+	}
+}
+
+func verifyAndSave(c *cobra.Command, opts cmdutil.Options, creds loginCredentials) error {
 	sp := output.NewSpinnerTo("Verifying token...", opts.Err())
 	if cmdutil.ShouldShowSpinner(opts) {
 		sp.Start()
 	}
 	defer sp.Stop()
 
-	client := cmdutil.NewAPIClient(opts, token)
+	client := cmdutil.NewAPIClient(opts, creds.SellerToken)
 	data, err := client.Get("/user", url.Values{})
 	if err != nil {
 		var apiErr *api.APIError
@@ -153,17 +204,35 @@ func verifyAndSave(c *cobra.Command, opts cmdutil.Options, token string) error {
 		return err
 	}
 
-	if err := config.Save(&config.Config{AccessToken: token}); err != nil {
+	if creds.AdminToken != nil {
+		if creds.AdminToken.Token == "" {
+			return fmt.Errorf("admin token response did not contain a token")
+		}
+		if err := revokeExistingAdminToken(opts); err != nil {
+			return err
+		}
+	}
+
+	if err := config.Save(&config.Config{AccessToken: creds.SellerToken}); err != nil {
 		return fmt.Errorf("could not save token: %w", err)
+	}
+	if creds.AdminToken != nil {
+		if err := adminconfig.Save(creds.AdminToken); err != nil {
+			return fmt.Errorf("could not save admin token: %w", err)
+		}
 	}
 
 	sp.Stop()
 
 	if opts.UsesJSONOutput() {
-		return printAuthJSON(opts, statusOutput{
+		status := statusOutput{
 			Authenticated: true,
 			User:          resp.User,
-		})
+		}
+		if creds.AdminToken != nil {
+			status.Admin = adminStatusFromConfig(creds.AdminToken, true, "")
+		}
+		return printAuthJSON(opts, status)
 	}
 
 	user, err := decodeAuthUser(resp.User)
@@ -172,14 +241,44 @@ func verifyAndSave(c *cobra.Command, opts cmdutil.Options, token string) error {
 	}
 
 	if opts.PlainOutput {
-		return output.PrintPlain(opts.Out(), [][]string{
-			{"true", user.Name, user.Email},
-		})
+		row := []string{"true", user.Name, user.Email}
+		if creds.AdminToken != nil {
+			row = append(row, "true", adminActorName(creds.AdminToken.Actor), creds.AdminToken.Actor.Email, creds.AdminToken.ExpiresAt)
+		}
+		return output.PrintPlain(opts.Out(), [][]string{row})
 	}
 
 	if opts.Quiet {
 		return nil
 	}
 
-	return writeAuthenticatedMessage(opts.Out(), opts.Style(), user, "Logged in.")
+	if err := writeAuthenticatedMessage(opts.Out(), opts.Style(), user, "Logged in."); err != nil {
+		return err
+	}
+	if creds.AdminToken != nil {
+		return output.Writeln(opts.Out(), opts.Style().Green("✓")+" Admin operations authorized as "+opts.Style().Bold(adminActorName(creds.AdminToken.Actor)))
+	}
+	return nil
+}
+
+func revokeExistingAdminToken(opts cmdutil.Options) error {
+	tokenInfo, err := adminconfig.ResolveStoredToken()
+	if err != nil {
+		if errors.Is(err, adminconfig.ErrNotAuthenticated) {
+			return nil
+		}
+		return err
+	}
+
+	client := adminapi.NewClientWithContext(opts.Context, tokenInfo.Value, opts.Version, opts.DebugEnabled())
+	client.SetDebugWriter(opts.Err())
+	if err := client.RevokeSelf(); err != nil {
+		var apiErr *api.APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == 401 {
+			_ = adminconfig.Delete()
+			return nil
+		}
+		return fmt.Errorf("could not revoke previous admin token: %w", err)
+	}
+	return nil
 }

--- a/internal/cmd/auth/logout.go
+++ b/internal/cmd/auth/logout.go
@@ -1,8 +1,13 @@
 package auth
 
 import (
+	"errors"
+	"fmt"
 	"strconv"
 
+	"github.com/antiwork/gumroad-cli/internal/adminapi"
+	"github.com/antiwork/gumroad-cli/internal/adminconfig"
+	"github.com/antiwork/gumroad-cli/internal/api"
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/config"
 	"github.com/antiwork/gumroad-cli/internal/output"
@@ -10,10 +15,11 @@ import (
 )
 
 type logoutStatus struct {
-	Authenticated bool               `json:"authenticated"`
-	LoggedOut     bool               `json:"logged_out"`
-	Source        config.TokenSource `json:"source,omitempty"`
-	Message       string             `json:"message,omitempty"`
+	Authenticated  bool               `json:"authenticated"`
+	LoggedOut      bool               `json:"logged_out"`
+	AdminLoggedOut bool               `json:"admin_logged_out,omitempty"`
+	Source         config.TokenSource `json:"source,omitempty"`
+	Message        string             `json:"message,omitempty"`
 }
 
 func newLogoutCmd() *cobra.Command {
@@ -35,13 +41,18 @@ func newLogoutCmd() *cobra.Command {
 				return cmdutil.PrintDryRunAction(opts, "remove stored API token")
 			}
 
+			adminLoggedOut, adminErr := revokeAndDeleteAdminToken(opts)
 			if err := config.Delete(); err != nil {
 				return err
 			}
+			if adminErr != nil {
+				return adminErr
+			}
 
 			status := logoutStatus{
-				Authenticated: false,
-				LoggedOut:     true,
+				Authenticated:  false,
+				LoggedOut:      true,
+				AdminLoggedOut: adminLoggedOut,
 			}
 			message := "Logged out successfully."
 			tokenInfo, err := config.ResolveToken()
@@ -55,9 +66,11 @@ func newLogoutCmd() *cobra.Command {
 				return printAuthJSON(opts, status)
 			}
 			if opts.PlainOutput {
-				return output.PrintPlain(opts.Out(), [][]string{
-					{strconv.FormatBool(status.Authenticated), strconv.FormatBool(status.LoggedOut), string(status.Source)},
-				})
+				row := []string{strconv.FormatBool(status.Authenticated), strconv.FormatBool(status.LoggedOut), string(status.Source)}
+				if status.AdminLoggedOut {
+					row = append(row, strconv.FormatBool(status.AdminLoggedOut))
+				}
+				return output.PrintPlain(opts.Out(), [][]string{row})
 			}
 			if opts.Quiet {
 				return nil
@@ -69,4 +82,25 @@ func newLogoutCmd() *cobra.Command {
 			return output.Writeln(opts.Out(), style.Green("✓")+" "+message)
 		},
 	}
+}
+
+func revokeAndDeleteAdminToken(opts cmdutil.Options) (bool, error) {
+	tokenInfo, err := adminconfig.ResolveStoredToken()
+	if err != nil {
+		if errors.Is(err, adminconfig.ErrNotAuthenticated) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	client := adminapi.NewClientWithContext(opts.Context, tokenInfo.Value, opts.Version, opts.DebugEnabled())
+	client.SetDebugWriter(opts.Err())
+	if err := client.RevokeSelf(); err != nil {
+		var apiErr *api.APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == 401 {
+			return true, adminconfig.Delete()
+		}
+		return false, fmt.Errorf("couldn't revoke server-side; retry with 'gumroad auth logout', or revoke from %s", adminapi.AdminTokensURL())
+	}
+	return true, adminconfig.Delete()
 }

--- a/internal/cmd/auth/status.go
+++ b/internal/cmd/auth/status.go
@@ -21,6 +21,7 @@ const (
 	statusReasonNotLoggedIn      = "not_logged_in"
 	statusReasonInvalidOrExpired = "invalid_or_expired"
 	statusReasonAccessDenied     = "access_denied"
+	statusReasonUnreachable      = "unreachable"
 )
 
 type statusOutput struct {
@@ -102,12 +103,20 @@ func newStatusCmd() *cobra.Command {
 			}
 
 			if !status.Authenticated {
+				var message string
 				switch status.Reason {
 				case statusReasonAccessDenied:
-					return output.Writeln(opts.Out(), authSourceMessage(status.Source, "Token was accepted but access is denied. Check that it has the required scope.", "GUMROAD_ACCESS_TOKEN was accepted but access is denied. Check that it has the required scope."))
+					message = authSourceMessage(status.Source, "Token was accepted but access is denied. Check that it has the required scope.", "GUMROAD_ACCESS_TOKEN was accepted but access is denied. Check that it has the required scope.")
 				default:
-					return output.Writeln(opts.Out(), authSourceMessage(status.Source, "Token is invalid or expired. Run "+style.Bold("gumroad auth login")+" to re-authenticate.", "GUMROAD_ACCESS_TOKEN is invalid or expired. Update it in your shell and try again."))
+					message = authSourceMessage(status.Source, "Token is invalid or expired. Run "+style.Bold("gumroad auth login")+" to re-authenticate.", "GUMROAD_ACCESS_TOKEN is invalid or expired. Update it in your shell and try again.")
 				}
+				if err := output.Writeln(opts.Out(), message); err != nil {
+					return err
+				}
+				if status.Admin != nil {
+					return writeAdminStatusMessage(opts, *status.Admin)
+				}
+				return nil
 			}
 
 			user, err := decodeAuthUser(status.User)
@@ -185,7 +194,8 @@ func lookupAdminStatusIfStored(opts cmdutil.Options) (*adminStatusOutput, error)
 				return &status, nil
 			}
 		}
-		return nil, fmt.Errorf("could not verify admin token: %w", err)
+		status := adminStatusFromTokenInfo(tokenInfo, false, statusReasonUnreachable)
+		return &status, nil
 	}
 
 	status := adminStatusOutput{
@@ -239,8 +249,11 @@ func writeAuthenticatedMessage(w io.Writer, style output.Styler, user authUser, 
 func writeAdminStatusMessage(opts cmdutil.Options, status adminStatusOutput) error {
 	style := opts.Style()
 	if !status.Authenticated {
-		if status.Reason == statusReasonAccessDenied {
+		switch status.Reason {
+		case statusReasonAccessDenied:
 			return output.Writeln(opts.Out(), "Admin token was accepted but admin access is denied. Request admin access for this account.")
+		case statusReasonUnreachable:
+			return output.Writeln(opts.Out(), "Could not reach the admin API to verify admin token. Try again later.")
 		}
 		return output.Writeln(opts.Out(), "Admin token is invalid or expired. Run "+style.Bold("gumroad auth login")+" and check the admin box.")
 	}

--- a/internal/cmd/auth/status.go
+++ b/internal/cmd/auth/status.go
@@ -64,13 +64,24 @@ func newStatusCmd() *cobra.Command {
 					return err
 				}
 				status := unauthenticatedStatus(statusReasonNotLoggedIn)
+				adminStatus, err := lookupAdminStatusIfStored(opts)
+				if err != nil {
+					return err
+				}
+				status.Admin = adminStatus
 				if opts.UsesJSONOutput() {
 					return printAuthJSON(opts, status)
 				}
 				if opts.PlainOutput {
 					return printStatusPlain(opts, status)
 				}
-				return output.Writeln(opts.Out(), "Not logged in. Run "+style.Bold("gumroad auth login")+" or set "+style.Bold(config.EnvAccessToken)+" to authenticate.")
+				if err := output.Writeln(opts.Out(), "Not logged in. Run "+style.Bold("gumroad auth login")+" or set "+style.Bold(config.EnvAccessToken)+" to authenticate."); err != nil {
+					return err
+				}
+				if status.Admin != nil {
+					return writeAdminStatusMessage(opts, *status.Admin)
+				}
+				return nil
 			}
 
 			status, err := lookupStatus(opts, tokenInfo)
@@ -228,6 +239,9 @@ func writeAuthenticatedMessage(w io.Writer, style output.Styler, user authUser, 
 func writeAdminStatusMessage(opts cmdutil.Options, status adminStatusOutput) error {
 	style := opts.Style()
 	if !status.Authenticated {
+		if status.Reason == statusReasonAccessDenied {
+			return output.Writeln(opts.Out(), "Admin token was accepted but admin access is denied. Request admin access for this account.")
+		}
 		return output.Writeln(opts.Out(), "Admin token is invalid or expired. Run "+style.Bold("gumroad auth login")+" and check the admin box.")
 	}
 

--- a/internal/cmd/auth/status.go
+++ b/internal/cmd/auth/status.go
@@ -8,6 +8,8 @@ import (
 	"net/url"
 	"strconv"
 
+	"github.com/antiwork/gumroad-cli/internal/adminapi"
+	"github.com/antiwork/gumroad-cli/internal/adminconfig"
 	"github.com/antiwork/gumroad-cli/internal/api"
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/config"
@@ -24,8 +26,22 @@ const (
 type statusOutput struct {
 	Authenticated bool               `json:"authenticated"`
 	User          json.RawMessage    `json:"user,omitempty"`
+	Admin         *adminStatusOutput `json:"admin,omitempty"`
 	Reason        string             `json:"reason,omitempty"`
 	Source        config.TokenSource `json:"source,omitempty"`
+}
+
+type adminStatusOutput struct {
+	Authenticated bool                    `json:"authenticated"`
+	Actor         adminconfig.Actor       `json:"actor,omitempty"`
+	Token         adminStatusToken        `json:"token,omitempty"`
+	Reason        string                  `json:"reason,omitempty"`
+	Source        adminconfig.TokenSource `json:"source,omitempty"`
+}
+
+type adminStatusToken struct {
+	ExternalID string `json:"external_id,omitempty"`
+	ExpiresAt  string `json:"expires_at,omitempty"`
 }
 
 type authUser struct {
@@ -61,6 +77,11 @@ func newStatusCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			adminStatus, err := lookupAdminStatusIfStored(opts)
+			if err != nil {
+				return err
+			}
+			status.Admin = adminStatus
 
 			if opts.UsesJSONOutput() {
 				return printAuthJSON(opts, status)
@@ -84,6 +105,11 @@ func newStatusCmd() *cobra.Command {
 			}
 			if err := writeAuthenticatedMessage(opts.Out(), style, user, "Authenticated."); err != nil {
 				return err
+			}
+			if status.Admin != nil {
+				if err := writeAdminStatusMessage(opts, *status.Admin); err != nil {
+					return err
+				}
 			}
 			return output.Writeln(opts.Out(), style.Dim("Source: "+authSourceLabel(status.Source)))
 		},
@@ -124,6 +150,45 @@ func lookupStatus(opts cmdutil.Options, tokenInfo config.TokenInfo) (statusOutpu
 	}, nil
 }
 
+func lookupAdminStatusIfStored(opts cmdutil.Options) (*adminStatusOutput, error) {
+	tokenInfo, err := adminconfig.ResolveStoredToken()
+	if err != nil {
+		if errors.Is(err, adminconfig.ErrNotAuthenticated) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	client := adminapi.NewClientWithContext(opts.Context, tokenInfo.Value, opts.Version, opts.DebugEnabled())
+	client.SetDebugWriter(opts.Err())
+	resp, err := client.Whoami()
+	if err != nil {
+		var apiErr *api.APIError
+		if errors.As(err, &apiErr) {
+			switch apiErr.StatusCode {
+			case 401:
+				status := adminStatusFromTokenInfo(tokenInfo, false, statusReasonInvalidOrExpired)
+				return &status, nil
+			case 403:
+				status := adminStatusFromTokenInfo(tokenInfo, false, statusReasonAccessDenied)
+				return &status, nil
+			}
+		}
+		return nil, fmt.Errorf("could not verify admin token: %w", err)
+	}
+
+	status := adminStatusOutput{
+		Authenticated: true,
+		Actor:         resp.Actor,
+		Token: adminStatusToken{
+			ExternalID: resp.Token.ExternalID,
+			ExpiresAt:  resp.Token.ExpiresAt,
+		},
+		Source: tokenInfo.Source,
+	}
+	return &status, nil
+}
+
 func unauthenticatedStatus(reason string) statusOutput {
 	return statusOutput{
 		Authenticated: false,
@@ -160,6 +225,58 @@ func writeAuthenticatedMessage(w io.Writer, style output.Styler, user authUser, 
 	return output.Writeln(w, style.Green("✓")+" "+fallback)
 }
 
+func writeAdminStatusMessage(opts cmdutil.Options, status adminStatusOutput) error {
+	style := opts.Style()
+	if !status.Authenticated {
+		return output.Writeln(opts.Out(), "Admin token is invalid or expired. Run "+style.Bold("gumroad auth login")+" and check the admin box.")
+	}
+
+	line := "Admin: " + adminActorName(status.Actor)
+	if status.Token.ExpiresAt != "" {
+		line += " (expires " + status.Token.ExpiresAt + ")"
+	}
+	return output.Writeln(opts.Out(), line)
+}
+
+func adminStatusFromConfig(cfg *adminconfig.Config, authenticated bool, reason string) *adminStatusOutput {
+	if cfg == nil {
+		return nil
+	}
+	return &adminStatusOutput{
+		Authenticated: authenticated,
+		Actor:         cfg.Actor,
+		Token: adminStatusToken{
+			ExternalID: cfg.TokenExternalID,
+			ExpiresAt:  cfg.ExpiresAt,
+		},
+		Reason: reason,
+		Source: adminconfig.TokenSourceConfig,
+	}
+}
+
+func adminStatusFromTokenInfo(info adminconfig.TokenInfo, authenticated bool, reason string) adminStatusOutput {
+	return adminStatusOutput{
+		Authenticated: authenticated,
+		Actor:         info.Actor,
+		Token: adminStatusToken{
+			ExternalID: info.TokenExternalID,
+			ExpiresAt:  info.ExpiresAt,
+		},
+		Reason: reason,
+		Source: info.Source,
+	}
+}
+
+func adminActorName(actor adminconfig.Actor) string {
+	if actor.Name != "" {
+		return actor.Name
+	}
+	if actor.Email != "" {
+		return actor.Email
+	}
+	return "admin token"
+}
+
 func printAuthJSON(opts cmdutil.Options, v any) error {
 	data, err := json.Marshal(v)
 	if err != nil {
@@ -174,9 +291,17 @@ func printStatusPlain(opts cmdutil.Options, status statusOutput) error {
 		return err
 	}
 
-	return output.PrintPlain(opts.Out(), [][]string{
-		{strconv.FormatBool(status.Authenticated), user.Name, user.Email, status.Reason},
-	})
+	row := []string{strconv.FormatBool(status.Authenticated), user.Name, user.Email, status.Reason}
+	if status.Admin != nil {
+		row = append(row,
+			strconv.FormatBool(status.Admin.Authenticated),
+			adminActorName(status.Admin.Actor),
+			status.Admin.Actor.Email,
+			status.Admin.Token.ExpiresAt,
+			status.Admin.Reason,
+		)
+	}
+	return output.PrintPlain(opts.Out(), [][]string{row})
 }
 
 func authSourceLabel(source config.TokenSource) string {

--- a/internal/oauth/flow.go
+++ b/internal/oauth/flow.go
@@ -18,19 +18,41 @@ import (
 
 // TokenResponse is the JSON body returned by the OAuth token endpoint.
 type TokenResponse struct {
-	AccessToken string `json:"access_token"`
-	TokenType   string `json:"token_type"`
-	Scope       string `json:"scope"`
+	AccessToken string              `json:"access_token"`
+	TokenType   string              `json:"token_type"`
+	Scope       string              `json:"scope"`
+	AdminToken  *AdminTokenResponse `json:"admin_token,omitempty"`
+	Admin       *AdminTokenResponse `json:"admin,omitempty"`
+}
+
+type AdminTokenResponse struct {
+	Token           string     `json:"token"`
+	TokenExternalID string     `json:"token_external_id"`
+	Actor           AdminActor `json:"actor"`
+	ExpiresAt       string     `json:"expires_at"`
+}
+
+type AdminActor struct {
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
+type FlowResult struct {
+	AccessToken            string
+	AdminToken             *AdminTokenResponse
+	AdminAuthorizationCode string
+	CodeVerifier           string
 }
 
 // FlowConfig holds the parameters for an OAuth authorization code flow.
 type FlowConfig struct {
-	ClientID     string
-	AuthorizeURL string
-	TokenURL     string
-	Scopes       string
-	Timeout      time.Duration
-	HTTPClient   *http.Client // optional; defaults to http.DefaultClient
+	ClientID      string
+	AuthorizeURL  string
+	TokenURL      string
+	Scopes        string
+	OptionalAdmin bool
+	Timeout       time.Duration
+	HTTPClient    *http.Client // optional; defaults to http.DefaultClient
 }
 
 // DefaultFlowConfigFunc returns a FlowConfig using the built-in constants.
@@ -44,24 +66,40 @@ func DefaultFlowConfig() FlowConfig {
 
 func defaultFlowConfig() FlowConfig {
 	return FlowConfig{
-		ClientID:     ClientID,
-		AuthorizeURL: AuthorizeURL,
-		TokenURL:     TokenURL,
-		Scopes:       Scopes,
-		Timeout:      DefaultTimeout,
+		ClientID:      ClientID,
+		AuthorizeURL:  AuthorizeURL,
+		TokenURL:      TokenURL,
+		Scopes:        Scopes,
+		OptionalAdmin: true,
+		Timeout:       DefaultTimeout,
 	}
 }
 
-// callbackResult carries the authorization code or error from the callback handler.
+type callbackPayload struct {
+	Code      string
+	AdminCode string
+}
+
+// callbackResult carries the authorization callback payload or error from the callback handler.
 type callbackResult struct {
-	Code string
-	Err  error
+	Payload callbackPayload
+	Err     error
 }
 
 // BrowserFlow runs the full OAuth authorization code flow with PKCE.
 // It binds a local listener, opens the authorize URL via openBrowser,
 // waits for the callback, and exchanges the code for an access token.
 func BrowserFlow(ctx context.Context, cfg FlowConfig, openBrowser func(string) error) (string, error) {
+	result, err := BrowserFlowResult(ctx, cfg, openBrowser)
+	if err != nil {
+		return "", err
+	}
+	return result.AccessToken, nil
+}
+
+// BrowserFlowResult runs BrowserFlow and returns optional admin credential
+// material emitted by the unified Gumroad authorization page.
+func BrowserFlowResult(ctx context.Context, cfg FlowConfig, openBrowser func(string) error) (FlowResult, error) {
 	if cfg.HTTPClient == nil {
 		cfg.HTTPClient = http.DefaultClient
 	}
@@ -72,7 +110,7 @@ func BrowserFlow(ctx context.Context, cfg FlowConfig, openBrowser func(string) e
 	// Bind ephemeral port.
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
-		return "", fmt.Errorf("could not bind local listener: %w", err)
+		return FlowResult{}, fmt.Errorf("could not bind local listener: %w", err)
 	}
 
 	port := listener.Addr().(*net.TCPAddr).Port
@@ -82,7 +120,7 @@ func BrowserFlow(ctx context.Context, cfg FlowConfig, openBrowser func(string) e
 	verifier, err := GenerateVerifier()
 	if err != nil {
 		_ = listener.Close()
-		return "", fmt.Errorf("could not generate PKCE verifier: %w", err)
+		return FlowResult{}, fmt.Errorf("could not generate PKCE verifier: %w", err)
 	}
 	challenge := ChallengeFromVerifier(verifier)
 
@@ -90,7 +128,7 @@ func BrowserFlow(ctx context.Context, cfg FlowConfig, openBrowser func(string) e
 	state, err := generateState()
 	if err != nil {
 		_ = listener.Close()
-		return "", fmt.Errorf("could not generate state: %w", err)
+		return FlowResult{}, fmt.Errorf("could not generate state: %w", err)
 	}
 
 	// Build authorize URL.
@@ -119,7 +157,7 @@ func BrowserFlow(ctx context.Context, cfg FlowConfig, openBrowser func(string) e
 
 	// Open browser.
 	if err := openBrowser(authURL); err != nil {
-		return "", fmt.Errorf("could not open browser: %w", err)
+		return FlowResult{}, fmt.Errorf("could not open browser: %w", err)
 	}
 
 	// Wait for callback or timeout.
@@ -128,33 +166,42 @@ func BrowserFlow(ctx context.Context, cfg FlowConfig, openBrowser func(string) e
 	case result = <-resultCh:
 	case <-ctx.Done():
 		if ctx.Err() != context.DeadlineExceeded {
-			return "", fmt.Errorf("authorization cancelled")
+			return FlowResult{}, fmt.Errorf("authorization cancelled")
 		}
 		// Drain resultCh in case the callback arrived at the exact deadline.
 		select {
 		case result = <-resultCh:
 			if result.Err != nil {
-				return "", result.Err
+				return FlowResult{}, result.Err
 			}
 			// Original ctx expired; give the token exchange its own deadline.
 			xctx, xcancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer xcancel()
-			return exchangeCode(xctx, cfg, result.Code, redirectURI, verifier)
+			return exchangeCodeResult(xctx, cfg, result.Payload, redirectURI, verifier)
 		default:
-			return "", fmt.Errorf("authorization timed out after %s", cfg.Timeout)
+			return FlowResult{}, fmt.Errorf("authorization timed out after %s", cfg.Timeout)
 		}
 	}
 	if result.Err != nil {
-		return "", result.Err
+		return FlowResult{}, result.Err
 	}
 
 	// Exchange code for token.
-	return exchangeCode(ctx, cfg, result.Code, redirectURI, verifier)
+	return exchangeCodeResult(ctx, cfg, result.Payload, redirectURI, verifier)
 }
 
 // HeadlessFlow runs the OAuth flow without a browser: prints the authorize URL
 // and prompts the user to paste the redirect URL.
 func HeadlessFlow(ctx context.Context, cfg FlowConfig, out io.Writer, readLine func() (string, error)) (string, error) {
+	result, err := HeadlessFlowResult(ctx, cfg, out, readLine)
+	if err != nil {
+		return "", err
+	}
+	return result.AccessToken, nil
+}
+
+// HeadlessFlowResult is HeadlessFlow with optional admin credential metadata.
+func HeadlessFlowResult(ctx context.Context, cfg FlowConfig, out io.Writer, readLine func() (string, error)) (FlowResult, error) {
 	if cfg.HTTPClient == nil {
 		cfg.HTTPClient = http.DefaultClient
 	}
@@ -164,13 +211,13 @@ func HeadlessFlow(ctx context.Context, cfg FlowConfig, out io.Writer, readLine f
 
 	verifier, err := GenerateVerifier()
 	if err != nil {
-		return "", fmt.Errorf("could not generate PKCE verifier: %w", err)
+		return FlowResult{}, fmt.Errorf("could not generate PKCE verifier: %w", err)
 	}
 	challenge := ChallengeFromVerifier(verifier)
 
 	state, err := generateState()
 	if err != nil {
-		return "", fmt.Errorf("could not generate state: %w", err)
+		return FlowResult{}, fmt.Errorf("could not generate state: %w", err)
 	}
 
 	// Use a placeholder redirect URI — user will paste the URL from their browser.
@@ -196,19 +243,19 @@ func HeadlessFlow(ctx context.Context, cfg FlowConfig, out io.Writer, readLine f
 	select {
 	case res := <-lineCh:
 		if res.err != nil {
-			return "", fmt.Errorf("could not read URL: %w", res.err)
+			return FlowResult{}, fmt.Errorf("could not read URL: %w", res.err)
 		}
 		line = res.line
 	case <-ctx.Done():
-		return "", fmt.Errorf("authorization timed out after %s", cfg.Timeout)
+		return FlowResult{}, fmt.Errorf("authorization timed out after %s", cfg.Timeout)
 	}
 
-	code, err := parseCallbackURL(strings.TrimSpace(line), state)
+	payload, err := parseCallbackPayload(strings.TrimSpace(line), state)
 	if err != nil {
-		return "", err
+		return FlowResult{}, err
 	}
 
-	return exchangeCode(ctx, cfg, code, redirectURI, verifier)
+	return exchangeCodeResult(ctx, cfg, payload, redirectURI, verifier)
 }
 
 func generateState() (string, error) {
@@ -228,6 +275,9 @@ func buildAuthorizeURL(cfg FlowConfig, redirectURI, challenge, state string) str
 		"code_challenge":        {challenge},
 		"code_challenge_method": {"S256"},
 		"state":                 {state},
+	}
+	if cfg.OptionalAdmin {
+		v.Set("admin_scope", "optional")
 	}
 	return cfg.AuthorizeURL + "?" + v.Encode()
 }
@@ -249,12 +299,12 @@ func callbackHandler(expectedState string, resultCh chan<- callbackResult) http.
 		}
 
 		// State matches — this is the real callback. Extract the result once.
-		code, err := extractCode(q, expectedState)
+		payload, err := extractCallbackPayload(q, expectedState)
 		once.Do(func() {
 			if err != nil {
 				resultCh <- callbackResult{Err: err}
 			} else {
-				resultCh <- callbackResult{Code: code}
+				resultCh <- callbackResult{Payload: payload}
 			}
 		})
 
@@ -270,18 +320,34 @@ func callbackHandler(expectedState string, resultCh chan<- callbackResult) http.
 }
 
 func parseCallbackURL(rawURL, expectedState string) (string, error) {
+	payload, err := parseCallbackPayload(rawURL, expectedState)
+	if err != nil {
+		return "", err
+	}
+	return payload.Code, nil
+}
+
+func parseCallbackPayload(rawURL, expectedState string) (callbackPayload, error) {
 	u, err := url.Parse(rawURL)
 	if err != nil {
-		return "", fmt.Errorf("invalid URL: %w", err)
+		return callbackPayload{}, fmt.Errorf("invalid URL: %w", err)
 	}
-	return extractCode(u.Query(), expectedState)
+	return extractCallbackPayload(u.Query(), expectedState)
 }
 
 // extractCode validates the OAuth callback parameters and returns the authorization code.
 // State is checked first to reject forged responses before trusting any other parameters.
 func extractCode(q url.Values, expectedState string) (string, error) {
+	payload, err := extractCallbackPayload(q, expectedState)
+	if err != nil {
+		return "", err
+	}
+	return payload.Code, nil
+}
+
+func extractCallbackPayload(q url.Values, expectedState string) (callbackPayload, error) {
 	if q.Get("state") != expectedState {
-		return "", fmt.Errorf("state mismatch: possible CSRF attack")
+		return callbackPayload{}, fmt.Errorf("state mismatch: possible CSRF attack")
 	}
 
 	if errParam := q.Get("error"); errParam != "" {
@@ -289,20 +355,32 @@ func extractCode(q url.Values, expectedState string) (string, error) {
 		if desc == "" {
 			desc = errParam
 		}
-		return "", fmt.Errorf("authorization denied: %s", desc)
+		return callbackPayload{}, fmt.Errorf("authorization denied: %s", desc)
 	}
 
 	code := q.Get("code")
 	if code == "" {
-		return "", fmt.Errorf("no authorization code received")
+		return callbackPayload{}, fmt.Errorf("no authorization code received")
 	}
-	return code, nil
+	adminCode := q.Get("admin_code")
+	if adminCode == "" {
+		adminCode = q.Get("admin_authorization_code")
+	}
+	return callbackPayload{Code: code, AdminCode: adminCode}, nil
 }
 
 func exchangeCode(ctx context.Context, cfg FlowConfig, code, redirectURI, verifier string) (string, error) {
+	result, err := exchangeCodeResult(ctx, cfg, callbackPayload{Code: code}, redirectURI, verifier)
+	if err != nil {
+		return "", err
+	}
+	return result.AccessToken, nil
+}
+
+func exchangeCodeResult(ctx context.Context, cfg FlowConfig, payload callbackPayload, redirectURI, verifier string) (FlowResult, error) {
 	data := url.Values{
 		"grant_type":    {"authorization_code"},
-		"code":          {code},
+		"code":          {payload.Code},
 		"redirect_uri":  {redirectURI},
 		"client_id":     {cfg.ClientID},
 		"code_verifier": {verifier},
@@ -310,35 +388,44 @@ func exchangeCode(ctx context.Context, cfg FlowConfig, code, redirectURI, verifi
 
 	req, err := http.NewRequestWithContext(ctx, "POST", cfg.TokenURL, strings.NewReader(data.Encode()))
 	if err != nil {
-		return "", fmt.Errorf("could not build token request: %w", err)
+		return FlowResult{}, fmt.Errorf("could not build token request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("token exchange failed: %w", err)
+		return FlowResult{}, fmt.Errorf("token exchange failed: %w", err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
-		return "", fmt.Errorf("could not read token response: %w", err)
+		return FlowResult{}, fmt.Errorf("could not read token response: %w", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("token exchange failed (HTTP %d)", resp.StatusCode)
+		return FlowResult{}, fmt.Errorf("token exchange failed (HTTP %d)", resp.StatusCode)
 	}
 
 	var tokenResp TokenResponse
 	if err := json.Unmarshal(body, &tokenResp); err != nil {
-		return "", fmt.Errorf("could not parse token response: %w", err)
+		return FlowResult{}, fmt.Errorf("could not parse token response: %w", err)
 	}
 
 	if tokenResp.AccessToken == "" {
-		return "", fmt.Errorf("token response did not contain an access token")
+		return FlowResult{}, fmt.Errorf("token response did not contain an access token")
 	}
 
-	return tokenResp.AccessToken, nil
+	adminToken := tokenResp.AdminToken
+	if adminToken == nil {
+		adminToken = tokenResp.Admin
+	}
+	return FlowResult{
+		AccessToken:            tokenResp.AccessToken,
+		AdminToken:             adminToken,
+		AdminAuthorizationCode: payload.AdminCode,
+		CodeVerifier:           verifier,
+	}, nil
 }
 
 func htmlPage(title, message string, isError bool) string {

--- a/internal/oauth/flow.go
+++ b/internal/oauth/flow.go
@@ -319,30 +319,12 @@ func callbackHandler(expectedState string, resultCh chan<- callbackResult) http.
 	}
 }
 
-func parseCallbackURL(rawURL, expectedState string) (string, error) {
-	payload, err := parseCallbackPayload(rawURL, expectedState)
-	if err != nil {
-		return "", err
-	}
-	return payload.Code, nil
-}
-
 func parseCallbackPayload(rawURL, expectedState string) (callbackPayload, error) {
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		return callbackPayload{}, fmt.Errorf("invalid URL: %w", err)
 	}
 	return extractCallbackPayload(u.Query(), expectedState)
-}
-
-// extractCode validates the OAuth callback parameters and returns the authorization code.
-// State is checked first to reject forged responses before trusting any other parameters.
-func extractCode(q url.Values, expectedState string) (string, error) {
-	payload, err := extractCallbackPayload(q, expectedState)
-	if err != nil {
-		return "", err
-	}
-	return payload.Code, nil
 }
 
 func extractCallbackPayload(q url.Values, expectedState string) (callbackPayload, error) {
@@ -367,14 +349,6 @@ func extractCallbackPayload(q url.Values, expectedState string) (callbackPayload
 		adminCode = q.Get("admin_authorization_code")
 	}
 	return callbackPayload{Code: code, AdminCode: adminCode}, nil
-}
-
-func exchangeCode(ctx context.Context, cfg FlowConfig, code, redirectURI, verifier string) (string, error) {
-	result, err := exchangeCodeResult(ctx, cfg, callbackPayload{Code: code}, redirectURI, verifier)
-	if err != nil {
-		return "", err
-	}
-	return result.AccessToken, nil
 }
 
 func exchangeCodeResult(ctx context.Context, cfg FlowConfig, payload callbackPayload, redirectURI, verifier string) (FlowResult, error) {

--- a/internal/oauth/flow_test.go
+++ b/internal/oauth/flow_test.go
@@ -100,6 +100,72 @@ func TestBrowserFlow_HappyPath(t *testing.T) {
 	}
 }
 
+func TestBrowserFlowResult_ReturnsAdminCodeFromUnifiedCallback(t *testing.T) {
+	tokenSrv := httptest.NewServer(tokenHandler(t, true))
+	defer tokenSrv.Close()
+	cfg := testConfig(tokenSrv)
+	cfg.OptionalAdmin = true
+
+	result, err := BrowserFlowResult(context.Background(), cfg, func(authURL string) error {
+		u, _ := url.Parse(authURL)
+		if u.Query().Get("admin_scope") != "optional" {
+			t.Fatalf("admin_scope = %q, want optional", u.Query().Get("admin_scope"))
+		}
+		state := u.Query().Get("state")
+		redirectURI := u.Query().Get("redirect_uri")
+		callbackURL := fmt.Sprintf("%s?code=test-auth-code&admin_code=admin-auth-code&state=%s", redirectURI, state)
+		resp := mustGet(t, callbackURL)
+		resp.Body.Close()
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("BrowserFlowResult: %v", err)
+	}
+	if result.AccessToken != "test-access-token" {
+		t.Fatalf("token = %q, want test-access-token", result.AccessToken)
+	}
+	if result.AdminAuthorizationCode != "admin-auth-code" {
+		t.Fatalf("admin code = %q, want admin-auth-code", result.AdminAuthorizationCode)
+	}
+	if result.CodeVerifier == "" {
+		t.Fatal("expected code verifier for admin exchange")
+	}
+}
+
+func TestBrowserFlowResult_ReturnsAdminTokenFromTokenResponse(t *testing.T) {
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		mustEncode(t, w, TokenResponse{
+			AccessToken: "test-access-token",
+			TokenType:   "bearer",
+			AdminToken: &AdminTokenResponse{
+				Token:           "admin-token",
+				TokenExternalID: "adm_123",
+				Actor:           AdminActor{Name: "Admin User", Email: "admin@example.com"},
+				ExpiresAt:       "2026-06-01T00:00:00Z",
+			},
+		})
+	}))
+	defer tokenSrv.Close()
+	cfg := testConfig(tokenSrv)
+
+	result, err := BrowserFlowResult(context.Background(), cfg, func(authURL string) error {
+		u, _ := url.Parse(authURL)
+		state := u.Query().Get("state")
+		redirectURI := u.Query().Get("redirect_uri")
+		callbackURL := fmt.Sprintf("%s?code=test-auth-code&state=%s", redirectURI, state)
+		resp := mustGet(t, callbackURL)
+		resp.Body.Close()
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("BrowserFlowResult: %v", err)
+	}
+	if result.AdminToken == nil || result.AdminToken.Token != "admin-token" || result.AdminToken.Actor.Email != "admin@example.com" {
+		t.Fatalf("unexpected admin token result: %+v", result.AdminToken)
+	}
+}
+
 func TestBrowserFlow_StateMismatch(t *testing.T) {
 	tokenSrv := httptest.NewServer(tokenHandler(t, false))
 	defer tokenSrv.Close()

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -53,7 +53,13 @@ func SetupAdmin(t *testing.T, handler http.HandlerFunc) *httptest.Server {
 	t.Setenv(config.EnvAccessToken, "")
 	t.Setenv(adminconfig.EnvAccessToken, "")
 
-	if err := adminconfig.Save(&adminconfig.Config{AccessToken: "admin-token"}); err != nil {
+	if err := adminconfig.Save(&adminconfig.Config{
+		Token: "admin-token",
+		Actor: adminconfig.Actor{
+			Name:  "Test Admin",
+			Email: "admin@example.com",
+		},
+	}); err != nil {
 		t.Fatalf("Save admin config failed: %v", err)
 	}
 

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -34,7 +34,8 @@ Always follow these rules:
 - Use `--page-delay 200ms` with `--all` to avoid rate limits on large datasets.
 - Prices are in whole currency units (e.g. `--price 10.00` for $10), not cents. The CLI converts internally. Use `--currency eur` to change currency.
 - Products are created as drafts — use `gumroad products publish <id>` to make them live.
-- If a command fails with an auth error, tell the user to run `gumroad auth login` interactively — agents cannot do this step.
+- If a command fails with a seller auth error, tell the user to run `gumroad auth login` interactively — agents cannot do this step.
+- For admin commands in agents/CI, set `GUMROAD_ADMIN_ACCESS_TOKEN`; interactive shells can store an admin token with `gumroad auth login`.
 
 ## Response shapes
 
@@ -66,7 +67,7 @@ gumroad auth status --no-input
 # gumroad auth login
 
 # Logout
-gumroad auth logout --no-input
+gumroad auth logout --yes --no-input
 ```
 
 ### user — Account info


### PR DESCRIPTION
Ref antiwork/gumroad/issues/4677

## What

- Extends the existing `gumroad auth login` flow so one browser approval can store both the seller token and a separate admin token.
- Keeps seller auth in the public config and stores admin auth in its own local config, with status and logout handling both paths.
- Preserves the current `gumroad auth` namespace and keeps the admin command env-token behavior for now.
- Leaves admin command safety/runtime policy for a follow-up PR: interactive env-token rules, `--non-interactive`, and destructive-command actor banners.

## Why

- This avoids making people log in twice for the same session.
- It keeps seller and admin credentials separate while using the same browser approval flow, which is simpler for users and easier to manage safely.
- Splitting the command-runtime policy keeps this PR focused on the auth lifecycle and avoids mixing user-login behavior with admin command guardrails.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh.
