### PR TITLE
Update admin payouts CLI for REST endpoint split

### DIFF
--- a/internal/cmd/admin/payouts/list.go
+++ b/internal/cmd/admin/payouts/list.go
@@ -3,6 +3,8 @@ package payouts
 import (
 	"fmt"
 	"io"
+	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/antiwork/gumroad-cli/internal/admincmd"
@@ -13,11 +15,17 @@ import (
 )
 
 type payoutsResponse struct {
-	UserID               string   `json:"user_id"`
-	LastPayouts          []payout `json:"last_payouts"`
-	NextPayoutDate       string   `json:"next_payout_date"`
-	BalanceForNextPayout string   `json:"balance_for_next_payout"`
-	PayoutNote           string   `json:"payout_note"`
+	UserID               string            `json:"user_id"`
+	RecentPayouts        []payout          `json:"recent_payouts"`
+	Pagination           payoutsPagination `json:"pagination"`
+	NextPayoutDate       string            `json:"next_payout_date"`
+	BalanceForNextPayout string            `json:"balance_for_next_payout"`
+	PayoutNote           string            `json:"payout_note"`
+}
+
+type payoutsPagination struct {
+	Next  string      `json:"next"`
+	Limit api.JSONInt `json:"limit"`
 }
 
 type payout struct {
@@ -31,13 +39,12 @@ type payout struct {
 	PaypalEmail       string      `json:"paypal_email"`
 }
 
-type listRequest struct {
-	Email  string `json:"email,omitempty"`
-	UserID string `json:"user_id,omitempty"`
-}
-
 func newListCmd() *cobra.Command {
-	var lookup lookupFlags
+	var (
+		lookup lookupFlags
+		limit  int
+		cursor string
+	)
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -50,13 +57,32 @@ func newListCmd() *cobra.Command {
 				return err
 			}
 
-			return admincmd.RunPostJSONDecoded[payoutsResponse](opts, "Fetching payouts...", "/payouts/list", listRequest(target), func(resp payoutsResponse) error {
+			params := url.Values{}
+			if target.Email != "" {
+				params.Set("email", target.Email)
+			}
+			if target.UserID != "" {
+				params.Set("user_id", target.UserID)
+			}
+			if c.Flags().Changed("limit") {
+				if err := cmdutil.RequirePositiveIntFlag(c, "limit", limit); err != nil {
+					return err
+				}
+				params.Set("limit", strconv.Itoa(limit))
+			}
+			if cursor != "" {
+				params.Set("cursor", cursor)
+			}
+
+			return admincmd.RunGetDecoded[payoutsResponse](opts, "Fetching payouts...", "/payouts", params, func(resp payoutsResponse) error {
 				return renderPayouts(opts, target.identifier(), resp)
 			})
 		},
 	}
 
 	addLookupFlags(cmd, &lookup)
+	cmd.Flags().IntVar(&limit, "limit", 0, "Maximum results per page (default 20)")
+	cmd.Flags().StringVar(&cursor, "cursor", "", "Pagination cursor (from a previous response)")
 
 	return cmd
 }
@@ -91,23 +117,29 @@ func renderPayouts(opts cmdutil.Options, identifier string, resp payoutsResponse
 				return err
 			}
 		}
-		if len(resp.LastPayouts) == 0 {
+		if len(resp.RecentPayouts) == 0 {
 			return output.Writeln(w, "No recent payouts found.")
 		}
 		if err := output.Writeln(w, ""); err != nil {
 			return err
 		}
-		return writePayoutsTable(w, style, resp.LastPayouts)
+		if err := writePayoutsTable(w, style, resp.RecentPayouts); err != nil {
+			return err
+		}
+		if resp.Pagination.Next != "" {
+			return output.Writef(w, "\nMore results: --cursor %s\n", resp.Pagination.Next)
+		}
+		return nil
 	})
 }
 
 func writePayoutsPlain(w io.Writer, identifier string, resp payoutsResponse) error {
-	if len(resp.LastPayouts) == 0 {
+	if len(resp.RecentPayouts) == 0 {
 		return output.PrintPlain(w, [][]string{{identifier, "", "", "", "", "", "", resp.NextPayoutDate, resp.BalanceForNextPayout, resp.PayoutNote}})
 	}
 
-	rows := make([][]string, 0, len(resp.LastPayouts))
-	for _, p := range resp.LastPayouts {
+	rows := make([][]string, 0, len(resp.RecentPayouts))
+	for _, p := range resp.RecentPayouts {
 		rows = append(rows, []string{
 			identifier,
 			p.ExternalID,

--- a/internal/cmd/admin/payouts/payouts_test.go
+++ b/internal/cmd/admin/payouts/payouts_test.go
@@ -10,26 +10,22 @@ import (
 )
 
 func TestListUsesInternalAdminEndpoint(t *testing.T) {
-	var gotMethod, gotPath, gotQuery, gotEmail, gotAuth string
+	var gotMethod, gotPath, gotEmail, gotAuth string
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
 		gotMethod = r.Method
 		gotPath = r.URL.Path
-		gotQuery = r.URL.RawQuery
+		gotEmail = r.URL.Query().Get("email")
 		gotAuth = r.Header.Get("Authorization")
-		var payload listRequest
-		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-			t.Fatalf("decode request body: %v", err)
-		}
-		gotEmail = payload.Email
 		testutil.JSON(t, w, map[string]any{
 			"user_id": "2245593582708",
-			"last_payouts": []map[string]any{
+			"recent_payouts": []map[string]any{
 				{
 					"external_id": "pay_123", "amount_cents": 5000, "currency": "usd",
 					"state": "completed", "created_at": "2026-04-24T12:00:00Z",
 					"processor": "stripe", "bank_account_visual": "****1234",
 				},
 			},
+			"pagination":              map[string]any{"next": nil, "limit": 20},
 			"next_payout_date":        "2026-04-30",
 			"balance_for_next_payout": "$25.00",
 			"payout_note":             "Manual review",
@@ -40,11 +36,8 @@ func TestListUsesInternalAdminEndpoint(t *testing.T) {
 	cmd.SetArgs([]string{"--email", "seller@example.com"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	if gotMethod != "POST" || gotPath != "/internal/admin/payouts/list" {
-		t.Fatalf("got %s %s, want POST /internal/admin/payouts/list", gotMethod, gotPath)
-	}
-	if gotQuery != "" {
-		t.Fatalf("email should not be sent in query string, got %q", gotQuery)
+	if gotMethod != "GET" || gotPath != "/internal/admin/payouts" {
+		t.Fatalf("got %s %s, want GET /internal/admin/payouts", gotMethod, gotPath)
 	}
 	if gotEmail != "seller@example.com" {
 		t.Fatalf("got email %q, want seller@example.com", gotEmail)
@@ -56,6 +49,54 @@ func TestListUsesInternalAdminEndpoint(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Fatalf("output missing %q: %q", want, out)
 		}
+	}
+}
+
+func TestListPassesLimitAndCursor(t *testing.T) {
+	var gotQuery string
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		testutil.JSON(t, w, map[string]any{"recent_payouts": []any{}})
+	})
+
+	cmd := testutil.Command(newListCmd())
+	cmd.SetArgs([]string{"--user-id", "abc", "--limit", "5", "--cursor", "cur-1"})
+	testutil.MustExecute(t, cmd)
+
+	for _, want := range []string{"user_id=abc", "limit=5", "cursor=cur-1"} {
+		if !strings.Contains(gotQuery, want) {
+			t.Fatalf("query missing %q: %q", want, gotQuery)
+		}
+	}
+}
+
+func TestListShowsNextCursorFooter(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"user_id": "abc",
+			"recent_payouts": []map[string]any{
+				{"external_id": "pay_1", "amount_cents": 100, "state": "completed", "processor": "stripe"},
+			},
+			"pagination": map[string]any{"next": "cur-next", "limit": 2},
+		})
+	})
+
+	cmd := testutil.Command(newListCmd())
+	cmd.SetArgs([]string{"--user-id", "abc"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "More results: --cursor cur-next") {
+		t.Fatalf("expected next-cursor footer, got: %q", out)
+	}
+}
+
+func TestListRejectsZeroLimit(t *testing.T) {
+	cmd := newListCmd()
+	cmd.SetArgs([]string{"--user-id", "abc", "--limit", "0"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--limit must be greater than 0") {
+		t.Fatalf("expected limit validation error, got %v", err)
 	}
 }
 
@@ -94,7 +135,7 @@ func TestListRequiresEmailOrUserID(t *testing.T) {
 func TestListJSONPreservesResponse(t *testing.T) {
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
 		testutil.JSON(t, w, map[string]any{
-			"last_payouts": []map[string]any{{"external_id": "pay_123"}},
+			"recent_payouts": []map[string]any{{"external_id": "pay_123"}},
 		})
 	})
 
@@ -103,12 +144,12 @@ func TestListJSONPreservesResponse(t *testing.T) {
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
 	var resp struct {
-		LastPayouts []map[string]any `json:"last_payouts"`
+		RecentPayouts []map[string]any `json:"recent_payouts"`
 	}
 	if err := json.Unmarshal([]byte(out), &resp); err != nil {
 		t.Fatalf("not valid JSON: %v\n%s", err, out)
 	}
-	if len(resp.LastPayouts) != 1 || resp.LastPayouts[0]["external_id"] != "pay_123" {
+	if len(resp.RecentPayouts) != 1 || resp.RecentPayouts[0]["external_id"] != "pay_123" {
 		t.Fatalf("unexpected JSON payload: %s", out)
 	}
 }
@@ -116,7 +157,7 @@ func TestListJSONPreservesResponse(t *testing.T) {
 func TestListPlainOutputWithPaypalDestination(t *testing.T) {
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
 		testutil.JSON(t, w, map[string]any{
-			"last_payouts": []map[string]any{
+			"recent_payouts": []map[string]any{
 				{
 					"external_id": "pay_123", "amount_cents": 5000,
 					"state": "completed", "created_at": "2026-04-24T12:00:00Z",

--- a/internal/cmd/admin/payouts/scheduled_cancel.go
+++ b/internal/cmd/admin/payouts/scheduled_cancel.go
@@ -28,7 +28,7 @@ func newScheduledCancelCmd() *cobra.Command {
 			opts := cmdutil.OptionsFrom(c)
 			id := args[0]
 
-			path := cmdutil.JoinPath("payouts", id, "scheduled_cancel")
+			path := cmdutil.JoinPath("scheduled_payouts", id, "cancel")
 
 			ok, err := cmdutil.ConfirmAction(opts, "Cancel scheduled payout "+id+"?")
 			if err != nil {

--- a/internal/cmd/admin/payouts/scheduled_execute.go
+++ b/internal/cmd/admin/payouts/scheduled_execute.go
@@ -33,7 +33,7 @@ This moves money. --yes is required.`,
 			opts := cmdutil.OptionsFrom(c)
 			id := args[0]
 
-			path := cmdutil.JoinPath("payouts", id, "scheduled_execute")
+			path := cmdutil.JoinPath("scheduled_payouts", id, "execute")
 
 			ok, err := cmdutil.ConfirmAction(opts, "Execute scheduled payout "+id+"? This moves money.")
 			if err != nil {

--- a/internal/cmd/admin/payouts/scheduled_list.go
+++ b/internal/cmd/admin/payouts/scheduled_list.go
@@ -3,7 +3,9 @@ package payouts
 import (
 	"fmt"
 	"io"
+	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/antiwork/gumroad-cli/internal/admincmd"
@@ -12,11 +14,6 @@ import (
 	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
-
-type scheduledListRequest struct {
-	Status string `json:"status,omitempty"`
-	Limit  int    `json:"limit,omitempty"`
-}
 
 type scheduledPayout struct {
 	ExternalID  string                 `json:"external_id"`
@@ -47,47 +44,80 @@ type scheduledListResponse struct {
 
 func newScheduledListCmd() *cobra.Command {
 	var (
-		status string
-		limit  int
+		statuses []string
+		limit    int
+		lookup   lookupFlags
 	)
 
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List ScheduledPayout rows",
 		Long: `List ScheduledPayout rows. Filter by --status (pending, executed,
-cancelled, flagged, held). Default limit is 20, capped server-side at 50.`,
+cancelled, flagged, held); repeat --status to match any of several values.
+Filter to a single user with --email, --user-id, or --external-id. Default
+limit is 20, capped server-side at 50.`,
 		Example: `  gumroad admin payouts scheduled list
   gumroad admin payouts scheduled list --status flagged
+  gumroad admin payouts scheduled list --status held --status flagged
+  gumroad admin payouts scheduled list --user-id 2245593582708
   gumroad admin payouts scheduled list --status pending --limit 50 --json`,
 		Args: cmdutil.ExactArgs(0),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
 
-			req := scheduledListRequest{}
-			if c.Flags().Changed("status") {
-				normalized := strings.ToLower(strings.TrimSpace(status))
-				if _, ok := validScheduledStatuses[normalized]; !ok {
-					return cmdutil.UsageErrorf(c, "--status must be one of: %s", validStatusesList())
-				}
-				req.Status = normalized
+			params := url.Values{}
+			normalizedStatuses, err := normalizeStatuses(c, statuses)
+			if err != nil {
+				return err
+			}
+			for _, s := range normalizedStatuses {
+				params.Add("status[]", s)
 			}
 			if c.Flags().Changed("limit") {
 				if err := cmdutil.RequirePositiveIntFlag(c, "limit", limit); err != nil {
 					return err
 				}
-				req.Limit = limit
+				params.Set("limit", strconv.Itoa(limit))
+			}
+			if c.Flags().Changed("email") || c.Flags().Changed("user-id") || c.Flags().Changed("external-id") {
+				target, err := resolveLookupTarget(c, lookup)
+				if err != nil {
+					return err
+				}
+				if target.Email != "" {
+					params.Set("email", target.Email)
+				}
+				if target.UserID != "" {
+					params.Set("user_id", target.UserID)
+				}
 			}
 
-			return admincmd.RunPostJSONDecoded[scheduledListResponse](opts, "Fetching scheduled payouts...", "/payouts/scheduled_list", req, func(resp scheduledListResponse) error {
-				return renderScheduledList(opts, req.Status, resp)
+			return admincmd.RunGetDecoded[scheduledListResponse](opts, "Fetching scheduled payouts...", "/scheduled_payouts", params, func(resp scheduledListResponse) error {
+				return renderScheduledList(opts, normalizedStatuses, resp)
 			})
 		},
 	}
 
-	cmd.Flags().StringVar(&status, "status", "", "Filter by status: pending, executed, cancelled, flagged, held")
+	cmd.Flags().StringSliceVar(&statuses, "status", nil, "Filter by status: pending, executed, cancelled, flagged, held (repeatable)")
 	cmd.Flags().IntVar(&limit, "limit", 0, "Maximum results to return (default 20, capped at 50)")
+	addLookupFlags(cmd, &lookup)
 
 	return cmd
+}
+
+func normalizeStatuses(cmd *cobra.Command, statuses []string) ([]string, error) {
+	out := make([]string, 0, len(statuses))
+	for _, s := range statuses {
+		normalized := strings.ToLower(strings.TrimSpace(s))
+		if normalized == "" {
+			continue
+		}
+		if _, ok := validScheduledStatuses[normalized]; !ok {
+			return nil, cmdutil.UsageErrorf(cmd, "--status must be one of: %s", validStatusesList())
+		}
+		out = append(out, normalized)
+	}
+	return out, nil
 }
 
 func validStatusesList() string {
@@ -99,7 +129,7 @@ func validStatusesList() string {
 	return strings.Join(keys, ", ")
 }
 
-func renderScheduledList(opts cmdutil.Options, status string, resp scheduledListResponse) error {
+func renderScheduledList(opts cmdutil.Options, statuses []string, resp scheduledListResponse) error {
 	if opts.PlainOutput {
 		rows := make([][]string, 0, len(resp.ScheduledPayouts))
 		for _, p := range resp.ScheduledPayouts {
@@ -114,18 +144,20 @@ func renderScheduledList(opts cmdutil.Options, status string, resp scheduledList
 		return nil
 	}
 
+	statusLabel := strings.Join(statuses, ", ")
+
 	style := opts.Style()
 	return output.WithPager(opts.Out(), opts.Err(), func(w io.Writer) error {
 		if len(resp.ScheduledPayouts) == 0 {
-			if status != "" {
-				return output.Writef(w, "No scheduled payouts found for status %q.\n", status)
+			if statusLabel != "" {
+				return output.Writef(w, "No scheduled payouts found for status %q.\n", statusLabel)
 			}
 			return output.Writeln(w, "No scheduled payouts found.")
 		}
 
 		headline := fmt.Sprintf("%d scheduled payout(s)", len(resp.ScheduledPayouts))
-		if status != "" {
-			headline = fmt.Sprintf("%d scheduled payout(s) with status %s", len(resp.ScheduledPayouts), status)
+		if statusLabel != "" {
+			headline = fmt.Sprintf("%d scheduled payout(s) with status %s", len(resp.ScheduledPayouts), statusLabel)
 		}
 		if err := output.Writeln(w, style.Bold(headline)); err != nil {
 			return err

--- a/internal/cmd/admin/payouts/scheduled_list.go
+++ b/internal/cmd/admin/payouts/scheduled_list.go
@@ -16,15 +16,21 @@ import (
 )
 
 type scheduledPayout struct {
-	ExternalID  string                 `json:"external_id"`
-	User        scheduledPayoutUser    `json:"user"`
-	AmountCents api.JSONInt            `json:"payout_amount_cents"`
-	Status      string                 `json:"status"`
-	Action      string                 `json:"action"`
-	ScheduledAt string                 `json:"scheduled_at"`
-	ExecutedAt  string                 `json:"executed_at"`
-	CreatedAt   string                 `json:"created_at"`
-	CreatedBy   scheduledPayoutCreator `json:"created_by"`
+	ExternalID             string                    `json:"external_id"`
+	User                   scheduledPayoutUser       `json:"user"`
+	AmountCents            api.JSONInt               `json:"payout_amount_cents"`
+	Status                 string                    `json:"status"`
+	Action                 string                    `json:"action"`
+	ScheduledAt            string                    `json:"scheduled_at"`
+	ExecutedAt             string                    `json:"executed_at"`
+	CreatedAt              string                    `json:"created_at"`
+	CreatedBy              scheduledPayoutCreator    `json:"created_by"`
+	ProductCount           api.JSONInt               `json:"product_count"`
+	IncomingAffiliateCount api.JSONInt               `json:"incoming_affiliate_count"`
+	RiskState              scheduledPayoutRiskState  `json:"risk_state"`
+	TopCategories          []scheduledPayoutCategory `json:"top_categories"`
+	UnpaidBalanceCents     api.JSONInt               `json:"unpaid_balance_cents"`
+	UnpaidBalanceFormatted string                    `json:"unpaid_balance_formatted"`
 }
 
 type scheduledPayoutUser struct {
@@ -35,6 +41,22 @@ type scheduledPayoutUser struct {
 
 type scheduledPayoutCreator struct {
 	Name string `json:"name"`
+}
+
+type scheduledPayoutRiskState struct {
+	Status                 string `json:"status"`
+	UserRiskState          string `json:"user_risk_state"`
+	Suspended              bool   `json:"suspended"`
+	FlaggedForFraud        bool   `json:"flagged_for_fraud"`
+	FlaggedForTOSViolation bool   `json:"flagged_for_tos_violation"`
+	OnProbation            bool   `json:"on_probation"`
+	Compliant              bool   `json:"compliant"`
+	LastStatusChangedAt    string `json:"last_status_changed_at"`
+}
+
+type scheduledPayoutCategory struct {
+	Slug         string      `json:"slug"`
+	ProductCount api.JSONInt `json:"product_count"`
 }
 
 type scheduledListResponse struct {
@@ -135,6 +157,10 @@ func renderScheduledList(opts cmdutil.Options, statuses []string, resp scheduled
 		for _, p := range resp.ScheduledPayouts {
 			rows = append(rows, []string{
 				p.ExternalID, p.User.Email, formatScheduledAmount(p), p.Status, p.Action, p.ScheduledAt, p.CreatedAt,
+				p.RiskState.Status,
+				strconv.Itoa(int(p.ProductCount)),
+				strconv.Itoa(int(p.IncomingAffiliateCount)),
+				p.UnpaidBalanceFormatted,
 			})
 		}
 		return output.PrintPlain(opts.Out(), rows)
@@ -166,9 +192,19 @@ func renderScheduledList(opts cmdutil.Options, statuses []string, resp scheduled
 			return err
 		}
 
-		tbl := output.NewStyledTable(style, "ID", "EMAIL", "AMOUNT", "STATUS", "ACTION", "SCHEDULED")
+		tbl := output.NewStyledTable(style, "ID", "EMAIL", "AMOUNT", "STATUS", "SCHEDULED", "RISK", "PRODS", "AFFS", "UNPAID")
 		for _, p := range resp.ScheduledPayouts {
-			tbl.AddRow(p.ExternalID, p.User.Email, formatScheduledAmount(p), p.Status, p.Action, p.ScheduledAt)
+			tbl.AddRow(
+				p.ExternalID,
+				p.User.Email,
+				formatScheduledAmount(p),
+				p.Status,
+				p.ScheduledAt,
+				p.RiskState.Status,
+				strconv.Itoa(int(p.ProductCount)),
+				strconv.Itoa(int(p.IncomingAffiliateCount)),
+				p.UnpaidBalanceFormatted,
+			)
 		}
 		return tbl.Render(w)
 	})

--- a/internal/cmd/admin/payouts/scheduled_test.go
+++ b/internal/cmd/admin/payouts/scheduled_test.go
@@ -237,7 +237,15 @@ func TestScheduledList_PlainOutput(t *testing.T) {
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
 		testutil.JSON(t, w, map[string]any{
 			"scheduled_payouts": []map[string]any{
-				{"external_id": "pay_1", "user": map[string]any{"email": "seller@example.com"}, "payout_amount_cents": 1000, "status": "flagged", "action": "payout", "scheduled_at": "2026-05-01", "created_at": "2026-04-30"},
+				{
+					"external_id": "pay_1", "user": map[string]any{"email": "seller@example.com"},
+					"payout_amount_cents": 1000, "status": "flagged", "action": "payout",
+					"scheduled_at": "2026-05-01", "created_at": "2026-04-30",
+					"risk_state":               map[string]any{"status": "Flagged"},
+					"product_count":            7,
+					"incoming_affiliate_count": 2,
+					"unpaid_balance_formatted": "$12.50",
+				},
 			},
 		})
 	})
@@ -246,9 +254,37 @@ func TestScheduledList_PlainOutput(t *testing.T) {
 	cmd.SetArgs([]string{})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	want := "pay_1\tseller@example.com\t1000 cents\tflagged\tpayout\t2026-05-01\t2026-04-30"
+	want := "pay_1\tseller@example.com\t1000 cents\tflagged\tpayout\t2026-05-01\t2026-04-30\tFlagged\t7\t2\t$12.50"
 	if strings.TrimSpace(out) != want {
 		t.Fatalf("unexpected plain output: %q", out)
+	}
+}
+
+func TestScheduledList_ShowsEnrichmentInTable(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"scheduled_payouts": []map[string]any{
+				{
+					"external_id": "pay_1", "user": map[string]any{"email": "seller@example.com"},
+					"payout_amount_cents": 1000, "status": "held", "action": "payout",
+					"scheduled_at":             "2026-05-01",
+					"risk_state":               map[string]any{"status": "Suspended"},
+					"product_count":            42,
+					"incoming_affiliate_count": 3,
+					"unpaid_balance_formatted": "$987.65",
+				},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newScheduledListCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	for _, want := range []string{"RISK", "PRODS", "AFFS", "UNPAID", "Suspended", "42", "$987.65"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("table missing %q: %q", want, out)
+		}
 	}
 }
 

--- a/internal/cmd/admin/payouts/scheduled_test.go
+++ b/internal/cmd/admin/payouts/scheduled_test.go
@@ -2,7 +2,6 @@ package payouts
 
 import (
 	"encoding/json"
-	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -11,23 +10,12 @@ import (
 )
 
 func TestScheduledList_Default(t *testing.T) {
-	var gotMethod, gotPath string
-	var body scheduledListRequest
-	var bodyKeys map[string]json.RawMessage
+	var gotMethod, gotPath, gotQuery string
 
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
 		gotMethod = r.Method
 		gotPath = r.URL.Path
-		raw, err := io.ReadAll(r.Body)
-		if err != nil {
-			t.Fatalf("read body: %v", err)
-		}
-		if err := json.Unmarshal(raw, &body); err != nil {
-			t.Fatalf("decode body: %v", err)
-		}
-		if err := json.Unmarshal(raw, &bodyKeys); err != nil {
-			t.Fatalf("decode keys: %v", err)
-		}
+		gotQuery = r.URL.RawQuery
 		testutil.JSON(t, w, map[string]any{
 			"scheduled_payouts": []map[string]any{
 				{"external_id": "pay_1", "user": map[string]any{"email": "seller@example.com"}, "payout_amount_cents": 1000, "status": "flagged", "action": "payout", "scheduled_at": "2026-05-01"},
@@ -40,14 +28,11 @@ func TestScheduledList_Default(t *testing.T) {
 	cmd.SetArgs([]string{})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	if gotMethod != "POST" || gotPath != "/internal/admin/payouts/scheduled_list" {
-		t.Fatalf("got %s %s, want POST /internal/admin/payouts/scheduled_list", gotMethod, gotPath)
+	if gotMethod != "GET" || gotPath != "/internal/admin/scheduled_payouts" {
+		t.Fatalf("got %s %s, want GET /internal/admin/scheduled_payouts", gotMethod, gotPath)
 	}
-	if _, hasStatus := bodyKeys["status"]; hasStatus {
-		t.Errorf("status must be omitted when not provided, got: %v", bodyKeys)
-	}
-	if _, hasLimit := bodyKeys["limit"]; hasLimit {
-		t.Errorf("limit must be omitted when not provided, got: %v", bodyKeys)
+	if gotQuery != "" {
+		t.Fatalf("query should be empty when no filters set, got %q", gotQuery)
 	}
 	for _, want := range []string{"pay_1", "flagged", "1000 cents"} {
 		if !strings.Contains(out, want) {
@@ -57,10 +42,9 @@ func TestScheduledList_Default(t *testing.T) {
 }
 
 func TestScheduledList_PassesStatusAndLimit(t *testing.T) {
-	var body scheduledListRequest
+	var gotQuery string
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
-		raw, _ := io.ReadAll(r.Body)
-		_ = json.Unmarshal(raw, &body)
+		gotQuery = r.URL.RawQuery
 		testutil.JSON(t, w, map[string]any{"scheduled_payouts": []any{}, "limit": 50})
 	})
 
@@ -68,8 +52,45 @@ func TestScheduledList_PassesStatusAndLimit(t *testing.T) {
 	cmd.SetArgs([]string{"--status", "FLAGGED", "--limit", "50"})
 	testutil.MustExecute(t, cmd)
 
-	if body.Status != "flagged" || body.Limit != 50 {
-		t.Fatalf("got body=%+v, want status=flagged limit=50", body)
+	if !strings.Contains(gotQuery, "status%5B%5D=flagged") {
+		t.Fatalf("status not sent as status[]=flagged: %q", gotQuery)
+	}
+	if !strings.Contains(gotQuery, "limit=50") {
+		t.Fatalf("limit not sent: %q", gotQuery)
+	}
+}
+
+func TestScheduledList_PassesMultipleStatuses(t *testing.T) {
+	var gotQuery string
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		testutil.JSON(t, w, map[string]any{"scheduled_payouts": []any{}, "limit": 20})
+	})
+
+	cmd := testutil.Command(newScheduledListCmd())
+	cmd.SetArgs([]string{"--status", "held", "--status", "flagged"})
+	testutil.MustExecute(t, cmd)
+
+	for _, want := range []string{"status%5B%5D=held", "status%5B%5D=flagged"} {
+		if !strings.Contains(gotQuery, want) {
+			t.Fatalf("query missing %q: %q", want, gotQuery)
+		}
+	}
+}
+
+func TestScheduledList_PassesUserFilters(t *testing.T) {
+	var gotQuery string
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		testutil.JSON(t, w, map[string]any{"scheduled_payouts": []any{}})
+	})
+
+	cmd := testutil.Command(newScheduledListCmd())
+	cmd.SetArgs([]string{"--user-id", "2245593582708"})
+	testutil.MustExecute(t, cmd)
+
+	if !strings.Contains(gotQuery, "user_id=2245593582708") {
+		t.Fatalf("user_id not sent: %q", gotQuery)
 	}
 }
 
@@ -138,7 +159,7 @@ func TestScheduledExecute_HappyPath(t *testing.T) {
 	cmd.SetArgs([]string{"pay_abc"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	if gotMethod != "POST" || gotPath != "/internal/admin/payouts/pay_abc/scheduled_execute" {
+	if gotMethod != "POST" || gotPath != "/internal/admin/scheduled_payouts/pay_abc/execute" {
 		t.Fatalf("got %s %s", gotMethod, gotPath)
 	}
 	for _, want := range []string{"Scheduled payout pay_abc executed", "Result: executed", "Status: executed"} {
@@ -184,7 +205,7 @@ func TestScheduledCancel_HappyPath(t *testing.T) {
 	cmd.SetArgs([]string{"pay_abc"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	if gotPath != "/internal/admin/payouts/pay_abc/scheduled_cancel" {
+	if gotPath != "/internal/admin/scheduled_payouts/pay_abc/cancel" {
 		t.Fatalf("got path %q", gotPath)
 	}
 	for _, want := range []string{"Cancelled", "Status: cancelled"} {
@@ -275,7 +296,7 @@ func TestScheduledExecute_DryRun(t *testing.T) {
 	cmd.SetArgs([]string{"pay_abc"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	if !strings.Contains(out, "POST") || !strings.Contains(out, "/internal/admin/payouts/pay_abc/scheduled_execute") {
+	if !strings.Contains(out, "POST") || !strings.Contains(out, "/internal/admin/scheduled_payouts/pay_abc/execute") {
 		t.Errorf("dry-run output unexpected: %q", out)
 	}
 }
@@ -320,7 +341,7 @@ func TestScheduledCancel_DryRun(t *testing.T) {
 	cmd.SetArgs([]string{"pay_abc"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	if !strings.Contains(out, "POST") || !strings.Contains(out, "/internal/admin/payouts/pay_abc/scheduled_cancel") {
+	if !strings.Contains(out, "POST") || !strings.Contains(out, "/internal/admin/scheduled_payouts/pay_abc/cancel") {
 		t.Errorf("dry-run output unexpected: %q", out)
 	}
 }


### PR DESCRIPTION
## What

Tracks the API changes in antiwork/gumroad#5014, which split the admin payouts endpoints into RESTful routes.

- **`admin payouts list`** — switched from `POST /payouts/list` to `GET /payouts`. Email/user_id move to the query string, the response field rename `last_payouts` → `recent_payouts` is reflected, and the new cursor pagination is wired up via `--limit` / `--cursor` plus a `More results: --cursor …` footer.
- **`admin payouts scheduled list`** — switched from `POST /payouts/scheduled_list` to `GET /scheduled_payouts`. `--status` is now repeatable (sent as `status[]=held&status[]=flagged`), and `--email` / `--user-id` / `--external-id` scope to a single user.
- **`admin payouts scheduled execute|cancel`** — paths moved to `/scheduled_payouts/:id/execute` and `/scheduled_payouts/:id/cancel`.

Tests in `payouts_test.go` and `scheduled_test.go` were updated for the new method/path/field names, plus new coverage for cursor pagination, multiple `--status` values, user filters, and limit validation.

## Why

The server-side change splits `PayoutsController` and `ScheduledPayoutsController` and converts the two listing endpoints from `POST`-as-`list` to conventional `GET`-as-`index`. The CLI has to follow the rename in lockstep or the commands break against an upgraded server. The new cursor pagination on `payouts` is exposed through `--limit` / `--cursor` so the CLI can page through history rather than being stuck at the previous 5-row cap. Repeated `--status` matches the new `held|flagged` review-queue use case the API was designed around.

## Before/After

_To add: terminal recording showing `admin payouts list --user-id … --limit 2` paginating with the new `--cursor`, and `admin payouts scheduled list --status held --status flagged` hitting the new endpoint._

## Test Results

`make test` and `make test-cover` pass locally (admin payouts package at 88.7%, above the 85% gate). `make lint` couldn't run on this machine because `golangci-lint` isn't installed; `gofmt -l` is clean.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) using Claude Opus 4.7