### PR TITLE
Add admin users purchases command

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Admin commands use a separate internal token. Run `gumroad auth login` and check
 ```sh
 gumroad admin users info --email seller@example.com --json
 gumroad admin users affiliates --user-id 2245593582708 --direction granted --limit 50
+gumroad admin users purchases --user-id 2245593582708 --status successful --limit 50
 gumroad admin users watch --user-id 2245593582708 --expected-email seller@example.com --revenue-threshold 200 --note "Review next buyers"
 gumroad admin users update-watch --user-id 2245593582708 --expected-email seller@example.com --revenue-threshold 500
 gumroad admin users unwatch --user-id 2245593582708 --expected-email seller@example.com

--- a/internal/cmd/admin/admin.go
+++ b/internal/cmd/admin/admin.go
@@ -20,6 +20,7 @@ func NewAdminCmd() *cobra.Command {
   gumroad admin licenses lookup --key <license-key>
   gumroad admin users info --email <email>
   gumroad admin users affiliates --user-id <user-id> --direction granted
+  gumroad admin users purchases --user-id <user-id> --status successful
   gumroad admin users suspension --email <email>
   gumroad admin users watch --user-id <user-id> --expected-email <email> --revenue-threshold 200
   gumroad admin payouts list --email <email>

--- a/internal/cmd/admin/purchases/view.go
+++ b/internal/cmd/admin/purchases/view.go
@@ -3,6 +3,7 @@ package purchases
 import (
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/antiwork/gumroad-cli/internal/admincmd"
 	"github.com/antiwork/gumroad-cli/internal/api"
@@ -15,21 +16,43 @@ type purchaseResponse struct {
 	Purchase purchase `json:"purchase"`
 }
 
+type Purchase = purchase
+
 type purchase struct {
-	ID                              string      `json:"id"`
-	Email                           string      `json:"email"`
-	SellerEmail                     string      `json:"seller_email"`
-	ProductName                     string      `json:"product_name"`
-	ProductAlias                    string      `json:"link_name"`
-	ProductID                       string      `json:"product_id"`
-	FormattedTotalPrice             string      `json:"formatted_total_price"`
-	PriceCents                      api.JSONInt `json:"price_cents"`
-	CurrencyType                    string      `json:"currency_type"`
-	AmountRefundableCentsInCurrency api.JSONInt `json:"amount_refundable_cents_in_currency"`
-	PurchaseState                   string      `json:"purchase_state"`
-	RefundStatus                    string      `json:"refund_status"`
-	CreatedAt                       string      `json:"created_at"`
-	ReceiptURL                      string      `json:"receipt_url"`
+	ID                              string        `json:"id"`
+	Email                           string        `json:"email"`
+	SellerEmail                     string        `json:"seller_email"`
+	Seller                          seller        `json:"seller"`
+	ProductName                     string        `json:"product_name"`
+	ProductAlias                    string        `json:"link_name"`
+	ProductID                       string        `json:"product_id"`
+	FormattedTotalPrice             string        `json:"formatted_total_price"`
+	PriceCents                      api.JSONInt   `json:"price_cents"`
+	CurrencyType                    string        `json:"currency_type"`
+	AmountRefundableCentsInCurrency api.JSONInt   `json:"amount_refundable_cents_in_currency"`
+	PurchaseState                   string        `json:"purchase_state"`
+	RefundStatus                    string        `json:"refund_status"`
+	CreatedAt                       string        `json:"created_at"`
+	ReceiptURL                      string        `json:"receipt_url"`
+	ChargebackDate                  string        `json:"chargeback_date"`
+	CountryMismatches               mismatches    `json:"country_mismatches"`
+	EarlyFraudWarning               *fraudWarning `json:"early_fraud_warning"`
+}
+
+type seller struct {
+	ID    string `json:"id"`
+	Email string `json:"email"`
+	Name  string `json:"name"`
+}
+
+type mismatches struct {
+	BillingVsIP   bool `json:"billing_vs_ip"`
+	BillingVsCard bool `json:"billing_vs_card"`
+	IPVsCard      bool `json:"ip_vs_card"`
+}
+
+type fraudWarning struct {
+	ID string `json:"id"`
 }
 
 func newViewCmd() *cobra.Command {
@@ -57,6 +80,10 @@ func productLabel(p purchase) string {
 	return p.ProductID
 }
 
+func ProductLabel(p Purchase) string {
+	return productLabel(p)
+}
+
 func amountLabel(p purchase) string {
 	if p.FormattedTotalPrice != "" {
 		return p.FormattedTotalPrice
@@ -65,6 +92,10 @@ func amountLabel(p purchase) string {
 		return fmt.Sprintf("%d cents", p.PriceCents)
 	}
 	return ""
+}
+
+func AmountLabel(p Purchase) string {
+	return amountLabel(p)
 }
 
 func statusLabel(p purchase) string {
@@ -76,6 +107,37 @@ func statusLabel(p purchase) string {
 		status += p.RefundStatus
 	}
 	return status
+}
+
+func StatusLabel(p Purchase) string {
+	return statusLabel(p)
+}
+
+func SellerLabel(p Purchase) string {
+	switch {
+	case p.Seller.Email != "":
+		return p.Seller.Email
+	case p.SellerEmail != "":
+		return p.SellerEmail
+	case p.Seller.Name != "":
+		return p.Seller.Name
+	default:
+		return p.Seller.ID
+	}
+}
+
+func RiskFlagsLabel(p Purchase) string {
+	flags := make([]string, 0, 3)
+	if p.ChargebackDate != "" {
+		flags = append(flags, "CB")
+	}
+	if p.EarlyFraudWarning != nil {
+		flags = append(flags, "EFW")
+	}
+	if p.CountryMismatches.BillingVsIP || p.CountryMismatches.BillingVsCard || p.CountryMismatches.IPVsCard {
+		flags = append(flags, "CM")
+	}
+	return strings.Join(flags, ",")
 }
 
 func renderPurchase(opts cmdutil.Options, p purchase) error {

--- a/internal/cmd/admin/users/purchases.go
+++ b/internal/cmd/admin/users/purchases.go
@@ -1,0 +1,192 @@
+package users
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/antiwork/gumroad-cli/internal/admincmd"
+	adminpurchases "github.com/antiwork/gumroad-cli/internal/cmd/admin/purchases"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil/cursor"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+type userPurchasesResponse struct {
+	UserID     string                    `json:"user_id"`
+	Purchases  []adminpurchases.Purchase `json:"purchases"`
+	Pagination cursor.Pagination         `json:"pagination"`
+}
+
+func newPurchasesCmd() *cobra.Command {
+	var (
+		lookup               userLookupFlags
+		page                 cursor.Flags
+		statuses             []string
+		startAt              string
+		endAt                string
+		stripeFingerprint    string
+		ipAddress            string
+		chargedback          bool
+		hasEarlyFraudWarning bool
+		hasAffiliate         bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "purchases",
+		Short: "List purchases for a user",
+		Long: `List a user's purchase history across sellers.
+
+Status filters are sent as purchase_state values. Use --chargedback,
+--has-early-fraud-warning, and --has-affiliate for the boolean risk filters.`,
+		Example: `  gumroad admin users purchases --user-id 2245593582708
+  gumroad admin users purchases --email buyer@example.com --status successful --status failed
+  gumroad admin users purchases --user-id 2245593582708 --start-at 2026-01-01T00:00:00Z
+  gumroad admin users purchases --user-id 2245593582708 --chargedback=false --limit 50`,
+		Args: cmdutil.ExactArgs(0),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			target, err := resolveUserLookupTarget(c, lookup)
+			if err != nil {
+				return err
+			}
+			if err := cmdutil.RequirePositiveIntFlag(c, "limit", page.Limit); err != nil {
+				return err
+			}
+
+			params := target.values()
+			if err := applyUserPurchaseFilters(c, params, statuses, startAt, endAt, stripeFingerprint, ipAddress, chargedback, hasEarlyFraudWarning, hasAffiliate); err != nil {
+				return err
+			}
+			cursor.Apply(params, page)
+
+			return admincmd.RunGetDecoded[userPurchasesResponse](opts, "Fetching user purchases...", "/users/purchases", params, func(resp userPurchasesResponse) error {
+				return renderUserPurchases(opts, target.identifier(), resp)
+			})
+		},
+	}
+
+	addUserLookupFlags(cmd, &lookup)
+	cmd.Flags().StringArrayVar(&statuses, "status", nil, "Purchase state filter (repeatable)")
+	cmd.Flags().StringVar(&startAt, "start-at", "", "Only include purchases created at or after this ISO 8601 timestamp")
+	cmd.Flags().StringVar(&endAt, "end-at", "", "Only include purchases created at or before this ISO 8601 timestamp")
+	cmd.Flags().StringVar(&stripeFingerprint, "stripe-fingerprint", "", "Filter by Stripe card fingerprint")
+	cmd.Flags().StringVar(&ipAddress, "ip-address", "", "Filter by purchase IP address")
+	cmd.Flags().BoolVar(&chargedback, "chargedback", false, "Filter by whether the purchase has a chargeback")
+	cmd.Flags().BoolVar(&hasEarlyFraudWarning, "has-early-fraud-warning", false, "Filter by whether the purchase has an early fraud warning")
+	cmd.Flags().BoolVar(&hasAffiliate, "has-affiliate", false, "Filter by whether the purchase has affiliate credit")
+	cursor.AddFlags(cmd, &page)
+
+	return cmd
+}
+
+func applyUserPurchaseFilters(cmd *cobra.Command, params url.Values, statuses []string, startAt, endAt, stripeFingerprint, ipAddress string, chargedback, hasEarlyFraudWarning, hasAffiliate bool) error {
+	normalizedStatuses, err := normalizePurchaseStatuses(cmd, statuses)
+	if err != nil {
+		return err
+	}
+	if len(normalizedStatuses) > 0 {
+		params.Set("status", strings.Join(normalizedStatuses, ","))
+	}
+	if startAt != "" {
+		params.Set("start_at", startAt)
+	}
+	if endAt != "" {
+		params.Set("end_at", endAt)
+	}
+	if stripeFingerprint != "" {
+		params.Set("stripe_fingerprint", stripeFingerprint)
+	}
+	if ipAddress != "" {
+		params.Set("ip_address", ipAddress)
+	}
+	if cmd.Flags().Changed("chargedback") {
+		params.Set("chargedback", strconv.FormatBool(chargedback))
+	}
+	if cmd.Flags().Changed("has-early-fraud-warning") {
+		params.Set("has_early_fraud_warning", strconv.FormatBool(hasEarlyFraudWarning))
+	}
+	if cmd.Flags().Changed("has-affiliate") {
+		params.Set("has_affiliate", strconv.FormatBool(hasAffiliate))
+	}
+	return nil
+}
+
+func normalizePurchaseStatuses(cmd *cobra.Command, statuses []string) ([]string, error) {
+	normalized := make([]string, 0, len(statuses))
+	for _, status := range statuses {
+		value := strings.TrimSpace(status)
+		if value == "" {
+			return nil, cmdutil.UsageErrorf(cmd, "--status cannot be empty")
+		}
+		normalized = append(normalized, value)
+	}
+	return normalized, nil
+}
+
+func renderUserPurchases(opts cmdutil.Options, identifier string, resp userPurchasesResponse) error {
+	if opts.PlainOutput {
+		return writeUserPurchasesPlain(opts.Out(), resp.Purchases)
+	}
+
+	if opts.Quiet {
+		return nil
+	}
+
+	style := opts.Style()
+	return output.WithPager(opts.Out(), opts.Err(), func(w io.Writer) error {
+		if len(resp.Purchases) == 0 {
+			if err := output.Writef(w, "No purchases found for %s.\n", identifier); err != nil {
+				return err
+			}
+			return cursor.WriteMoreFooter(w, resp.Pagination)
+		}
+
+		if err := output.Writeln(w, style.Bold(fmt.Sprintf("%d purchase(s) for %s", len(resp.Purchases), identifier))); err != nil {
+			return err
+		}
+		if resp.UserID != "" && resp.UserID != identifier {
+			if err := output.Writef(w, "User ID: %s\n", resp.UserID); err != nil {
+				return err
+			}
+		}
+		if err := output.Writeln(w, ""); err != nil {
+			return err
+		}
+		if err := writeUserPurchasesTable(w, style, resp.Purchases); err != nil {
+			return err
+		}
+		return cursor.WriteMoreFooter(w, resp.Pagination)
+	})
+}
+
+func writeUserPurchasesPlain(w io.Writer, purchases []adminpurchases.Purchase) error {
+	rows := make([][]string, 0, len(purchases))
+	for _, p := range purchases {
+		rows = append(rows, purchaseRow(p))
+	}
+	return output.PrintPlain(w, rows)
+}
+
+func writeUserPurchasesTable(w io.Writer, style output.Styler, purchases []adminpurchases.Purchase) error {
+	tbl := output.NewStyledTable(style, "ID", "SELLER", "PRODUCT", "AMOUNT", "STATE", "FLAGS", "CREATED")
+	for _, p := range purchases {
+		tbl.AddRow(purchaseRow(p)...)
+	}
+	return tbl.Render(w)
+}
+
+func purchaseRow(p adminpurchases.Purchase) []string {
+	return []string{
+		p.ID,
+		adminpurchases.SellerLabel(p),
+		adminpurchases.ProductLabel(p),
+		adminpurchases.AmountLabel(p),
+		adminpurchases.StatusLabel(p),
+		adminpurchases.RiskFlagsLabel(p),
+		p.CreatedAt,
+	}
+}

--- a/internal/cmd/admin/users/purchases_test.go
+++ b/internal/cmd/admin/users/purchases_test.go
@@ -1,0 +1,281 @@
+package users
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestUserPurchasesUsesInternalAdminEndpoint(t *testing.T) {
+	var gotMethod, gotPath, gotAuth string
+	var gotQuery url.Values
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotQuery = r.URL.Query()
+		testutil.JSON(t, w, map[string]any{
+			"success": true,
+			"user_id": "user_123",
+			"purchases": []map[string]any{
+				userPurchaseFixture(),
+			},
+			"pagination": map[string]any{"next": "cur-next", "limit": 50},
+		})
+	})
+
+	cmd := testutil.Command(newPurchasesCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{
+		"--email", "buyer@example.com",
+		"--status", "successful",
+		"--status", "failed",
+		"--start-at", "2026-01-01T00:00:00Z",
+		"--end-at", "2026-05-01T00:00:00Z",
+		"--stripe-fingerprint", "fp_shared",
+		"--ip-address", "203.0.113.7",
+		"--chargedback",
+		"--has-early-fraud-warning=false",
+		"--has-affiliate",
+		"--limit", "50",
+		"--cursor", "cur-1",
+	})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != "GET" || gotPath != "/internal/admin/users/purchases" {
+		t.Fatalf("got %s %s, want GET /internal/admin/users/purchases", gotMethod, gotPath)
+	}
+	if gotAuth != "Bearer admin-token" {
+		t.Fatalf("got auth %q, want Bearer admin-token", gotAuth)
+	}
+	for key, want := range map[string]string{
+		"email":                   "buyer@example.com",
+		"status":                  "successful,failed",
+		"start_at":                "2026-01-01T00:00:00Z",
+		"end_at":                  "2026-05-01T00:00:00Z",
+		"stripe_fingerprint":      "fp_shared",
+		"ip_address":              "203.0.113.7",
+		"chargedback":             "true",
+		"has_early_fraud_warning": "false",
+		"has_affiliate":           "true",
+		"limit":                   "50",
+		"cursor":                  "cur-1",
+	} {
+		if got := gotQuery.Get(key); got != want {
+			t.Fatalf("query %s = %q, want %q; full query %s", key, got, want, gotQuery.Encode())
+		}
+	}
+	for _, want := range []string{
+		"1 purchase(s) for buyer@example.com",
+		"User ID: user_123",
+		"seller@example.com",
+		"Investigation guide",
+		"$12.34",
+		"successful, refunded",
+		"CB,EFW,CM",
+		"2026-05-01T12:00:00Z",
+		"More results: --cursor cur-next",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestUserPurchasesPassesUserIDAndFalseBooleanFilters(t *testing.T) {
+	var gotQuery url.Values
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		testutil.JSON(t, w, map[string]any{
+			"user_id":    "user_123",
+			"purchases":  []any{},
+			"pagination": map[string]any{"next": nil, "limit": 20},
+		})
+	})
+
+	cmd := testutil.Command(newPurchasesCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--user-id", "user_123", "--chargedback=false", "--has-early-fraud-warning=false", "--has-affiliate=false"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	for key, want := range map[string]string{
+		"user_id":                 "user_123",
+		"chargedback":             "false",
+		"has_early_fraud_warning": "false",
+		"has_affiliate":           "false",
+	} {
+		if got := gotQuery.Get(key); got != want {
+			t.Fatalf("query %s = %q, want %q; full query %s", key, got, want, gotQuery.Encode())
+		}
+	}
+}
+
+func TestUserPurchasesOmitsUnsetBooleanFilters(t *testing.T) {
+	var gotQuery url.Values
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		testutil.JSON(t, w, map[string]any{
+			"user_id":    "user_123",
+			"purchases":  []any{},
+			"pagination": map[string]any{"next": nil, "limit": 20},
+		})
+	})
+
+	cmd := testutil.Command(newPurchasesCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--user-id", "user_123"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	for _, key := range []string{"chargedback", "has_early_fraud_warning", "has_affiliate"} {
+		if gotQuery.Has(key) {
+			t.Fatalf("query unexpectedly included %s: %s", key, gotQuery.Encode())
+		}
+	}
+}
+
+func TestUserPurchasesEmptyResultShowsFooter(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"user_id":    "user_123",
+			"purchases":  []any{},
+			"pagination": map[string]any{"next": "cur-next", "limit": 20},
+		})
+	})
+
+	cmd := testutil.Command(newPurchasesCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--user-id", "user_123"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	for _, want := range []string{
+		"No purchases found for user_123.",
+		"More results: --cursor cur-next",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestUserPurchasesJSONPreservesResponse(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"success":   true,
+			"user_id":   "user_123",
+			"purchases": []map[string]any{userPurchaseFixture()},
+			"pagination": map[string]any{
+				"next":  "cur-next",
+				"limit": 20,
+			},
+		})
+	})
+
+	cmd := testutil.Command(newPurchasesCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--user-id", "user_123"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp struct {
+		Success    bool             `json:"success"`
+		UserID     string           `json:"user_id"`
+		Purchases  []map[string]any `json:"purchases"`
+		Pagination map[string]any   `json:"pagination"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if !resp.Success || resp.UserID != "user_123" {
+		t.Fatalf("unexpected JSON envelope: %s", out)
+	}
+	if len(resp.Purchases) != 1 || resp.Purchases[0]["id"] != "purchase_123" {
+		t.Fatalf("unexpected purchases JSON: %s", out)
+	}
+	if resp.Pagination["next"] != "cur-next" {
+		t.Fatalf("unexpected pagination JSON: %s", out)
+	}
+}
+
+func TestUserPurchasesPlainOutput(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"purchases": []map[string]any{
+				userPurchaseFixture(),
+				{
+					"id":                  "purchase_456",
+					"email":               "buyer@example.com",
+					"seller_email":        "legacy-seller@example.com",
+					"product_name":        "Second product",
+					"price_cents":         900,
+					"currency_type":       "usd",
+					"purchase_state":      "failed",
+					"created_at":          "2026-04-30T12:00:00Z",
+					"country_mismatches":  map[string]any{"billing_vs_ip": false, "billing_vs_card": false, "ip_vs_card": false},
+					"early_fraud_warning": nil,
+				},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newPurchasesCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{"--email", "buyer@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	want := strings.Join([]string{
+		"purchase_123\tseller@example.com\tInvestigation guide\t$12.34\tsuccessful, refunded\tCB,EFW,CM\t2026-05-01T12:00:00Z",
+		"purchase_456\tlegacy-seller@example.com\tSecond product\t900 cents\tfailed\t\t2026-04-30T12:00:00Z",
+	}, "\n")
+	if strings.TrimSpace(out) != want {
+		t.Fatalf("unexpected plain output:\ngot  %q\nwant %q", strings.TrimSpace(out), want)
+	}
+}
+
+func TestUserPurchasesRequiresEmailOrUserID(t *testing.T) {
+	cmd := newPurchasesCmd()
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "supply --email or --user-id") {
+		t.Fatalf("expected missing identifier error, got %v", err)
+	}
+}
+
+func TestUserPurchasesRejectsInvalidLimit(t *testing.T) {
+	cmd := newPurchasesCmd()
+	cmd.SetArgs([]string{"--user-id", "user_123", "--limit", "0"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--limit must be greater than 0") {
+		t.Fatalf("expected limit validation error, got %v", err)
+	}
+}
+
+func TestUserPurchasesRejectsEmptyStatus(t *testing.T) {
+	cmd := newPurchasesCmd()
+	cmd.SetArgs([]string{"--user-id", "user_123", "--status", ""})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--status cannot be empty") {
+		t.Fatalf("expected empty status validation error, got %v", err)
+	}
+}
+
+func userPurchaseFixture() map[string]any {
+	return map[string]any{
+		"id":                                  "purchase_123",
+		"email":                               "buyer@example.com",
+		"seller_email":                        "legacy-seller@example.com",
+		"seller":                              map[string]any{"id": "seller_123", "email": "seller@example.com", "name": "Seller User"},
+		"product_name":                        "Investigation guide",
+		"link_name":                           "investigation-guide",
+		"product_id":                          "prod_123",
+		"formatted_total_price":               "$12.34",
+		"price_cents":                         1234,
+		"currency_type":                       "usd",
+		"purchase_state":                      "successful",
+		"refund_status":                       "refunded",
+		"chargeback_date":                     "2026-05-02T12:00:00Z",
+		"created_at":                          "2026-05-01T12:00:00Z",
+		"country_mismatches":                  map[string]any{"billing_vs_ip": true, "billing_vs_card": false, "ip_vs_card": false},
+		"early_fraud_warning":                 map[string]any{"id": "efw_123"},
+		"amount_refundable_cents_in_currency": 0,
+	}
+}

--- a/internal/cmd/admin/users/users.go
+++ b/internal/cmd/admin/users/users.go
@@ -17,6 +17,7 @@ func NewUsersCmd() *cobra.Command {
 		Example: `  gumroad admin users info --email user@example.com
   gumroad admin users info --user-id 2245593582708
   gumroad admin users affiliates --user-id 2245593582708 --direction granted
+  gumroad admin users purchases --user-id 2245593582708 --status successful
   gumroad admin users suspension --email user@example.com
   gumroad admin users mark-compliant --user-id 2245593582708 --expected-email user@example.com
   gumroad admin users watch --user-id 2245593582708 --revenue-threshold 200 --note "Review next buyers"
@@ -31,6 +32,7 @@ func NewUsersCmd() *cobra.Command {
 
 	cmd.AddCommand(newInfoCmd())
 	cmd.AddCommand(newAffiliatesCmd())
+	cmd.AddCommand(newPurchasesCmd())
 	cmd.AddCommand(newSuspensionCmd())
 	cmd.AddCommand(newMarkCompliantCmd())
 	cmd.AddCommand(newWatchCmd())

--- a/internal/cmd/admin/users/users_test.go
+++ b/internal/cmd/admin/users/users_test.go
@@ -179,6 +179,7 @@ func TestNewUsersCmdWiresSubcommands(t *testing.T) {
 	want := []string{
 		"info",
 		"affiliates",
+		"purchases",
 		"suspension",
 		"mark-compliant",
 		"watch",


### PR DESCRIPTION
Ref antiwork/gumroad/issues/4989

## What

- Adds `gumroad admin users purchases` to list a user's purchase history across sellers.
- Supports the new filters for status, time range, IP, Stripe fingerprint, chargebacks, early fraud warnings, and affiliate credit.
- Reuses the existing purchase display so seller, amount, state, and risk flags stay consistent with other admin purchase views.

## Why

- This gives admins a direct way to review a buyer's purchase history without jumping between separate purchase searches.
- The new filters make it easier to narrow results for fraud and support checks while keeping pagination simple and cursor based.

---

This PR was implemented with AI assistance using gpt-5.5 xhigh.