### PR TITLE
Add admin users related command

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Admin commands use a separate internal token. Run `gumroad auth login` and check
 ```sh
 gumroad admin users info --email seller@example.com --json
 gumroad admin users affiliates --user-id 2245593582708 --direction granted --limit 50
+gumroad admin users related --email seller@example.com --signal ip --signal payment_address
 gumroad admin users watch --user-id 2245593582708 --expected-email seller@example.com --revenue-threshold 200 --note "Review next buyers"
 gumroad admin users update-watch --user-id 2245593582708 --expected-email seller@example.com --revenue-threshold 500
 gumroad admin users unwatch --user-id 2245593582708 --expected-email seller@example.com

--- a/internal/cmd/admin/admin.go
+++ b/internal/cmd/admin/admin.go
@@ -20,6 +20,7 @@ func NewAdminCmd() *cobra.Command {
   gumroad admin licenses lookup --key <license-key>
   gumroad admin users info --email <email>
   gumroad admin users affiliates --user-id <user-id> --direction granted
+  gumroad admin users related --email <email> --signal ip
   gumroad admin users suspension --email <email>
   gumroad admin users watch --user-id <user-id> --expected-email <email> --revenue-threshold 200
   gumroad admin payouts list --email <email>

--- a/internal/cmd/admin/users/related.go
+++ b/internal/cmd/admin/users/related.go
@@ -168,7 +168,7 @@ func writeRelatedPlain(w io.Writer, users []relatedUser) error {
 			user.ID,
 			user.Email,
 			user.Name,
-			relatedRiskLabel(user.RiskState),
+			relatedRiskLabel(user),
 			relatedRelationsLabel(user.Relations),
 		})
 	}
@@ -182,15 +182,22 @@ func writeRelatedTable(w io.Writer, style output.Styler, users []relatedUser) er
 			user.ID,
 			user.Email,
 			user.Name,
-			relatedRiskLabel(user.RiskState),
+			relatedRiskLabel(user),
 			relatedRelationsLabel(user.Relations),
 		)
 	}
 	return tbl.Render(w)
 }
 
-func relatedRiskLabel(risk riskState) string {
-	return fallback(risk.Status, risk.UserRiskState)
+func relatedRiskLabel(user relatedUser) string {
+	label := fallback(user.RiskState.Status, user.RiskState.UserRiskState)
+	if user.DeletedAt == "" {
+		return label
+	}
+	if label == "" {
+		return "deleted " + user.DeletedAt
+	}
+	return label + " (deleted " + user.DeletedAt + ")"
 }
 
 func relatedRelationsLabel(relations []relatedRelation) string {

--- a/internal/cmd/admin/users/related.go
+++ b/internal/cmd/admin/users/related.go
@@ -1,0 +1,252 @@
+package users
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/antiwork/gumroad-cli/internal/admincmd"
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+var relatedSignalOrder = []string{"ip", "payment_address", "card_fingerprint"}
+
+var validRelatedSignals = map[string]bool{
+	"ip":               true,
+	"payment_address":  true,
+	"card_fingerprint": true,
+}
+
+type relatedResponse struct {
+	UserID           string          `json:"user_id"`
+	SignalsEvaluated []string        `json:"signals_evaluated"`
+	PerSignalLimit   api.JSONInt     `json:"per_signal_limit"`
+	RelatedUsers     []relatedUser   `json:"related_users"`
+	Truncated        map[string]bool `json:"truncated"`
+}
+
+type relatedUser struct {
+	ID        string            `json:"id"`
+	Email     string            `json:"email"`
+	Name      string            `json:"name"`
+	DeletedAt string            `json:"deleted_at"`
+	RiskState riskState         `json:"risk_state"`
+	Relations []relatedRelation `json:"relations"`
+}
+
+type relatedRelation struct {
+	Signal      string   `json:"signal"`
+	SharedValue string   `json:"shared_value"`
+	Via         []string `json:"via"`
+}
+
+func newRelatedCmd() *cobra.Command {
+	var (
+		lookup  userLookupFlags
+		signals []string
+		limit   int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "related",
+		Short: "Find users related by shared risk signals",
+		Long: `Find users related by shared IP address, payment address, or card
+fingerprint. By default the server evaluates all available signals; repeat
+--signal to restrict the search to one or more signals.`,
+		Example: `  gumroad admin users related --user-id 2245593582708
+  gumroad admin users related --email user@example.com --signal ip --signal payment_address
+  gumroad admin users related --email user@example.com --limit 25 --json`,
+		Args: cmdutil.ExactArgs(0),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			target, err := resolveUserLookupTarget(c, lookup)
+			if err != nil {
+				return err
+			}
+			normalizedSignals, err := normalizeRelatedSignals(c, signals)
+			if err != nil {
+				return err
+			}
+			if err := cmdutil.RequirePositiveIntFlag(c, "limit", limit); err != nil {
+				return err
+			}
+
+			params := target.values()
+			applyRelatedParams(params, normalizedSignals, limit, c.Flags().Changed("limit"))
+
+			return admincmd.RunGetDecoded[relatedResponse](opts, "Fetching related users...", "/users/related", params, func(resp relatedResponse) error {
+				return renderRelated(opts, target.identifier(), resp)
+			})
+		},
+	}
+
+	addUserLookupFlags(cmd, &lookup)
+	cmd.Flags().StringArrayVar(&signals, "signal", nil, "Related signal to evaluate: ip, payment_address, card_fingerprint (repeatable)")
+	cmd.Flags().IntVar(&limit, "limit", 0, "Maximum related users per signal (default 50, capped server-side at 50)")
+
+	return cmd
+}
+
+func applyRelatedParams(params url.Values, signals []string, limit int, limitChanged bool) {
+	if len(signals) > 0 {
+		params.Set("signals", strings.Join(signals, ","))
+	}
+	if limitChanged {
+		params.Set("limit", strconv.Itoa(limit))
+	}
+}
+
+func normalizeRelatedSignals(cmd *cobra.Command, signals []string) ([]string, error) {
+	out := make([]string, 0, len(signals))
+	for _, signal := range signals {
+		normalized := strings.TrimSpace(signal)
+		if normalized == "" || !validRelatedSignals[normalized] {
+			return nil, cmdutil.UsageErrorf(cmd, "--signal must be one of: %s", strings.Join(relatedSignalOrder, ", "))
+		}
+		out = append(out, normalized)
+	}
+	return out, nil
+}
+
+func renderRelated(opts cmdutil.Options, identifier string, resp relatedResponse) error {
+	if opts.PlainOutput {
+		return writeRelatedPlain(opts.Out(), resp.RelatedUsers)
+	}
+
+	if opts.Quiet {
+		return nil
+	}
+
+	style := opts.Style()
+	return output.WithPager(opts.Out(), opts.Err(), func(w io.Writer) error {
+		headline := fmt.Sprintf("%d related user(s) for %s", len(resp.RelatedUsers), identifier)
+		if err := output.Writeln(w, style.Bold(headline)); err != nil {
+			return err
+		}
+		if resp.UserID != "" && resp.UserID != identifier {
+			if err := output.Writef(w, "User ID: %s\n", resp.UserID); err != nil {
+				return err
+			}
+		}
+		if err := output.Writef(w, "Signals evaluated: %s\n", relatedListLabel(resp.SignalsEvaluated)); err != nil {
+			return err
+		}
+		if err := output.Writef(w, "Per-signal limit: %d\n", resp.PerSignalLimit); err != nil {
+			return err
+		}
+
+		if len(resp.RelatedUsers) == 0 {
+			if err := output.Writeln(w, ""); err != nil {
+				return err
+			}
+			if err := output.Writef(w, "No related users found for %s.\n", identifier); err != nil {
+				return err
+			}
+			return writeRelatedCapWarning(w, style, resp.Truncated)
+		}
+
+		if err := output.Writeln(w, ""); err != nil {
+			return err
+		}
+		if err := writeRelatedTable(w, style, resp.RelatedUsers); err != nil {
+			return err
+		}
+		return writeRelatedCapWarning(w, style, resp.Truncated)
+	})
+}
+
+func writeRelatedPlain(w io.Writer, users []relatedUser) error {
+	rows := make([][]string, 0, len(users))
+	for _, user := range users {
+		rows = append(rows, []string{
+			user.ID,
+			user.Email,
+			user.Name,
+			relatedRiskLabel(user.RiskState),
+			relatedRelationsLabel(user.Relations),
+		})
+	}
+	return output.PrintPlain(w, rows)
+}
+
+func writeRelatedTable(w io.Writer, style output.Styler, users []relatedUser) error {
+	tbl := output.NewStyledTable(style, "ID", "EMAIL", "NAME", "RISK", "RELATIONS")
+	for _, user := range users {
+		tbl.AddRow(
+			user.ID,
+			user.Email,
+			user.Name,
+			relatedRiskLabel(user.RiskState),
+			relatedRelationsLabel(user.Relations),
+		)
+	}
+	return tbl.Render(w)
+}
+
+func relatedRiskLabel(risk riskState) string {
+	return fallback(risk.Status, risk.UserRiskState)
+}
+
+func relatedRelationsLabel(relations []relatedRelation) string {
+	labels := make([]string, 0, len(relations))
+	for _, relation := range relations {
+		labels = append(labels, relatedRelationLabel(relation))
+	}
+	return strings.Join(labels, ", ")
+}
+
+func relatedRelationLabel(relation relatedRelation) string {
+	label := relation.Signal
+	if relation.SharedValue != "" {
+		label += ":" + relation.SharedValue
+	}
+	if len(relation.Via) > 0 {
+		label += " (" + strings.Join(relation.Via, ", ") + ")"
+	}
+	return label
+}
+
+func relatedListLabel(values []string) string {
+	if len(values) == 0 {
+		return "none"
+	}
+	return strings.Join(values, ", ")
+}
+
+func writeRelatedCapWarning(w io.Writer, style output.Styler, truncated map[string]bool) error {
+	signals := truncatedRelatedSignals(truncated)
+	if len(signals) == 0 {
+		return nil
+	}
+	return output.Writef(w, "\n%s results capped for signals: %s.\n", style.Yellow("Warning:"), strings.Join(signals, ", "))
+}
+
+func truncatedRelatedSignals(truncated map[string]bool) []string {
+	if len(truncated) == 0 {
+		return nil
+	}
+
+	signals := make([]string, 0, len(truncated))
+	seen := make(map[string]bool, len(truncated))
+	for _, signal := range relatedSignalOrder {
+		if truncated[signal] {
+			signals = append(signals, signal)
+			seen[signal] = true
+		}
+	}
+
+	extras := make([]string, 0)
+	for signal, capped := range truncated {
+		if capped && !seen[signal] {
+			extras = append(extras, signal)
+		}
+	}
+	sort.Strings(extras)
+	return append(signals, extras...)
+}

--- a/internal/cmd/admin/users/related_test.go
+++ b/internal/cmd/admin/users/related_test.go
@@ -56,7 +56,7 @@ func TestRelatedUsesInternalAdminEndpoint(t *testing.T) {
 		"rel_123",
 		"related@example.com",
 		"Related User",
-		"Suspended for fraud",
+		"Suspended for fraud (deleted 2026-01-15T10:00:00Z)",
 		"ip:1.2.3.4 (account_created_ip, current_sign_in_ip)",
 		"payment_address:shared@example.com",
 	} {
@@ -230,7 +230,7 @@ func TestRelatedPlainOutput(t *testing.T) {
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
 	want := strings.Join([]string{
-		"rel_123\trelated@example.com\tRelated User\tSuspended for fraud\tip:1.2.3.4 (account_created_ip, current_sign_in_ip), payment_address:shared@example.com",
+		"rel_123\trelated@example.com\tRelated User\tSuspended for fraud (deleted 2026-01-15T10:00:00Z)\tip:1.2.3.4 (account_created_ip, current_sign_in_ip), payment_address:shared@example.com",
 		"rel_456\tcard@example.com\t\tcompliant\tcard_fingerprint",
 	}, "\n")
 	if strings.TrimSpace(out) != want {
@@ -247,9 +247,10 @@ func TestRelatedRelationLabelWithoutSharedValueIncludesVia(t *testing.T) {
 
 func relatedUserFixture() map[string]any {
 	return map[string]any{
-		"id":    "rel_123",
-		"email": "related@example.com",
-		"name":  "Related User",
+		"id":         "rel_123",
+		"email":      "related@example.com",
+		"name":       "Related User",
+		"deleted_at": "2026-01-15T10:00:00Z",
 		"risk_state": map[string]any{
 			"status":          "Suspended for fraud",
 			"user_risk_state": "suspended_for_fraud",

--- a/internal/cmd/admin/users/related_test.go
+++ b/internal/cmd/admin/users/related_test.go
@@ -1,0 +1,269 @@
+package users
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestRelatedUsesInternalAdminEndpoint(t *testing.T) {
+	var gotMethod, gotPath, gotEmail, gotSignals, gotLimit, gotAuth string
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotEmail = r.URL.Query().Get("email")
+		gotSignals = r.URL.Query().Get("signals")
+		gotLimit = r.URL.Query().Get("limit")
+		gotAuth = r.Header.Get("Authorization")
+		testutil.JSON(t, w, map[string]any{
+			"user_id":           "target_123",
+			"signals_evaluated": []string{"ip", "payment_address"},
+			"per_signal_limit":  10,
+			"related_users": []map[string]any{
+				relatedUserFixture(),
+			},
+			"truncated": map[string]any{"ip": false, "payment_address": false},
+		})
+	})
+
+	cmd := testutil.Command(newRelatedCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--email", "target@example.com", "--signal", "ip", "--signal", "payment_address", "--limit", "10"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != "GET" || gotPath != "/internal/admin/users/related" {
+		t.Fatalf("got %s %s, want GET /internal/admin/users/related", gotMethod, gotPath)
+	}
+	if gotEmail != "target@example.com" {
+		t.Fatalf("got email %q, want target@example.com", gotEmail)
+	}
+	if gotSignals != "ip,payment_address" {
+		t.Fatalf("got signals %q, want ip,payment_address", gotSignals)
+	}
+	if gotLimit != "10" {
+		t.Fatalf("got limit %q, want 10", gotLimit)
+	}
+	if gotAuth != "Bearer admin-token" {
+		t.Fatalf("got auth %q, want Bearer admin-token", gotAuth)
+	}
+	for _, want := range []string{
+		"1 related user(s) for target@example.com",
+		"User ID: target_123",
+		"Signals evaluated: ip, payment_address",
+		"Per-signal limit: 10",
+		"rel_123",
+		"related@example.com",
+		"Related User",
+		"Suspended for fraud",
+		"ip:1.2.3.4 (account_created_ip, current_sign_in_ip)",
+		"payment_address:shared@example.com",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestRelatedDefaultOmitsSignalsAndLimit(t *testing.T) {
+	var gotSignals, gotLimit, gotUserID string
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotSignals = r.URL.Query().Get("signals")
+		gotLimit = r.URL.Query().Get("limit")
+		gotUserID = r.URL.Query().Get("user_id")
+		testutil.JSON(t, w, map[string]any{
+			"user_id":           "user_123",
+			"signals_evaluated": []string{},
+			"per_signal_limit":  50,
+			"related_users":     []any{},
+			"truncated":         map[string]any{},
+		})
+	})
+
+	cmd := testutil.Command(newRelatedCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--user-id", "user_123"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotUserID != "user_123" {
+		t.Fatalf("got user_id %q, want user_123", gotUserID)
+	}
+	if gotSignals != "" {
+		t.Fatalf("default command must omit signals, got %q", gotSignals)
+	}
+	if gotLimit != "" {
+		t.Fatalf("default command must omit limit, got %q", gotLimit)
+	}
+	for _, want := range []string{
+		"0 related user(s) for user_123",
+		"Signals evaluated: none",
+		"Per-signal limit: 50",
+		"No related users found for user_123.",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestRelatedRequiresEmailOrUserID(t *testing.T) {
+	cmd := newRelatedCmd()
+	cmd.SetArgs([]string{"--signal", "ip"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "supply --email or --user-id") {
+		t.Fatalf("expected missing identifier error, got %v", err)
+	}
+}
+
+func TestRelatedRejectsInvalidSignal(t *testing.T) {
+	cmd := newRelatedCmd()
+	cmd.SetArgs([]string{"--user-id", "user_123", "--signal", "ip,payment_address"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--signal must be one of: ip, payment_address, card_fingerprint") {
+		t.Fatalf("expected signal validation error, got %v", err)
+	}
+}
+
+func TestRelatedRejectsInvalidLimit(t *testing.T) {
+	cmd := newRelatedCmd()
+	cmd.SetArgs([]string{"--user-id", "user_123", "--limit", "0"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--limit must be greater than 0") {
+		t.Fatalf("expected limit validation error, got %v", err)
+	}
+}
+
+func TestRelatedShowsTruncationFooter(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"signals_evaluated": []string{"ip", "payment_address"},
+			"per_signal_limit":  1,
+			"related_users": []map[string]any{
+				relatedUserFixture(),
+			},
+			"truncated": map[string]any{"payment_address": true, "ip": true},
+		})
+	})
+
+	cmd := testutil.Command(newRelatedCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--user-id", "target_123", "--signal", "ip", "--signal", "payment_address", "--limit", "1"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "Warning: results capped for signals: ip, payment_address.") {
+		t.Fatalf("expected truncation warning, got: %q", out)
+	}
+}
+
+func TestRelatedJSONPreservesResponse(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"success":           true,
+			"user_id":           "target_123",
+			"signals_evaluated": []string{"card_fingerprint"},
+			"per_signal_limit":  50,
+			"related_users": []map[string]any{
+				relatedUserFixture(),
+			},
+			"truncated": map[string]any{"card_fingerprint": false},
+		})
+	})
+
+	cmd := testutil.Command(newRelatedCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--user-id", "target_123", "--signal", "card_fingerprint"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp struct {
+		Success          bool             `json:"success"`
+		UserID           string           `json:"user_id"`
+		SignalsEvaluated []string         `json:"signals_evaluated"`
+		RelatedUsers     []map[string]any `json:"related_users"`
+		Truncated        map[string]bool  `json:"truncated"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if !resp.Success || resp.UserID != "target_123" {
+		t.Fatalf("unexpected JSON envelope: %s", out)
+	}
+	if len(resp.SignalsEvaluated) != 1 || resp.SignalsEvaluated[0] != "card_fingerprint" {
+		t.Fatalf("unexpected JSON signals: %s", out)
+	}
+	if len(resp.RelatedUsers) != 1 || resp.RelatedUsers[0]["id"] != "rel_123" {
+		t.Fatalf("unexpected JSON related users: %s", out)
+	}
+	if resp.Truncated["card_fingerprint"] {
+		t.Fatalf("unexpected JSON truncated map: %s", out)
+	}
+}
+
+func TestRelatedPlainOutput(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"signals_evaluated": []string{"ip", "card_fingerprint"},
+			"per_signal_limit":  50,
+			"related_users": []map[string]any{
+				relatedUserFixture(),
+				{
+					"id":    "rel_456",
+					"email": "card@example.com",
+					"name":  "",
+					"risk_state": map[string]any{
+						"user_risk_state": "compliant",
+					},
+					"relations": []map[string]any{
+						{
+							"signal":       "card_fingerprint",
+							"shared_value": nil,
+						},
+					},
+				},
+			},
+			"truncated": map[string]any{"ip": true},
+		})
+	})
+
+	cmd := testutil.Command(newRelatedCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{"--email", "target@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	want := strings.Join([]string{
+		"rel_123\trelated@example.com\tRelated User\tSuspended for fraud\tip:1.2.3.4 (account_created_ip, current_sign_in_ip), payment_address:shared@example.com",
+		"rel_456\tcard@example.com\t\tcompliant\tcard_fingerprint",
+	}, "\n")
+	if strings.TrimSpace(out) != want {
+		t.Fatalf("unexpected plain output:\ngot  %q\nwant %q", strings.TrimSpace(out), want)
+	}
+}
+
+func TestRelatedRelationLabelWithoutSharedValueIncludesVia(t *testing.T) {
+	got := relatedRelationLabel(relatedRelation{Signal: "card_fingerprint", Via: []string{"credit_card"}})
+	if got != "card_fingerprint (credit_card)" {
+		t.Fatalf("got %q, want card_fingerprint (credit_card)", got)
+	}
+}
+
+func relatedUserFixture() map[string]any {
+	return map[string]any{
+		"id":    "rel_123",
+		"email": "related@example.com",
+		"name":  "Related User",
+		"risk_state": map[string]any{
+			"status":          "Suspended for fraud",
+			"user_risk_state": "suspended_for_fraud",
+		},
+		"relations": []map[string]any{
+			{
+				"signal":       "ip",
+				"shared_value": "1.2.3.4",
+				"via":          []string{"account_created_ip", "current_sign_in_ip"},
+			},
+			{
+				"signal":       "payment_address",
+				"shared_value": "shared@example.com",
+			},
+		},
+	}
+}

--- a/internal/cmd/admin/users/users.go
+++ b/internal/cmd/admin/users/users.go
@@ -17,6 +17,7 @@ func NewUsersCmd() *cobra.Command {
 		Example: `  gumroad admin users info --email user@example.com
   gumroad admin users info --user-id 2245593582708
   gumroad admin users affiliates --user-id 2245593582708 --direction granted
+  gumroad admin users related --email user@example.com --signal ip --signal payment_address
   gumroad admin users suspension --email user@example.com
   gumroad admin users mark-compliant --user-id 2245593582708 --expected-email user@example.com
   gumroad admin users watch --user-id 2245593582708 --revenue-threshold 200 --note "Review next buyers"
@@ -31,6 +32,7 @@ func NewUsersCmd() *cobra.Command {
 
 	cmd.AddCommand(newInfoCmd())
 	cmd.AddCommand(newAffiliatesCmd())
+	cmd.AddCommand(newRelatedCmd())
 	cmd.AddCommand(newSuspensionCmd())
 	cmd.AddCommand(newMarkCompliantCmd())
 	cmd.AddCommand(newWatchCmd())

--- a/internal/cmd/admin/users/users_test.go
+++ b/internal/cmd/admin/users/users_test.go
@@ -179,6 +179,7 @@ func TestNewUsersCmdWiresSubcommands(t *testing.T) {
 	want := []string{
 		"info",
 		"affiliates",
+		"related",
 		"suspension",
 		"mark-compliant",
 		"watch",


### PR DESCRIPTION
Ref antiwork/gumroad/issues/4989

## What
- Adds `gumroad admin users related` to find users linked by shared IP, payment address, or card fingerprint.
- Supports filtering the evaluated signals, capping per-signal results, and showing a warning when results are truncated.
- Renders the related-user data in both human-readable and JSON output.

## Why
- Gives support and fraud review workflows a direct way to inspect user connections from the CLI.
- Matches the new admin API contract so the CLI can use the related-users endpoint without extra manual lookup steps.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh.