### PR TITLE
Add admin user affiliates command

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Admin commands use a separate internal token. Run `gumroad auth login` and check
 
 ```sh
 gumroad admin users info --email seller@example.com --json
+gumroad admin users affiliates --user-id 2245593582708 --direction granted --limit 50
 gumroad admin users watch --user-id 2245593582708 --expected-email seller@example.com --revenue-threshold 200 --note "Review next buyers"
 gumroad admin users update-watch --user-id 2245593582708 --expected-email seller@example.com --revenue-threshold 500
 gumroad admin users unwatch --user-id 2245593582708 --expected-email seller@example.com

--- a/internal/cmd/admin/admin.go
+++ b/internal/cmd/admin/admin.go
@@ -19,6 +19,7 @@ func NewAdminCmd() *cobra.Command {
   gumroad admin purchases cancel-subscription <purchase-id> --email <email>
   gumroad admin licenses lookup --key <license-key>
   gumroad admin users info --email <email>
+  gumroad admin users affiliates --user-id <user-id> --direction granted
   gumroad admin users suspension --email <email>
   gumroad admin users watch --user-id <user-id> --expected-email <email> --revenue-threshold 200
   gumroad admin payouts list --email <email>

--- a/internal/cmd/admin/users/affiliates.go
+++ b/internal/cmd/admin/users/affiliates.go
@@ -1,0 +1,218 @@
+package users
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/antiwork/gumroad-cli/internal/admincmd"
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil/cursor"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+const maxAffiliateLimit = 100
+
+var validAffiliateDirections = map[string]bool{
+	"granted":  true,
+	"received": true,
+}
+
+type affiliatesResponse struct {
+	UserID     string              `json:"user_id"`
+	Direction  string              `json:"direction"`
+	Affiliates []affiliateRelation `json:"affiliates"`
+	Pagination cursor.Pagination   `json:"pagination"`
+}
+
+type affiliateRelation struct {
+	ID                   string             `json:"id"`
+	Type                 string             `json:"type"`
+	Direction            string             `json:"direction"`
+	Counterparty         affiliateUser      `json:"counterparty"`
+	AffiliateBasisPoints api.JSONInt        `json:"affiliate_basis_points"`
+	DestinationURL       string             `json:"destination_url"`
+	ApplyToAllProducts   bool               `json:"apply_to_all_products"`
+	Alive                bool               `json:"alive"`
+	DeletedAt            string             `json:"deleted_at"`
+	CreatedAt            string             `json:"created_at"`
+	Products             []affiliateProduct `json:"products"`
+}
+
+type affiliateUser struct {
+	ID    string `json:"id"`
+	Email string `json:"email"`
+	Name  string `json:"name"`
+}
+
+type affiliateProduct struct {
+	ID             string      `json:"id"`
+	Name           string      `json:"name"`
+	BasisPoints    api.JSONInt `json:"basis_points"`
+	DestinationURL string      `json:"destination_url"`
+}
+
+func newAffiliatesCmd() *cobra.Command {
+	var (
+		lookup    userLookupFlags
+		page      cursor.Flags
+		direction string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "affiliates",
+		Short: "List affiliate relationships for a user",
+		Long: `List affiliate relationships for a user in one direction. Use
+--direction granted when the user is the seller granting affiliate access, or
+--direction received when the user is the affiliate receiving access.`,
+		Example: `  gumroad admin users affiliates --user-id 2245593582708 --direction granted
+  gumroad admin users affiliates --email user@example.com --direction received --limit 50
+  gumroad admin users affiliates --email user@example.com --direction received --cursor cur-next`,
+		Args: cmdutil.ExactArgs(0),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			target, err := resolveUserLookupTarget(c, lookup)
+			if err != nil {
+				return err
+			}
+			if direction == "" {
+				return cmdutil.MissingFlagError(c, "--direction")
+			}
+			if !validAffiliateDirections[direction] {
+				return cmdutil.UsageErrorf(c, "--direction must be one of: granted, received")
+			}
+			if err := cmdutil.RequirePositiveIntFlag(c, "limit", page.Limit); err != nil {
+				return err
+			}
+			if c.Flags().Changed("limit") && page.Limit > maxAffiliateLimit {
+				return cmdutil.UsageErrorf(c, "--limit must be %d or less", maxAffiliateLimit)
+			}
+
+			params := target.values()
+			params.Set("direction", direction)
+			cursor.Apply(params, page)
+
+			return admincmd.RunGetDecoded[affiliatesResponse](opts, "Fetching user affiliates...", "/users/affiliates", params, func(resp affiliatesResponse) error {
+				return renderAffiliates(opts, target.identifier(), direction, resp)
+			})
+		},
+	}
+
+	addUserLookupFlags(cmd, &lookup)
+	cmd.Flags().StringVar(&direction, "direction", "", "Affiliate direction: granted or received (required)")
+	cursor.AddFlags(cmd, &page, cursor.Options{LimitUsage: "Maximum results to return (default 20, capped at 100)"})
+
+	return cmd
+}
+
+func renderAffiliates(opts cmdutil.Options, identifier, direction string, resp affiliatesResponse) error {
+	if opts.PlainOutput {
+		return writeAffiliatesPlain(opts.Out(), resp.Affiliates)
+	}
+
+	if opts.Quiet {
+		return nil
+	}
+
+	style := opts.Style()
+	return output.WithPager(opts.Out(), opts.Err(), func(w io.Writer) error {
+		if len(resp.Affiliates) == 0 {
+			if err := output.Writef(w, "No %s affiliate relationships found for %s.\n", direction, identifier); err != nil {
+				return err
+			}
+			return cursor.WriteMoreFooter(w, resp.Pagination)
+		}
+
+		headline := fmt.Sprintf("%d %s affiliate relationship(s) for %s", len(resp.Affiliates), direction, identifier)
+		if err := output.Writeln(w, style.Bold(headline)); err != nil {
+			return err
+		}
+		if resp.UserID != "" && resp.UserID != identifier {
+			if err := output.Writef(w, "User ID: %s\n", resp.UserID); err != nil {
+				return err
+			}
+		}
+		if err := output.Writeln(w, ""); err != nil {
+			return err
+		}
+		if err := writeAffiliatesTable(w, style, resp.Affiliates); err != nil {
+			return err
+		}
+		return cursor.WriteMoreFooter(w, resp.Pagination)
+	})
+}
+
+func writeAffiliatesPlain(w io.Writer, affiliates []affiliateRelation) error {
+	rows := make([][]string, 0, len(affiliates))
+	for _, a := range affiliates {
+		rows = append(rows, []string{
+			a.ID,
+			a.Type,
+			affiliateCounterpartyLabel(a.Counterparty),
+			strconv.Itoa(int(a.AffiliateBasisPoints)),
+			affiliateProductsLabel(a),
+			strconv.FormatBool(a.Alive),
+			a.CreatedAt,
+		})
+	}
+	return output.PrintPlain(w, rows)
+}
+
+func writeAffiliatesTable(w io.Writer, style output.Styler, affiliates []affiliateRelation) error {
+	tbl := output.NewStyledTable(style, "ID", "TYPE", "COUNTERPARTY", "BPS", "PRODUCTS", "ALIVE", "CREATED")
+	for _, a := range affiliates {
+		tbl.AddRow(
+			a.ID,
+			a.Type,
+			affiliateCounterpartyLabel(a.Counterparty),
+			strconv.Itoa(int(a.AffiliateBasisPoints)),
+			affiliateProductsLabel(a),
+			strconv.FormatBool(a.Alive),
+			a.CreatedAt,
+		)
+	}
+	return tbl.Render(w)
+}
+
+func affiliateCounterpartyLabel(user affiliateUser) string {
+	parts := make([]string, 0, 3)
+	if user.Email != "" {
+		parts = append(parts, user.Email)
+	}
+	if user.Name != "" && user.Name != user.Email {
+		parts = append(parts, user.Name)
+	}
+	if user.ID != "" {
+		parts = append(parts, user.ID)
+	}
+	return strings.Join(parts, " / ")
+}
+
+func affiliateProductsLabel(a affiliateRelation) string {
+	if a.ApplyToAllProducts {
+		return "all products"
+	}
+	if len(a.Products) == 0 {
+		return ""
+	}
+
+	labels := make([]string, 0, len(a.Products))
+	for _, p := range a.Products {
+		labels = append(labels, affiliateProductLabel(p))
+	}
+	return strings.Join(labels, ", ")
+}
+
+func affiliateProductLabel(p affiliateProduct) string {
+	switch {
+	case p.Name != "" && p.ID != "":
+		return fmt.Sprintf("%s (%s)", p.Name, p.ID)
+	case p.Name != "":
+		return p.Name
+	default:
+		return p.ID
+	}
+}

--- a/internal/cmd/admin/users/affiliates_test.go
+++ b/internal/cmd/admin/users/affiliates_test.go
@@ -1,0 +1,259 @@
+package users
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestAffiliatesUsesInternalAdminEndpoint(t *testing.T) {
+	var gotMethod, gotPath, gotEmail, gotDirection, gotAuth string
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotEmail = r.URL.Query().Get("email")
+		gotDirection = r.URL.Query().Get("direction")
+		gotAuth = r.Header.Get("Authorization")
+		testutil.JSON(t, w, map[string]any{
+			"user_id":   "seller_123",
+			"direction": "granted",
+			"affiliates": []map[string]any{
+				affiliateFixture(),
+			},
+			"pagination": map[string]any{"next": nil, "limit": 20},
+		})
+	})
+
+	cmd := testutil.Command(newAffiliatesCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--email", "seller@example.com", "--direction", "granted"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != "GET" || gotPath != "/internal/admin/users/affiliates" {
+		t.Fatalf("got %s %s, want GET /internal/admin/users/affiliates", gotMethod, gotPath)
+	}
+	if gotEmail != "seller@example.com" {
+		t.Fatalf("got email %q, want seller@example.com", gotEmail)
+	}
+	if gotDirection != "granted" {
+		t.Fatalf("got direction %q, want granted", gotDirection)
+	}
+	if gotAuth != "Bearer admin-token" {
+		t.Fatalf("got auth %q, want Bearer admin-token", gotAuth)
+	}
+	for _, want := range []string{
+		"1 granted affiliate relationship(s) for seller@example.com",
+		"User ID: seller_123",
+		"DirectAffiliate",
+		"affiliate@example.com / Affiliate User / user_456",
+		"1500",
+		"Starter Pack (prod_123)",
+		"true",
+		"2026-05-01T12:00:00Z",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestAffiliatesPassesUserIDLimitAndCursor(t *testing.T) {
+	var gotQuery string
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		testutil.JSON(t, w, map[string]any{
+			"affiliates":  []any{},
+			"pagination":  map[string]any{"next": nil, "limit": 50},
+			"success":     true,
+			"user_id":     "user_123",
+			"unused_note": "ignored",
+		})
+	})
+
+	cmd := testutil.Command(newAffiliatesCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--user-id", "user_123", "--direction", "received", "--limit", "50", "--cursor", "cur-1"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	for _, want := range []string{"user_id=user_123", "direction=received", "limit=50", "cursor=cur-1"} {
+		if !strings.Contains(gotQuery, want) {
+			t.Fatalf("query missing %q: %q", want, gotQuery)
+		}
+	}
+	if !strings.Contains(out, "No received affiliate relationships found for user_123.") {
+		t.Fatalf("unexpected empty output: %q", out)
+	}
+}
+
+func TestAffiliatesShowsNextCursorFooter(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"direction": "granted",
+			"affiliates": []map[string]any{
+				affiliateFixture(),
+			},
+			"pagination": map[string]any{"next": "cur-next", "limit": 1},
+		})
+	})
+
+	cmd := testutil.Command(newAffiliatesCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--user-id", "seller_123", "--direction", "granted"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "More results: --cursor cur-next") {
+		t.Fatalf("expected next-cursor footer, got: %q", out)
+	}
+}
+
+func TestAffiliatesRequiresEmailOrUserID(t *testing.T) {
+	cmd := newAffiliatesCmd()
+	cmd.SetArgs([]string{"--direction", "granted"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "supply --email or --user-id") {
+		t.Fatalf("expected missing identifier error, got %v", err)
+	}
+}
+
+func TestAffiliatesRequiresDirection(t *testing.T) {
+	cmd := newAffiliatesCmd()
+	cmd.SetArgs([]string{"--user-id", "user_123"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "missing required flag: --direction") {
+		t.Fatalf("expected missing direction error, got %v", err)
+	}
+}
+
+func TestAffiliatesRejectsInvalidDirection(t *testing.T) {
+	cmd := newAffiliatesCmd()
+	cmd.SetArgs([]string{"--user-id", "user_123", "--direction", "both"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--direction must be one of: granted, received") {
+		t.Fatalf("expected direction validation error, got %v", err)
+	}
+}
+
+func TestAffiliatesRejectsInvalidLimit(t *testing.T) {
+	t.Run("zero", func(t *testing.T) {
+		cmd := newAffiliatesCmd()
+		cmd.SetArgs([]string{"--user-id", "user_123", "--direction", "granted", "--limit", "0"})
+
+		err := cmd.Execute()
+		if err == nil || !strings.Contains(err.Error(), "--limit must be greater than 0") {
+			t.Fatalf("expected zero limit error, got %v", err)
+		}
+	})
+
+	t.Run("too large", func(t *testing.T) {
+		cmd := newAffiliatesCmd()
+		cmd.SetArgs([]string{"--user-id", "user_123", "--direction", "granted", "--limit", "101"})
+
+		err := cmd.Execute()
+		if err == nil || !strings.Contains(err.Error(), "--limit must be 100 or less") {
+			t.Fatalf("expected max limit error, got %v", err)
+		}
+	})
+}
+
+func TestAffiliatesJSONPreservesResponse(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"success":   true,
+			"user_id":   "seller_123",
+			"direction": "granted",
+			"affiliates": []map[string]any{
+				affiliateFixture(),
+			},
+			"pagination": map[string]any{"next": "cur-next", "limit": 20},
+		})
+	})
+
+	cmd := testutil.Command(newAffiliatesCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--user-id", "seller_123", "--direction", "granted"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp struct {
+		Success    bool             `json:"success"`
+		UserID     string           `json:"user_id"`
+		Direction  string           `json:"direction"`
+		Affiliates []map[string]any `json:"affiliates"`
+		Pagination map[string]any   `json:"pagination"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if !resp.Success || resp.UserID != "seller_123" || resp.Direction != "granted" {
+		t.Fatalf("unexpected JSON envelope: %s", out)
+	}
+	if len(resp.Affiliates) != 1 || resp.Affiliates[0]["id"] != "aff_123" {
+		t.Fatalf("unexpected JSON affiliates: %s", out)
+	}
+	if resp.Pagination["next"] != "cur-next" {
+		t.Fatalf("unexpected pagination: %s", out)
+	}
+}
+
+func TestAffiliatesPlainOutput(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"direction": "received",
+			"affiliates": []map[string]any{
+				affiliateFixture(),
+				{
+					"id":                     "aff_all",
+					"type":                   "Collaborator",
+					"direction":              "received",
+					"counterparty":           map[string]any{"email": "seller@example.com"},
+					"affiliate_basis_points": 2000,
+					"apply_to_all_products":  true,
+					"alive":                  false,
+					"created_at":             "2026-04-30T12:00:00Z",
+				},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newAffiliatesCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{"--email", "affiliate@example.com", "--direction", "received"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	want := strings.Join([]string{
+		"aff_123\tDirectAffiliate\taffiliate@example.com / Affiliate User / user_456\t1500\tStarter Pack (prod_123)\ttrue\t2026-05-01T12:00:00Z",
+		"aff_all\tCollaborator\tseller@example.com\t2000\tall products\tfalse\t2026-04-30T12:00:00Z",
+	}, "\n")
+	if strings.TrimSpace(out) != want {
+		t.Fatalf("unexpected plain output:\ngot  %q\nwant %q", strings.TrimSpace(out), want)
+	}
+}
+
+func TestAffiliateProductLabelFallsBackToID(t *testing.T) {
+	if got := affiliateProductLabel(affiliateProduct{ID: "prod_123"}); got != "prod_123" {
+		t.Fatalf("got %q, want prod_123", got)
+	}
+}
+
+func affiliateFixture() map[string]any {
+	return map[string]any{
+		"id":                     "aff_123",
+		"type":                   "DirectAffiliate",
+		"direction":              "granted",
+		"counterparty":           map[string]any{"id": "user_456", "email": "affiliate@example.com", "name": "Affiliate User"},
+		"affiliate_basis_points": 1500,
+		"destination_url":        "https://example.com/aff",
+		"apply_to_all_products":  false,
+		"alive":                  true,
+		"deleted_at":             nil,
+		"created_at":             "2026-05-01T12:00:00Z",
+		"products": []map[string]any{
+			{
+				"id":              "prod_123",
+				"name":            "Starter Pack",
+				"basis_points":    1500,
+				"destination_url": "https://example.com/product",
+			},
+		},
+	}
+}

--- a/internal/cmd/admin/users/users.go
+++ b/internal/cmd/admin/users/users.go
@@ -16,6 +16,7 @@ func NewUsersCmd() *cobra.Command {
 		Short: "Read and manage admin user records",
 		Example: `  gumroad admin users info --email user@example.com
   gumroad admin users info --user-id 2245593582708
+  gumroad admin users affiliates --user-id 2245593582708 --direction granted
   gumroad admin users suspension --email user@example.com
   gumroad admin users mark-compliant --user-id 2245593582708 --expected-email user@example.com
   gumroad admin users watch --user-id 2245593582708 --revenue-threshold 200 --note "Review next buyers"
@@ -29,6 +30,7 @@ func NewUsersCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(newInfoCmd())
+	cmd.AddCommand(newAffiliatesCmd())
 	cmd.AddCommand(newSuspensionCmd())
 	cmd.AddCommand(newMarkCompliantCmd())
 	cmd.AddCommand(newWatchCmd())

--- a/internal/cmd/admin/users/users_test.go
+++ b/internal/cmd/admin/users/users_test.go
@@ -178,6 +178,7 @@ func TestNewUsersCmdWiresSubcommands(t *testing.T) {
 	got := cmd.Commands()
 	want := []string{
 		"info",
+		"affiliates",
 		"suspension",
 		"mark-compliant",
 		"watch",


### PR DESCRIPTION
Ref antiwork/gumroad/issues/4989

## What

Adds `gumroad admin users affiliates` so admins can list affiliate relationships for a user in either direction: granted or received. The command supports email or user ID lookup, cursor pagination, JSON output, and a readable table for human review.

## Why

Gumroad now exposes affiliate relationships through the internal admin API. This lets support and risk workflows inspect those relationships from the CLI without using the web admin or raw API calls.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh.
