### PR TITLE
Add admin purchases lookup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ gumroad admin users affiliates --user-id 2245593582708 --direction granted --lim
 gumroad admin users compliance --user-id 2245593582708
 gumroad admin users purchases --user-id 2245593582708 --status successful --limit 50
 gumroad admin users related --email seller@example.com --signal ip --signal payment_address
+gumroad admin purchases lookup --stripe-fingerprint fp_abc --limit 25
 gumroad admin users watch --user-id 2245593582708 --expected-email seller@example.com --revenue-threshold 200 --note "Review next buyers"
 gumroad admin users update-watch --user-id 2245593582708 --expected-email seller@example.com --revenue-threshold 500
 gumroad admin users unwatch --user-id 2245593582708 --expected-email seller@example.com

--- a/internal/cmd/admin/admin.go
+++ b/internal/cmd/admin/admin.go
@@ -15,6 +15,7 @@ func NewAdminCmd() *cobra.Command {
 		Short: "Run Gumroad admin commands",
 		Long:  "Run internal Gumroad admin API commands with a separate admin token.",
 		Example: `  gumroad admin purchases view <purchase-id>
+  gumroad admin purchases lookup --stripe-fingerprint <fingerprint>
   gumroad admin purchases refund <purchase-id> --email <email>
   gumroad admin purchases cancel-subscription <purchase-id> --email <email>
   gumroad admin licenses lookup --key <license-key>

--- a/internal/cmd/admin/purchases/lookup.go
+++ b/internal/cmd/admin/purchases/lookup.go
@@ -1,0 +1,187 @@
+package purchases
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"strings"
+
+	"github.com/antiwork/gumroad-cli/internal/admincmd"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil/cursor"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+type lookupResponse struct {
+	Lookup     lookupInfo        `json:"lookup"`
+	Purchases  []purchase        `json:"purchases"`
+	Pagination cursor.Pagination `json:"pagination"`
+}
+
+type lookupInfo struct {
+	Field string `json:"field"`
+	Value string `json:"value"`
+}
+
+type lookupFlags struct {
+	StripeFingerprint string
+	BrowserGUID       string
+	IPAddress         string
+}
+
+type lookupSignal struct {
+	flag  string
+	field string
+	value string
+}
+
+func newLookupCmd() *cobra.Command {
+	var (
+		signals lookupFlags
+		page    cursor.Flags
+	)
+
+	cmd := &cobra.Command{
+		Use:   "lookup",
+		Short: "Look up purchases sharing a fingerprint, browser, or IP",
+		Example: `  gumroad admin purchases lookup --stripe-fingerprint fp_abc
+  gumroad admin purchases lookup --browser-guid bguid_abc
+  gumroad admin purchases lookup --ip-address 1.2.3.4 --limit 25
+  gumroad admin purchases lookup --ip-address 1.2.3.4 --cursor cur-next`,
+		Args: cmdutil.ExactArgs(0),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			signal, err := resolveLookupSignal(c, signals)
+			if err != nil {
+				return err
+			}
+			if err := cmdutil.RequirePositiveIntFlag(c, "limit", page.Limit); err != nil {
+				return err
+			}
+
+			params := url.Values{}
+			params.Set(signal.field, signal.value)
+			cursor.Apply(params, page)
+
+			return admincmd.RunGetDecoded[lookupResponse](opts, "Looking up purchases...", "/purchases/lookup", params, func(resp lookupResponse) error {
+				return renderLookup(opts, signal, resp)
+			})
+		},
+	}
+
+	cmd.Flags().StringVar(&signals.StripeFingerprint, "stripe-fingerprint", "", "Stripe card fingerprint to match")
+	cmd.Flags().StringVar(&signals.BrowserGUID, "browser-guid", "", "Browser GUID to match")
+	cmd.Flags().StringVar(&signals.IPAddress, "ip-address", "", "IP address to match")
+	cursor.AddFlags(cmd, &page)
+
+	return cmd
+}
+
+func resolveLookupSignal(cmd *cobra.Command, flags lookupFlags) (lookupSignal, error) {
+	candidates := []lookupSignal{
+		{flag: "stripe-fingerprint", field: "stripe_fingerprint", value: flags.StripeFingerprint},
+		{flag: "browser-guid", field: "browser_guid", value: flags.BrowserGUID},
+		{flag: "ip-address", field: "ip_address", value: flags.IPAddress},
+	}
+
+	var selected lookupSignal
+	changedCount := 0
+	for i := range candidates {
+		candidate := candidates[i]
+		if !cmd.Flags().Changed(candidate.flag) {
+			continue
+		}
+		changedCount++
+		selected = candidate
+	}
+
+	if changedCount != 1 {
+		return lookupSignal{}, lookupSignalCountError(cmd)
+	}
+
+	selected.value = strings.TrimSpace(selected.value)
+	if selected.value == "" {
+		return lookupSignal{}, cmdutil.UsageErrorf(cmd, "--%s cannot be empty", selected.flag)
+	}
+	return selected, nil
+}
+
+func lookupSignalCountError(cmd *cobra.Command) error {
+	return cmdutil.UsageErrorf(cmd, "exactly one of --stripe-fingerprint, --browser-guid, or --ip-address must be provided")
+}
+
+func renderLookup(opts cmdutil.Options, signal lookupSignal, resp lookupResponse) error {
+	if opts.PlainOutput {
+		return writeLookupPlain(opts.Out(), resp.Purchases)
+	}
+
+	if opts.Quiet {
+		return nil
+	}
+
+	style := opts.Style()
+	return output.WithPager(opts.Out(), opts.Err(), func(w io.Writer) error {
+		label := lookupLabel(signal, resp.Lookup)
+		if len(resp.Purchases) == 0 {
+			if err := output.Writef(w, "No purchases found for %s.\n", label); err != nil {
+				return err
+			}
+			return cursor.WriteMoreFooter(w, resp.Pagination)
+		}
+
+		if err := output.Writeln(w, style.Bold(fmt.Sprintf("%d purchase(s) for %s", len(resp.Purchases), label))); err != nil {
+			return err
+		}
+		if err := output.Writeln(w, ""); err != nil {
+			return err
+		}
+		if err := writeLookupTable(w, style, resp.Purchases); err != nil {
+			return err
+		}
+		return cursor.WriteMoreFooter(w, resp.Pagination)
+	})
+}
+
+func writeLookupPlain(w io.Writer, purchases []purchase) error {
+	rows := make([][]string, 0, len(purchases))
+	for _, p := range purchases {
+		rows = append(rows, lookupRow(p))
+	}
+	return output.PrintPlain(w, rows)
+}
+
+func writeLookupTable(w io.Writer, style output.Styler, purchases []purchase) error {
+	tbl := output.NewStyledTable(style, "ID", "BUYER", "SELLER", "PRODUCT", "AMOUNT", "STATE", "CREATED")
+	for _, p := range purchases {
+		tbl.AddRow(lookupRow(p)...)
+	}
+	return tbl.Render(w)
+}
+
+func lookupRow(p purchase) []string {
+	return []string{
+		p.ID,
+		buyerLabel(p),
+		sellerLabel(p),
+		productLabel(p),
+		amountLabel(p),
+		statusLabel(p),
+		p.CreatedAt,
+	}
+}
+
+func lookupLabel(signal lookupSignal, info lookupInfo) string {
+	field := info.Field
+	if field == "" {
+		field = signal.field
+	}
+	value := info.Value
+	if value == "" {
+		value = signal.value
+	}
+	if field == "" {
+		return value
+	}
+	return fmt.Sprintf("%s=%s", field, value)
+}

--- a/internal/cmd/admin/purchases/lookup_test.go
+++ b/internal/cmd/admin/purchases/lookup_test.go
@@ -1,0 +1,284 @@
+package purchases
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestLookupUsesInternalAdminEndpoint(t *testing.T) {
+	var gotMethod, gotPath, gotAuth string
+	var gotFingerprint, gotBrowserGUID, gotIPAddress, gotLimit, gotCursor string
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotFingerprint = r.URL.Query().Get("stripe_fingerprint")
+		gotBrowserGUID = r.URL.Query().Get("browser_guid")
+		gotIPAddress = r.URL.Query().Get("ip_address")
+		gotLimit = r.URL.Query().Get("limit")
+		gotCursor = r.URL.Query().Get("cursor")
+		testutil.JSON(t, w, map[string]any{
+			"success": true,
+			"lookup":  map[string]any{"field": "stripe_fingerprint", "value": "fp_shared"},
+			"purchases": []map[string]any{
+				lookupPurchaseFixture(),
+			},
+			"pagination": map[string]any{"next": nil, "limit": 25},
+		})
+	})
+
+	cmd := testutil.Command(newLookupCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--stripe-fingerprint", " fp_shared ", "--limit", "25", "--cursor", "cur-1"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != "GET" || gotPath != "/internal/admin/purchases/lookup" {
+		t.Fatalf("got %s %s, want GET /internal/admin/purchases/lookup", gotMethod, gotPath)
+	}
+	if gotAuth != "Bearer admin-token" {
+		t.Fatalf("got auth %q, want Bearer admin-token", gotAuth)
+	}
+	if gotFingerprint != "fp_shared" {
+		t.Fatalf("got stripe_fingerprint %q, want fp_shared", gotFingerprint)
+	}
+	if gotBrowserGUID != "" || gotIPAddress != "" {
+		t.Fatalf("unexpected extra lookup params: browser_guid=%q ip_address=%q", gotBrowserGUID, gotIPAddress)
+	}
+	if gotLimit != "25" || gotCursor != "cur-1" {
+		t.Fatalf("got limit=%q cursor=%q, want 25 cur-1", gotLimit, gotCursor)
+	}
+	for _, want := range []string{
+		"1 purchase(s) for stripe_fingerprint=fp_shared",
+		"SELLER",
+		"BUYER",
+		"seller@example.com / Seller User / seller_123",
+		"buyer@example.com",
+		"Course",
+		"$12",
+		"successful",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestLookupSupportsBrowserGUIDAndIPAddress(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		wantField string
+		wantValue string
+	}{
+		{
+			name:      "browser GUID",
+			args:      []string{"--browser-guid", "bguid_abc"},
+			wantField: "browser_guid",
+			wantValue: "bguid_abc",
+		},
+		{
+			name:      "IP address",
+			args:      []string{"--ip-address", "203.0.113.7"},
+			wantField: "ip_address",
+			wantValue: "203.0.113.7",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotValue string
+			testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+				gotValue = r.URL.Query().Get(tt.wantField)
+				testutil.JSON(t, w, map[string]any{
+					"lookup":     map[string]any{"field": tt.wantField, "value": tt.wantValue},
+					"purchases":  []map[string]any{},
+					"pagination": map[string]any{"next": nil, "limit": 20},
+				})
+			})
+
+			cmd := testutil.Command(newLookupCmd(), testutil.Quiet(false))
+			cmd.SetArgs(tt.args)
+			testutil.MustExecute(t, cmd)
+
+			if gotValue != tt.wantValue {
+				t.Fatalf("got %s=%q, want %q", tt.wantField, gotValue, tt.wantValue)
+			}
+		})
+	}
+}
+
+func TestLookupShowsEmptyResultAndNextCursorFooter(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"success":    true,
+			"lookup":     map[string]any{"field": "ip_address", "value": "203.0.113.7"},
+			"purchases":  []map[string]any{},
+			"pagination": map[string]any{"next": "cur-next", "limit": 20},
+		})
+	})
+
+	cmd := testutil.Command(newLookupCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--ip-address", "203.0.113.7"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	for _, want := range []string{
+		"No purchases found for ip_address=203.0.113.7.",
+		"More results: --cursor cur-next",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestLookupPlainOutput(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"lookup": map[string]any{"field": "stripe_fingerprint", "value": "fp_shared"},
+			"purchases": []map[string]any{
+				lookupPurchaseFixture(),
+				{
+					"id":                    "456",
+					"email":                 "second-buyer@example.com",
+					"seller_email":          "legacy-seller@example.com",
+					"link_name":             "Bundle",
+					"formatted_total_price": "$20",
+					"purchase_state":        "refunded",
+					"created_at":            "2026-05-11T12:00:00Z",
+				},
+			},
+			"pagination": map[string]any{"next": nil, "limit": 20},
+		})
+	})
+
+	cmd := testutil.Command(newLookupCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{"--stripe-fingerprint", "fp_shared"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	want := strings.Join([]string{
+		"123\tbuyer@example.com\tseller@example.com / Seller User / seller_123\tCourse\t$12\tsuccessful\t2026-05-12T12:00:00Z",
+		"456\tsecond-buyer@example.com\tlegacy-seller@example.com\tBundle\t$20\trefunded\t2026-05-11T12:00:00Z",
+	}, "\n")
+	if strings.TrimSpace(out) != want {
+		t.Fatalf("unexpected plain output:\ngot  %q\nwant %q", strings.TrimSpace(out), want)
+	}
+}
+
+func TestLookupSellerLabelSkipsDuplicateName(t *testing.T) {
+	p := purchase{Seller: &purchaseSeller{
+		ID:    "seller_123",
+		Email: "seller@example.com",
+		Name:  "seller@example.com",
+	}}
+
+	if got, want := sellerLabel(p), "seller@example.com / seller_123"; got != want {
+		t.Fatalf("sellerLabel() = %q, want %q", got, want)
+	}
+}
+
+func TestLookupJSONPreservesResponse(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"success": true,
+			"lookup":  map[string]any{"field": "browser_guid", "value": "bguid_abc"},
+			"purchases": []map[string]any{
+				lookupPurchaseFixture(),
+			},
+			"pagination": map[string]any{"next": "cur-next", "limit": 20},
+		})
+	})
+
+	cmd := testutil.Command(newLookupCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--browser-guid", "bguid_abc"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp struct {
+		Success    bool             `json:"success"`
+		Lookup     map[string]any   `json:"lookup"`
+		Purchases  []map[string]any `json:"purchases"`
+		Pagination map[string]any   `json:"pagination"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if !resp.Success || resp.Lookup["field"] != "browser_guid" || resp.Lookup["value"] != "bguid_abc" {
+		t.Fatalf("unexpected JSON lookup envelope: %s", out)
+	}
+	if len(resp.Purchases) != 1 || resp.Purchases[0]["id"] != "123" {
+		t.Fatalf("unexpected JSON purchases: %s", out)
+	}
+	if resp.Pagination["next"] != "cur-next" {
+		t.Fatalf("unexpected JSON pagination: %s", out)
+	}
+}
+
+func TestLookupRequiresExactlyOneSignal(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "missing signal",
+			args: []string{},
+			want: "exactly one of --stripe-fingerprint, --browser-guid, or --ip-address must be provided",
+		},
+		{
+			name: "multiple signals",
+			args: []string{"--stripe-fingerprint", "fp_abc", "--ip-address", "203.0.113.7"},
+			want: "exactly one of --stripe-fingerprint, --browser-guid, or --ip-address must be provided",
+		},
+		{
+			name: "empty signal",
+			args: []string{"--stripe-fingerprint", "  "},
+			want: "--stripe-fingerprint cannot be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+				t.Error("must not request when signal validation fails")
+			})
+
+			cmd := testutil.Command(newLookupCmd())
+			cmd.SetArgs(tt.args)
+
+			err := cmd.Execute()
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected %q error, got %v", tt.want, err)
+			}
+		})
+	}
+}
+
+func TestLookupRejectsInvalidLimit(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("must not request when --limit is invalid")
+	})
+
+	cmd := testutil.Command(newLookupCmd())
+	cmd.SetArgs([]string{"--ip-address", "203.0.113.7", "--limit", "0"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--limit must be greater than 0") {
+		t.Fatalf("expected zero-limit error, got: %v", err)
+	}
+}
+
+func lookupPurchaseFixture() map[string]any {
+	return map[string]any{
+		"id":                    "123",
+		"email":                 "buyer@example.com",
+		"seller_email":          "seller@example.com",
+		"seller":                map[string]any{"id": "seller_123", "email": "seller@example.com", "name": "Seller User"},
+		"product_name":          "Course",
+		"formatted_total_price": "$12",
+		"purchase_state":        "successful",
+		"created_at":            "2026-05-12T12:00:00Z",
+	}
+}

--- a/internal/cmd/admin/purchases/purchases.go
+++ b/internal/cmd/admin/purchases/purchases.go
@@ -8,6 +8,7 @@ func NewPurchasesCmd() *cobra.Command {
 		Short: "Read and manage admin purchase records",
 		Example: `  gumroad admin purchases view <purchase-id>
   gumroad admin purchases search --email buyer@example.com
+  gumroad admin purchases lookup --stripe-fingerprint fp_abc
   gumroad admin purchases refund <purchase-id> --email buyer@example.com
   gumroad admin purchases refund-taxes <purchase-id> --email buyer@example.com
   gumroad admin purchases refund-for-fraud <purchase-id> --email buyer@example.com
@@ -21,6 +22,7 @@ func NewPurchasesCmd() *cobra.Command {
 
 	cmd.AddCommand(newViewCmd())
 	cmd.AddCommand(newSearchCmd())
+	cmd.AddCommand(newLookupCmd())
 	cmd.AddCommand(newRefundCmd())
 	cmd.AddCommand(newRefundTaxesCmd())
 	cmd.AddCommand(newRefundForFraudCmd())

--- a/internal/cmd/admin/purchases/purchases_test.go
+++ b/internal/cmd/admin/purchases/purchases_test.go
@@ -306,6 +306,7 @@ func TestNewPurchasesCmdWiresSubcommands(t *testing.T) {
 	want := []string{
 		"view <purchase-id>",
 		"search",
+		"lookup",
 		"refund <purchase-id>",
 		"refund-taxes <purchase-id>",
 		"refund-for-fraud <purchase-id>",

--- a/internal/cmd/admin/purchases/view.go
+++ b/internal/cmd/admin/purchases/view.go
@@ -190,6 +190,31 @@ func SellerLabel(p Purchase) string {
 	return sellerEmail(p)
 }
 
+func buyerLabel(p purchase) string {
+	return p.Email
+}
+
+func sellerLabel(p purchase) string {
+	if p.Seller != nil && (p.Seller.Email != "" || p.Seller.Name != "" || p.Seller.ID != "") {
+		return userLabel(*p.Seller)
+	}
+	return p.SellerEmail
+}
+
+func userLabel(user purchaseSeller) string {
+	parts := make([]string, 0, 3)
+	if user.Email != "" {
+		parts = append(parts, user.Email)
+	}
+	if user.Name != "" && user.Name != user.Email {
+		parts = append(parts, user.Name)
+	}
+	if user.ID != "" {
+		parts = append(parts, user.ID)
+	}
+	return strings.Join(parts, " / ")
+}
+
 func purchaseFlags(p purchase) string {
 	flags := []string{}
 	if p.ChargebackDate != "" {


### PR DESCRIPTION
Ref antiwork/gumroad/issues/4989

## What

Adds a new `gumroad admin purchases lookup` command to find purchases by Stripe fingerprint, browser GUID, or IP address. It validates that exactly one lookup signal is provided, supports cursor paging, and shows seller and buyer context in the results so clusters are easier to read.

## Why

This gives the CLI a direct way to consume the new admin lookup endpoint and inspect related purchases without falling back to broader search commands. It keeps the output aligned with the server contract and makes investigator workflows faster and clearer.

---

This PR was implemented with AI assistance using gpt-5.5 xhigh.