### PR TITLE
Add product advisor skill for agent-driven product optimization

### DIFF
--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -14,6 +14,9 @@ description: >
   request to query or act on Gumroad data — even if the user doesn't say
   "Gumroad" explicitly but is clearly referring to their creator store or
   digital product sales.
+  Also trigger on: "improve my product", "optimize product page", "product advisor",
+  "review my listing", "product page score", "increase conversions", "product audit",
+  "optimize listing", "score my product", "product feedback".
   Do NOT trigger for Gumroad web UI, Rails, or codebase questions.
 ---
 
@@ -273,6 +276,56 @@ gumroad webhooks create --resource sale --url https://example.com/hook --json --
 # Delete
 gumroad webhooks delete <id> --yes --json --no-input
 ```
+
+## Product Advisor
+
+Analyze a seller's product page and generate a scored improvement report.
+
+### Steps
+
+1. Fetch product data:
+   ```sh
+   gumroad products view <id> --json --no-input
+   ```
+2. Fetch sales data for social proof:
+   ```sh
+   gumroad sales list --product <id> --all --json --no-input
+   ```
+3. Score the product across five dimensions (0–10 each):
+
+   | Dimension | What to evaluate |
+   |-----------|-----------------|
+   | Description quality | Clarity, structure, benefit-first copy, formatting |
+   | Cover image | Relevance, visual appeal, text legibility, aspect ratio |
+   | Pricing strategy | Value perception, price anchoring, tiering, pay-what-you-want range |
+   | Discoverability | SEO title, tags, category fit, permalink clarity |
+   | Social proof | Sales count, reviews, ratings, repeat buyers |
+
+4. For each dimension below 8, provide a specific **before/after** suggestion using actual product data.
+5. Output the report as markdown. Do not modify any files in the repo.
+
+### Report format
+
+```markdown
+# Product Advisor: [product name]
+## Overall Score: [total]/50
+| Dimension | Score | Status |
+|-----------|-------|--------|
+| Description quality | X/10 | ✅ or ⚠️ |
+| Cover image | X/10 | ✅ or ⚠️ |
+| Pricing strategy | X/10 | ✅ or ⚠️ |
+| Discoverability | X/10 | ✅ or ⚠️ |
+| Social proof | X/10 | ✅ or ⚠️ |
+## Suggestions
+### [Dimension]: X/10
+**Current:** [quote from product data]
+**Suggested:** [improved version]
+**Why:** [reasoning]
+```
+
+- **Score from actual product data.** Do not invent attributes.
+- **Suggestions must be copy-paste ready.** The seller applies changes directly.
+- **Use `gumroad products update`** to apply changes if the seller asks.
 
 ## Tips
 


### PR DESCRIPTION
## What

Adds a Product Advisor section to the embedded SKILL.md that lets sellers analyze and optimize their product pages using the gumroad CLI.

The agent uses existing CLI commands (`gumroad products view`, `gumroad sales list`) to fetch product data, scores across 5 dimensions (description quality, cover image, pricing strategy, discoverability, social proof), and generates specific before/after improvement suggestions.

Changes:
- Added trigger phrases for product advisor queries to SKILL.md frontmatter
- Added Product Advisor section with scoring workflow, report format, and CLI command references
- No Go code changes — extends existing embedded skill only (53 LOC)

## Why

Issue antiwork/gumroad#4932 raised the need for AI-assisted product page optimization. Sahil (slavingia) directed that this should be an agent + CLI workflow, not a backend scoring system.

This PR follows that direction: the skill teaches the agent to use existing `gumroad` CLI commands, performs all analysis client-side via the seller’s own LLM, and adds zero Gumroad OpEx.

## Before/After

https://github.com/user-attachments/assets/070087a7-b91a-4009-b26b-d5fb72223342
## Test Results

No Go code changed — only SKILL.md content. Existing tests for the skill install command remain passing.

---

**AI disclosure:** GLM-5.1 (Zhipu AI) was used to draft the SKILL.md changes. Prompts included the research findings from analyzing the gumroad-cli codebase (embed.go, skill.go, existing SKILL.md), CONTRIBUTING.md rules, and the product advisor requirements from Issue #4932.