### PR TITLE
Fix product create file uploads to populate rich content

### DIFF
--- a/internal/cmd/products/create.go
+++ b/internal/cmd/products/create.go
@@ -170,12 +170,18 @@ func newCreateCmd() *cobra.Command {
 			}
 
 			if len(plannedUploads) > 0 {
+				fileRefs, err := newCreateRichContentFileRefs(len(plannedUploads))
+				if err != nil {
+					return err
+				}
+
 				if opts.DryRun {
 					fileURLs := make([]string, len(plannedUploads))
 					for i := range plannedUploads {
 						fileURLs[i] = dryRunFilePlaceholder(i)
 					}
-					body := buildProductJSONBody(params, buildCreateUploadFilesPayload(plannedUploads, fileURLs))
+					body := buildProductJSONBody(params, buildCreateUploadFilesPayload(plannedUploads, fileURLs, fileRefs))
+					body["rich_content"] = buildCreateFileRichContent(fileRefs)
 					return renderCreateDryRun(opts, plannedUploads, body)
 				}
 
@@ -188,7 +194,8 @@ func newCreateCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				body := buildProductJSONBody(params, buildCreateUploadFilesPayload(plannedUploads, fileURLs))
+				body := buildProductJSONBody(params, buildCreateUploadFilesPayload(plannedUploads, fileURLs, fileRefs))
+				body["rich_content"] = buildCreateFileRichContent(fileRefs)
 				data, err := cmdutil.RunWithTokenData(opts, token, "Creating product...",
 					func(client *api.Client) (json.RawMessage, error) {
 						return client.PostJSON("/products", body)
@@ -285,10 +292,13 @@ func alignCreateUploadValues(c *cobra.Command, flagName string, values []string,
 	}
 }
 
-func buildCreateUploadFilesPayload(uploads []createUploadInput, fileURLs []string) []map[string]any {
+func buildCreateUploadFilesPayload(uploads []createUploadInput, fileURLs []string, fileRefs []createRichContentFileRef) []map[string]any {
 	files := make([]map[string]any, 0, len(uploads))
 	for i, planned := range uploads {
-		entry := map[string]any{"url": fileURLs[i]}
+		entry := map[string]any{
+			"id":  fileRefs[i].FileID,
+			"url": fileURLs[i],
+		}
 		if planned.DisplayName != "" {
 			entry["display_name"] = planned.DisplayName
 		}

--- a/internal/cmd/products/create_files_test.go
+++ b/internal/cmd/products/create_files_test.go
@@ -174,6 +174,75 @@ func createJSONFiles(t *testing.T, body map[string]any) []map[string]any {
 	return files
 }
 
+func assertCreateRichContentEmbedsFiles(t *testing.T, body map[string]any, files []map[string]any) {
+	t.Helper()
+
+	rawPages, ok := body["rich_content"].([]any)
+	if !ok {
+		t.Fatalf("rich_content payload has wrong type: %T", body["rich_content"])
+	}
+	if len(rawPages) != 1 {
+		t.Fatalf("rich_content payload len = %d, want 1", len(rawPages))
+	}
+	page, ok := rawPages[0].(map[string]any)
+	if !ok {
+		t.Fatalf("rich_content[0] has wrong type: %T", rawPages[0])
+	}
+	if got := page["title"]; got != defaultCreateRichContentTitle {
+		t.Fatalf("rich_content title = %#v, want %q", got, defaultCreateRichContentTitle)
+	}
+	description, ok := page["description"].(map[string]any)
+	if !ok {
+		t.Fatalf("rich_content description has wrong type: %T", page["description"])
+	}
+	if got := description["type"]; got != "doc" {
+		t.Fatalf("rich_content description type = %#v, want doc", got)
+	}
+	rawContent, ok := description["content"].([]any)
+	if !ok {
+		t.Fatalf("rich_content content has wrong type: %T", description["content"])
+	}
+	if len(rawContent) != len(files)+1 {
+		t.Fatalf("rich_content content len = %d, want %d", len(rawContent), len(files)+1)
+	}
+
+	for i, file := range files {
+		fileID, ok := file["id"].(string)
+		if !ok || !strings.HasPrefix(fileID, "cli-upload-") {
+			t.Fatalf("files[%d].id = %#v, want generated cli upload id", i, file["id"])
+		}
+
+		node, ok := rawContent[i].(map[string]any)
+		if !ok {
+			t.Fatalf("rich_content content[%d] has wrong type: %T", i, rawContent[i])
+		}
+		if got := node["type"]; got != "fileEmbed" {
+			t.Fatalf("rich_content content[%d].type = %#v, want fileEmbed", i, got)
+		}
+		attrs, ok := node["attrs"].(map[string]any)
+		if !ok {
+			t.Fatalf("rich_content content[%d].attrs has wrong type: %T", i, node["attrs"])
+		}
+		if got := attrs["id"]; got != fileID {
+			t.Fatalf("fileEmbed[%d].attrs.id = %#v, want matching file id %q", i, got, fileID)
+		}
+		if uid, ok := attrs["uid"].(string); !ok || uid == "" {
+			t.Fatalf("fileEmbed[%d].attrs.uid = %#v, want generated uid", i, attrs["uid"])
+		}
+		if got := attrs["collapsed"]; got != false {
+			t.Fatalf("fileEmbed[%d].attrs.collapsed = %#v, want false", i, got)
+		}
+	}
+
+	trailing, ok := rawContent[len(files)].(map[string]any)
+	if !ok {
+		t.Fatalf("trailing rich_content node has wrong type: %T", rawContent[len(files)])
+	}
+	if got := trailing["type"]; got != "paragraph" {
+		t.Fatalf("trailing rich_content node type = %#v, want paragraph", got)
+	}
+}
+
 func TestCreate_WithFiles_UploadsAndPostsIndexedFields(t *testing.T) {
 	srv := newCreateUploadServers(t)
 	testutil.Setup(t, srv.dispatch(t))
@@ -221,6 +290,7 @@ func TestCreate_WithFiles_UploadsAndPostsIndexedFields(t *testing.T) {
 	if got := files[1]["description"]; got != "Second file" {
 		t.Fatalf("files[1].description = %#v", got)
 	}
+	assertCreateRichContentEmbedsFiles(t, productJSON, files)
 	if s3Calls != 2 {
 		t.Fatalf("S3 calls = %d, want 2", s3Calls)
 	}
@@ -315,6 +385,7 @@ func TestCreate_WithFiles_DryRunJSONIncludesUploadsAndRequest(t *testing.T) {
 	if got := files[0]["description"]; got != "Bonus download" {
 		t.Fatalf("files[0].description = %#v", got)
 	}
+	assertCreateRichContentEmbedsFiles(t, payload.Request.Body, files)
 }
 
 func TestCreate_FileMetadataCountMustMatchFiles(t *testing.T) {

--- a/internal/cmd/products/rich_content.go
+++ b/internal/cmd/products/rich_content.go
@@ -1,0 +1,67 @@
+package products
+
+import (
+	"crypto/rand"
+	"fmt"
+)
+
+const defaultCreateRichContentTitle = "Page 1"
+
+type createRichContentFileRef struct {
+	FileID   string
+	EmbedUID string
+}
+
+func newCreateRichContentFileRefs(count int) ([]createRichContentFileRef, error) {
+	refs := make([]createRichContentFileRef, count)
+	for i := range refs {
+		fileUUID, err := newUUIDV4()
+		if err != nil {
+			return nil, fmt.Errorf("could not generate file id: %w", err)
+		}
+		embedUUID, err := newUUIDV4()
+		if err != nil {
+			return nil, fmt.Errorf("could not generate file embed id: %w", err)
+		}
+		refs[i] = createRichContentFileRef{
+			FileID:   "cli-upload-" + fileUUID,
+			EmbedUID: embedUUID,
+		}
+	}
+	return refs, nil
+}
+
+func buildCreateFileRichContent(fileRefs []createRichContentFileRef) []map[string]any {
+	content := make([]map[string]any, 0, len(fileRefs)+1)
+	for _, ref := range fileRefs {
+		content = append(content, map[string]any{
+			"type": "fileEmbed",
+			"attrs": map[string]any{
+				"id":        ref.FileID,
+				"uid":       ref.EmbedUID,
+				"collapsed": false,
+			},
+		})
+	}
+	content = append(content, map[string]any{"type": "paragraph"})
+
+	return []map[string]any{{
+		"title": defaultCreateRichContentTitle,
+		"description": map[string]any{
+			"type":    "doc",
+			"content": content,
+		},
+	}}
+}
+
+func newUUIDV4() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:]), nil
+}


### PR DESCRIPTION
Fixes #71

## What

- Make `gumroad products create --file` send a matching `rich_content` document alongside the uploaded files.
- Use file embed nodes that point at the same temporary file IDs so Gumroad can remap them when the product is created.
- Add regression coverage for normal and dry-run product creation.

## Why

- This fixes the gap where file uploads succeeded but the created product had an empty Content tab.
- The change uses the existing `POST /v2/products` contract, so no new Gumroad endpoint is needed.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh.