### PR TITLE
Fix admin purchase fraud context output

### DIFF
--- a/internal/cmd/admin/purchases/purchases_test.go
+++ b/internal/cmd/admin/purchases/purchases_test.go
@@ -87,6 +87,7 @@ func TestViewSendsWithClustersAndRendersFraudContext(t *testing.T) {
 					"charge_risk_level":    "highest",
 					"actionable":           true,
 					"resolution":           "unknown",
+					"resolution_message":   "Issuer reported a stolen card",
 					"processor_created_at": "2026-04-24T12:00:00Z",
 				},
 				"affiliate_credit": map[string]any{
@@ -118,7 +119,7 @@ func TestViewSendsWithClustersAndRendersFraudContext(t *testing.T) {
 		"Card: **** **** **** 4242, visa, BIN 424242, country FR, exp 11/2030",
 		"Chargeback: 2026-04-25T12:00:00Z",
 		"Dispute: formalized, fraudulent, dp_123, formalized 2026-04-26T12:00:00Z",
-		"Early fraud warning: made_with_stolen_card, risk highest, actionable, resolution unknown, issfr_123",
+		"Early fraud warning: made_with_stolen_card, risk highest, actionable, resolution unknown: Issuer reported a stolen card, issfr_123",
 		"IP: 203.0.113.42 (United States)",
 		"Processor: stripe",
 		"PayPal order: PAY-123",
@@ -131,6 +132,34 @@ func TestViewSendsWithClustersAndRendersFraudContext(t *testing.T) {
 	}
 	if strings.Contains(out, "legacy-seller@example.com") {
 		t.Fatalf("output must prefer seller.email over legacy seller_email: %q", out)
+	}
+}
+
+func TestViewOmitsSparseFraudContext(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"purchase": map[string]any{
+				"id":                  "123",
+				"card":                map[string]any{"visual": "**** **** **** 4242", "expiry_year": 2030},
+				"dispute":             map[string]any{},
+				"early_fraud_warning": map[string]any{},
+				"affiliate_credit":    map[string]any{},
+				"country_mismatches":  map[string]any{"billing_vs_ip": false, "billing_vs_card": false, "ip_vs_card": false},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newViewCmd())
+	cmd.SetArgs([]string{"123"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "Card: **** **** **** 4242") {
+		t.Fatalf("expected card visual in output: %q", out)
+	}
+	for _, unwanted := range []string{"exp ", "Dispute: \n", "Early fraud warning: \n", "Affiliate credit: 0 cents"} {
+		if strings.Contains(out, unwanted) {
+			t.Fatalf("output must omit sparse fraud detail %q: %q", unwanted, out)
+		}
 	}
 }
 

--- a/internal/cmd/admin/purchases/purchases_test.go
+++ b/internal/cmd/admin/purchases/purchases_test.go
@@ -41,6 +41,123 @@ func TestViewUsesInternalAdminEndpoint(t *testing.T) {
 	}
 }
 
+func TestViewSendsWithClustersAndRendersFraudContext(t *testing.T) {
+	var gotClusters string
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotClusters = r.URL.Query().Get("with_clusters")
+		testutil.JSON(t, w, map[string]any{
+			"purchase": map[string]any{
+				"id":                    "123",
+				"email":                 "buyer@example.com",
+				"seller_email":          "legacy-seller@example.com",
+				"seller":                map[string]any{"id": "usr_123", "email": "seller@example.com", "name": "Seller"},
+				"product_name":          "Course",
+				"formatted_total_price": "$12",
+				"purchase_state":        "successful",
+				"chargeback_date":       "2026-04-25T12:00:00Z",
+				"charge_processor":      "stripe",
+				"paypal_order_id":       "PAY-123",
+				"ip_address":            "203.0.113.42",
+				"ip_country":            "United States",
+				"billing_country":       "Germany",
+				"card_country":          "FR",
+				"country_mismatches": map[string]any{
+					"billing_vs_ip":   true,
+					"billing_vs_card": true,
+					"ip_vs_card":      true,
+				},
+				"card": map[string]any{
+					"bin":          "424242",
+					"type":         "visa",
+					"visual":       "**** **** **** 4242",
+					"expiry_month": 11,
+					"expiry_year":  2030,
+				},
+				"dispute": map[string]any{
+					"id":                          "disp_123",
+					"state":                       "formalized",
+					"reason":                      "fraudulent",
+					"charge_processor_dispute_id": "dp_123",
+					"formalized_at":               "2026-04-26T12:00:00Z",
+				},
+				"early_fraud_warning": map[string]any{
+					"id":                   "1",
+					"processor_id":         "issfr_123",
+					"fraud_type":           "made_with_stolen_card",
+					"charge_risk_level":    "highest",
+					"actionable":           true,
+					"resolution":           "unknown",
+					"processor_created_at": "2026-04-24T12:00:00Z",
+				},
+				"affiliate_credit": map[string]any{
+					"amount_cents":      750,
+					"fee_cents":         50,
+					"basis_points":      1000,
+					"affiliate_user_id": "usr_aff",
+				},
+				"clusters": map[string]any{
+					"fingerprint_count": 2,
+					"browser_count":     1,
+					"ip_count":          3,
+				},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newViewCmd())
+	cmd.SetArgs([]string{"123", "--with-clusters"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotClusters != "true" {
+		t.Fatalf("got with_clusters=%q, want true", gotClusters)
+	}
+	for _, want := range []string{
+		"Seller: seller@example.com",
+		"Risk:",
+		"Country mismatches: billing_vs_ip, billing_vs_card, ip_vs_card",
+		"Card: **** **** **** 4242, visa, BIN 424242, country FR, exp 11/2030",
+		"Chargeback: 2026-04-25T12:00:00Z",
+		"Dispute: formalized, fraudulent, dp_123, formalized 2026-04-26T12:00:00Z",
+		"Early fraud warning: made_with_stolen_card, risk highest, actionable, resolution unknown, issfr_123",
+		"IP: 203.0.113.42 (United States)",
+		"Processor: stripe",
+		"PayPal order: PAY-123",
+		"Affiliate credit: 750 cents (fee 50 cents, 1000 bps, affiliate usr_aff)",
+		"Clusters: fingerprint 2, browser 1, IP 3",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q: %q", want, out)
+		}
+	}
+	if strings.Contains(out, "legacy-seller@example.com") {
+		t.Fatalf("output must prefer seller.email over legacy seller_email: %q", out)
+	}
+}
+
+func TestViewOmitsClustersUnlessRequested(t *testing.T) {
+	var gotClusters string
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotClusters = r.URL.Query().Get("with_clusters")
+		testutil.JSON(t, w, map[string]any{
+			"purchase": map[string]any{
+				"id":       "123",
+				"clusters": map[string]any{"fingerprint_count": 2, "browser_count": 1, "ip_count": 3},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newViewCmd())
+	cmd.SetArgs([]string{"123"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotClusters != "" {
+		t.Fatalf("with_clusters must be omitted by default, got %q", gotClusters)
+	}
+	if strings.Contains(out, "Clusters:") {
+		t.Fatalf("clusters must be hidden unless --with-clusters is set: %q", out)
+	}
+}
+
 func TestViewJSONPreservesResponse(t *testing.T) {
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
 		testutil.JSON(t, w, map[string]any{

--- a/internal/cmd/admin/purchases/search.go
+++ b/internal/cmd/admin/purchases/search.go
@@ -2,6 +2,7 @@ package purchases
 
 import (
 	"fmt"
+	"io"
 	"net/url"
 	"strconv"
 
@@ -66,7 +67,7 @@ func renderSearch(opts cmdutil.Options, email string, resp searchResponse) error
 	if opts.PlainOutput {
 		rows := make([][]string, 0, len(resp.Purchases))
 		for _, p := range resp.Purchases {
-			rows = append(rows, []string{p.ID, p.Email, productLabel(p), amountLabel(p), statusLabel(p), p.CreatedAt})
+			rows = append(rows, []string{p.ID, p.Email, sellerEmail(p), productLabel(p), amountLabel(p), statusLabel(p), purchaseFlags(p), p.CreatedAt})
 		}
 		return output.PrintPlain(opts.Out(), rows)
 	}
@@ -84,19 +85,18 @@ func renderSearch(opts cmdutil.Options, email string, resp searchResponse) error
 	if resp.HasMore {
 		headline = fmt.Sprintf("Showing first %d purchase(s) for %s (truncated)", len(resp.Purchases), email)
 	}
-	if err := output.Writeln(opts.Out(), style.Bold(headline)); err != nil {
-		return err
-	}
 
-	for i, p := range resp.Purchases {
-		if i > 0 {
-			if err := output.Writeln(opts.Out(), ""); err != nil {
-				return err
-			}
-		}
-		if err := renderPurchase(opts, p); err != nil {
+	return output.WithPager(opts.Out(), opts.Err(), func(w io.Writer) error {
+		if err := output.Writeln(w, style.Bold(headline)); err != nil {
 			return err
 		}
-	}
-	return nil
+		if err := output.Writeln(w, ""); err != nil {
+			return err
+		}
+		table := output.NewStyledTable(style, "ID", "BUYER", "SELLER", "PRODUCT", "AMOUNT", "STATE", "FLAGS", "CREATED")
+		for _, p := range resp.Purchases {
+			table.AddRow(p.ID, p.Email, sellerEmail(p), productLabel(p), amountLabel(p), statusLabel(p), purchaseFlags(p), p.CreatedAt)
+		}
+		return table.Render(w)
+	})
 }

--- a/internal/cmd/admin/purchases/search_test.go
+++ b/internal/cmd/admin/purchases/search_test.go
@@ -36,6 +36,7 @@ func TestSearch_SendsEmailInQuery(t *testing.T) {
 				{
 					"id":                    "1",
 					"email":                 "buyer@example.com",
+					"seller":                map[string]any{"email": "seller@example.com"},
 					"product_name":          "Course",
 					"formatted_total_price": "$12",
 					"purchase_state":        "successful",
@@ -61,7 +62,7 @@ func TestSearch_SendsEmailInQuery(t *testing.T) {
 	if gotEmail != "buyer@example.com" {
 		t.Errorf("got email %q, want buyer@example.com", gotEmail)
 	}
-	for _, want := range []string{"1 purchase(s) for buyer@example.com", "Course", "Buyer: buyer@example.com"} {
+	for _, want := range []string{"1 purchase(s) for buyer@example.com", "BUYER", "SELLER", "FLAGS", "Course", "buyer@example.com", "seller@example.com"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("expected %q in output: %q", want, out)
 		}
@@ -172,6 +173,41 @@ func TestSearch_HasMoreShowsTruncated(t *testing.T) {
 	}
 }
 
+func TestSearch_ShowsFraudFlags(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"purchases": []map[string]any{
+				{
+					"id":              "1",
+					"email":           "buyer@example.com",
+					"seller":          map[string]any{"email": "seller@example.com"},
+					"product_name":    "Course",
+					"chargeback_date": "2026-04-25T12:00:00Z",
+					"country_mismatches": map[string]any{
+						"billing_vs_ip":   true,
+						"billing_vs_card": false,
+						"ip_vs_card":      false,
+					},
+					"early_fraud_warning": map[string]any{"id": "1", "fraud_type": "made_with_stolen_card"},
+				},
+			},
+			"count":    1,
+			"limit":    25,
+			"has_more": false,
+		})
+	})
+
+	cmd := testutil.Command(newSearchCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--email", "buyer@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	for _, want := range []string{"seller@example.com", "CB,EFW,COUNTRY"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %q in output: %q", want, out)
+		}
+	}
+}
+
 func TestSearch_PlainOutput(t *testing.T) {
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
 		testutil.JSON(t, w, map[string]any{
@@ -179,6 +215,7 @@ func TestSearch_PlainOutput(t *testing.T) {
 				{
 					"id":                    "1",
 					"email":                 "buyer@example.com",
+					"seller":                map[string]any{"email": "seller@example.com"},
 					"product_name":          "Course",
 					"formatted_total_price": "$12",
 					"purchase_state":        "successful",
@@ -187,9 +224,11 @@ func TestSearch_PlainOutput(t *testing.T) {
 				{
 					"id":                    "2",
 					"email":                 "buyer@example.com",
+					"seller_email":          "legacy-seller@example.com",
 					"link_name":             "Bundle",
 					"formatted_total_price": "$20",
 					"purchase_state":        "refunded",
+					"chargeback_date":       "2026-04-23T13:00:00Z",
 					"created_at":            "2026-04-23T12:00:00Z",
 				},
 			},
@@ -204,8 +243,8 @@ func TestSearch_PlainOutput(t *testing.T) {
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
 	wants := []string{
-		"1\tbuyer@example.com\tCourse\t$12\tsuccessful\t2026-04-24T12:00:00Z",
-		"2\tbuyer@example.com\tBundle\t$20\trefunded\t2026-04-23T12:00:00Z",
+		"1\tbuyer@example.com\tseller@example.com\tCourse\t$12\tsuccessful\t\t2026-04-24T12:00:00Z",
+		"2\tbuyer@example.com\tlegacy-seller@example.com\tBundle\t$20\trefunded\tCB\t2026-04-23T12:00:00Z",
 	}
 	for _, want := range wants {
 		if !strings.Contains(out, want) {
@@ -238,7 +277,7 @@ func TestSearch_PlainOutputAmountAndStatusFallbacksMatchStyled(t *testing.T) {
 	cmd.SetArgs([]string{"--email", "buyer@example.com"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	want := "9\tbuyer@example.com\tCourse\t1200 cents\tsuccessful, partially_refunded\t2026-04-24T12:00:00Z"
+	want := "9\tbuyer@example.com\t\tCourse\t1200 cents\tsuccessful, partially_refunded\t\t2026-04-24T12:00:00Z"
 	if !strings.Contains(out, want) {
 		t.Fatalf("plain row must derive amount from price_cents and combine purchase_state with refund_status (matching styled mode), got: %q", out)
 	}

--- a/internal/cmd/admin/purchases/view.go
+++ b/internal/cmd/admin/purchases/view.go
@@ -2,7 +2,9 @@ package purchases
 
 import (
 	"fmt"
+	"io"
 	"net/url"
+	"strings"
 
 	"github.com/antiwork/gumroad-cli/internal/admincmd"
 	"github.com/antiwork/gumroad-cli/internal/api"
@@ -16,35 +18,120 @@ type purchaseResponse struct {
 }
 
 type purchase struct {
-	ID                              string      `json:"id"`
-	Email                           string      `json:"email"`
-	SellerEmail                     string      `json:"seller_email"`
-	ProductName                     string      `json:"product_name"`
-	ProductAlias                    string      `json:"link_name"`
-	ProductID                       string      `json:"product_id"`
-	FormattedTotalPrice             string      `json:"formatted_total_price"`
-	PriceCents                      api.JSONInt `json:"price_cents"`
-	CurrencyType                    string      `json:"currency_type"`
-	AmountRefundableCentsInCurrency api.JSONInt `json:"amount_refundable_cents_in_currency"`
-	PurchaseState                   string      `json:"purchase_state"`
-	RefundStatus                    string      `json:"refund_status"`
-	CreatedAt                       string      `json:"created_at"`
-	ReceiptURL                      string      `json:"receipt_url"`
+	ID                              string                   `json:"id"`
+	Email                           string                   `json:"email"`
+	SellerEmail                     string                   `json:"seller_email"`
+	ProductName                     string                   `json:"product_name"`
+	ProductAlias                    string                   `json:"link_name"`
+	ProductID                       string                   `json:"product_id"`
+	FormattedTotalPrice             string                   `json:"formatted_total_price"`
+	PriceCents                      api.JSONInt              `json:"price_cents"`
+	CurrencyType                    string                   `json:"currency_type"`
+	AmountRefundableCentsInCurrency api.JSONInt              `json:"amount_refundable_cents_in_currency"`
+	PurchaseState                   string                   `json:"purchase_state"`
+	RefundStatus                    string                   `json:"refund_status"`
+	ChargebackDate                  string                   `json:"chargeback_date"`
+	CreatedAt                       string                   `json:"created_at"`
+	ReceiptURL                      string                   `json:"receipt_url"`
+	ChargeProcessor                 string                   `json:"charge_processor"`
+	PaypalOrderID                   string                   `json:"paypal_order_id"`
+	IPAddress                       string                   `json:"ip_address"`
+	IPCountry                       string                   `json:"ip_country"`
+	BillingCountry                  string                   `json:"billing_country"`
+	CardCountry                     string                   `json:"card_country"`
+	CountryMismatches               countryMismatches        `json:"country_mismatches"`
+	Card                            purchaseCard             `json:"card"`
+	Dispute                         *purchaseDispute         `json:"dispute"`
+	EarlyFraudWarning               *earlyFraudWarning       `json:"early_fraud_warning"`
+	AffiliateCredit                 *purchaseAffiliateCredit `json:"affiliate_credit"`
+	Clusters                        *purchaseClusters        `json:"clusters"`
+	Seller                          *purchaseSeller          `json:"seller"`
+}
+
+type purchaseSeller struct {
+	ID    string `json:"id"`
+	Email string `json:"email"`
+	Name  string `json:"name"`
+}
+
+type countryMismatches struct {
+	BillingVsIP   bool `json:"billing_vs_ip"`
+	BillingVsCard bool `json:"billing_vs_card"`
+	IPVsCard      bool `json:"ip_vs_card"`
+}
+
+type purchaseCard struct {
+	Bin         string      `json:"bin"`
+	Type        string      `json:"type"`
+	Visual      string      `json:"visual"`
+	ExpiryMonth api.JSONInt `json:"expiry_month"`
+	ExpiryYear  api.JSONInt `json:"expiry_year"`
+}
+
+type purchaseDispute struct {
+	ID                       string `json:"id"`
+	State                    string `json:"state"`
+	Reason                   string `json:"reason"`
+	ChargeProcessorDisputeID string `json:"charge_processor_dispute_id"`
+	CreatedAt                string `json:"created_at"`
+	InitiatedAt              string `json:"initiated_at"`
+	FormalizedAt             string `json:"formalized_at"`
+	WonAt                    string `json:"won_at"`
+	LostAt                   string `json:"lost_at"`
+}
+
+type earlyFraudWarning struct {
+	ID                 string `json:"id"`
+	ProcessorID        string `json:"processor_id"`
+	FraudType          string `json:"fraud_type"`
+	ChargeRiskLevel    string `json:"charge_risk_level"`
+	Actionable         bool   `json:"actionable"`
+	Resolution         string `json:"resolution"`
+	ResolutionMessage  string `json:"resolution_message"`
+	ResolvedAt         string `json:"resolved_at"`
+	ProcessorCreatedAt string `json:"processor_created_at"`
+}
+
+type purchaseAffiliateCredit struct {
+	AmountCents     api.JSONInt `json:"amount_cents"`
+	FeeCents        api.JSONInt `json:"fee_cents"`
+	BasisPoints     api.JSONInt `json:"basis_points"`
+	AffiliateUserID string      `json:"affiliate_user_id"`
+}
+
+type purchaseClusters struct {
+	FingerprintCount *api.JSONInt `json:"fingerprint_count"`
+	BrowserCount     *api.JSONInt `json:"browser_count"`
+	IPCount          *api.JSONInt `json:"ip_count"`
+}
+
+type purchaseRenderOptions struct {
+	ShowClusters bool
 }
 
 func newViewCmd() *cobra.Command {
-	return &cobra.Command{
+	var withClusters bool
+
+	cmd := &cobra.Command{
 		Use:   "view <purchase-id>",
 		Short: "View an admin purchase record",
 		Args:  cmdutil.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
+			params := url.Values{}
+			if withClusters {
+				params.Set("with_clusters", "true")
+			}
 			path := cmdutil.JoinPath("purchases", args[0])
-			return admincmd.RunGetDecoded[purchaseResponse](opts, "Fetching purchase...", path, url.Values{}, func(resp purchaseResponse) error {
-				return renderPurchase(opts, resp.Purchase)
+			return admincmd.RunGetDecoded[purchaseResponse](opts, "Fetching purchase...", path, params, func(resp purchaseResponse) error {
+				return renderPurchaseWithOptions(opts, resp.Purchase, purchaseRenderOptions{ShowClusters: withClusters})
 			})
 		},
 	}
+
+	cmd.Flags().BoolVar(&withClusters, "with-clusters", false, "Include matching fingerprint, browser, and IP cluster counts")
+
+	return cmd
 }
 
 func productLabel(p purchase) string {
@@ -78,18 +165,57 @@ func statusLabel(p purchase) string {
 	return status
 }
 
+func sellerEmail(p purchase) string {
+	if p.Seller != nil && p.Seller.Email != "" {
+		return p.Seller.Email
+	}
+	return p.SellerEmail
+}
+
+func purchaseFlags(p purchase) string {
+	flags := []string{}
+	if p.ChargebackDate != "" {
+		flags = append(flags, "CB")
+	}
+	if p.EarlyFraudWarning != nil {
+		flags = append(flags, "EFW")
+	}
+	if p.CountryMismatches.hasAny() {
+		flags = append(flags, "COUNTRY")
+	}
+	return strings.Join(flags, ",")
+}
+
+func (m countryMismatches) hasAny() bool {
+	return m.BillingVsIP || m.BillingVsCard || m.IPVsCard
+}
+
 func renderPurchase(opts cmdutil.Options, p purchase) error {
+	return renderPurchaseWithOptions(opts, p, purchaseRenderOptions{})
+}
+
+func renderPurchaseWithOptions(opts cmdutil.Options, p purchase, renderOpts purchaseRenderOptions) error {
 	product := productLabel(p)
 	amount := amountLabel(p)
 	status := statusLabel(p)
+	seller := sellerEmail(p)
 
 	if opts.PlainOutput {
 		return output.PrintPlain(opts.Out(), [][]string{
-			{p.ID, p.Email, p.SellerEmail, product, amount, status, p.CreatedAt, p.ReceiptURL},
+			{p.ID, p.Email, seller, product, amount, status, p.CreatedAt, p.ReceiptURL},
 		})
 	}
+	return writePurchase(opts.Out(), opts.Style(), p, purchaseRenderOptions{
+		ShowClusters: renderOpts.ShowClusters,
+	})
+}
 
-	style := opts.Style()
+func writePurchase(w io.Writer, style output.Styler, p purchase, renderOpts purchaseRenderOptions) error {
+	product := productLabel(p)
+	amount := amountLabel(p)
+	status := statusLabel(p)
+	seller := sellerEmail(p)
+
 	headlineFromID := false
 	headline := product
 	if headline == "" {
@@ -99,36 +225,265 @@ func renderPurchase(opts cmdutil.Options, p purchase) error {
 	if amount != "" {
 		headline += "  " + amount
 	}
-	if err := output.Writeln(opts.Out(), style.Bold(headline)); err != nil {
+	if err := output.Writeln(w, style.Bold(headline)); err != nil {
 		return err
 	}
 	if !headlineFromID {
-		if err := output.Writef(opts.Out(), "Purchase ID: %s\n", p.ID); err != nil {
+		if err := output.Writef(w, "Purchase ID: %s\n", p.ID); err != nil {
 			return err
 		}
 	}
 	if p.Email != "" {
-		if err := output.Writef(opts.Out(), "Buyer: %s\n", p.Email); err != nil {
+		if err := output.Writef(w, "Buyer: %s\n", p.Email); err != nil {
 			return err
 		}
 	}
-	if p.SellerEmail != "" {
-		if err := output.Writef(opts.Out(), "Seller: %s\n", p.SellerEmail); err != nil {
+	if seller != "" {
+		if err := output.Writef(w, "Seller: %s\n", seller); err != nil {
 			return err
 		}
 	}
 	if status != "" {
-		if err := output.Writef(opts.Out(), "Status: %s\n", status); err != nil {
+		if err := output.Writef(w, "Status: %s\n", status); err != nil {
 			return err
 		}
 	}
 	if p.CreatedAt != "" {
-		if err := output.Writef(opts.Out(), "Date: %s\n", p.CreatedAt); err != nil {
+		if err := output.Writef(w, "Date: %s\n", p.CreatedAt); err != nil {
 			return err
 		}
 	}
 	if p.ReceiptURL != "" {
-		return output.Writef(opts.Out(), "Receipt: %s\n", p.ReceiptURL)
+		if err := output.Writef(w, "Receipt: %s\n", p.ReceiptURL); err != nil {
+			return err
+		}
+	}
+	if err := writeRiskBlock(w, p); err != nil {
+		return err
+	}
+	if p.AffiliateCredit != nil {
+		if err := output.Writef(w, "Affiliate credit: %d cents", p.AffiliateCredit.AmountCents); err != nil {
+			return err
+		}
+		details := []string{}
+		if p.AffiliateCredit.FeeCents != 0 {
+			details = append(details, fmt.Sprintf("fee %d cents", p.AffiliateCredit.FeeCents))
+		}
+		if p.AffiliateCredit.BasisPoints != 0 {
+			details = append(details, fmt.Sprintf("%d bps", p.AffiliateCredit.BasisPoints))
+		}
+		if p.AffiliateCredit.AffiliateUserID != "" {
+			details = append(details, "affiliate "+p.AffiliateCredit.AffiliateUserID)
+		}
+		if len(details) > 0 {
+			if err := output.Writef(w, " (%s)", strings.Join(details, ", ")); err != nil {
+				return err
+			}
+		}
+		if err := output.Writeln(w, ""); err != nil {
+			return err
+		}
+	}
+	if renderOpts.ShowClusters {
+		return writeClusters(w, p.Clusters)
 	}
 	return nil
+}
+
+func writeRiskBlock(w io.Writer, p purchase) error {
+	if !hasRiskDetails(p) {
+		return nil
+	}
+
+	if err := output.Writeln(w, ""); err != nil {
+		return err
+	}
+	if err := output.Writeln(w, "Risk:"); err != nil {
+		return err
+	}
+	if p.CountryMismatches.hasAny() {
+		if err := output.Writef(w, "  Country mismatches: %s", strings.Join(countryMismatchLabels(p.CountryMismatches), ", ")); err != nil {
+			return err
+		}
+		countries := []string{}
+		if p.BillingCountry != "" {
+			countries = append(countries, "billing "+p.BillingCountry)
+		}
+		if p.IPCountry != "" {
+			countries = append(countries, "IP "+p.IPCountry)
+		}
+		if p.CardCountry != "" {
+			countries = append(countries, "card "+p.CardCountry)
+		}
+		if len(countries) > 0 {
+			if err := output.Writef(w, " (%s)", strings.Join(countries, ", ")); err != nil {
+				return err
+			}
+		}
+		if err := output.Writeln(w, ""); err != nil {
+			return err
+		}
+	}
+	if card := cardSummary(p); card != "" {
+		if err := output.Writef(w, "  Card: %s\n", card); err != nil {
+			return err
+		}
+	}
+	if p.ChargebackDate != "" {
+		if err := output.Writef(w, "  Chargeback: %s\n", p.ChargebackDate); err != nil {
+			return err
+		}
+	}
+	if p.Dispute != nil {
+		if err := output.Writef(w, "  Dispute: %s\n", disputeSummary(p.Dispute)); err != nil {
+			return err
+		}
+	}
+	if p.EarlyFraudWarning != nil {
+		if err := output.Writef(w, "  Early fraud warning: %s\n", earlyFraudWarningSummary(p.EarlyFraudWarning)); err != nil {
+			return err
+		}
+	}
+	if p.IPAddress != "" {
+		ip := p.IPAddress
+		if p.IPCountry != "" {
+			ip += " (" + p.IPCountry + ")"
+		}
+		if err := output.Writef(w, "  IP: %s\n", ip); err != nil {
+			return err
+		}
+	}
+	if p.ChargeProcessor != "" {
+		if err := output.Writef(w, "  Processor: %s\n", p.ChargeProcessor); err != nil {
+			return err
+		}
+	}
+	if p.PaypalOrderID != "" {
+		if err := output.Writef(w, "  PayPal order: %s\n", p.PaypalOrderID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func hasRiskDetails(p purchase) bool {
+	return p.CountryMismatches.hasAny() ||
+		cardSummary(p) != "" ||
+		p.ChargebackDate != "" ||
+		p.Dispute != nil ||
+		p.EarlyFraudWarning != nil ||
+		p.IPAddress != "" ||
+		p.ChargeProcessor != "" ||
+		p.PaypalOrderID != ""
+}
+
+func countryMismatchLabels(m countryMismatches) []string {
+	labels := []string{}
+	if m.BillingVsIP {
+		labels = append(labels, "billing_vs_ip")
+	}
+	if m.BillingVsCard {
+		labels = append(labels, "billing_vs_card")
+	}
+	if m.IPVsCard {
+		labels = append(labels, "ip_vs_card")
+	}
+	return labels
+}
+
+func cardSummary(p purchase) string {
+	parts := []string{}
+	if p.Card.Visual != "" {
+		parts = append(parts, p.Card.Visual)
+	}
+	if p.Card.Type != "" {
+		parts = append(parts, p.Card.Type)
+	}
+	if p.Card.Bin != "" {
+		parts = append(parts, "BIN "+p.Card.Bin)
+	}
+	if p.CardCountry != "" {
+		parts = append(parts, "country "+p.CardCountry)
+	}
+	if p.Card.ExpiryMonth != 0 || p.Card.ExpiryYear != 0 {
+		parts = append(parts, fmt.Sprintf("exp %02d/%d", p.Card.ExpiryMonth, p.Card.ExpiryYear))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func disputeSummary(dispute *purchaseDispute) string {
+	parts := []string{}
+	if dispute.State != "" {
+		parts = append(parts, dispute.State)
+	}
+	if dispute.Reason != "" {
+		parts = append(parts, dispute.Reason)
+	}
+	if dispute.ChargeProcessorDisputeID != "" {
+		parts = append(parts, dispute.ChargeProcessorDisputeID)
+	} else if dispute.ID != "" {
+		parts = append(parts, dispute.ID)
+	}
+	for _, timestamp := range []struct {
+		label string
+		value string
+	}{
+		{"formalized", dispute.FormalizedAt},
+		{"initiated", dispute.InitiatedAt},
+		{"won", dispute.WonAt},
+		{"lost", dispute.LostAt},
+		{"created", dispute.CreatedAt},
+	} {
+		if timestamp.value != "" {
+			parts = append(parts, timestamp.label+" "+timestamp.value)
+			break
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+func earlyFraudWarningSummary(efw *earlyFraudWarning) string {
+	parts := []string{}
+	if efw.FraudType != "" {
+		parts = append(parts, efw.FraudType)
+	}
+	if efw.ChargeRiskLevel != "" {
+		parts = append(parts, "risk "+efw.ChargeRiskLevel)
+	}
+	if efw.Actionable {
+		parts = append(parts, "actionable")
+	}
+	if efw.Resolution != "" {
+		parts = append(parts, "resolution "+efw.Resolution)
+	}
+	if efw.ProcessorID != "" {
+		parts = append(parts, efw.ProcessorID)
+	}
+	if efw.ResolvedAt != "" {
+		parts = append(parts, "resolved "+efw.ResolvedAt)
+	}
+	if efw.ProcessorCreatedAt != "" {
+		parts = append(parts, "processor created "+efw.ProcessorCreatedAt)
+	}
+	return strings.Join(parts, ", ")
+}
+
+func writeClusters(w io.Writer, clusters *purchaseClusters) error {
+	if clusters == nil {
+		return nil
+	}
+	parts := []string{}
+	if clusters.FingerprintCount != nil {
+		parts = append(parts, fmt.Sprintf("fingerprint %d", *clusters.FingerprintCount))
+	}
+	if clusters.BrowserCount != nil {
+		parts = append(parts, fmt.Sprintf("browser %d", *clusters.BrowserCount))
+	}
+	if clusters.IPCount != nil {
+		parts = append(parts, fmt.Sprintf("IP %d", *clusters.IPCount))
+	}
+	if len(parts) == 0 {
+		return nil
+	}
+	return output.Writef(w, "Clusters: %s\n", strings.Join(parts, ", "))
 }

--- a/internal/cmd/admin/purchases/view.go
+++ b/internal/cmd/admin/purchases/view.go
@@ -261,26 +261,8 @@ func writePurchase(w io.Writer, style output.Styler, p purchase, renderOpts purc
 	if err := writeRiskBlock(w, p); err != nil {
 		return err
 	}
-	if p.AffiliateCredit != nil {
-		if err := output.Writef(w, "Affiliate credit: %d cents", p.AffiliateCredit.AmountCents); err != nil {
-			return err
-		}
-		details := []string{}
-		if p.AffiliateCredit.FeeCents != 0 {
-			details = append(details, fmt.Sprintf("fee %d cents", p.AffiliateCredit.FeeCents))
-		}
-		if p.AffiliateCredit.BasisPoints != 0 {
-			details = append(details, fmt.Sprintf("%d bps", p.AffiliateCredit.BasisPoints))
-		}
-		if p.AffiliateCredit.AffiliateUserID != "" {
-			details = append(details, "affiliate "+p.AffiliateCredit.AffiliateUserID)
-		}
-		if len(details) > 0 {
-			if err := output.Writef(w, " (%s)", strings.Join(details, ", ")); err != nil {
-				return err
-			}
-		}
-		if err := output.Writeln(w, ""); err != nil {
+	if credit := affiliateCreditSummary(p.AffiliateCredit); credit != "" {
+		if err := output.Writef(w, "Affiliate credit: %s\n", credit); err != nil {
 			return err
 		}
 	}
@@ -334,13 +316,13 @@ func writeRiskBlock(w io.Writer, p purchase) error {
 			return err
 		}
 	}
-	if p.Dispute != nil {
-		if err := output.Writef(w, "  Dispute: %s\n", disputeSummary(p.Dispute)); err != nil {
+	if dispute := disputeSummary(p.Dispute); dispute != "" {
+		if err := output.Writef(w, "  Dispute: %s\n", dispute); err != nil {
 			return err
 		}
 	}
-	if p.EarlyFraudWarning != nil {
-		if err := output.Writef(w, "  Early fraud warning: %s\n", earlyFraudWarningSummary(p.EarlyFraudWarning)); err != nil {
+	if efw := earlyFraudWarningSummary(p.EarlyFraudWarning); efw != "" {
+		if err := output.Writef(w, "  Early fraud warning: %s\n", efw); err != nil {
 			return err
 		}
 	}
@@ -370,8 +352,8 @@ func hasRiskDetails(p purchase) bool {
 	return p.CountryMismatches.hasAny() ||
 		cardSummary(p) != "" ||
 		p.ChargebackDate != "" ||
-		p.Dispute != nil ||
-		p.EarlyFraudWarning != nil ||
+		disputeSummary(p.Dispute) != "" ||
+		earlyFraudWarningSummary(p.EarlyFraudWarning) != "" ||
 		p.IPAddress != "" ||
 		p.ChargeProcessor != "" ||
 		p.PaypalOrderID != ""
@@ -405,13 +387,17 @@ func cardSummary(p purchase) string {
 	if p.CardCountry != "" {
 		parts = append(parts, "country "+p.CardCountry)
 	}
-	if p.Card.ExpiryMonth != 0 || p.Card.ExpiryYear != 0 {
+	if p.Card.ExpiryMonth != 0 && p.Card.ExpiryYear != 0 {
 		parts = append(parts, fmt.Sprintf("exp %02d/%d", p.Card.ExpiryMonth, p.Card.ExpiryYear))
 	}
 	return strings.Join(parts, ", ")
 }
 
 func disputeSummary(dispute *purchaseDispute) string {
+	if dispute == nil {
+		return ""
+	}
+
 	parts := []string{}
 	if dispute.State != "" {
 		parts = append(parts, dispute.State)
@@ -443,6 +429,10 @@ func disputeSummary(dispute *purchaseDispute) string {
 }
 
 func earlyFraudWarningSummary(efw *earlyFraudWarning) string {
+	if efw == nil {
+		return ""
+	}
+
 	parts := []string{}
 	if efw.FraudType != "" {
 		parts = append(parts, efw.FraudType)
@@ -454,7 +444,13 @@ func earlyFraudWarningSummary(efw *earlyFraudWarning) string {
 		parts = append(parts, "actionable")
 	}
 	if efw.Resolution != "" {
-		parts = append(parts, "resolution "+efw.Resolution)
+		resolution := "resolution " + efw.Resolution
+		if efw.ResolutionMessage != "" {
+			resolution += ": " + efw.ResolutionMessage
+		}
+		parts = append(parts, resolution)
+	} else if efw.ResolutionMessage != "" {
+		parts = append(parts, "resolution message "+efw.ResolutionMessage)
 	}
 	if efw.ProcessorID != "" {
 		parts = append(parts, efw.ProcessorID)
@@ -466,6 +462,32 @@ func earlyFraudWarningSummary(efw *earlyFraudWarning) string {
 		parts = append(parts, "processor created "+efw.ProcessorCreatedAt)
 	}
 	return strings.Join(parts, ", ")
+}
+
+func affiliateCreditSummary(credit *purchaseAffiliateCredit) string {
+	if credit == nil {
+		return ""
+	}
+
+	details := []string{}
+	if credit.FeeCents != 0 {
+		details = append(details, fmt.Sprintf("fee %d cents", credit.FeeCents))
+	}
+	if credit.BasisPoints != 0 {
+		details = append(details, fmt.Sprintf("%d bps", credit.BasisPoints))
+	}
+	if credit.AffiliateUserID != "" {
+		details = append(details, "affiliate "+credit.AffiliateUserID)
+	}
+	if credit.AmountCents == 0 && len(details) == 0 {
+		return ""
+	}
+
+	summary := fmt.Sprintf("%d cents", credit.AmountCents)
+	if len(details) > 0 {
+		summary += " (" + strings.Join(details, ", ") + ")"
+	}
+	return summary
 }
 
 func writeClusters(w io.Writer, clusters *purchaseClusters) error {


### PR DESCRIPTION
Ref antiwork/gumroad/issues/4989

## What

- Extends admin purchase views with fraud, card, dispute, affiliate credit, and seller context.
- Adds optional cluster counts to purchase detail output behind `--with-clusters`.
- Updates purchase search output to show seller information and compact risk flags so suspicious rows are easier to scan.

## Why

- Support and fraud review need the new server data surfaced in the CLI without extra lookup steps.
- The new output keeps the common path concise while still exposing deeper risk details when they are available.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh.