### PR TITLE
Add product fraud context to admin product commands

### DIFF
--- a/internal/cmd/admin/products/list.go
+++ b/internal/cmd/admin/products/list.go
@@ -147,8 +147,11 @@ func writeListPlain(w io.Writer, products []product) error {
 			p.ID,
 			productNameWithDeleted(p),
 			formatPrice(p.PriceCents, p.CurrencyCode),
-			strconv.Itoa(len(p.Files)),
 			productStatusLabel(p),
+			strconv.Itoa(int(p.BadCardCounter)),
+			taxonomyPath(p.Taxonomy),
+			strconv.Itoa(len(p.Affiliates)),
+			strconv.Itoa(len(p.Files)),
 			p.CreatedAt,
 		})
 	}
@@ -156,14 +159,17 @@ func writeListPlain(w io.Writer, products []product) error {
 }
 
 func writeListTable(w io.Writer, style output.Styler, products []product) error {
-	tbl := output.NewStyledTable(style, "ID", "NAME", "PRICE", "FILES", "STATUS", "CREATED")
+	tbl := output.NewStyledTable(style, "ID", "NAME", "PRICE", "STATUS", "BAD CARDS", "TAXONOMY", "AFFILIATES", "FILES", "CREATED")
 	for _, p := range products {
 		tbl.AddRow(
 			p.ID,
 			productNameWithDeleted(p),
 			formatPrice(p.PriceCents, p.CurrencyCode),
-			strconv.Itoa(len(p.Files)),
 			productStatusLabel(p),
+			strconv.Itoa(int(p.BadCardCounter)),
+			taxonomyPath(p.Taxonomy),
+			strconv.Itoa(len(p.Affiliates)),
+			strconv.Itoa(len(p.Files)),
 			p.CreatedAt,
 		)
 	}

--- a/internal/cmd/admin/products/list_test.go
+++ b/internal/cmd/admin/products/list_test.go
@@ -258,14 +258,34 @@ func TestListRendersOneLevelAndMultiLevelTaxonomyPaths(t *testing.T) {
 	cmd.SetArgs([]string{"--email", "seller@example.com"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	for _, want := range []string{
-		"books",
-		"education/books/textbooks",
+	for _, tc := range []struct {
+		id       string
+		name     string
+		taxonomy string
+	}{
+		{"one123", "Book", "books"},
+		{"multi123", "Textbook", "education/books/textbooks"},
 	} {
-		if !strings.Contains(out, want) {
-			t.Errorf("output missing %q: %q", want, out)
+		if !outputLineContains(out, tc.id, tc.name, tc.taxonomy) {
+			t.Errorf("output missing taxonomy %q on row %s/%s: %q", tc.taxonomy, tc.id, tc.name, out)
 		}
 	}
+}
+
+func outputLineContains(out string, values ...string) bool {
+	for _, line := range strings.Split(out, "\n") {
+		matches := true
+		for _, value := range values {
+			if !strings.Contains(line, value) {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return true
+		}
+	}
+	return false
 }
 
 func TestListEmptyResultStillShowsPaginationFooter(t *testing.T) {

--- a/internal/cmd/admin/products/list_test.go
+++ b/internal/cmd/admin/products/list_test.go
@@ -11,18 +11,40 @@ import (
 
 func sampleProduct(id, name string) map[string]any {
 	return map[string]any{
-		"id":            id,
-		"name":          name,
-		"description":   "A short description",
-		"price_cents":   20000,
-		"currency_code": "usd",
-		"permalink":     id,
-		"long_url":      "https://gumroad.com/l/" + id,
-		"preview_url":   "https://example.com/preview.jpg",
-		"created_at":    "2026-05-01T12:00:00Z",
-		"deleted_at":    nil,
-		"alive":         true,
-		"is_adult":      false,
+		"id":                   id,
+		"name":                 name,
+		"description":          "A short description",
+		"price_cents":          20000,
+		"currency_code":        "usd",
+		"permalink":            id,
+		"long_url":             "https://gumroad.com/l/" + id,
+		"preview_url":          "https://example.com/preview.jpg",
+		"created_at":           "2026-05-01T12:00:00Z",
+		"deleted_at":           nil,
+		"banned_at":            nil,
+		"purchase_disabled_at": nil,
+		"alive":                true,
+		"is_adult":             false,
+		"bad_card_counter":     3,
+		"taxonomy": map[string]any{
+			"id":            "tax_1",
+			"slug":          "painting",
+			"ancestry_path": []string{"art", "painting"},
+		},
+		"affiliates": []map[string]any{
+			{
+				"id":   "aff_1",
+				"type": "DirectAffiliate",
+				"affiliate_user": map[string]any{
+					"id":    "u_aff",
+					"email": "affiliate@example.com",
+				},
+				"basis_points":    1500,
+				"destination_url": "https://example.com/a",
+				"alive":           true,
+				"deleted_at":      nil,
+			},
+		},
 		"seller": map[string]any{
 			"id":    "u_123",
 			"email": "seller@example.com",
@@ -131,6 +153,7 @@ func TestListUsesInternalAdminEndpointAndRendersHumanOutput(t *testing.T) {
 		"abc123",
 		"Art Pack",
 		"200.00 USD",
+		"art/painting",
 		"Page 1 of 5 (47 total)",
 	} {
 		if !strings.Contains(out, want) {
@@ -178,6 +201,70 @@ func TestListMarksDeletedProducts(t *testing.T) {
 	}
 	if !strings.Contains(out, "deleted") {
 		t.Errorf("expected deleted status column: %q", out)
+	}
+}
+
+func TestListMarksBannedAndPurchaseDisabledProducts(t *testing.T) {
+	payload := sampleListPayload()
+	banned := sampleProduct("ban123", "Banned Pack")
+	banned["banned_at"] = "2026-04-15T10:00:00Z"
+	banned["alive"] = false
+	disabled := sampleProduct("dis123", "Disabled Pack")
+	disabled["purchase_disabled_at"] = "2026-04-16T10:00:00Z"
+	disabled["alive"] = false
+	payload["products"] = []map[string]any{banned, disabled}
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, payload)
+	})
+
+	cmd := testutil.Command(newListCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--email", "seller@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	for _, want := range []string{
+		"Banned Pack",
+		"banned",
+		"Disabled Pack",
+		"purchase-disabled",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestListRendersOneLevelAndMultiLevelTaxonomyPaths(t *testing.T) {
+	payload := sampleListPayload()
+	oneLevel := sampleProduct("one123", "Book")
+	oneLevel["taxonomy"] = map[string]any{
+		"id":            "tax_book",
+		"slug":          "books",
+		"ancestry_path": []string{"books"},
+	}
+	multiLevel := sampleProduct("multi123", "Textbook")
+	multiLevel["taxonomy"] = map[string]any{
+		"id":            "tax_textbook",
+		"slug":          "textbooks",
+		"ancestry_path": []string{"education", "books", "textbooks"},
+	}
+	payload["products"] = []map[string]any{oneLevel, multiLevel}
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, payload)
+	})
+
+	cmd := testutil.Command(newListCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--email", "seller@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	for _, want := range []string{
+		"books",
+		"education/books/textbooks",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q: %q", want, out)
+		}
 	}
 }
 
@@ -297,7 +384,7 @@ func TestListPlainOutput(t *testing.T) {
 	cmd.SetArgs([]string{"--email", "seller@example.com"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	want := "abc123\tArt Pack\t200.00 USD\t1\talive\t2026-05-01T12:00:00Z"
+	want := "abc123\tArt Pack\t200.00 USD\talive\t3\tart/painting\t1\t1\t2026-05-01T12:00:00Z"
 	if strings.TrimSpace(out) != want {
 		t.Fatalf("unexpected plain output:\n got: %q\nwant: %q", out, want)
 	}

--- a/internal/cmd/admin/products/view.go
+++ b/internal/cmd/admin/products/view.go
@@ -16,25 +16,59 @@ import (
 )
 
 type product struct {
-	ID           string        `json:"id"`
-	Name         string        `json:"name"`
-	Description  string        `json:"description"`
-	PriceCents   api.JSONInt   `json:"price_cents"`
-	CurrencyCode string        `json:"currency_code"`
-	Permalink    string        `json:"permalink"`
-	LongURL      string        `json:"long_url"`
-	PreviewURL   string        `json:"preview_url"`
-	CreatedAt    string        `json:"created_at"`
-	DeletedAt    string        `json:"deleted_at"`
-	Alive        bool          `json:"alive"`
-	IsAdult      bool          `json:"is_adult"`
-	Seller       productSeller `json:"seller"`
-	Files        []productFile `json:"files"`
+	ID                   string                 `json:"id"`
+	Name                 string                 `json:"name"`
+	Description          string                 `json:"description"`
+	PriceCents           api.JSONInt            `json:"price_cents"`
+	CurrencyCode         string                 `json:"currency_code"`
+	Permalink            string                 `json:"permalink"`
+	LongURL              string                 `json:"long_url"`
+	PreviewURL           string                 `json:"preview_url"`
+	CreatedAt            string                 `json:"created_at"`
+	DeletedAt            string                 `json:"deleted_at"`
+	BannedAt             string                 `json:"banned_at"`
+	PurchaseDisabledAt   string                 `json:"purchase_disabled_at"`
+	Alive                bool                   `json:"alive"`
+	IsAdult              bool                   `json:"is_adult"`
+	BadCardCounter       api.JSONInt            `json:"bad_card_counter"`
+	Taxonomy             productTaxonomy        `json:"taxonomy"`
+	Affiliates           []productAffiliate     `json:"affiliates"`
+	RecentChargebackRate *productChargebackRate `json:"recent_chargeback_rate"`
+	Seller               productSeller          `json:"seller"`
+	Files                []productFile          `json:"files"`
 }
 
 type productSeller struct {
 	ID    string `json:"id"`
 	Email string `json:"email"`
+}
+
+type productTaxonomy struct {
+	ID           string   `json:"id"`
+	Slug         string   `json:"slug"`
+	AncestryPath []string `json:"ancestry_path"`
+}
+
+type productAffiliate struct {
+	ID             string               `json:"id"`
+	Type           string               `json:"type"`
+	AffiliateUser  productAffiliateUser `json:"affiliate_user"`
+	BasisPoints    api.JSONInt          `json:"basis_points"`
+	DestinationURL string               `json:"destination_url"`
+	Alive          bool                 `json:"alive"`
+	DeletedAt      string               `json:"deleted_at"`
+}
+
+type productAffiliateUser struct {
+	ID    string `json:"id"`
+	Email string `json:"email"`
+}
+
+type productChargebackRate struct {
+	WindowDays       api.JSONInt `json:"window_days"`
+	SuccessfulCount  api.JSONInt `json:"successful_count"`
+	ChargedbackCount api.JSONInt `json:"chargedback_count"`
+	Rate             *float64    `json:"rate"`
 }
 
 type productFile struct {
@@ -53,20 +87,31 @@ type viewResponse struct {
 }
 
 func newViewCmd() *cobra.Command {
-	return &cobra.Command{
+	var withFraudContext bool
+
+	cmd := &cobra.Command{
 		Use:   "view <product-id>",
 		Short: "View an admin product record",
 		Example: `  gumroad admin products view abc123
+  gumroad admin products view abc123 --with-fraud-context
   gumroad admin products view abc123 --json`,
 		Args: cmdutil.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
 			path := cmdutil.JoinPath("products", args[0])
-			return admincmd.RunGetDecoded[viewResponse](opts, "Fetching product...", path, url.Values{}, func(resp viewResponse) error {
+			params := url.Values{}
+			if withFraudContext {
+				params.Set("with_fraud_context", "true")
+			}
+			return admincmd.RunGetDecoded[viewResponse](opts, "Fetching product...", path, params, func(resp viewResponse) error {
 				return renderProduct(opts, resp.Product)
 			})
 		},
 	}
+
+	cmd.Flags().BoolVar(&withFraudContext, "with-fraud-context", false, "Request expensive fraud context such as recent chargeback rate")
+
+	return cmd
 }
 
 func renderProduct(opts cmdutil.Options, p product) error {
@@ -80,6 +125,15 @@ func renderProduct(opts cmdutil.Options, p product) error {
 	style := opts.Style()
 	return output.WithPager(opts.Out(), opts.Err(), func(w io.Writer) error {
 		if err := output.Writef(w, "%s", buildProductHeader(style, p)); err != nil {
+			return err
+		}
+		if err := writeLifecycleSection(w, style, p); err != nil {
+			return err
+		}
+		if err := writeRiskSection(w, style, p); err != nil {
+			return err
+		}
+		if err := writeAffiliatesSection(w, style, p.Affiliates); err != nil {
 			return err
 		}
 		return writeFilesSection(w, style, p.Files)
@@ -109,11 +163,8 @@ func buildProductHeader(style output.Styler, p product) string {
 	if p.IsAdult {
 		fmt.Fprintln(&b, "Adult: true")
 	}
-	if p.CreatedAt != "" {
-		fmt.Fprintf(&b, "Created: %s\n", p.CreatedAt)
-	}
-	if p.DeletedAt != "" {
-		fmt.Fprintf(&b, "Deleted: %s\n", p.DeletedAt)
+	if path := taxonomyPath(p.Taxonomy); path != "" {
+		fmt.Fprintf(&b, "Taxonomy: %s\n", path)
 	}
 	if p.Description != "" {
 		fmt.Fprintln(&b)
@@ -132,10 +183,82 @@ func writeProductPlain(w io.Writer, p product) error {
 		formatPrice(p.PriceCents, p.CurrencyCode),
 		productStatusLabel(p),
 		p.Seller.Email,
+		strconv.Itoa(int(p.BadCardCounter)),
+		taxonomyPath(p.Taxonomy),
+		strconv.Itoa(len(p.Affiliates)),
 		strconv.Itoa(len(p.Files)),
 		p.CreatedAt,
 		p.LongURL,
+		formatChargebackRate(p.RecentChargebackRate),
 	}})
+}
+
+func writeLifecycleSection(w io.Writer, style output.Styler, p product) error {
+	if p.CreatedAt == "" && p.DeletedAt == "" && p.BannedAt == "" && p.PurchaseDisabledAt == "" {
+		return nil
+	}
+
+	if err := output.Writef(w, "%s\n", style.Bold("Lifecycle:")); err != nil {
+		return err
+	}
+	for _, row := range []struct {
+		label string
+		value string
+	}{
+		{"Created", p.CreatedAt},
+		{"Deleted", p.DeletedAt},
+		{"Banned", p.BannedAt},
+		{"Purchase disabled", p.PurchaseDisabledAt},
+	} {
+		if row.value == "" {
+			continue
+		}
+		if err := output.Writef(w, "  %s: %s\n", row.label, row.value); err != nil {
+			return err
+		}
+	}
+	return output.Writeln(w, "")
+}
+
+func writeRiskSection(w io.Writer, style output.Styler, p product) error {
+	if err := output.Writef(w, "%s\n", style.Bold("Risk:")); err != nil {
+		return err
+	}
+	if err := output.Writef(w, "  Bad-card counter: %d\n", p.BadCardCounter); err != nil {
+		return err
+	}
+	if rate := formatChargebackRate(p.RecentChargebackRate); rate != "" {
+		if err := output.Writef(w, "  Recent chargeback rate: %s\n", rate); err != nil {
+			return err
+		}
+	}
+	return output.Writeln(w, "")
+}
+
+func writeAffiliatesSection(w io.Writer, style output.Styler, affiliates []productAffiliate) error {
+	if len(affiliates) == 0 {
+		return output.Writef(w, "%s none\n\n", style.Bold("Affiliates:"))
+	}
+
+	if err := output.Writef(w, "%s\n", style.Bold(fmt.Sprintf("Affiliates (%d):", len(affiliates)))); err != nil {
+		return err
+	}
+	tbl := output.NewStyledTable(style, "ID", "TYPE", "USER", "BPS", "ALIVE", "DELETED", "URL")
+	for _, a := range affiliates {
+		tbl.AddRow(
+			a.ID,
+			a.Type,
+			affiliateUserLabel(a.AffiliateUser),
+			strconv.Itoa(int(a.BasisPoints)),
+			strconv.FormatBool(a.Alive),
+			a.DeletedAt,
+			a.DestinationURL,
+		)
+	}
+	if err := tbl.Render(w); err != nil {
+		return err
+	}
+	return output.Writeln(w, "")
 }
 
 func writeFilesSection(w io.Writer, style output.Styler, files []productFile) error {
@@ -189,6 +312,12 @@ func productStatusLabel(p product) string {
 	if p.DeletedAt != "" {
 		return "deleted"
 	}
+	if p.BannedAt != "" {
+		return "banned"
+	}
+	if p.PurchaseDisabledAt != "" {
+		return "purchase-disabled"
+	}
 	if p.Alive {
 		return "alive"
 	}
@@ -215,6 +344,42 @@ func formatPrice(cents api.JSONInt, currency string) string {
 		return formatted
 	}
 	return formatted + " " + code
+}
+
+func taxonomyPath(t productTaxonomy) string {
+	if len(t.AncestryPath) > 0 {
+		return strings.Join(t.AncestryPath, "/")
+	}
+	return t.Slug
+}
+
+func affiliateUserLabel(u productAffiliateUser) string {
+	switch {
+	case u.Email != "" && u.ID != "":
+		return u.Email + " (" + u.ID + ")"
+	case u.Email != "":
+		return u.Email
+	default:
+		return u.ID
+	}
+}
+
+func formatChargebackRate(rate *productChargebackRate) string {
+	if rate == nil {
+		return ""
+	}
+
+	percent := "n/a"
+	if rate.Rate != nil {
+		percent = fmt.Sprintf("%.2f%%", *rate.Rate*100)
+	}
+	return fmt.Sprintf(
+		"%s (%d/%d over %dd)",
+		percent,
+		rate.ChargedbackCount,
+		rate.SuccessfulCount,
+		rate.WindowDays,
+	)
 }
 
 const (

--- a/internal/cmd/admin/products/view_test.go
+++ b/internal/cmd/admin/products/view_test.go
@@ -11,6 +11,12 @@ import (
 
 func sampleViewPayload() map[string]any {
 	p := sampleProduct("abc123", "Art Pack")
+	p["recent_chargeback_rate"] = map[string]any{
+		"window_days":       90,
+		"successful_count":  5,
+		"chargedback_count": 1,
+		"rate":              0.2,
+	}
 	p["files"] = []map[string]any{
 		{
 			"id":           "f_1",
@@ -76,7 +82,16 @@ func TestViewUsesInternalAdminEndpointAndRendersHumanOutput(t *testing.T) {
 		"Seller: seller@example.com (u_123)",
 		"Price: 200.00 USD",
 		"Status: alive",
+		"Taxonomy: art/painting",
+		"Lifecycle:",
 		"Created: 2026-05-01T12:00:00Z",
+		"Risk:",
+		"Bad-card counter: 3",
+		"Recent chargeback rate: 20.00% (1/5 over 90d)",
+		"Affiliates (1):",
+		"DirectAffiliate",
+		"affiliate@example.com (u_aff)",
+		"1500",
 		"Description:",
 		"A short description",
 		"Files (2):",
@@ -89,6 +104,40 @@ func TestViewUsesInternalAdminEndpointAndRendersHumanOutput(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("output missing %q: %q", want, out)
 		}
+	}
+}
+
+func TestViewSendsWithFraudContextFlag(t *testing.T) {
+	var gotFraudContext string
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotFraudContext = r.URL.Query().Get("with_fraud_context")
+		testutil.JSON(t, w, sampleViewPayload())
+	})
+
+	cmd := testutil.Command(newViewCmd())
+	cmd.SetArgs([]string{"abc123", "--with-fraud-context"})
+	testutil.MustExecute(t, cmd)
+
+	if gotFraudContext != "true" {
+		t.Fatalf("with_fraud_context = %q, want true", gotFraudContext)
+	}
+}
+
+func TestViewOmitsWithFraudContextByDefault(t *testing.T) {
+	var gotFraudContext string
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotFraudContext = r.URL.Query().Get("with_fraud_context")
+		testutil.JSON(t, w, sampleViewPayload())
+	})
+
+	cmd := testutil.Command(newViewCmd())
+	cmd.SetArgs([]string{"abc123"})
+	testutil.MustExecute(t, cmd)
+
+	if gotFraudContext != "" {
+		t.Fatalf("with_fraud_context should be omitted by default, got %q", gotFraudContext)
 	}
 }
 
@@ -168,7 +217,7 @@ func TestViewPlainOutput(t *testing.T) {
 	cmd.SetArgs([]string{"abc123"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	want := "abc123\tArt Pack\t200.00 USD\talive\tseller@example.com\t2\t2026-05-01T12:00:00Z\thttps://gumroad.com/l/abc123"
+	want := "abc123\tArt Pack\t200.00 USD\talive\tseller@example.com\t3\tart/painting\t1\t2\t2026-05-01T12:00:00Z\thttps://gumroad.com/l/abc123\t20.00% (1/5 over 90d)"
 	if strings.TrimSpace(out) != want {
 		t.Fatalf("unexpected plain output:\n got: %q\nwant: %q", out, want)
 	}
@@ -240,6 +289,23 @@ func TestSellerLabelHandlesPartialIdentifiers(t *testing.T) {
 	}
 }
 
+func TestTaxonomyPath(t *testing.T) {
+	cases := []struct {
+		taxonomy productTaxonomy
+		want     string
+	}{
+		{productTaxonomy{}, ""},
+		{productTaxonomy{Slug: "books"}, "books"},
+		{productTaxonomy{Slug: "books", AncestryPath: []string{"books"}}, "books"},
+		{productTaxonomy{Slug: "books", AncestryPath: []string{"physical-goods", "books"}}, "physical-goods/books"},
+	}
+	for _, tc := range cases {
+		if got := taxonomyPath(tc.taxonomy); got != tc.want {
+			t.Errorf("taxonomyPath(%+v) = %q, want %q", tc.taxonomy, got, tc.want)
+		}
+	}
+}
+
 func TestProductStatusLabel(t *testing.T) {
 	cases := []struct {
 		p    product
@@ -247,11 +313,31 @@ func TestProductStatusLabel(t *testing.T) {
 	}{
 		{product{Alive: true}, "alive"},
 		{product{Alive: false}, "unpublished"},
+		{product{Alive: true, PurchaseDisabledAt: "2026-04-15T10:00:00Z"}, "purchase-disabled"},
+		{product{Alive: true, BannedAt: "2026-04-15T10:00:00Z"}, "banned"},
+		{product{Alive: true, BannedAt: "x", PurchaseDisabledAt: "y"}, "banned"},
 		{product{Alive: true, DeletedAt: "2026-04-15T10:00:00Z"}, "deleted"},
 	}
 	for _, tc := range cases {
 		if got := productStatusLabel(tc.p); got != tc.want {
 			t.Errorf("productStatusLabel(%+v) = %q, want %q", tc.p, got, tc.want)
+		}
+	}
+}
+
+func TestFormatChargebackRate(t *testing.T) {
+	rate := 0.1667
+	cases := []struct {
+		rate *productChargebackRate
+		want string
+	}{
+		{nil, ""},
+		{&productChargebackRate{WindowDays: 90, SuccessfulCount: 0, ChargedbackCount: 0}, "n/a (0/0 over 90d)"},
+		{&productChargebackRate{WindowDays: 90, SuccessfulCount: 6, ChargedbackCount: 1, Rate: &rate}, "16.67% (1/6 over 90d)"},
+	}
+	for _, tc := range cases {
+		if got := formatChargebackRate(tc.rate); got != tc.want {
+			t.Errorf("formatChargebackRate(%+v) = %q, want %q", tc.rate, got, tc.want)
 		}
 	}
 }


### PR DESCRIPTION
Ref antiwork/gumroad/issues/4989

## What

- Surface the new product fraud context in `admin products view` and `admin products list`.
- Show lifecycle, risk, taxonomy, and affiliate details so reviewers can inspect product state without jumping back to the web app.
- Add an opt-in fraud-context flag on product view so the expensive chargeback data is only fetched when needed.

## Why

- The new server contract exposes product fields that are useful for fraud review and support work.
- Keeping the extra data opt-in on `view` avoids paying for it on the common path.
- The list output stays scannable while still exposing the key fraud signals.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh.