### PR TITLE
Add admin users compliance command

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Admin commands use a separate internal token. Run `gumroad auth login` and check
 ```sh
 gumroad admin users info --email seller@example.com --json
 gumroad admin users affiliates --user-id 2245593582708 --direction granted --limit 50
+gumroad admin users compliance --user-id 2245593582708
 gumroad admin users watch --user-id 2245593582708 --expected-email seller@example.com --revenue-threshold 200 --note "Review next buyers"
 gumroad admin users update-watch --user-id 2245593582708 --expected-email seller@example.com --revenue-threshold 500
 gumroad admin users unwatch --user-id 2245593582708 --expected-email seller@example.com

--- a/internal/cmd/admin/admin.go
+++ b/internal/cmd/admin/admin.go
@@ -20,6 +20,7 @@ func NewAdminCmd() *cobra.Command {
   gumroad admin licenses lookup --key <license-key>
   gumroad admin users info --email <email>
   gumroad admin users affiliates --user-id <user-id> --direction granted
+  gumroad admin users compliance --user-id <user-id>
   gumroad admin users suspension --email <email>
   gumroad admin users watch --user-id <user-id> --expected-email <email> --revenue-threshold 200
   gumroad admin payouts list --email <email>

--- a/internal/cmd/admin/users/compliance.go
+++ b/internal/cmd/admin/users/compliance.go
@@ -1,0 +1,376 @@
+package users
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/antiwork/gumroad-cli/internal/admincmd"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+type complianceResponse struct {
+	UserID         string                  `json:"user_id"`
+	ComplianceInfo *complianceInfo         `json:"compliance_info"`
+	InfoRequests   []complianceInfoRequest `json:"info_requests"`
+}
+
+type complianceInfo struct {
+	ID                  string                      `json:"id"`
+	IsBusiness          bool                        `json:"is_business"`
+	LegalName           string                      `json:"legal_name"`
+	FirstName           string                      `json:"first_name"`
+	LastName            string                      `json:"last_name"`
+	DBA                 string                      `json:"dba"`
+	Birthday            string                      `json:"birthday"`
+	Nationality         string                      `json:"nationality"`
+	Phone               string                      `json:"phone"`
+	JobTitle            string                      `json:"job_title"`
+	Address             complianceAddress           `json:"address"`
+	BusinessName        string                      `json:"business_name"`
+	BusinessType        string                      `json:"business_type"`
+	BusinessPhone       string                      `json:"business_phone"`
+	BusinessVATIDNumber string                      `json:"business_vat_id_number"`
+	BusinessAddress     *complianceAddress          `json:"business_address"`
+	TaxIDs              complianceTaxIDs            `json:"tax_ids"`
+	IdentityDocuments   complianceIdentityDocuments `json:"identity_documents"`
+	CreatedAt           string                      `json:"created_at"`
+	UpdatedAt           string                      `json:"updated_at"`
+}
+
+type complianceAddress struct {
+	StreetAddress string `json:"street_address"`
+	City          string `json:"city"`
+	State         string `json:"state"`
+	StateCode     string `json:"state_code"`
+	ZipCode       string `json:"zip_code"`
+	Country       string `json:"country"`
+	CountryCode   string `json:"country_code"`
+}
+
+type complianceTaxIDs struct {
+	IndividualLastFour string `json:"individual_last_four"`
+	BusinessLastFour   string `json:"business_last_four"`
+}
+
+type complianceIdentityDocuments struct {
+	StripeIdentityDocumentID   string `json:"stripe_identity_document_id"`
+	StripeCompanyDocumentID    string `json:"stripe_company_document_id"`
+	StripeAdditionalDocumentID string `json:"stripe_additional_document_id"`
+}
+
+type complianceInfoRequest struct {
+	ID              string `json:"id"`
+	FieldNeeded     string `json:"field_needed"`
+	State           string `json:"state"`
+	DueAt           string `json:"due_at"`
+	Overdue         bool   `json:"overdue"`
+	CreatedAt       string `json:"created_at"`
+	LastEmailSentAt string `json:"last_email_sent_at"`
+}
+
+func newComplianceCmd() *cobra.Command {
+	var lookup userLookupFlags
+
+	cmd := &cobra.Command{
+		Use:   "compliance",
+		Short: "View a user's submitted compliance info",
+		Long: `View a user's submitted KYC data and open compliance info requests.
+
+Identify the user with --email or --user-id. When both are supplied, the
+server resolves by --user-id.`,
+		Example: `  gumroad admin users compliance --user-id 2245593582708
+  gumroad admin users compliance --email user@example.com --json`,
+		Args: cmdutil.ExactArgs(0),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			target, err := resolveUserLookupTarget(c, lookup)
+			if err != nil {
+				return err
+			}
+
+			return admincmd.RunGetDecoded[complianceResponse](opts, "Fetching compliance info...", "/users/compliance_info", target.values(), func(resp complianceResponse) error {
+				return renderCompliance(opts, target.identifier(), resp)
+			})
+		},
+	}
+
+	addUserLookupFlags(cmd, &lookup)
+
+	return cmd
+}
+
+func renderCompliance(opts cmdutil.Options, identifier string, resp complianceResponse) error {
+	if opts.PlainOutput {
+		return writeCompliancePlain(opts.Out(), identifier, resp)
+	}
+	if opts.Quiet {
+		return nil
+	}
+
+	style := opts.Style()
+	return output.WithPager(opts.Out(), opts.Err(), func(w io.Writer) error {
+		if resp.ComplianceInfo == nil {
+			if err := output.Writef(w, "No compliance info submitted for %s\n", identifier); err != nil {
+				return err
+			}
+			if resp.UserID != "" && resp.UserID != identifier {
+				if err := output.Writef(w, "User ID: %s\n", resp.UserID); err != nil {
+					return err
+				}
+			}
+			if len(resp.InfoRequests) > 0 {
+				if err := output.Writeln(w, ""); err != nil {
+					return err
+				}
+				return writeInfoRequestsSection(w, style, resp.InfoRequests)
+			}
+			return nil
+		}
+
+		if err := writeComplianceSummary(w, style, identifier, resp.UserID, *resp.ComplianceInfo); err != nil {
+			return err
+		}
+		if err := writeBusinessSection(w, style, *resp.ComplianceInfo); err != nil {
+			return err
+		}
+		if err := writeTaxIDsSection(w, style, resp.ComplianceInfo.TaxIDs); err != nil {
+			return err
+		}
+		if err := writeIdentityDocumentsSection(w, style, resp.ComplianceInfo.IdentityDocuments); err != nil {
+			return err
+		}
+		return writeInfoRequestsSection(w, style, resp.InfoRequests)
+	})
+}
+
+func writeCompliancePlain(w io.Writer, identifier string, resp complianceResponse) error {
+	if resp.ComplianceInfo == nil {
+		return output.PrintPlain(w, [][]string{{
+			identifier,
+			resp.UserID,
+			"none",
+			"",
+			"",
+			"",
+			"",
+			"",
+			"",
+			strconv.Itoa(len(resp.InfoRequests)),
+		}})
+	}
+
+	info := resp.ComplianceInfo
+	return output.PrintPlain(w, [][]string{{
+		identifier,
+		resp.UserID,
+		complianceEntityType(*info),
+		info.LegalName,
+		info.BusinessName,
+		info.Birthday,
+		info.Nationality,
+		maskTaxID(info.TaxIDs.IndividualLastFour),
+		maskTaxID(info.TaxIDs.BusinessLastFour),
+		strconv.Itoa(len(resp.InfoRequests)),
+	}})
+}
+
+func writeComplianceSummary(w io.Writer, style output.Styler, identifier, userID string, info complianceInfo) error {
+	if err := output.Writef(w, "%s\n", style.Bold("Compliance info for "+identifier)); err != nil {
+		return err
+	}
+	if userID != "" && userID != identifier {
+		if err := output.Writef(w, "User ID: %s\n", userID); err != nil {
+			return err
+		}
+	}
+
+	for _, row := range []struct {
+		label string
+		value string
+	}{
+		{"Type", complianceEntityType(info)},
+		{"Legal name", info.LegalName},
+		{"First name", info.FirstName},
+		{"Last name", info.LastName},
+		{"DBA", info.DBA},
+		{"Birthday", info.Birthday},
+		{"Nationality", info.Nationality},
+		{"Phone", info.Phone},
+		{"Job title", info.JobTitle},
+		{"Individual address", formatComplianceAddress(info.Address)},
+		{"Created", info.CreatedAt},
+		{"Updated", info.UpdatedAt},
+	} {
+		if row.value == "" {
+			continue
+		}
+		if err := output.Writef(w, "%s: %s\n", row.label, row.value); err != nil {
+			return err
+		}
+	}
+
+	return output.Writeln(w, "")
+}
+
+func writeBusinessSection(w io.Writer, style output.Styler, info complianceInfo) error {
+	if !info.IsBusiness {
+		return nil
+	}
+
+	if err := output.Writef(w, "%s\n", style.Bold("Business:")); err != nil {
+		return err
+	}
+	for _, row := range []struct {
+		label string
+		value string
+	}{
+		{"Name", info.BusinessName},
+		{"Type", info.BusinessType},
+		{"Phone", info.BusinessPhone},
+		{"VAT ID", info.BusinessVATIDNumber},
+		{"Address", formatOptionalComplianceAddress(info.BusinessAddress)},
+	} {
+		if row.value == "" {
+			continue
+		}
+		if err := output.Writef(w, "  %s: %s\n", row.label, row.value); err != nil {
+			return err
+		}
+	}
+	return output.Writeln(w, "")
+}
+
+func writeTaxIDsSection(w io.Writer, style output.Styler, taxIDs complianceTaxIDs) error {
+	if err := output.Writef(w, "%s\n", style.Bold("Tax IDs:")); err != nil {
+		return err
+	}
+	if err := output.Writef(w, "  individual_last_four: %s\n", submittedOrNone(maskTaxID(taxIDs.IndividualLastFour))); err != nil {
+		return err
+	}
+	if err := output.Writef(w, "  business_last_four: %s\n", submittedOrNone(maskTaxID(taxIDs.BusinessLastFour))); err != nil {
+		return err
+	}
+	return output.Writeln(w, "")
+}
+
+func writeIdentityDocumentsSection(w io.Writer, style output.Styler, docs complianceIdentityDocuments) error {
+	if err := output.Writef(w, "%s\n", style.Bold("Identity docs:")); err != nil {
+		return err
+	}
+	for _, row := range []struct {
+		label string
+		value string
+	}{
+		{"stripe_identity_document_id", docs.StripeIdentityDocumentID},
+		{"stripe_company_document_id", docs.StripeCompanyDocumentID},
+		{"stripe_additional_document_id", docs.StripeAdditionalDocumentID},
+	} {
+		if err := output.Writef(w, "  %s: %s\n", row.label, submittedOrNone(row.value)); err != nil {
+			return err
+		}
+	}
+	return output.Writeln(w, "")
+}
+
+func writeInfoRequestsSection(w io.Writer, style output.Styler, requests []complianceInfoRequest) error {
+	if len(requests) == 0 {
+		return output.Writef(w, "%s none\n", style.Bold("Info requests:"))
+	}
+
+	if err := output.Writef(w, "%s\n", style.Bold("Info requests:")); err != nil {
+		return err
+	}
+	tbl := output.NewStyledTable(style, "ID", "FIELD", "STATE", "DUE", "STATUS", "CREATED", "LAST EMAIL")
+	for _, request := range requests {
+		tbl.AddRow(
+			request.ID,
+			request.FieldNeeded,
+			request.State,
+			request.DueAt,
+			infoRequestStatus(style, request),
+			request.CreatedAt,
+			request.LastEmailSentAt,
+		)
+	}
+	return tbl.Render(w)
+}
+
+func complianceEntityType(info complianceInfo) string {
+	if info.IsBusiness {
+		return "business"
+	}
+	return "individual"
+}
+
+func formatOptionalComplianceAddress(address *complianceAddress) string {
+	if address == nil {
+		return ""
+	}
+	return formatComplianceAddress(*address)
+}
+
+func formatComplianceAddress(address complianceAddress) string {
+	parts := []string{
+		address.StreetAddress,
+		address.City,
+		formatState(address.State, address.StateCode),
+		address.ZipCode,
+		formatCountry(address.Country, address.CountryCode),
+	}
+
+	return joinNonEmpty(parts, ", ")
+}
+
+func formatState(state, code string) string {
+	return formatNameWithCode(state, code)
+}
+
+func formatCountry(country, code string) string {
+	return formatNameWithCode(country, code)
+}
+
+func formatNameWithCode(name, code string) string {
+	switch {
+	case name != "" && code != "" && name != code:
+		return fmt.Sprintf("%s (%s)", name, code)
+	case name != "":
+		return name
+	default:
+		return code
+	}
+}
+
+func joinNonEmpty(values []string, sep string) string {
+	parts := make([]string, 0, len(values))
+	for _, value := range values {
+		if value != "" {
+			parts = append(parts, value)
+		}
+	}
+	return strings.Join(parts, sep)
+}
+
+func maskTaxID(lastFour string) string {
+	if lastFour == "" {
+		return ""
+	}
+	return "••••" + lastFour
+}
+
+func submittedOrNone(value string) string {
+	if value == "" {
+		return "(not submitted)"
+	}
+	return value
+}
+
+func infoRequestStatus(style output.Styler, request complianceInfoRequest) string {
+	if request.Overdue {
+		return style.Red("OVERDUE")
+	}
+	return "open"
+}

--- a/internal/cmd/admin/users/compliance_test.go
+++ b/internal/cmd/admin/users/compliance_test.go
@@ -1,0 +1,289 @@
+package users
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestComplianceUsesInternalAdminEndpointAndRendersHumanOutput(t *testing.T) {
+	var gotMethod, gotPath, gotEmail, gotAuth string
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotEmail = r.URL.Query().Get("email")
+		gotAuth = r.Header.Get("Authorization")
+		testutil.JSON(t, w, individualCompliancePayload())
+	})
+
+	cmd := testutil.Command(newComplianceCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--email", "seller@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != "GET" || gotPath != "/internal/admin/users/compliance_info" {
+		t.Fatalf("got %s %s, want GET /internal/admin/users/compliance_info", gotMethod, gotPath)
+	}
+	if gotEmail != "seller@example.com" {
+		t.Fatalf("got email %q, want seller@example.com", gotEmail)
+	}
+	if gotAuth != "Bearer admin-token" {
+		t.Fatalf("got auth %q, want Bearer admin-token", gotAuth)
+	}
+
+	for _, want := range []string{
+		"Compliance info for seller@example.com",
+		"User ID: user_123",
+		"Type: individual",
+		"Legal name: Alice Investigator",
+		"First name: Alice",
+		"Last name: Investigator",
+		"DBA: Alice & Co",
+		"Birthday: 1985-06-07",
+		"Nationality: US",
+		"Phone: 5551234567",
+		"Job title: Owner",
+		"Individual address: address_full_match, San Francisco, California (CA), 94107, United States (US)",
+		"Tax IDs:",
+		"individual_last_four: ••••6789",
+		"business_last_four: (not submitted)",
+		"Identity docs:",
+		"stripe_identity_document_id: idoc_individual",
+		"stripe_company_document_id: (not submitted)",
+		"Info requests:",
+		"req_overdue",
+		"individual_tax_id",
+		"OVERDUE",
+		"LAST EMAIL",
+		"2026-05-02T00:00:00Z",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestComplianceRendersBusinessFields(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, businessCompliancePayload())
+	})
+
+	cmd := testutil.Command(newComplianceCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--user-id", "user_123"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	for _, want := range []string{
+		"Compliance info for user_123",
+		"Type: business",
+		"Legal name: Acme LLC",
+		"Business:",
+		"Name: Acme LLC",
+		"Type: llc",
+		"Phone: 5550009999",
+		"VAT ID: GB123456789",
+		"Address: address_full_match, Burbank, California (CA), 91506, United States (US)",
+		"individual_last_four: ••••0000",
+		"business_last_four: ••••6789",
+		"stripe_company_document_id: idoc_company",
+		"stripe_additional_document_id: idoc_additional",
+		"Info requests: none",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestCompliancePassesUserIDAndEmail(t *testing.T) {
+	var gotEmail, gotUserID string
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotEmail = r.URL.Query().Get("email")
+		gotUserID = r.URL.Query().Get("user_id")
+		testutil.JSON(t, w, map[string]any{
+			"success":         true,
+			"user_id":         "user_123",
+			"compliance_info": nil,
+			"info_requests":   []any{},
+		})
+	})
+
+	cmd := testutil.Command(newComplianceCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--email", "seller@example.com", "--user-id", "user_123"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotEmail != "seller@example.com" || gotUserID != "user_123" {
+		t.Fatalf("got email=%q user_id=%q, want both forwarded", gotEmail, gotUserID)
+	}
+	if !strings.Contains(out, "No compliance info submitted for user_123") {
+		t.Fatalf("unexpected no-info output: %q", out)
+	}
+}
+
+func TestComplianceRequiresEmailOrUserID(t *testing.T) {
+	cmd := newComplianceCmd()
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "supply --email or --user-id") {
+		t.Fatalf("expected missing identifier error, got %v", err)
+	}
+}
+
+func TestComplianceJSONPreservesResponse(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, individualCompliancePayload())
+	})
+
+	cmd := testutil.Command(newComplianceCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--email", "seller@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp struct {
+		Success        bool             `json:"success"`
+		UserID         string           `json:"user_id"`
+		ComplianceInfo map[string]any   `json:"compliance_info"`
+		InfoRequests   []map[string]any `json:"info_requests"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if !resp.Success || resp.UserID != "user_123" {
+		t.Fatalf("unexpected JSON envelope: %s", out)
+	}
+	if resp.ComplianceInfo["legal_name"] != "Alice Investigator" {
+		t.Fatalf("unexpected compliance_info JSON: %s", out)
+	}
+	if len(resp.InfoRequests) != 1 || resp.InfoRequests[0]["overdue"] != true {
+		t.Fatalf("unexpected info_requests JSON: %s", out)
+	}
+}
+
+func TestCompliancePlainOutput(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, businessCompliancePayload())
+	})
+
+	cmd := testutil.Command(newComplianceCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{"--email", "seller@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	want := "seller@example.com\tuser_123\tbusiness\tAcme LLC\tAcme LLC\t1985-06-07\tUS\t••••0000\t••••6789\t0"
+	if strings.TrimSpace(out) != want {
+		t.Fatalf("unexpected plain output:\ngot  %q\nwant %q", strings.TrimSpace(out), want)
+	}
+}
+
+func TestComplianceHighlightsOverdueRequestsWithColor(t *testing.T) {
+	testutil.SetColorEnabled(t, true)
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, individualCompliancePayload())
+	})
+
+	cmd := testutil.Command(newComplianceCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--email", "seller@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "\x1b[31mOVERDUE\x1b[0m") {
+		t.Fatalf("expected red overdue marker, got %q", out)
+	}
+}
+
+func individualCompliancePayload() map[string]any {
+	return map[string]any{
+		"success": true,
+		"user_id": "user_123",
+		"compliance_info": map[string]any{
+			"id":                     "uci_123",
+			"is_business":            false,
+			"legal_name":             "Alice Investigator",
+			"first_name":             "Alice",
+			"last_name":              "Investigator",
+			"dba":                    "Alice & Co",
+			"birthday":               "1985-06-07",
+			"nationality":            "US",
+			"phone":                  "5551234567",
+			"job_title":              "Owner",
+			"address":                complianceAddressFixture("San Francisco", "94107"),
+			"business_name":          nil,
+			"business_type":          nil,
+			"business_phone":         nil,
+			"business_vat_id_number": nil,
+			"business_address":       nil,
+			"tax_ids": map[string]any{
+				"individual_last_four": "6789",
+				"business_last_four":   nil,
+			},
+			"identity_documents": map[string]any{
+				"stripe_identity_document_id":   "idoc_individual",
+				"stripe_company_document_id":    nil,
+				"stripe_additional_document_id": nil,
+			},
+			"created_at": "2026-05-01T12:00:00Z",
+			"updated_at": "2026-05-02T12:00:00Z",
+		},
+		"info_requests": []map[string]any{
+			{
+				"id":                 "req_overdue",
+				"field_needed":       "individual_tax_id",
+				"state":              "requested",
+				"due_at":             "2026-05-01T00:00:00Z",
+				"overdue":            true,
+				"created_at":         "2026-04-25T00:00:00Z",
+				"last_email_sent_at": "2026-05-02T00:00:00Z",
+			},
+		},
+	}
+}
+
+func businessCompliancePayload() map[string]any {
+	return map[string]any{
+		"success": true,
+		"user_id": "user_123",
+		"compliance_info": map[string]any{
+			"id":                     "uci_456",
+			"is_business":            true,
+			"legal_name":             "Acme LLC",
+			"first_name":             "Alice",
+			"last_name":              "Investigator",
+			"dba":                    "Acme",
+			"birthday":               "1985-06-07",
+			"nationality":            "US",
+			"phone":                  "5551234567",
+			"job_title":              "Owner",
+			"address":                complianceAddressFixture("San Francisco", "94107"),
+			"business_name":          "Acme LLC",
+			"business_type":          "llc",
+			"business_phone":         "5550009999",
+			"business_vat_id_number": "GB123456789",
+			"business_address":       complianceAddressFixture("Burbank", "91506"),
+			"tax_ids": map[string]any{
+				"individual_last_four": "0000",
+				"business_last_four":   "6789",
+			},
+			"identity_documents": map[string]any{
+				"stripe_identity_document_id":   nil,
+				"stripe_company_document_id":    "idoc_company",
+				"stripe_additional_document_id": "idoc_additional",
+			},
+			"created_at": "2026-05-01T12:00:00Z",
+			"updated_at": "2026-05-02T12:00:00Z",
+		},
+		"info_requests": []any{},
+	}
+}
+
+func complianceAddressFixture(city, zipCode string) map[string]any {
+	return map[string]any{
+		"street_address": "address_full_match",
+		"city":           city,
+		"state":          "California",
+		"state_code":     "CA",
+		"zip_code":       zipCode,
+		"country":        "United States",
+		"country_code":   "US",
+	}
+}

--- a/internal/cmd/admin/users/users.go
+++ b/internal/cmd/admin/users/users.go
@@ -17,6 +17,7 @@ func NewUsersCmd() *cobra.Command {
 		Example: `  gumroad admin users info --email user@example.com
   gumroad admin users info --user-id 2245593582708
   gumroad admin users affiliates --user-id 2245593582708 --direction granted
+  gumroad admin users compliance --user-id 2245593582708
   gumroad admin users suspension --email user@example.com
   gumroad admin users mark-compliant --user-id 2245593582708 --expected-email user@example.com
   gumroad admin users watch --user-id 2245593582708 --revenue-threshold 200 --note "Review next buyers"
@@ -31,6 +32,7 @@ func NewUsersCmd() *cobra.Command {
 
 	cmd.AddCommand(newInfoCmd())
 	cmd.AddCommand(newAffiliatesCmd())
+	cmd.AddCommand(newComplianceCmd())
 	cmd.AddCommand(newSuspensionCmd())
 	cmd.AddCommand(newMarkCompliantCmd())
 	cmd.AddCommand(newWatchCmd())

--- a/internal/cmd/admin/users/users_test.go
+++ b/internal/cmd/admin/users/users_test.go
@@ -179,6 +179,7 @@ func TestNewUsersCmdWiresSubcommands(t *testing.T) {
 	want := []string{
 		"info",
 		"affiliates",
+		"compliance",
 		"suspension",
 		"mark-compliant",
 		"watch",


### PR DESCRIPTION
Ref antiwork/gumroad/issues/4989

## What

- Adds `gumroad admin users compliance` so support can read a user's submitted KYC data and open compliance requests in one place.
- Renders the key personal and business compliance fields, masks tax IDs to the last four digits, and highlights overdue info requests.
- Keeps the raw JSON response available for machine use while adding a concise human view for day-to-day investigation.

## Why

- This gives the CLI a direct path to the new compliance endpoint instead of forcing investigators to stitch together several admin calls.
- The output is shaped for quick review during support and fraud triage, with the sensitive parts masked and the most actionable requests shown first.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh.