### PR TITLE
Flip admin read commands to GET

### DIFF
--- a/internal/cmd/admin/licenses/licenses_test.go
+++ b/internal/cmd/admin/licenses/licenses_test.go
@@ -10,17 +10,12 @@ import (
 )
 
 func TestLookupUsesInternalAdminEndpoint(t *testing.T) {
-	var gotMethod, gotPath, gotQuery, gotKey, gotAuth string
+	var gotMethod, gotPath, gotKey, gotAuth string
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
 		gotMethod = r.Method
 		gotPath = r.URL.Path
-		gotQuery = r.URL.RawQuery
 		gotAuth = r.Header.Get("Authorization")
-		var payload lookupRequest
-		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-			t.Fatalf("decode request body: %v", err)
-		}
-		gotKey = payload.LicenseKey
+		gotKey = r.URL.Query().Get("license_key")
 		testutil.JSON(t, w, map[string]any{
 			"license": map[string]any{
 				"email": "buyer@example.com", "product_name": "Course", "purchase_id": "123",
@@ -33,11 +28,8 @@ func TestLookupUsesInternalAdminEndpoint(t *testing.T) {
 	cmd.SetArgs([]string{"--key", "ABC-123"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	if gotMethod != "POST" || gotPath != "/internal/admin/licenses/lookup" {
-		t.Fatalf("got %s %s, want POST /internal/admin/licenses/lookup", gotMethod, gotPath)
-	}
-	if gotQuery != "" {
-		t.Fatalf("license key should not be sent in query string, got %q", gotQuery)
+	if gotMethod != "GET" || gotPath != "/internal/admin/licenses/lookup" {
+		t.Fatalf("got %s %s, want GET /internal/admin/licenses/lookup", gotMethod, gotPath)
 	}
 	if gotKey != "ABC-123" {
 		t.Fatalf("got license_key %q, want ABC-123", gotKey)
@@ -58,14 +50,7 @@ func TestLookupUsesInternalAdminEndpoint(t *testing.T) {
 func TestLookupReadsLicenseKeyFromStdin(t *testing.T) {
 	var gotKey string
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.RawQuery != "" {
-			t.Fatalf("license key should not be sent in query string, got %q", r.URL.RawQuery)
-		}
-		var payload lookupRequest
-		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-			t.Fatalf("decode request body: %v", err)
-		}
-		gotKey = payload.LicenseKey
+		gotKey = r.URL.Query().Get("license_key")
 		testutil.JSON(t, w, map[string]any{
 			"purchase": map[string]any{"email": "buyer@example.com", "product_id": "prod_123"},
 			"uses":     1,

--- a/internal/cmd/admin/licenses/lookup.go
+++ b/internal/cmd/admin/licenses/lookup.go
@@ -2,6 +2,7 @@ package licenses
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/antiwork/gumroad-cli/internal/admincmd"
@@ -43,10 +44,6 @@ type purchase struct {
 	Uses         api.JSONInt `json:"uses"`
 }
 
-type lookupRequest struct {
-	LicenseKey string `json:"license_key"`
-}
-
 func newLookupCmd() *cobra.Command {
 	var key string
 
@@ -61,7 +58,8 @@ func newLookupCmd() *cobra.Command {
 				return err
 			}
 
-			return admincmd.RunPostJSONDecoded[licenseResponse](opts, "Fetching license...", "/licenses/lookup", lookupRequest{LicenseKey: resolvedKey}, func(resp licenseResponse) error {
+			params := url.Values{"license_key": []string{resolvedKey}}
+			return admincmd.RunGetDecoded[licenseResponse](opts, "Fetching license...", "/licenses/lookup", params, func(resp licenseResponse) error {
 				return renderLicense(opts, resp)
 			})
 		},

--- a/internal/cmd/admin/products/list.go
+++ b/internal/cmd/admin/products/list.go
@@ -3,6 +3,7 @@ package products
 import (
 	"fmt"
 	"io"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -11,13 +12,6 @@ import (
 	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
-
-type listRequest struct {
-	Email      string `json:"email,omitempty"`
-	ExternalID string `json:"external_id,omitempty"`
-	Page       int    `json:"page,omitempty"`
-	PerPage    int    `json:"per_page,omitempty"`
-}
 
 type listResponse struct {
 	Products   []product         `json:"products"`
@@ -69,15 +63,21 @@ since those are the cases where the email path can't resolve them.`,
 				return err
 			}
 
-			req := listRequest{Email: email, ExternalID: externalID}
+			params := url.Values{}
+			if email != "" {
+				params.Set("email", email)
+			}
+			if externalID != "" {
+				params.Set("external_id", externalID)
+			}
 			if c.Flags().Changed("page") {
-				req.Page = page
+				params.Set("page", strconv.Itoa(page))
 			}
 			if c.Flags().Changed("per-page") {
-				req.PerPage = perPage
+				params.Set("per_page", strconv.Itoa(perPage))
 			}
 
-			return admincmd.RunPostJSONDecoded[listResponse](opts, "Fetching products...", "/products/list", req, func(resp listResponse) error {
+			return admincmd.RunGetDecoded[listResponse](opts, "Fetching products...", "/products", params, func(resp listResponse) error {
 				return renderList(opts, sellerSubject(email, externalID), resp)
 			})
 		},

--- a/internal/cmd/admin/products/list_test.go
+++ b/internal/cmd/admin/products/list_test.go
@@ -2,7 +2,6 @@ package products
 
 import (
 	"encoding/json"
-	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -101,19 +100,16 @@ func TestListRejectsNonPositivePerPage(t *testing.T) {
 
 func TestListUsesInternalAdminEndpointAndRendersHumanOutput(t *testing.T) {
 	var gotMethod, gotPath, gotAuth string
-	var body listRequest
+	var gotEmail, gotPage, gotPerPage string
 
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
 		gotMethod = r.Method
 		gotPath = r.URL.Path
 		gotAuth = r.Header.Get("Authorization")
-		raw, err := io.ReadAll(r.Body)
-		if err != nil {
-			t.Fatalf("read body: %v", err)
-		}
-		if err := json.Unmarshal(raw, &body); err != nil {
-			t.Fatalf("decode body: %v", err)
-		}
+		query := r.URL.Query()
+		gotEmail = query.Get("email")
+		gotPage = query.Get("page")
+		gotPerPage = query.Get("per_page")
 		testutil.JSON(t, w, sampleListPayload())
 	})
 
@@ -121,14 +117,14 @@ func TestListUsesInternalAdminEndpointAndRendersHumanOutput(t *testing.T) {
 	cmd.SetArgs([]string{"--email", "seller@example.com", "--page", "1", "--per-page", "10"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	if gotMethod != "POST" || gotPath != "/internal/admin/products/list" {
-		t.Fatalf("got %s %s, want POST /internal/admin/products/list", gotMethod, gotPath)
+	if gotMethod != "GET" || gotPath != "/internal/admin/products" {
+		t.Fatalf("got %s %s, want GET /internal/admin/products", gotMethod, gotPath)
 	}
 	if gotAuth != "Bearer admin-token" {
 		t.Fatalf("got auth %q, want Bearer admin-token", gotAuth)
 	}
-	if body.Email != "seller@example.com" || body.Page != 1 || body.PerPage != 10 {
-		t.Fatalf("got body %+v, want email=seller@example.com page=1 per_page=10", body)
+	if gotEmail != "seller@example.com" || gotPage != "1" || gotPerPage != "10" {
+		t.Fatalf("got query email=%q page=%q per_page=%q, want email=seller@example.com page=1 per_page=10", gotEmail, gotPage, gotPerPage)
 	}
 	for _, want := range []string{
 		"Products for seller@example.com",
@@ -144,16 +140,12 @@ func TestListUsesInternalAdminEndpointAndRendersHumanOutput(t *testing.T) {
 }
 
 func TestListOmitsPagingWhenFlagsUnset(t *testing.T) {
-	var body listRequest
+	var gotPage, gotPerPage string
 
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
-		raw, err := io.ReadAll(r.Body)
-		if err != nil {
-			t.Fatalf("read body: %v", err)
-		}
-		if err := json.Unmarshal(raw, &body); err != nil {
-			t.Fatalf("decode body: %v", err)
-		}
+		query := r.URL.Query()
+		gotPage = query.Get("page")
+		gotPerPage = query.Get("per_page")
 		testutil.JSON(t, w, sampleListPayload())
 	})
 
@@ -161,8 +153,8 @@ func TestListOmitsPagingWhenFlagsUnset(t *testing.T) {
 	cmd.SetArgs([]string{"--email", "seller@example.com"})
 	testutil.MustExecute(t, cmd)
 
-	if body.Page != 0 || body.PerPage != 0 {
-		t.Fatalf("page/per_page must default to API when flags unset, got %+v", body)
+	if gotPage != "" || gotPerPage != "" {
+		t.Fatalf("page/per_page must default to API when flags unset, got page=%q per_page=%q", gotPage, gotPerPage)
 	}
 }
 
@@ -234,15 +226,11 @@ func TestListMissingEmailFromAPISurfacesMessage(t *testing.T) {
 }
 
 func TestListAcceptsExternalIDInsteadOfEmail(t *testing.T) {
-	var body listRequest
+	var gotEmail, gotExternalID string
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
-		raw, err := io.ReadAll(r.Body)
-		if err != nil {
-			t.Fatalf("read body: %v", err)
-		}
-		if err := json.Unmarshal(raw, &body); err != nil {
-			t.Fatalf("decode body: %v", err)
-		}
+		query := r.URL.Query()
+		gotEmail = query.Get("email")
+		gotExternalID = query.Get("external_id")
 		testutil.JSON(t, w, sampleListPayload())
 	})
 
@@ -250,11 +238,11 @@ func TestListAcceptsExternalIDInsteadOfEmail(t *testing.T) {
 	cmd.SetArgs([]string{"--external-id", "2245593582708"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	if body.Email != "" {
-		t.Errorf("body.email must be empty when only --external-id is set, got %q", body.Email)
+	if gotEmail != "" {
+		t.Errorf("query email must be empty when only --external-id is set, got %q", gotEmail)
 	}
-	if body.ExternalID != "2245593582708" {
-		t.Errorf("body.external_id = %q, want 2245593582708", body.ExternalID)
+	if gotExternalID != "2245593582708" {
+		t.Errorf("query external_id = %q, want 2245593582708", gotExternalID)
 	}
 	if !strings.Contains(out, "Products for external_id 2245593582708") {
 		t.Errorf("expected header to mention external_id subject: %q", out)
@@ -262,15 +250,11 @@ func TestListAcceptsExternalIDInsteadOfEmail(t *testing.T) {
 }
 
 func TestListSendsBothWhenEmailAndExternalIDProvided(t *testing.T) {
-	var body listRequest
+	var gotEmail, gotExternalID string
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
-		raw, err := io.ReadAll(r.Body)
-		if err != nil {
-			t.Fatalf("read body: %v", err)
-		}
-		if err := json.Unmarshal(raw, &body); err != nil {
-			t.Fatalf("decode body: %v", err)
-		}
+		query := r.URL.Query()
+		gotEmail = query.Get("email")
+		gotExternalID = query.Get("external_id")
 		testutil.JSON(t, w, sampleListPayload())
 	})
 
@@ -278,8 +262,8 @@ func TestListSendsBothWhenEmailAndExternalIDProvided(t *testing.T) {
 	cmd.SetArgs([]string{"--email", "seller@example.com", "--external-id", "u_1"})
 	testutil.MustExecute(t, cmd)
 
-	if body.Email != "seller@example.com" || body.ExternalID != "u_1" {
-		t.Fatalf("expected both email and external_id forwarded so the server can resolve, got %+v", body)
+	if gotEmail != "seller@example.com" || gotExternalID != "u_1" {
+		t.Fatalf("expected both email and external_id forwarded so the server can resolve, got email=%q external_id=%q", gotEmail, gotExternalID)
 	}
 }
 

--- a/internal/cmd/admin/purchases/search.go
+++ b/internal/cmd/admin/purchases/search.go
@@ -2,6 +2,8 @@ package purchases
 
 import (
 	"fmt"
+	"net/url"
+	"strconv"
 
 	"github.com/antiwork/gumroad-cli/internal/admincmd"
 	"github.com/antiwork/gumroad-cli/internal/api"
@@ -9,11 +11,6 @@ import (
 	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
-
-type searchRequest struct {
-	Email string `json:"email"`
-	Limit int    `json:"limit,omitempty"`
-}
 
 type searchResponse struct {
 	Purchases []purchase  `json:"purchases"`
@@ -45,15 +42,15 @@ exposes only --email and --limit for now.`,
 				return cmdutil.MissingFlagError(c, "--email")
 			}
 
-			req := searchRequest{Email: email}
+			params := url.Values{"email": []string{email}}
 			if c.Flags().Changed("limit") {
 				if limit <= 0 {
 					return cmdutil.UsageErrorf(c, "--limit must be greater than 0")
 				}
-				req.Limit = limit
+				params.Set("limit", strconv.Itoa(limit))
 			}
 
-			return admincmd.RunPostJSONDecoded[searchResponse](opts, "Searching purchases...", "/purchases/search", req, func(resp searchResponse) error {
+			return admincmd.RunGetDecoded[searchResponse](opts, "Searching purchases...", "/purchases/search", params, func(resp searchResponse) error {
 				return renderSearch(opts, email, resp)
 			})
 		},

--- a/internal/cmd/admin/purchases/search_test.go
+++ b/internal/cmd/admin/purchases/search_test.go
@@ -2,7 +2,6 @@ package purchases
 
 import (
 	"encoding/json"
-	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -23,18 +22,15 @@ func TestSearch_RequiresEmail(t *testing.T) {
 	}
 }
 
-func TestSearch_PostsEmailInBody(t *testing.T) {
-	var gotMethod, gotPath, gotAuth, gotQuery string
-	var body searchRequest
+func TestSearch_SendsEmailInQuery(t *testing.T) {
+	var gotMethod, gotPath, gotAuth string
+	var gotEmail string
 
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
 		gotMethod = r.Method
 		gotPath = r.URL.Path
 		gotAuth = r.Header.Get("Authorization")
-		gotQuery = r.URL.RawQuery
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("decode body: %v", err)
-		}
+		gotEmail = r.URL.Query().Get("email")
 		testutil.JSON(t, w, map[string]any{
 			"purchases": []map[string]any{
 				{
@@ -56,17 +52,14 @@ func TestSearch_PostsEmailInBody(t *testing.T) {
 	cmd.SetArgs([]string{"--email", "buyer@example.com"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	if gotMethod != "POST" || gotPath != "/internal/admin/purchases/search" {
-		t.Fatalf("got %s %s, want POST /internal/admin/purchases/search", gotMethod, gotPath)
+	if gotMethod != "GET" || gotPath != "/internal/admin/purchases/search" {
+		t.Fatalf("got %s %s, want GET /internal/admin/purchases/search", gotMethod, gotPath)
 	}
 	if gotAuth != "Bearer admin-token" {
 		t.Fatalf("got auth %q, want Bearer admin-token", gotAuth)
 	}
-	if gotQuery != "" {
-		t.Fatalf("email must not appear in query string, got %q", gotQuery)
-	}
-	if body.Email != "buyer@example.com" {
-		t.Errorf("got email %q, want buyer@example.com", body.Email)
+	if gotEmail != "buyer@example.com" {
+		t.Errorf("got email %q, want buyer@example.com", gotEmail)
 	}
 	for _, want := range []string{"1 purchase(s) for buyer@example.com", "Course", "Buyer: buyer@example.com"} {
 		if !strings.Contains(out, want) {
@@ -76,20 +69,10 @@ func TestSearch_PostsEmailInBody(t *testing.T) {
 }
 
 func TestSearch_OmitsLimitWhenNotSet(t *testing.T) {
-	var body searchRequest
-	var bodyKeys map[string]json.RawMessage
+	var gotLimit string
 
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
-		raw, err := io.ReadAll(r.Body)
-		if err != nil {
-			t.Fatalf("read body: %v", err)
-		}
-		if err := json.Unmarshal(raw, &body); err != nil {
-			t.Fatalf("decode body: %v", err)
-		}
-		if err := json.Unmarshal(raw, &bodyKeys); err != nil {
-			t.Fatalf("decode body keys: %v", err)
-		}
+		gotLimit = r.URL.Query().Get("limit")
 		testutil.JSON(t, w, map[string]any{
 			"purchases": []map[string]any{},
 			"count":     0,
@@ -102,18 +85,16 @@ func TestSearch_OmitsLimitWhenNotSet(t *testing.T) {
 	cmd.SetArgs([]string{"--email", "buyer@example.com"})
 	testutil.MustExecute(t, cmd)
 
-	if _, present := bodyKeys["limit"]; present {
-		t.Errorf("limit must be omitted when not set, got body keys: %v", bodyKeys)
+	if gotLimit != "" {
+		t.Errorf("limit must be omitted when not set, got %q", gotLimit)
 	}
 }
 
 func TestSearch_ForwardsLimit(t *testing.T) {
-	var body searchRequest
+	var gotLimit string
 
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("decode body: %v", err)
-		}
+		gotLimit = r.URL.Query().Get("limit")
 		testutil.JSON(t, w, map[string]any{
 			"purchases": []map[string]any{},
 			"count":     0,
@@ -126,14 +107,14 @@ func TestSearch_ForwardsLimit(t *testing.T) {
 	cmd.SetArgs([]string{"--email", "buyer@example.com", "--limit", "5"})
 	testutil.MustExecute(t, cmd)
 
-	if body.Limit != 5 {
-		t.Errorf("got limit=%d, want 5", body.Limit)
+	if gotLimit != "5" {
+		t.Errorf("got limit=%q, want 5", gotLimit)
 	}
 }
 
 func TestSearch_RejectsZeroLimit(t *testing.T) {
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
-		t.Error("must not POST when --limit is invalid")
+		t.Error("must not request when --limit is invalid")
 	})
 
 	cmd := testutil.Command(newSearchCmd())

--- a/internal/cmd/admin/users/info.go
+++ b/internal/cmd/admin/users/info.go
@@ -11,11 +11,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type infoRequest struct {
-	Email  string `json:"email,omitempty"`
-	UserID string `json:"user_id,omitempty"`
-}
-
 type infoResponse struct {
 	UserID string   `json:"user_id"`
 	User   userInfo `json:"user"`
@@ -87,7 +82,7 @@ server resolves by --user-id.`,
 			}
 
 			identifier := target.identifier()
-			return admincmd.RunPostJSONDecoded[infoResponse](opts, "Fetching user info...", "/users/info", infoRequest(target), func(resp infoResponse) error {
+			return admincmd.RunGetDecoded[infoResponse](opts, "Fetching user info...", "/users/info", target.values(), func(resp infoResponse) error {
 				return renderInfo(opts, identifier, resp.UserID, resp.User)
 			})
 		},

--- a/internal/cmd/admin/users/info_test.go
+++ b/internal/cmd/admin/users/info_test.go
@@ -2,7 +2,6 @@ package users
 
 import (
 	"encoding/json"
-	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -65,22 +64,11 @@ func TestInfoRequiresEmailOrUserID(t *testing.T) {
 }
 
 func TestInfoResolvesByUserID(t *testing.T) {
-	var body infoRequest
+	var gotEmail, gotUserID string
 
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
-		raw, err := io.ReadAll(r.Body)
-		if err != nil {
-			t.Fatalf("read body: %v", err)
-		}
-		if err := json.Unmarshal(raw, &body); err != nil {
-			t.Fatalf("decode body: %v", err)
-		}
-		if !strings.Contains(string(raw), `"user_id"`) {
-			t.Fatalf("expected user_id in request body, got %q", raw)
-		}
-		if strings.Contains(string(raw), `"email"`) {
-			t.Fatalf("email field must be omitted when only --user-id is supplied, got %q", raw)
-		}
+		gotEmail = r.URL.Query().Get("email")
+		gotUserID = r.URL.Query().Get("user_id")
 		testutil.JSON(t, w, sampleInfoPayload())
 	})
 
@@ -88,11 +76,11 @@ func TestInfoResolvesByUserID(t *testing.T) {
 	cmd.SetArgs([]string{"--user-id", "2245593582708"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	if body.UserID != "2245593582708" {
-		t.Fatalf("got user_id %q, want 2245593582708", body.UserID)
+	if gotUserID != "2245593582708" {
+		t.Fatalf("got user_id %q, want 2245593582708", gotUserID)
 	}
-	if body.Email != "" {
-		t.Errorf("expected email to be empty, got %q", body.Email)
+	if gotEmail != "" {
+		t.Errorf("expected email to be empty, got %q", gotEmail)
 	}
 	if !strings.Contains(out, "Seller One") {
 		t.Errorf("expected resolved user info in output: %q", out)
@@ -100,16 +88,11 @@ func TestInfoResolvesByUserID(t *testing.T) {
 }
 
 func TestInfoSendsBothWhenEmailAndUserIDSupplied(t *testing.T) {
-	var body infoRequest
+	var gotEmail, gotUserID string
 
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
-		raw, err := io.ReadAll(r.Body)
-		if err != nil {
-			t.Fatalf("read body: %v", err)
-		}
-		if err := json.Unmarshal(raw, &body); err != nil {
-			t.Fatalf("decode body: %v", err)
-		}
+		gotEmail = r.URL.Query().Get("email")
+		gotUserID = r.URL.Query().Get("user_id")
 		testutil.JSON(t, w, sampleInfoPayload())
 	})
 
@@ -117,30 +100,22 @@ func TestInfoSendsBothWhenEmailAndUserIDSupplied(t *testing.T) {
 	cmd.SetArgs([]string{"--email", "seller@example.com", "--user-id", "2245593582708"})
 	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	if body.Email != "seller@example.com" {
-		t.Errorf("got email %q, want seller@example.com (server prefers user_id but CLI forwards both)", body.Email)
+	if gotEmail != "seller@example.com" {
+		t.Errorf("got email %q, want seller@example.com (server prefers user_id but CLI forwards both)", gotEmail)
 	}
-	if body.UserID != "2245593582708" {
-		t.Errorf("got user_id %q, want 2245593582708", body.UserID)
+	if gotUserID != "2245593582708" {
+		t.Errorf("got user_id %q, want 2245593582708", gotUserID)
 	}
 }
 
 func TestInfoUsesInternalAdminEndpointAndRendersHumanOutput(t *testing.T) {
-	var gotMethod, gotPath, gotQuery, gotAuth string
-	var body infoRequest
+	var gotMethod, gotPath, gotAuth, gotEmail string
 
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
 		gotMethod = r.Method
 		gotPath = r.URL.Path
-		gotQuery = r.URL.RawQuery
 		gotAuth = r.Header.Get("Authorization")
-		raw, err := io.ReadAll(r.Body)
-		if err != nil {
-			t.Fatalf("read body: %v", err)
-		}
-		if err := json.Unmarshal(raw, &body); err != nil {
-			t.Fatalf("decode body: %v", err)
-		}
+		gotEmail = r.URL.Query().Get("email")
 		testutil.JSON(t, w, sampleInfoPayload())
 	})
 
@@ -148,17 +123,14 @@ func TestInfoUsesInternalAdminEndpointAndRendersHumanOutput(t *testing.T) {
 	cmd.SetArgs([]string{"--email", "seller@example.com"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	if gotMethod != "POST" || gotPath != "/internal/admin/users/info" {
-		t.Fatalf("got %s %s, want POST /internal/admin/users/info", gotMethod, gotPath)
-	}
-	if gotQuery != "" {
-		t.Fatalf("email must not appear in query string, got %q", gotQuery)
+	if gotMethod != "GET" || gotPath != "/internal/admin/users/info" {
+		t.Fatalf("got %s %s, want GET /internal/admin/users/info", gotMethod, gotPath)
 	}
 	if gotAuth != "Bearer admin-token" {
 		t.Fatalf("got auth %q, want Bearer admin-token", gotAuth)
 	}
-	if body.Email != "seller@example.com" {
-		t.Fatalf("got email %q, want seller@example.com", body.Email)
+	if gotEmail != "seller@example.com" {
+		t.Fatalf("got email %q, want seller@example.com", gotEmail)
 	}
 	for _, want := range []string{
 		"Seller One",

--- a/internal/cmd/admin/users/suspension.go
+++ b/internal/cmd/admin/users/suspension.go
@@ -14,11 +14,6 @@ type suspensionResponse struct {
 	AppealURL string `json:"appeal_url"`
 }
 
-type suspensionRequest struct {
-	Email  string `json:"email,omitempty"`
-	UserID string `json:"user_id,omitempty"`
-}
-
 func newSuspensionCmd() *cobra.Command {
 	var lookup userLookupFlags
 
@@ -40,7 +35,7 @@ server resolves by --user-id.`,
 			}
 
 			identifier := target.identifier()
-			return admincmd.RunPostJSONDecoded[suspensionResponse](opts, "Fetching suspension info...", "/users/suspension", suspensionRequest(target), func(resp suspensionResponse) error {
+			return admincmd.RunGetDecoded[suspensionResponse](opts, "Fetching suspension info...", "/users/suspension", target.values(), func(resp suspensionResponse) error {
 				return renderSuspension(opts, identifier, resp)
 			})
 		},

--- a/internal/cmd/admin/users/users.go
+++ b/internal/cmd/admin/users/users.go
@@ -2,6 +2,7 @@ package users
 
 import (
 	"io"
+	"net/url"
 	"strings"
 
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
@@ -101,6 +102,17 @@ func resolveUserLookupTarget(cmd *cobra.Command, flags userLookupFlags) (userLoo
 
 func (t userLookupTarget) identifier() string {
 	return userIdentifier(t.Email, t.UserID)
+}
+
+func (t userLookupTarget) values() url.Values {
+	params := url.Values{}
+	if t.Email != "" {
+		params.Set("email", t.Email)
+	}
+	if t.UserID != "" {
+		params.Set("user_id", t.UserID)
+	}
+	return params
 }
 
 type userMutationFlags struct {

--- a/internal/cmd/admin/users/users_test.go
+++ b/internal/cmd/admin/users/users_test.go
@@ -2,7 +2,6 @@ package users
 
 import (
 	"encoding/json"
-	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -11,17 +10,12 @@ import (
 )
 
 func TestSuspensionUsesInternalAdminEndpoint(t *testing.T) {
-	var gotMethod, gotPath, gotQuery, gotEmail, gotAuth string
+	var gotMethod, gotPath, gotEmail, gotAuth string
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
 		gotMethod = r.Method
 		gotPath = r.URL.Path
-		gotQuery = r.URL.RawQuery
 		gotAuth = r.Header.Get("Authorization")
-		var payload suspensionRequest
-		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-			t.Fatalf("decode request body: %v", err)
-		}
-		gotEmail = payload.Email
+		gotEmail = r.URL.Query().Get("email")
 		testutil.JSON(t, w, map[string]any{
 			"status":     "Suspended",
 			"updated_at": "2026-04-24T12:00:00Z",
@@ -33,11 +27,8 @@ func TestSuspensionUsesInternalAdminEndpoint(t *testing.T) {
 	cmd.SetArgs([]string{"--email", "user@example.com"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	if gotMethod != "POST" || gotPath != "/internal/admin/users/suspension" {
-		t.Fatalf("got %s %s, want POST /internal/admin/users/suspension", gotMethod, gotPath)
-	}
-	if gotQuery != "" {
-		t.Fatalf("email should not be sent in query string, got %q", gotQuery)
+	if gotMethod != "GET" || gotPath != "/internal/admin/users/suspension" {
+		t.Fatalf("got %s %s, want GET /internal/admin/users/suspension", gotMethod, gotPath)
 	}
 	if gotEmail != "user@example.com" {
 		t.Fatalf("got email %q, want user@example.com", gotEmail)
@@ -66,18 +57,11 @@ func TestSuspensionRequiresEmailOrUserID(t *testing.T) {
 }
 
 func TestSuspensionResolvesByUserID(t *testing.T) {
-	var body suspensionRequest
-	var rawBody string
+	var gotEmail, gotUserID string
 
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
-		raw, err := readAllBody(r)
-		if err != nil {
-			t.Fatalf("read body: %v", err)
-		}
-		rawBody = string(raw)
-		if err := json.Unmarshal(raw, &body); err != nil {
-			t.Fatalf("decode body: %v", err)
-		}
+		gotEmail = r.URL.Query().Get("email")
+		gotUserID = r.URL.Query().Get("user_id")
 		testutil.JSON(t, w, map[string]any{
 			"user_id":    "2245593582708",
 			"status":     "Suspended",
@@ -89,11 +73,8 @@ func TestSuspensionResolvesByUserID(t *testing.T) {
 	cmd.SetArgs([]string{"--user-id", "2245593582708"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	if strings.Contains(rawBody, `"email"`) {
-		t.Errorf("email field must be omitted when only --user-id is supplied, got %q", rawBody)
-	}
-	if body.UserID != "2245593582708" || body.Email != "" {
-		t.Errorf("got email=%q user_id=%q, want only user_id", body.Email, body.UserID)
+	if gotEmail != "" || gotUserID != "2245593582708" {
+		t.Errorf("got email=%q user_id=%q, want only user_id", gotEmail, gotUserID)
 	}
 	if !strings.Contains(out, "2245593582708") {
 		t.Errorf("expected user_id in headline output: %q", out)
@@ -104,12 +85,11 @@ func TestSuspensionResolvesByUserID(t *testing.T) {
 }
 
 func TestSuspensionForwardsBothEmailAndUserID(t *testing.T) {
-	var body suspensionRequest
+	var gotEmail, gotUserID string
 
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("decode body: %v", err)
-		}
+		gotEmail = r.URL.Query().Get("email")
+		gotUserID = r.URL.Query().Get("user_id")
 		testutil.JSON(t, w, map[string]any{"status": "Compliant"})
 	})
 
@@ -117,14 +97,9 @@ func TestSuspensionForwardsBothEmailAndUserID(t *testing.T) {
 	cmd.SetArgs([]string{"--email", "user@example.com", "--user-id", "2245593582708"})
 	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	if body.Email != "user@example.com" || body.UserID != "2245593582708" {
-		t.Errorf("got email=%q user_id=%q, want both forwarded", body.Email, body.UserID)
+	if gotEmail != "user@example.com" || gotUserID != "2245593582708" {
+		t.Errorf("got email=%q user_id=%q, want both forwarded", gotEmail, gotUserID)
 	}
-}
-
-func readAllBody(r *http.Request) ([]byte, error) {
-	defer r.Body.Close()
-	return io.ReadAll(r.Body)
 }
 
 func TestSuspensionJSONPreservesResponse(t *testing.T) {


### PR DESCRIPTION
Ref antiwork/gumroad#4989

## What

Updates the remaining admin read CLI commands to use GET requests with query parameters instead of POST requests with JSON bodies. Product listing now calls the REST index path at `/internal/admin/products`.

## Why

The admin API is moving to “GET for reads, POST for writes.” This keeps the CLI in lockstep with the Rails route flip so these commands continue working once the old POST routes are removed.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh.