### PR TITLE
Fix product update file embeds

### DIFF
--- a/internal/cmd/products/create.go
+++ b/internal/cmd/products/create.go
@@ -170,7 +170,7 @@ func newCreateCmd() *cobra.Command {
 			}
 
 			if len(plannedUploads) > 0 {
-				fileRefs, err := newCreateRichContentFileRefs(len(plannedUploads))
+				fileRefs, err := newRichContentFileRefs(len(plannedUploads))
 				if err != nil {
 					return err
 				}
@@ -181,7 +181,7 @@ func newCreateCmd() *cobra.Command {
 						fileURLs[i] = dryRunFilePlaceholder(i)
 					}
 					body := buildProductJSONBody(params, buildCreateUploadFilesPayload(plannedUploads, fileURLs, fileRefs))
-					body["rich_content"] = buildCreateFileRichContent(fileRefs)
+					body["rich_content"] = buildFileRichContent(fileRefs)
 					return renderCreateDryRun(opts, plannedUploads, body)
 				}
 
@@ -195,7 +195,7 @@ func newCreateCmd() *cobra.Command {
 					return err
 				}
 				body := buildProductJSONBody(params, buildCreateUploadFilesPayload(plannedUploads, fileURLs, fileRefs))
-				body["rich_content"] = buildCreateFileRichContent(fileRefs)
+				body["rich_content"] = buildFileRichContent(fileRefs)
 				data, err := cmdutil.RunWithTokenData(opts, token, "Creating product...",
 					func(client *api.Client) (json.RawMessage, error) {
 						return client.PostJSON("/products", body)
@@ -292,7 +292,7 @@ func alignCreateUploadValues(c *cobra.Command, flagName string, values []string,
 	}
 }
 
-func buildCreateUploadFilesPayload(uploads []createUploadInput, fileURLs []string, fileRefs []createRichContentFileRef) []map[string]any {
+func buildCreateUploadFilesPayload(uploads []createUploadInput, fileURLs []string, fileRefs []richContentFileRef) []map[string]any {
 	files := make([]map[string]any, 0, len(uploads))
 	for i, planned := range uploads {
 		entry := map[string]any{

--- a/internal/cmd/products/create_files_test.go
+++ b/internal/cmd/products/create_files_test.go
@@ -188,8 +188,8 @@ func assertCreateRichContentEmbedsFiles(t *testing.T, body map[string]any, files
 	if !ok {
 		t.Fatalf("rich_content[0] has wrong type: %T", rawPages[0])
 	}
-	if got := page["title"]; got != defaultCreateRichContentTitle {
-		t.Fatalf("rich_content title = %#v, want %q", got, defaultCreateRichContentTitle)
+	if got := page["title"]; got != defaultFileRichContentTitle {
+		t.Fatalf("rich_content title = %#v, want %q", got, defaultFileRichContentTitle)
 	}
 	description, ok := page["description"].(map[string]any)
 	if !ok {

--- a/internal/cmd/products/file_updates.go
+++ b/internal/cmd/products/file_updates.go
@@ -38,15 +38,18 @@ type productFileUpdatePlan struct {
 	Uploads   []requestedProductUpload
 }
 
+type productFileUpdateState struct {
+	Files       []existingProductFile `json:"files"`
+	RichContent []map[string]any      `json:"rich_content"`
+}
+
 type productFileSelections struct {
 	Keep   map[string]struct{}
 	Remove map[string]struct{}
 }
 
 type productFilesResponse struct {
-	Product struct {
-		Files []existingProductFile `json:"files"`
-	} `json:"product"`
+	Product productFileUpdateState `json:"product"`
 }
 
 type dryRunUpdateBody struct {
@@ -95,17 +98,17 @@ func collectRequestedProductUploads(
 	return uploads, nil
 }
 
-func fetchExistingProductFiles(client *api.Client, productID string) ([]existingProductFile, error) {
+func fetchExistingProductFileState(client *api.Client, productID string) (productFileUpdateState, error) {
 	data, err := client.Get(cmdutil.JoinPath("products", productID), url.Values{})
 	if err != nil {
-		return nil, err
+		return productFileUpdateState{}, err
 	}
 
 	resp, err := cmdutil.DecodeJSON[productFilesResponse](data)
 	if err != nil {
-		return nil, err
+		return productFileUpdateState{}, err
 	}
-	return resp.Product.Files, nil
+	return resp.Product, nil
 }
 
 func planProductFileUpdate(
@@ -229,13 +232,31 @@ func validateProductFileSelections(
 	}, nil
 }
 
-func buildProductUpdateFilesPayload(plan productFileUpdatePlan, uploadURLs []string) []map[string]any {
+func buildProductUpdateJSONBody(
+	params url.Values,
+	plan productFileUpdatePlan,
+	uploadURLs []string,
+	fileRefs []richContentFileRef,
+	richContent []map[string]any,
+	includeRichContent bool,
+) map[string]any {
+	body := buildProductJSONBody(params, buildProductUpdateFilesPayload(plan, uploadURLs, fileRefs))
+	if includeRichContent {
+		body["rich_content"] = richContent
+	}
+	return body
+}
+
+func buildProductUpdateFilesPayload(plan productFileUpdatePlan, uploadURLs []string, fileRefs []richContentFileRef) []map[string]any {
 	files := make([]map[string]any, 0, len(plan.Preserved)+len(plan.Uploads))
 	for _, file := range plan.Preserved {
 		files = append(files, map[string]any{"id": file.ID})
 	}
 	for i, requested := range plan.Uploads {
-		entry := map[string]any{"url": uploadURLs[i]}
+		entry := map[string]any{
+			"id":  fileRefs[i].FileID,
+			"url": uploadURLs[i],
+		}
 		if requested.DisplayName != "" {
 			entry["display_name"] = requested.DisplayName
 		}

--- a/internal/cmd/products/rich_content.go
+++ b/internal/cmd/products/rich_content.go
@@ -93,7 +93,7 @@ func buildProductUpdateRichContent(
 		return nil, false, nil
 	}
 
-	richContent, err := appendFileEmbeds(existingRichContent, fileRefs)
+	richContent, err := appendFileEmbeds(existingRichContent, filePlan.Preserved, fileRefs)
 	if err != nil {
 		return nil, false, err
 	}
@@ -126,12 +126,16 @@ func removedFileEmbedIDs(richContent []map[string]any, removed []existingProduct
 	return ids
 }
 
-func appendFileEmbeds(richContent []map[string]any, fileRefs []richContentFileRef) ([]map[string]any, error) {
+func appendFileEmbeds(richContent []map[string]any, preserved []existingProductFile, fileRefs []richContentFileRef) ([]map[string]any, error) {
 	if len(fileRefs) == 0 {
 		return cloneRichContent(richContent)
 	}
 	if len(richContent) == 0 {
-		return buildFileRichContent(fileRefs), nil
+		preservedRefs, err := richContentRefsForExistingFiles(preserved)
+		if err != nil {
+			return nil, err
+		}
+		return buildFileRichContent(append(preservedRefs, fileRefs...)), nil
 	}
 
 	cloned, err := cloneRichContent(richContent)
@@ -145,11 +149,37 @@ func appendFileEmbeds(richContent []map[string]any, fileRefs []richContentFileRe
 		cloned[0]["description"] = description
 	}
 	content, _ := description["content"].([]any)
+	content = withoutTrailingParagraph(content)
 	content = append(content, fileEmbedNodes(fileRefs)...)
 	content = append(content, map[string]any{"type": "paragraph"})
 	description["type"] = "doc"
 	description["content"] = content
 	return cloned, nil
+}
+
+func richContentRefsForExistingFiles(files []existingProductFile) ([]richContentFileRef, error) {
+	refs := make([]richContentFileRef, len(files))
+	for i, file := range files {
+		embedUUID, err := newUUIDV4()
+		if err != nil {
+			return nil, fmt.Errorf("could not generate file embed id: %w", err)
+		}
+		refs[i] = richContentFileRef{
+			FileID:   file.ID,
+			EmbedUID: embedUUID,
+		}
+	}
+	return refs, nil
+}
+
+func withoutTrailingParagraph(content []any) []any {
+	if len(content) == 0 {
+		return content
+	}
+	if nodeHasType(content[len(content)-1], "paragraph") {
+		return content[:len(content)-1]
+	}
+	return content
 }
 
 func cloneRichContent(richContent []map[string]any) ([]map[string]any, error) {
@@ -248,10 +278,26 @@ func stripFileEmbedIDsInNode(node any, ids map[string]struct{}) {
 				}
 			}
 			stripFileEmbedIDsInNode(childMap, ids)
+			if isEmptyFileEmbedGroup(childMap) {
+				continue
+			}
 		}
 		kept = append(kept, child)
 	}
 	current["content"] = kept
+}
+
+func isEmptyFileEmbedGroup(node map[string]any) bool {
+	if node["type"] != "fileEmbedGroup" {
+		return false
+	}
+	children, ok := node["content"].([]any)
+	return !ok || len(children) == 0
+}
+
+func nodeHasType(node any, typ string) bool {
+	nodeMap, ok := node.(map[string]any)
+	return ok && nodeMap["type"] == typ
 }
 
 func replaceFileEmbedIDInNode(node any, oldID, newID string) {

--- a/internal/cmd/products/rich_content.go
+++ b/internal/cmd/products/rich_content.go
@@ -2,18 +2,23 @@ package products
 
 import (
 	"crypto/rand"
+	"encoding/json"
 	"fmt"
+	"sort"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
 )
 
-const defaultCreateRichContentTitle = "Page 1"
+const defaultFileRichContentTitle = "Page 1"
 
-type createRichContentFileRef struct {
+type richContentFileRef struct {
 	FileID   string
 	EmbedUID string
 }
 
-func newCreateRichContentFileRefs(count int) ([]createRichContentFileRef, error) {
-	refs := make([]createRichContentFileRef, count)
+func newRichContentFileRefs(count int) ([]richContentFileRef, error) {
+	refs := make([]richContentFileRef, count)
 	for i := range refs {
 		fileUUID, err := newUUIDV4()
 		if err != nil {
@@ -23,7 +28,7 @@ func newCreateRichContentFileRefs(count int) ([]createRichContentFileRef, error)
 		if err != nil {
 			return nil, fmt.Errorf("could not generate file embed id: %w", err)
 		}
-		refs[i] = createRichContentFileRef{
+		refs[i] = richContentFileRef{
 			FileID:   "cli-upload-" + fileUUID,
 			EmbedUID: embedUUID,
 		}
@@ -31,7 +36,7 @@ func newCreateRichContentFileRefs(count int) ([]createRichContentFileRef, error)
 	return refs, nil
 }
 
-func buildCreateFileRichContent(fileRefs []createRichContentFileRef) []map[string]any {
+func buildFileRichContent(fileRefs []richContentFileRef) []map[string]any {
 	content := make([]map[string]any, 0, len(fileRefs)+1)
 	for _, ref := range fileRefs {
 		content = append(content, map[string]any{
@@ -46,12 +51,174 @@ func buildCreateFileRichContent(fileRefs []createRichContentFileRef) []map[strin
 	content = append(content, map[string]any{"type": "paragraph"})
 
 	return []map[string]any{{
-		"title": defaultCreateRichContentTitle,
+		"title": defaultFileRichContentTitle,
 		"description": map[string]any{
 			"type":    "doc",
 			"content": content,
 		},
 	}}
+}
+
+func buildProductUpdateRichContent(
+	cmd *cobra.Command,
+	existingRichContent []map[string]any,
+	filePlan productFileUpdatePlan,
+	fileRefs []richContentFileRef,
+) ([]map[string]any, bool, error) {
+	removedEmbeddedIDs := removedFileEmbedIDs(existingRichContent, filePlan.Removed)
+	if len(removedEmbeddedIDs) > 0 {
+		if len(removedEmbeddedIDs) != 1 || len(fileRefs) != 1 {
+			return nil, false, cmdutil.UsageErrorf(cmd,
+				"cannot automatically update rich_content for embedded file removal (%s); replace one embedded file at a time with exactly one --remove-file and one --file",
+				joinComma(removedEmbeddedIDs))
+		}
+
+		richContent, err := cloneRichContent(existingRichContent)
+		if err != nil {
+			return nil, false, err
+		}
+		replaceFileEmbedID(richContent, removedEmbeddedIDs[0], fileRefs[0].FileID)
+		return richContent, true, nil
+	}
+
+	if len(fileRefs) == 0 {
+		return nil, false, nil
+	}
+
+	richContent, err := appendFileEmbeds(existingRichContent, fileRefs)
+	if err != nil {
+		return nil, false, err
+	}
+	return richContent, true, nil
+}
+
+func removedFileEmbedIDs(richContent []map[string]any, removed []existingProductFile) []string {
+	if len(richContent) == 0 || len(removed) == 0 {
+		return nil
+	}
+
+	removedIDs := make(map[string]struct{}, len(removed))
+	for _, file := range removed {
+		removedIDs[file.ID] = struct{}{}
+	}
+
+	seen := map[string]struct{}{}
+	for _, id := range fileEmbedIDs(richContent) {
+		if _, ok := removedIDs[id]; !ok {
+			continue
+		}
+		seen[id] = struct{}{}
+	}
+
+	ids := make([]string, 0, len(seen))
+	for id := range seen {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func appendFileEmbeds(richContent []map[string]any, fileRefs []richContentFileRef) ([]map[string]any, error) {
+	if len(fileRefs) == 0 {
+		return cloneRichContent(richContent)
+	}
+	if len(richContent) == 0 {
+		return buildFileRichContent(fileRefs), nil
+	}
+
+	cloned, err := cloneRichContent(richContent)
+	if err != nil {
+		return nil, err
+	}
+
+	description, ok := cloned[0]["description"].(map[string]any)
+	if !ok {
+		description = map[string]any{"type": "doc"}
+		cloned[0]["description"] = description
+	}
+	content, _ := description["content"].([]any)
+	content = append(content, fileEmbedNodes(fileRefs)...)
+	content = append(content, map[string]any{"type": "paragraph"})
+	description["type"] = "doc"
+	description["content"] = content
+	return cloned, nil
+}
+
+func cloneRichContent(richContent []map[string]any) ([]map[string]any, error) {
+	data, err := json.Marshal(richContent)
+	if err != nil {
+		return nil, fmt.Errorf("could not encode rich_content: %w", err)
+	}
+	var cloned []map[string]any
+	if err := json.Unmarshal(data, &cloned); err != nil {
+		return nil, fmt.Errorf("could not decode rich_content: %w", err)
+	}
+	return cloned, nil
+}
+
+func fileEmbedNodes(fileRefs []richContentFileRef) []any {
+	nodes := make([]any, len(fileRefs))
+	for i, ref := range fileRefs {
+		nodes[i] = map[string]any{
+			"type": "fileEmbed",
+			"attrs": map[string]any{
+				"id":        ref.FileID,
+				"uid":       ref.EmbedUID,
+				"collapsed": false,
+			},
+		}
+	}
+	return nodes
+}
+
+func fileEmbedIDs(richContent []map[string]any) []string {
+	var ids []string
+	for _, page := range richContent {
+		collectFileEmbedIDs(page["description"], &ids)
+	}
+	return ids
+}
+
+func collectFileEmbedIDs(node any, ids *[]string) {
+	current, ok := node.(map[string]any)
+	if !ok {
+		return
+	}
+	if current["type"] == "fileEmbed" {
+		if attrs, ok := current["attrs"].(map[string]any); ok {
+			if id, ok := attrs["id"].(string); ok && id != "" {
+				*ids = append(*ids, id)
+			}
+		}
+	}
+	if children, ok := current["content"].([]any); ok {
+		for _, child := range children {
+			collectFileEmbedIDs(child, ids)
+		}
+	}
+}
+
+func replaceFileEmbedID(richContent []map[string]any, oldID, newID string) {
+	for _, page := range richContent {
+		replaceFileEmbedIDInNode(page["description"], oldID, newID)
+	}
+}
+
+func replaceFileEmbedIDInNode(node any, oldID, newID string) {
+	current, ok := node.(map[string]any)
+	if !ok {
+		return
+	}
+	if current["type"] == "fileEmbed" {
+		if attrs, ok := current["attrs"].(map[string]any); ok && attrs["id"] == oldID {
+			attrs["id"] = newID
+		}
+	}
+	if children, ok := current["content"].([]any); ok {
+		for _, child := range children {
+			replaceFileEmbedIDInNode(child, oldID, newID)
+		}
+	}
 }
 
 func newUUIDV4() (string, error) {

--- a/internal/cmd/products/rich_content.go
+++ b/internal/cmd/products/rich_content.go
@@ -67,6 +67,14 @@ func buildProductUpdateRichContent(
 ) ([]map[string]any, bool, error) {
 	removedEmbeddedIDs := removedFileEmbedIDs(existingRichContent, filePlan.Removed)
 	if len(removedEmbeddedIDs) > 0 {
+		if len(fileRefs) == 0 {
+			richContent, err := cloneRichContent(existingRichContent)
+			if err != nil {
+				return nil, false, err
+			}
+			stripFileEmbedIDs(richContent, removedEmbeddedIDs)
+			return richContent, true, nil
+		}
 		if len(removedEmbeddedIDs) != 1 || len(fileRefs) != 1 {
 			return nil, false, cmdutil.UsageErrorf(cmd,
 				"cannot automatically update rich_content for embedded file removal (%s); replace one embedded file at a time with exactly one --remove-file and one --file",
@@ -202,6 +210,48 @@ func replaceFileEmbedID(richContent []map[string]any, oldID, newID string) {
 	for _, page := range richContent {
 		replaceFileEmbedIDInNode(page["description"], oldID, newID)
 	}
+}
+
+func stripFileEmbedIDs(richContent []map[string]any, ids []string) {
+	if len(ids) == 0 {
+		return
+	}
+	idSet := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		idSet[id] = struct{}{}
+	}
+	for _, page := range richContent {
+		stripFileEmbedIDsInNode(page["description"], idSet)
+	}
+}
+
+func stripFileEmbedIDsInNode(node any, ids map[string]struct{}) {
+	current, ok := node.(map[string]any)
+	if !ok {
+		return
+	}
+	children, ok := current["content"].([]any)
+	if !ok {
+		return
+	}
+
+	kept := make([]any, 0, len(children))
+	for _, child := range children {
+		if childMap, ok := child.(map[string]any); ok {
+			if childMap["type"] == "fileEmbed" {
+				if attrs, ok := childMap["attrs"].(map[string]any); ok {
+					if id, ok := attrs["id"].(string); ok {
+						if _, remove := ids[id]; remove {
+							continue
+						}
+					}
+				}
+			}
+			stripFileEmbedIDsInNode(childMap, ids)
+		}
+		kept = append(kept, child)
+	}
+	current["content"] = kept
 }
 
 func replaceFileEmbedIDInNode(node any, oldID, newID string) {

--- a/internal/cmd/products/rich_content.go
+++ b/internal/cmd/products/rich_content.go
@@ -150,7 +150,12 @@ func appendFileEmbeds(richContent []map[string]any, preserved []existingProductF
 		page["description"] = description
 	}
 	content, _ := description["content"].([]any)
-	content = appendFileEmbedsToContent(content, fileRefs)
+	if group := fileEmbedGroupForAppend(content); group != nil {
+		groupContent, _ := group["content"].([]any)
+		group["content"] = append(groupContent, fileEmbedNodes(fileRefs)...)
+	} else {
+		content = appendFileEmbedsToContent(content, fileRefs)
+	}
 	description["type"] = "doc"
 	description["content"] = content
 	return cloned, nil
@@ -185,6 +190,30 @@ func richContentPageHasFileEmbed(page map[string]any) bool {
 	var ids []string
 	collectFileEmbedIDs(page["description"], &ids)
 	return len(ids) > 0
+}
+
+func fileEmbedGroupForAppend(content []any) map[string]any {
+	var target map[string]any
+	for _, child := range content {
+		childMap, ok := child.(map[string]any)
+		if !ok {
+			continue
+		}
+		if childMap["type"] == "fileEmbed" {
+			return nil
+		}
+
+		var ids []string
+		collectFileEmbedIDs(childMap, &ids)
+		if len(ids) == 0 {
+			continue
+		}
+		if childMap["type"] != "fileEmbedGroup" || target != nil {
+			return nil
+		}
+		target = childMap
+	}
+	return target
 }
 
 func appendFileEmbedsToContent(content []any, fileRefs []richContentFileRef) []any {

--- a/internal/cmd/products/rich_content.go
+++ b/internal/cmd/products/rich_content.go
@@ -143,15 +143,14 @@ func appendFileEmbeds(richContent []map[string]any, preserved []existingProductF
 		return nil, err
 	}
 
-	description, ok := cloned[0]["description"].(map[string]any)
+	page := cloned[appendFileEmbedPage(cloned)]
+	description, ok := page["description"].(map[string]any)
 	if !ok {
 		description = map[string]any{"type": "doc"}
-		cloned[0]["description"] = description
+		page["description"] = description
 	}
 	content, _ := description["content"].([]any)
-	content = withoutTrailingParagraph(content)
-	content = append(content, fileEmbedNodes(fileRefs)...)
-	content = append(content, map[string]any{"type": "paragraph"})
+	content = appendFileEmbedsToContent(content, fileRefs)
 	description["type"] = "doc"
 	description["content"] = content
 	return cloned, nil
@@ -172,14 +171,33 @@ func richContentRefsForExistingFiles(files []existingProductFile) ([]richContent
 	return refs, nil
 }
 
-func withoutTrailingParagraph(content []any) []any {
-	if len(content) == 0 {
-		return content
+func appendFileEmbedPage(richContent []map[string]any) int {
+	target := len(richContent) - 1
+	for i, page := range richContent {
+		if richContentPageHasFileEmbed(page) {
+			target = i
+		}
 	}
-	if nodeHasType(content[len(content)-1], "paragraph") {
-		return content[:len(content)-1]
+	return target
+}
+
+func richContentPageHasFileEmbed(page map[string]any) bool {
+	var ids []string
+	collectFileEmbedIDs(page["description"], &ids)
+	return len(ids) > 0
+}
+
+func appendFileEmbedsToContent(content []any, fileRefs []richContentFileRef) []any {
+	var trailingParagraph any
+	if len(content) > 0 && nodeHasType(content[len(content)-1], "paragraph") {
+		trailingParagraph = content[len(content)-1]
+		content = content[:len(content)-1]
 	}
-	return content
+	content = append(content, fileEmbedNodes(fileRefs)...)
+	if trailingParagraph == nil {
+		trailingParagraph = map[string]any{"type": "paragraph"}
+	}
+	return append(content, trailingParagraph)
 }
 
 func cloneRichContent(richContent []map[string]any) ([]map[string]any, error) {

--- a/internal/cmd/products/rich_content.go
+++ b/internal/cmd/products/rich_content.go
@@ -298,7 +298,10 @@ func stripFileEmbedIDs(richContent []map[string]any, ids []string) {
 		idSet[id] = struct{}{}
 	}
 	for _, page := range richContent {
-		stripFileEmbedIDsInNode(page["description"], idSet)
+		if description, ok := page["description"].(map[string]any); ok {
+			stripFileEmbedIDsInNode(description, idSet)
+			ensureRichContentDescriptionContent(description)
+		}
 	}
 }
 
@@ -340,6 +343,14 @@ func isEmptyFileEmbedGroup(node map[string]any) bool {
 	}
 	children, ok := node["content"].([]any)
 	return !ok || len(children) == 0
+}
+
+func ensureRichContentDescriptionContent(description map[string]any) {
+	content, ok := description["content"].([]any)
+	if ok && len(content) > 0 {
+		return
+	}
+	description["content"] = []any{map[string]any{"type": "paragraph"}}
 }
 
 func nodeHasType(node any, typ string) bool {

--- a/internal/cmd/products/update.go
+++ b/internal/cmd/products/update.go
@@ -137,12 +137,22 @@ func newUpdateCmd() *cobra.Command {
 				return err
 			}
 			client := cmdutil.NewAPIClient(opts, token)
-			existingFiles, err := fetchExistingProductFiles(client, args[0])
+			existingState, err := fetchExistingProductFileState(client, args[0])
 			if err != nil {
 				return err
 			}
 
-			filePlan, err := planProductFileUpdate(c, existingFiles, requestedUploads, selections, replaceFiles)
+			filePlan, err := planProductFileUpdate(c, existingState.Files, requestedUploads, selections, replaceFiles)
+			if err != nil {
+				return err
+			}
+
+			fileRefs, err := newRichContentFileRefs(len(plannedUploads))
+			if err != nil {
+				return err
+			}
+
+			richContent, includeRichContent, err := buildProductUpdateRichContent(c, existingState.RichContent, filePlan, fileRefs)
 			if err != nil {
 				return err
 			}
@@ -156,8 +166,7 @@ func newUpdateCmd() *cobra.Command {
 			}
 
 			if opts.DryRun {
-				payload := buildProductJSONBody(params,
-					buildProductUpdateFilesPayload(filePlan, placeholderUploadURLs(len(plannedUploads))))
+				payload := buildProductUpdateJSONBody(params, filePlan, placeholderUploadURLs(len(plannedUploads)), fileRefs, richContent, includeRichContent)
 				return renderProductUpdateDryRun(opts, path, filePlan, plannedUploads, payload)
 			}
 
@@ -165,7 +174,7 @@ func newUpdateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			payload := buildProductJSONBody(params, buildProductUpdateFilesPayload(filePlan, uploadedURLs))
+			payload := buildProductUpdateJSONBody(params, filePlan, uploadedURLs, fileRefs, richContent, includeRichContent)
 			return runProductUpdateJSON(opts, client, path, args[0], payload, uploadedURLs)
 		},
 	}

--- a/internal/cmd/products/update_files_test.go
+++ b/internal/cmd/products/update_files_test.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -216,6 +217,36 @@ func richContentFileEmbedIDsFromBody(t *testing.T, body map[string]any) []string
 	return fileEmbedIDs(richContent)
 }
 
+func firstRichContentNodeTypesFromBody(t *testing.T, body map[string]any) []string {
+	t.Helper()
+
+	richContent := productUpdateJSONRichContent(t, body)
+	if len(richContent) == 0 {
+		t.Fatal("rich_content payload is empty")
+	}
+	description, ok := richContent[0]["description"].(map[string]any)
+	if !ok {
+		t.Fatalf("rich_content description has wrong type: %T", richContent[0]["description"])
+	}
+	content, ok := description["content"].([]any)
+	if !ok {
+		t.Fatalf("rich_content content has wrong type: %T", description["content"])
+	}
+	types := make([]string, len(content))
+	for i, node := range content {
+		nodeMap, ok := node.(map[string]any)
+		if !ok {
+			t.Fatalf("rich_content content[%d] has wrong type: %T", i, node)
+		}
+		nodeType, ok := nodeMap["type"].(string)
+		if !ok || nodeType == "" {
+			t.Fatalf("rich_content content[%d].type = %#v", i, nodeMap["type"])
+		}
+		types[i] = nodeType
+	}
+	return types
+}
+
 func TestUpdate_FilePreservesExistingByDefault(t *testing.T) {
 	srv := newProductUpdateFileServers(t)
 	srv.existingFiles = []existingProductFile{
@@ -263,11 +294,18 @@ func TestUpdate_FilePreservesExistingByDefault(t *testing.T) {
 	if files[2]["url"] != "https://example.com/attachments/u/k/original/upload-1.bin" {
 		t.Fatalf("files[2].url = %#v", files[2]["url"])
 	}
+	newFileID, ok := files[2]["id"].(string)
+	if !ok || !strings.HasPrefix(newFileID, "cli-upload-") {
+		t.Fatalf("files[2].id = %#v, want generated cli upload id", files[2]["id"])
+	}
 	if files[2]["display_name"] != "New Pack.zip" {
 		t.Fatalf("files[2].display_name = %#v", files[2]["display_name"])
 	}
 	if files[2]["description"] != "Updated bundle" {
 		t.Fatalf("files[2].description = %#v", files[2]["description"])
+	}
+	if ids := richContentFileEmbedIDsFromBody(t, srv.putJSON); !reflect.DeepEqual(ids, []string{"file_a", "file_b", newFileID}) {
+		t.Fatalf("rich_content fileEmbed ids = %#v, want preserved files and new upload", ids)
 	}
 }
 
@@ -448,8 +486,54 @@ func TestUpdate_ReplaceFilesClearAllStripsEmbeddedRichContent(t *testing.T) {
 	if ids := richContentFileEmbedIDsFromBody(t, srv.putJSON); len(ids) != 0 {
 		t.Fatalf("rich_content fileEmbed ids = %#v, want none", ids)
 	}
+	if types := firstRichContentNodeTypesFromBody(t, srv.putJSON); !reflect.DeepEqual(types, []string{"paragraph"}) {
+		t.Fatalf("rich_content node types = %#v, want only trailing paragraph", types)
+	}
 	if srv.s3Calls.Load() != 0 {
 		t.Fatalf("unexpected S3 calls: %d", srv.s3Calls.Load())
+	}
+}
+
+func TestUpdate_FileAppendsBeforeTrailingParagraph(t *testing.T) {
+	srv := newProductUpdateFileServers(t)
+	srv.existingFiles = []existingProductFile{
+		{ID: "file_old", Name: "Old Pack.zip"},
+	}
+	srv.existingRichContent = []map[string]any{{
+		"id":    "page_1",
+		"title": "Existing page",
+		"description": map[string]any{
+			"type": "doc",
+			"content": []any{
+				map[string]any{"type": "fileEmbed", "attrs": map[string]any{"id": "file_old"}},
+				map[string]any{"type": "paragraph"},
+			},
+		},
+	}}
+	testutil.Setup(t, srv.dispatch(t))
+
+	path := writeProductUploadFixture(t, "fresh bytes")
+	cmd := testutil.Command(newUpdateCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{
+		"prod1",
+		"--file", path,
+		"--file-name", "New Pack.zip",
+	})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	files := productUpdateJSONFiles(t, srv.putJSON)
+	if len(files) != 2 {
+		t.Fatalf("files payload len = %d, want 2", len(files))
+	}
+	newFileID, ok := files[1]["id"].(string)
+	if !ok || !strings.HasPrefix(newFileID, "cli-upload-") {
+		t.Fatalf("files[1].id = %#v, want generated cli upload id", files[1]["id"])
+	}
+	if ids := richContentFileEmbedIDsFromBody(t, srv.putJSON); !reflect.DeepEqual(ids, []string{"file_old", newFileID}) {
+		t.Fatalf("rich_content fileEmbed ids = %#v, want existing file then new upload", ids)
+	}
+	if types := firstRichContentNodeTypesFromBody(t, srv.putJSON); !reflect.DeepEqual(types, []string{"fileEmbed", "fileEmbed", "paragraph"}) {
+		t.Fatalf("rich_content node types = %#v, want adjacent file embeds then one trailing paragraph", types)
 	}
 }
 
@@ -677,8 +761,8 @@ func TestUpdate_FileDryRunPrefetchesButDoesNotUploadOrPut(t *testing.T) {
 		t.Fatalf("dry-run upload id = %#v, want generated cli upload id", files[1]["id"])
 	}
 	richContent := productUpdateJSONRichContent(t, payload.Request.Body)
-	if got := firstRichContentFileEmbedID(t, richContent[0]); got != newFileID {
-		t.Fatalf("dry-run fileEmbed id = %q, want new file id %q", got, newFileID)
+	if ids := fileEmbedIDs(richContent); !reflect.DeepEqual(ids, []string{"file_b", newFileID}) {
+		t.Fatalf("dry-run fileEmbed ids = %#v, want preserved file then new upload", ids)
 	}
 }
 

--- a/internal/cmd/products/update_files_test.go
+++ b/internal/cmd/products/update_files_test.go
@@ -209,6 +209,13 @@ func firstRichContentFileEmbedID(t *testing.T, page map[string]any) string {
 	return ""
 }
 
+func richContentFileEmbedIDsFromBody(t *testing.T, body map[string]any) []string {
+	t.Helper()
+
+	richContent := productUpdateJSONRichContent(t, body)
+	return fileEmbedIDs(richContent)
+}
+
 func TestUpdate_FilePreservesExistingByDefault(t *testing.T) {
 	srv := newProductUpdateFileServers(t)
 	srv.existingFiles = []existingProductFile{
@@ -349,6 +356,100 @@ func TestUpdate_FileSwapsRemovedRichContentEmbed(t *testing.T) {
 	}
 	if got := firstRichContentFileEmbedID(t, richContent[0]); got != newFileID {
 		t.Fatalf("fileEmbed id = %q, want new file id %q", got, newFileID)
+	}
+}
+
+func TestUpdate_RemoveEmbeddedFileStripsRichContentEmbed(t *testing.T) {
+	srv := newProductUpdateFileServers(t)
+	srv.existingFiles = []existingProductFile{
+		{ID: "file_old", Name: "Old Pack.zip"},
+		{ID: "file_keep", Name: "Keep.pdf"},
+	}
+	srv.existingRichContent = []map[string]any{{
+		"id":    "page_1",
+		"title": "Existing page",
+		"description": map[string]any{
+			"type": "doc",
+			"content": []any{
+				map[string]any{
+					"type": "paragraph",
+					"content": []any{
+						map[string]any{"type": "text", "text": "Download below"},
+					},
+				},
+				map[string]any{
+					"type": "fileEmbed",
+					"attrs": map[string]any{
+						"id":        "file_old",
+						"uid":       "old-uid",
+						"collapsed": false,
+					},
+				},
+			},
+		},
+	}}
+	testutil.Setup(t, srv.dispatch(t))
+
+	cmd := testutil.Command(newUpdateCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{
+		"prod1",
+		"--remove-file", "file_old",
+	})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	files := productUpdateJSONFiles(t, srv.putJSON)
+	if len(files) != 1 || files[0]["id"] != "file_keep" {
+		t.Fatalf("files payload = %#v, want only file_keep", files)
+	}
+	if ids := richContentFileEmbedIDsFromBody(t, srv.putJSON); len(ids) != 0 {
+		t.Fatalf("rich_content fileEmbed ids = %#v, want none", ids)
+	}
+	if srv.s3Calls.Load() != 0 {
+		t.Fatalf("unexpected S3 calls: %d", srv.s3Calls.Load())
+	}
+}
+
+func TestUpdate_ReplaceFilesClearAllStripsEmbeddedRichContent(t *testing.T) {
+	srv := newProductUpdateFileServers(t)
+	srv.existingFiles = []existingProductFile{
+		{ID: "file_a", Name: "Old A.zip"},
+		{ID: "file_b", Name: "Old B.zip"},
+	}
+	srv.existingRichContent = []map[string]any{{
+		"id":    "page_1",
+		"title": "Existing page",
+		"description": map[string]any{
+			"type": "doc",
+			"content": []any{
+				map[string]any{"type": "fileEmbed", "attrs": map[string]any{"id": "file_a"}},
+				map[string]any{
+					"type": "fileEmbedGroup",
+					"content": []any{
+						map[string]any{"type": "fileEmbed", "attrs": map[string]any{"id": "file_b"}},
+					},
+				},
+				map[string]any{"type": "paragraph"},
+			},
+		},
+	}}
+	testutil.Setup(t, srv.dispatch(t))
+
+	cmd := testutil.Command(newUpdateCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{
+		"prod1",
+		"--replace-files",
+	})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	files := productUpdateJSONFiles(t, srv.putJSON)
+	if len(files) != 0 {
+		t.Fatalf("files payload = %#v, want empty array", files)
+	}
+	if ids := richContentFileEmbedIDsFromBody(t, srv.putJSON); len(ids) != 0 {
+		t.Fatalf("rich_content fileEmbed ids = %#v, want none", ids)
+	}
+	if srv.s3Calls.Load() != 0 {
+		t.Fatalf("unexpected S3 calls: %d", srv.s3Calls.Load())
 	}
 }
 

--- a/internal/cmd/products/update_files_test.go
+++ b/internal/cmd/products/update_files_test.go
@@ -18,7 +18,8 @@ import (
 )
 
 type productUpdateFileServers struct {
-	existingFiles []existingProductFile
+	existingFiles       []existingProductFile
+	existingRichContent []map[string]any
 
 	s3 *httptest.Server
 
@@ -72,8 +73,9 @@ func (s *productUpdateFileServers) dispatch(t *testing.T) http.HandlerFunc {
 				s.getCalls.Add(1)
 				testutil.JSON(t, w, map[string]any{
 					"product": map[string]any{
-						"id":    "prod1",
-						"files": s.existingFiles,
+						"id":           "prod1",
+						"files":        s.existingFiles,
+						"rich_content": s.existingRichContent,
 					},
 				})
 			case http.MethodPut:
@@ -159,6 +161,54 @@ func productUpdateJSONFiles(t *testing.T, body map[string]any) []map[string]any 
 	return files
 }
 
+func productUpdateJSONRichContent(t *testing.T, body map[string]any) []map[string]any {
+	t.Helper()
+
+	raw, ok := body["rich_content"].([]any)
+	if !ok {
+		t.Fatalf("rich_content payload has wrong type: %T", body["rich_content"])
+	}
+	pages := make([]map[string]any, len(raw))
+	for i, current := range raw {
+		page, ok := current.(map[string]any)
+		if !ok {
+			t.Fatalf("rich_content[%d] has wrong type: %T", i, current)
+		}
+		pages[i] = page
+	}
+	return pages
+}
+
+func firstRichContentFileEmbedID(t *testing.T, page map[string]any) string {
+	t.Helper()
+
+	description, ok := page["description"].(map[string]any)
+	if !ok {
+		t.Fatalf("rich_content description has wrong type: %T", page["description"])
+	}
+	content, ok := description["content"].([]any)
+	if !ok {
+		t.Fatalf("rich_content content has wrong type: %T", description["content"])
+	}
+	for _, node := range content {
+		nodeMap, ok := node.(map[string]any)
+		if !ok || nodeMap["type"] != "fileEmbed" {
+			continue
+		}
+		attrs, ok := nodeMap["attrs"].(map[string]any)
+		if !ok {
+			t.Fatalf("fileEmbed attrs has wrong type: %T", nodeMap["attrs"])
+		}
+		id, ok := attrs["id"].(string)
+		if !ok || id == "" {
+			t.Fatalf("fileEmbed id = %#v", attrs["id"])
+		}
+		return id
+	}
+	t.Fatalf("rich_content page has no fileEmbed: %#v", page)
+	return ""
+}
+
 func TestUpdate_FilePreservesExistingByDefault(t *testing.T) {
 	srv := newProductUpdateFileServers(t)
 	srv.existingFiles = []existingProductFile{
@@ -211,6 +261,135 @@ func TestUpdate_FilePreservesExistingByDefault(t *testing.T) {
 	}
 	if files[2]["description"] != "Updated bundle" {
 		t.Fatalf("files[2].description = %#v", files[2]["description"])
+	}
+}
+
+func TestUpdate_FileCreatesRichContentForNewUpload(t *testing.T) {
+	srv := newProductUpdateFileServers(t)
+	testutil.Setup(t, srv.dispatch(t))
+
+	path := writeProductUploadFixture(t, "fresh bytes")
+	cmd := testutil.Command(newUpdateCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{
+		"prod1",
+		"--file", path,
+		"--file-name", "New Pack.zip",
+	})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	files := productUpdateJSONFiles(t, srv.putJSON)
+	if len(files) != 1 {
+		t.Fatalf("files payload len = %d, want 1", len(files))
+	}
+	if got := files[0]["url"]; got != "https://example.com/attachments/u/k/original/upload-1.bin" {
+		t.Fatalf("files[0].url = %#v", got)
+	}
+	assertCreateRichContentEmbedsFiles(t, srv.putJSON, files)
+}
+
+func TestUpdate_FileSwapsRemovedRichContentEmbed(t *testing.T) {
+	srv := newProductUpdateFileServers(t)
+	srv.existingFiles = []existingProductFile{
+		{ID: "file_old", Name: "Old Pack.zip"},
+		{ID: "file_keep", Name: "Keep.pdf"},
+	}
+	srv.existingRichContent = []map[string]any{{
+		"id":    "page_1",
+		"title": "Existing page",
+		"description": map[string]any{
+			"type": "doc",
+			"content": []any{
+				map[string]any{
+					"type": "paragraph",
+					"content": []any{
+						map[string]any{"type": "text", "text": "Download below"},
+					},
+				},
+				map[string]any{
+					"type": "fileEmbed",
+					"attrs": map[string]any{
+						"id":        "file_old",
+						"uid":       "old-uid",
+						"collapsed": false,
+					},
+				},
+			},
+		},
+	}}
+	testutil.Setup(t, srv.dispatch(t))
+
+	path := writeProductUploadFixture(t, "replacement bytes")
+	cmd := testutil.Command(newUpdateCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{
+		"prod1",
+		"--remove-file", "file_old",
+		"--file", path,
+		"--file-name", "New Pack.zip",
+	})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	files := productUpdateJSONFiles(t, srv.putJSON)
+	if len(files) != 2 {
+		t.Fatalf("files payload len = %d, want 2", len(files))
+	}
+	if got := files[0]["id"]; got != "file_keep" {
+		t.Fatalf("files[0].id = %#v, want file_keep", got)
+	}
+	newFileID, ok := files[1]["id"].(string)
+	if !ok || !strings.HasPrefix(newFileID, "cli-upload-") {
+		t.Fatalf("files[1].id = %#v, want generated cli upload id", files[1]["id"])
+	}
+
+	richContent := productUpdateJSONRichContent(t, srv.putJSON)
+	if len(richContent) != 1 {
+		t.Fatalf("rich_content len = %d, want 1", len(richContent))
+	}
+	if got := richContent[0]["id"]; got != "page_1" {
+		t.Fatalf("rich_content page id = %#v, want page_1", got)
+	}
+	if got := firstRichContentFileEmbedID(t, richContent[0]); got != newFileID {
+		t.Fatalf("fileEmbed id = %q, want new file id %q", got, newFileID)
+	}
+}
+
+func TestUpdate_FileAmbiguousEmbeddedReplacementErrorsBeforeUpload(t *testing.T) {
+	srv := newProductUpdateFileServers(t)
+	srv.existingFiles = []existingProductFile{
+		{ID: "file_a", Name: "Old A.zip"},
+		{ID: "file_b", Name: "Old B.zip"},
+	}
+	srv.existingRichContent = []map[string]any{{
+		"id":    "page_1",
+		"title": "Existing page",
+		"description": map[string]any{
+			"type": "doc",
+			"content": []any{
+				map[string]any{"type": "fileEmbed", "attrs": map[string]any{"id": "file_a"}},
+				map[string]any{"type": "fileEmbed", "attrs": map[string]any{"id": "file_b"}},
+			},
+		},
+	}}
+	testutil.Setup(t, srv.dispatch(t))
+
+	path := writeProductUploadFixture(t, "replacement bytes")
+	cmd := testutil.Command(newUpdateCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{
+		"prod1",
+		"--replace-files",
+		"--file", path,
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected ambiguous rich_content replacement error")
+	}
+	if !strings.Contains(err.Error(), "replace one embedded file at a time") {
+		t.Fatalf("expected rich_content disambiguation error, got %v", err)
+	}
+	if srv.s3Calls.Load() != 0 {
+		t.Fatalf("unexpected S3 calls: %d", srv.s3Calls.Load())
+	}
+	if srv.putCalls.Load() != 0 {
+		t.Fatalf("unexpected PUT calls: %d", srv.putCalls.Load())
 	}
 }
 
@@ -391,6 +570,14 @@ func TestUpdate_FileDryRunPrefetchesButDoesNotUploadOrPut(t *testing.T) {
 	}
 	if files[1]["url"] != "<uploaded:file:0>" {
 		t.Fatalf("dry-run upload placeholder = %#v", files[1]["url"])
+	}
+	newFileID, ok := files[1]["id"].(string)
+	if !ok || !strings.HasPrefix(newFileID, "cli-upload-") {
+		t.Fatalf("dry-run upload id = %#v, want generated cli upload id", files[1]["id"])
+	}
+	richContent := productUpdateJSONRichContent(t, payload.Request.Body)
+	if got := firstRichContentFileEmbedID(t, richContent[0]); got != newFileID {
+		t.Fatalf("dry-run fileEmbed id = %q, want new file id %q", got, newFileID)
 	}
 }
 

--- a/internal/cmd/products/update_files_test.go
+++ b/internal/cmd/products/update_files_test.go
@@ -224,14 +224,13 @@ func firstRichContentNodeTypesFromBody(t *testing.T, body map[string]any) []stri
 	if len(richContent) == 0 {
 		t.Fatal("rich_content payload is empty")
 	}
-	description, ok := richContent[0]["description"].(map[string]any)
-	if !ok {
-		t.Fatalf("rich_content description has wrong type: %T", richContent[0]["description"])
-	}
-	content, ok := description["content"].([]any)
-	if !ok {
-		t.Fatalf("rich_content content has wrong type: %T", description["content"])
-	}
+	return richContentNodeTypes(t, richContent[0])
+}
+
+func richContentNodeTypes(t *testing.T, page map[string]any) []string {
+	t.Helper()
+
+	content := richContentPageContent(t, page)
 	types := make([]string, len(content))
 	for i, node := range content {
 		nodeMap, ok := node.(map[string]any)
@@ -245,6 +244,20 @@ func firstRichContentNodeTypesFromBody(t *testing.T, body map[string]any) []stri
 		types[i] = nodeType
 	}
 	return types
+}
+
+func richContentPageContent(t *testing.T, page map[string]any) []any {
+	t.Helper()
+
+	description, ok := page["description"].(map[string]any)
+	if !ok {
+		t.Fatalf("rich_content description has wrong type: %T", page["description"])
+	}
+	content, ok := description["content"].([]any)
+	if !ok {
+		t.Fatalf("rich_content content has wrong type: %T", description["content"])
+	}
+	return content
 }
 
 func TestUpdate_FilePreservesExistingByDefault(t *testing.T) {
@@ -534,6 +547,133 @@ func TestUpdate_FileAppendsBeforeTrailingParagraph(t *testing.T) {
 	}
 	if types := firstRichContentNodeTypesFromBody(t, srv.putJSON); !reflect.DeepEqual(types, []string{"fileEmbed", "fileEmbed", "paragraph"}) {
 		t.Fatalf("rich_content node types = %#v, want adjacent file embeds then one trailing paragraph", types)
+	}
+}
+
+func TestUpdate_FileAppendsToPageWithExistingEmbed(t *testing.T) {
+	srv := newProductUpdateFileServers(t)
+	srv.existingFiles = []existingProductFile{
+		{ID: "file_old", Name: "Old Pack.zip"},
+	}
+	srv.existingRichContent = []map[string]any{
+		{
+			"id":    "page_1",
+			"title": "Welcome",
+			"description": map[string]any{
+				"type": "doc",
+				"content": []any{
+					map[string]any{"type": "paragraph"},
+					map[string]any{"type": "paragraph"},
+				},
+			},
+		},
+		{
+			"id":    "page_2",
+			"title": "Module 1",
+			"description": map[string]any{
+				"type": "doc",
+				"content": []any{
+					map[string]any{"type": "fileEmbed", "attrs": map[string]any{"id": "file_old"}},
+					map[string]any{"type": "paragraph"},
+				},
+			},
+		},
+	}
+	testutil.Setup(t, srv.dispatch(t))
+
+	path := writeProductUploadFixture(t, "fresh bytes")
+	cmd := testutil.Command(newUpdateCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{
+		"prod1",
+		"--file", path,
+		"--file-name", "New Pack.zip",
+	})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	files := productUpdateJSONFiles(t, srv.putJSON)
+	if len(files) != 2 {
+		t.Fatalf("files payload len = %d, want 2", len(files))
+	}
+	newFileID, ok := files[1]["id"].(string)
+	if !ok || !strings.HasPrefix(newFileID, "cli-upload-") {
+		t.Fatalf("files[1].id = %#v, want generated cli upload id", files[1]["id"])
+	}
+
+	richContent := productUpdateJSONRichContent(t, srv.putJSON)
+	if len(richContent) != 2 {
+		t.Fatalf("rich_content len = %d, want 2", len(richContent))
+	}
+	if ids := fileEmbedIDs([]map[string]any{richContent[0]}); len(ids) != 0 {
+		t.Fatalf("page 1 fileEmbed ids = %#v, want none", ids)
+	}
+	if ids := fileEmbedIDs([]map[string]any{richContent[1]}); !reflect.DeepEqual(ids, []string{"file_old", newFileID}) {
+		t.Fatalf("page 2 fileEmbed ids = %#v, want existing file then new upload", ids)
+	}
+	if types := richContentNodeTypes(t, richContent[0]); !reflect.DeepEqual(types, []string{"paragraph", "paragraph"}) {
+		t.Fatalf("page 1 node types = %#v, want unchanged paragraphs", types)
+	}
+	if types := richContentNodeTypes(t, richContent[1]); !reflect.DeepEqual(types, []string{"fileEmbed", "fileEmbed", "paragraph"}) {
+		t.Fatalf("page 2 node types = %#v, want adjacent file embeds then one trailing paragraph", types)
+	}
+}
+
+func TestUpdate_FilePreservesAuthoredTrailingParagraph(t *testing.T) {
+	srv := newProductUpdateFileServers(t)
+	srv.existingFiles = []existingProductFile{
+		{ID: "file_old", Name: "Old Pack.zip"},
+	}
+	srv.existingRichContent = []map[string]any{{
+		"id":    "page_1",
+		"title": "Existing page",
+		"description": map[string]any{
+			"type": "doc",
+			"content": []any{
+				map[string]any{"type": "fileEmbed", "attrs": map[string]any{"id": "file_old"}},
+				map[string]any{
+					"type": "paragraph",
+					"content": []any{
+						map[string]any{"type": "text", "text": "Important note"},
+					},
+				},
+			},
+		},
+	}}
+	testutil.Setup(t, srv.dispatch(t))
+
+	path := writeProductUploadFixture(t, "fresh bytes")
+	cmd := testutil.Command(newUpdateCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{
+		"prod1",
+		"--file", path,
+		"--file-name", "New Pack.zip",
+	})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	files := productUpdateJSONFiles(t, srv.putJSON)
+	if len(files) != 2 {
+		t.Fatalf("files payload len = %d, want 2", len(files))
+	}
+	newFileID, ok := files[1]["id"].(string)
+	if !ok || !strings.HasPrefix(newFileID, "cli-upload-") {
+		t.Fatalf("files[1].id = %#v, want generated cli upload id", files[1]["id"])
+	}
+	if ids := richContentFileEmbedIDsFromBody(t, srv.putJSON); !reflect.DeepEqual(ids, []string{"file_old", newFileID}) {
+		t.Fatalf("rich_content fileEmbed ids = %#v, want existing file then new upload", ids)
+	}
+
+	richContent := productUpdateJSONRichContent(t, srv.putJSON)
+	if types := richContentNodeTypes(t, richContent[0]); !reflect.DeepEqual(types, []string{"fileEmbed", "fileEmbed", "paragraph"}) {
+		t.Fatalf("rich_content node types = %#v, want file embeds then authored paragraph", types)
+	}
+	content := richContentPageContent(t, richContent[0])
+	paragraph := content[2].(map[string]any)
+	textNodes, ok := paragraph["content"].([]any)
+	if !ok || len(textNodes) != 1 {
+		t.Fatalf("trailing paragraph content = %#v, want one text node", paragraph["content"])
+	}
+	textNode, ok := textNodes[0].(map[string]any)
+	if !ok || textNode["text"] != "Important note" {
+		t.Fatalf("trailing paragraph text node = %#v, want Important note", textNodes[0])
 	}
 }
 

--- a/internal/cmd/products/update_files_test.go
+++ b/internal/cmd/products/update_files_test.go
@@ -507,6 +507,47 @@ func TestUpdate_ReplaceFilesClearAllStripsEmbeddedRichContent(t *testing.T) {
 	}
 }
 
+func TestUpdate_RemoveEmbeddedFileLeavesParagraphWhenPageWouldBeEmpty(t *testing.T) {
+	srv := newProductUpdateFileServers(t)
+	srv.existingFiles = []existingProductFile{
+		{ID: "file_old", Name: "Old Pack.zip"},
+	}
+	srv.existingRichContent = []map[string]any{{
+		"id":    "page_1",
+		"title": "Existing page",
+		"description": map[string]any{
+			"type": "doc",
+			"content": []any{
+				map[string]any{
+					"type": "fileEmbedGroup",
+					"content": []any{
+						map[string]any{"type": "fileEmbed", "attrs": map[string]any{"id": "file_old"}},
+					},
+				},
+			},
+		},
+	}}
+	testutil.Setup(t, srv.dispatch(t))
+
+	cmd := testutil.Command(newUpdateCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{
+		"prod1",
+		"--remove-file", "file_old",
+	})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	files := productUpdateJSONFiles(t, srv.putJSON)
+	if len(files) != 0 {
+		t.Fatalf("files payload = %#v, want empty array", files)
+	}
+	if ids := richContentFileEmbedIDsFromBody(t, srv.putJSON); len(ids) != 0 {
+		t.Fatalf("rich_content fileEmbed ids = %#v, want none", ids)
+	}
+	if types := firstRichContentNodeTypesFromBody(t, srv.putJSON); !reflect.DeepEqual(types, []string{"paragraph"}) {
+		t.Fatalf("rich_content node types = %#v, want fallback paragraph", types)
+	}
+}
+
 func TestUpdate_FileAppendsBeforeTrailingParagraph(t *testing.T) {
 	srv := newProductUpdateFileServers(t)
 	srv.existingFiles = []existingProductFile{

--- a/internal/cmd/products/update_files_test.go
+++ b/internal/cmd/products/update_files_test.go
@@ -617,6 +617,65 @@ func TestUpdate_FileAppendsToPageWithExistingEmbed(t *testing.T) {
 	}
 }
 
+func TestUpdate_FileAppendsInsideExistingFileEmbedGroup(t *testing.T) {
+	srv := newProductUpdateFileServers(t)
+	srv.existingFiles = []existingProductFile{
+		{ID: "file_a", Name: "Old A.zip"},
+		{ID: "file_b", Name: "Old B.zip"},
+	}
+	srv.existingRichContent = []map[string]any{{
+		"id":    "page_1",
+		"title": "Existing page",
+		"description": map[string]any{
+			"type": "doc",
+			"content": []any{
+				map[string]any{
+					"type": "fileEmbedGroup",
+					"content": []any{
+						map[string]any{"type": "fileEmbed", "attrs": map[string]any{"id": "file_a"}},
+						map[string]any{"type": "fileEmbed", "attrs": map[string]any{"id": "file_b"}},
+					},
+				},
+				map[string]any{"type": "paragraph"},
+			},
+		},
+	}}
+	testutil.Setup(t, srv.dispatch(t))
+
+	path := writeProductUploadFixture(t, "fresh bytes")
+	cmd := testutil.Command(newUpdateCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{
+		"prod1",
+		"--file", path,
+		"--file-name", "New Pack.zip",
+	})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	files := productUpdateJSONFiles(t, srv.putJSON)
+	if len(files) != 3 {
+		t.Fatalf("files payload len = %d, want 3", len(files))
+	}
+	newFileID, ok := files[2]["id"].(string)
+	if !ok || !strings.HasPrefix(newFileID, "cli-upload-") {
+		t.Fatalf("files[2].id = %#v, want generated cli upload id", files[2]["id"])
+	}
+
+	richContent := productUpdateJSONRichContent(t, srv.putJSON)
+	if types := richContentNodeTypes(t, richContent[0]); !reflect.DeepEqual(types, []string{"fileEmbedGroup", "paragraph"}) {
+		t.Fatalf("rich_content node types = %#v, want group plus trailing paragraph", types)
+	}
+	content := richContentPageContent(t, richContent[0])
+	group, ok := content[0].(map[string]any)
+	if !ok || group["type"] != "fileEmbedGroup" {
+		t.Fatalf("first rich_content node = %#v, want fileEmbedGroup", content[0])
+	}
+	var groupIDs []string
+	collectFileEmbedIDs(group, &groupIDs)
+	if !reflect.DeepEqual(groupIDs, []string{"file_a", "file_b", newFileID}) {
+		t.Fatalf("fileEmbedGroup ids = %#v, want existing files then new upload", groupIDs)
+	}
+}
+
 func TestUpdate_FilePreservesAuthoredTrailingParagraph(t *testing.T) {
 	srv := newProductUpdateFileServers(t)
 	srv.existingFiles = []existingProductFile{


### PR DESCRIPTION
Fixes #69

## What

This PR makes product file updates keep rich content in sync. Adding a new file now creates a matching file embed, and replacing a single embedded file now swaps the embed to the replacement in the same update request. Ambiguous embedded-file replacements fail before uploading so the CLI does not leave orphaned uploads.

## Why

Creators use `products update --file` and `--remove-file` to replace downloadable assets. Gumroad already supports updating files and rich content atomically, so the CLI should use that existing contract instead of exposing raw rich-content JSON or requiring a manual API call.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh.