### PR TITLE
Show sign-in and social details in admin user info

### DIFF
--- a/internal/cmd/admin/users/info.go
+++ b/internal/cmd/admin/users/info.go
@@ -22,13 +22,41 @@ type userInfo struct {
 	Username                       string           `json:"username"`
 	ProfileURL                     string           `json:"profile_url"`
 	Country                        string           `json:"country"`
+	Locale                         string           `json:"locale"`
+	Timezone                       string           `json:"timezone"`
 	CreatedAt                      string           `json:"created_at"`
 	DeletedAt                      string           `json:"deleted_at"`
 	RiskState                      riskState        `json:"risk_state"`
 	ActiveWatchedUser              *watchedUserInfo `json:"active_watched_user"`
 	TwoFactorAuthenticationEnabled bool             `json:"two_factor_authentication_enabled"`
+	SignIn                         signInInfo       `json:"sign_in"`
+	Social                         socialInfo       `json:"social"`
 	Payouts                        payoutsInfo      `json:"payouts"`
 	Stats                          statsInfo        `json:"stats"`
+}
+
+type signInInfo struct {
+	AccountCreatedIP string `json:"account_created_ip"`
+	CurrentIP        string `json:"current_ip"`
+	CurrentAt        string `json:"current_at"`
+	LastIP           string `json:"last_ip"`
+	LastAt           string `json:"last_at"`
+	Count            int    `json:"count"`
+}
+
+type socialInfo struct {
+	TwitterUserID           string                       `json:"twitter_user_id"`
+	TwitterHandle           string                       `json:"twitter_handle"`
+	FacebookUID             string                       `json:"facebook_uid"`
+	GoogleUID               string                       `json:"google_uid"`
+	OAuthProvider           string                       `json:"oauth_provider"`
+	ExternalAuthentications []externalAuthenticationInfo `json:"external_authentications"`
+}
+
+type externalAuthenticationInfo struct {
+	Provider string `json:"provider"`
+	UID      string `json:"uid"`
+	LinkedAt string `json:"linked_at"`
 }
 
 type riskState struct {
@@ -131,6 +159,8 @@ func renderInfo(opts cmdutil.Options, identifier, userID string, info userInfo) 
 	writeOptional(&b, "Username", info.Username)
 	writeOptional(&b, "Profile", info.ProfileURL)
 	writeOptional(&b, "Country", info.Country)
+	writeOptional(&b, "Locale", info.Locale)
+	writeOptional(&b, "Timezone", info.Timezone)
 	writeOptional(&b, "Created", info.CreatedAt)
 	writeOptional(&b, "Deleted", info.DeletedAt)
 
@@ -142,6 +172,18 @@ func renderInfo(opts cmdutil.Options, identifier, userID string, info userInfo) 
 		twoFactor = "enabled"
 	}
 	fmt.Fprintf(&b, "Two-factor: %s\n", twoFactor)
+
+	if !info.SignIn.empty() {
+		fmt.Fprintln(&b)
+		writeSignIn(&b, info.SignIn)
+	}
+
+	if !info.Social.empty() {
+		fmt.Fprintln(&b)
+		if err := writeSocial(&b, style, info.Social); err != nil {
+			return err
+		}
+	}
 
 	if info.ActiveWatchedUser != nil {
 		fmt.Fprintln(&b)
@@ -190,6 +232,119 @@ func writeRiskState(b *strings.Builder, risk riskState) {
 	if risk.LastStatusChangedAt != "" {
 		fmt.Fprintf(b, "  last status change: %s\n", risk.LastStatusChangedAt)
 	}
+}
+
+func (s signInInfo) empty() bool {
+	return s.AccountCreatedIP == "" &&
+		s.CurrentIP == "" &&
+		s.CurrentAt == "" &&
+		s.LastIP == "" &&
+		s.LastAt == "" &&
+		s.Count == 0
+}
+
+func writeSignIn(b *strings.Builder, signIn signInInfo) {
+	fmt.Fprintln(b, "Sign-in:")
+	if signIn.AccountCreatedIP != "" {
+		fmt.Fprintf(b, "  account-created IP: %s\n", signIn.AccountCreatedIP)
+	}
+	if current := formatIPWithTime(signIn.CurrentIP, signIn.CurrentAt); current != "" {
+		fmt.Fprintf(b, "  current: %s\n", current)
+	}
+	if last := formatIPWithTime(signIn.LastIP, signIn.LastAt); last != "" {
+		fmt.Fprintf(b, "  last: %s\n", last)
+	}
+	if signIn.Count > 0 {
+		fmt.Fprintf(b, "  count: %d\n", signIn.Count)
+	}
+}
+
+func formatIPWithTime(ip, at string) string {
+	switch {
+	case ip != "" && at != "":
+		return ip + " at " + at
+	case ip != "":
+		return ip
+	default:
+		return at
+	}
+}
+
+func (s socialInfo) empty() bool {
+	return s.TwitterUserID == "" &&
+		s.TwitterHandle == "" &&
+		s.FacebookUID == "" &&
+		s.GoogleUID == "" &&
+		s.OAuthProvider == "" &&
+		!hasExternalAuthentications(s.ExternalAuthentications)
+}
+
+func hasExternalAuthentications(auths []externalAuthenticationInfo) bool {
+	for _, auth := range auths {
+		if auth.Provider != "" || auth.UID != "" || auth.LinkedAt != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func writeSocial(b *strings.Builder, style output.Styler, social socialInfo) error {
+	fmt.Fprintln(b, "Social:")
+	if twitter := formatTwitter(social.TwitterHandle, social.TwitterUserID); twitter != "" {
+		fmt.Fprintf(b, "  twitter: %s\n", twitter)
+	}
+	writeOptionalIndented(b, "facebook UID", social.FacebookUID)
+	writeOptionalIndented(b, "google UID", social.GoogleUID)
+	writeOptionalIndented(b, "OAuth provider", social.OAuthProvider)
+
+	if hasExternalAuthentications(social.ExternalAuthentications) {
+		fmt.Fprintln(b, "  external authentications:")
+		tbl := output.NewStyledTable(style, "PROVIDER", "UID", "LINKED")
+		for _, auth := range social.ExternalAuthentications {
+			if auth.Provider == "" && auth.UID == "" && auth.LinkedAt == "" {
+				continue
+			}
+			tbl.AddRow(auth.Provider, auth.UID, auth.LinkedAt)
+		}
+		if err := writeIndentedTable(b, tbl, "    "); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func formatTwitter(handle, userID string) string {
+	handle = strings.TrimPrefix(handle, "@")
+	switch {
+	case handle != "" && userID != "":
+		return "@" + handle + " (id: " + userID + ")"
+	case handle != "":
+		return "@" + handle
+	case userID != "":
+		return "(id: " + userID + ")"
+	default:
+		return ""
+	}
+}
+
+func writeOptionalIndented(b *strings.Builder, label, value string) {
+	if value != "" {
+		fmt.Fprintf(b, "  %s: %s\n", label, value)
+	}
+}
+
+func writeIndentedTable(b *strings.Builder, tbl *output.Table, indent string) error {
+	var table strings.Builder
+	if err := tbl.Render(&table); err != nil {
+		return err
+	}
+	for _, line := range strings.Split(strings.TrimRight(table.String(), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		fmt.Fprintf(b, "%s%s\n", indent, line)
+	}
+	return nil
 }
 
 func writeWatchlist(b *strings.Builder, watchedUser *watchedUserInfo) {

--- a/internal/cmd/admin/users/info_test.go
+++ b/internal/cmd/admin/users/info_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/antiwork/gumroad-cli/internal/testutil"
 )
 
@@ -152,6 +153,128 @@ func TestInfoUsesInternalAdminEndpointAndRendersHumanOutput(t *testing.T) {
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestInfoRendersSignInAndSocialContext(t *testing.T) {
+	output.SetColorEnabledForTesting(true)
+	t.Cleanup(output.ResetColorEnabledForTesting)
+
+	payload := sampleInfoPayload()
+	user := payload["user"].(map[string]any)
+	user["locale"] = "fr"
+	user["timezone"] = "Eastern Time (US & Canada)"
+	user["sign_in"] = map[string]any{
+		"account_created_ip": "1.2.3.4",
+		"current_ip":         "5.6.7.8",
+		"current_at":         "2026-05-10T09:30:00Z",
+		"last_ip":            "9.10.11.12",
+		"last_at":            "2026-05-08T18:45:00Z",
+		"count":              42,
+	}
+	user["social"] = map[string]any{
+		"twitter_user_id": "1",
+		"twitter_handle":  "alice",
+		"facebook_uid":    "fb1",
+		"google_uid":      "gid1",
+		"oauth_provider":  "google_oauth2",
+		"external_authentications": []map[string]any{
+			{
+				"provider":  "apple",
+				"uid":       "001-test",
+				"linked_at": "2026-05-09T12:00:00Z",
+			},
+		},
+	}
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, payload)
+	})
+
+	cmd := testutil.Command(newInfoCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--email", "seller@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	for _, want := range []string{
+		"Locale: fr",
+		"Timezone: Eastern Time (US & Canada)",
+		"Sign-in:",
+		"account-created IP: 1.2.3.4",
+		"current: 5.6.7.8 at 2026-05-10T09:30:00Z",
+		"last: 9.10.11.12 at 2026-05-08T18:45:00Z",
+		"count: 42",
+		"Social:",
+		"twitter: @alice (id: 1)",
+		"facebook UID: fb1",
+		"google UID: gid1",
+		"OAuth provider: google_oauth2",
+		"external authentications:",
+		"\x1b[1mPROVIDER\x1b[0m",
+		"apple",
+		"001-test",
+		"2026-05-09T12:00:00Z",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestFormatTwitterLabelsUserIDOnly(t *testing.T) {
+	tests := []struct {
+		name   string
+		handle string
+		userID string
+		want   string
+	}{
+		{name: "handle and ID", handle: "alice", userID: "1", want: "@alice (id: 1)"},
+		{name: "handle with at-prefix", handle: "@alice", userID: "1", want: "@alice (id: 1)"},
+		{name: "handle only", handle: "alice", want: "@alice"},
+		{name: "ID only", userID: "1", want: "(id: 1)"},
+		{name: "empty", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatTwitter(tt.handle, tt.userID); got != tt.want {
+				t.Fatalf("formatTwitter(%q, %q) = %q, want %q", tt.handle, tt.userID, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInfoSkipsEmptySignInAndSocialContext(t *testing.T) {
+	payload := sampleInfoPayload()
+	user := payload["user"].(map[string]any)
+	user["sign_in"] = map[string]any{
+		"account_created_ip": nil,
+		"current_ip":         nil,
+		"current_at":         nil,
+		"last_ip":            nil,
+		"last_at":            nil,
+		"count":              0,
+	}
+	user["social"] = map[string]any{
+		"twitter_user_id":          nil,
+		"twitter_handle":           nil,
+		"facebook_uid":             nil,
+		"google_uid":               nil,
+		"oauth_provider":           nil,
+		"external_authentications": []map[string]any{},
+	}
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, payload)
+	})
+
+	cmd := testutil.Command(newInfoCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--email", "seller@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	for _, unwanted := range []string{"Sign-in:", "Social:"} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("output should skip empty %q block: %q", unwanted, out)
 		}
 	}
 }


### PR DESCRIPTION
Ref antiwork/gumroad/issues/4989

## What

- Adds the new sign-in and social context to `admin users info` output, including locale, timezone, IP history, sign-in counts, and linked external auth providers.
- Keeps the output terse by skipping the new sections when the server returns no meaningful data.
- Extends coverage with fixtures for populated and empty cases.

## Why

- This brings the CLI in line with the updated admin API so support can see the extra user context from one command.
- The new rendering keeps the output readable while exposing the added fields when they matter.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh.