### PR TITLE
Update the Gumroad skill for the admin rollout

### DIFF
--- a/skills/embed_test.go
+++ b/skills/embed_test.go
@@ -36,3 +36,30 @@ func TestSkillMarkdown_ContainsAllCommands(t *testing.T) {
 		}
 	}
 }
+
+func TestSkillMarkdown_ContainsAdminRolloutCommands(t *testing.T) {
+	data, err := SkillMarkdown()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	content := string(data)
+	for _, example := range []string{
+		"gumroad admin users info --email",
+		"gumroad admin users affiliates --user-id",
+		"gumroad admin users comments list --user-id",
+		"gumroad admin users comments add --user-id",
+		"gumroad admin users compliance --user-id",
+		"gumroad admin users purchases --user-id",
+		"gumroad admin users related --email",
+		"gumroad admin purchases view <purchase-id> --with-clusters",
+		"gumroad admin purchases search --email",
+		"gumroad admin purchases lookup --stripe-fingerprint",
+		"gumroad admin products list --email",
+		"gumroad admin products view <product-id> --with-fraud-context",
+	} {
+		if !strings.Contains(content, example) {
+			t.Errorf("expected skill to mention admin example %q", example)
+		}
+	}
+}

--- a/skills/embed_test.go
+++ b/skills/embed_test.go
@@ -57,6 +57,12 @@ func TestSkillMarkdown_ContainsAdminRolloutCommands(t *testing.T) {
 		"gumroad admin purchases lookup --stripe-fingerprint",
 		"gumroad admin products list --email",
 		"gumroad admin products view <product-id> --with-fraud-context",
+		"Cursor-paginated: `admin users affiliates`",
+		"Page-paginated: `admin products list`",
+		"Capped, not continuable: `admin users related`",
+		"Capped, not continuable: `admin purchases search`",
+		".truncated",
+		".has_more",
 	} {
 		if !strings.Contains(content, example) {
 			t.Errorf("expected skill to mention admin example %q", example)

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -60,12 +60,18 @@ Responses are wrapped in `{"success": true, ...}` with resource-specific keys:
 - `admin users comments add` → `.comment`
 - `admin users compliance` → `.compliance_info`, `.info_requests[]`
 - `admin users purchases` → `.purchases[]`
-- `admin users related` → `.related_users[]`
+- `admin users related` → `.related_users[]`, `.truncated`, `.per_signal_limit`
 - `admin purchases view` → `.purchase`
-- `admin purchases search` → `.purchases[]`
+- `admin purchases search` → `.purchases[]`, `.has_more`, `.limit`
 - `admin purchases lookup` → `.purchases[]`
 - `admin products list` → `.products[]`, `admin products view` → `.product`
-- Cursor-paginated admin reads include `.pagination.next`; pass it back with `--cursor`.
+
+Admin pagination models differ by command:
+
+- Cursor-paginated: `admin users affiliates`, `admin users comments list`, `admin users purchases`, and `admin purchases lookup` return `.pagination.next` as a cursor string. Pass it back with `--cursor`.
+- Page-paginated: `admin products list` returns `.pagination.next` as an integer page number. Pass it back with `--page`; use `--per-page` for page size.
+- Capped, not continuable: `admin users related` returns at most 50 related users per signal. Always inspect `.truncated`; when any signal is `true`, the result hit the cap and there is no cursor/page to fetch the rest.
+- Capped, not continuable: `admin purchases search` returns `.has_more` when the server capped results. `--limit` is server-capped at 25 and there is no continuation token.
 
 ## Commands
 
@@ -112,12 +118,13 @@ gumroad admin users purchases --user-id 2245593582708 --status successful --has-
 
 # Find related accounts by risk signals
 gumroad admin users related --email seller@example.com --signal ip --signal payment_address --json --non-interactive --no-input
+gumroad admin users related --email seller@example.com --json --jq '{related_users, truncated, per_signal_limit}' --non-interactive --no-input
 
 # Inspect purchase and product fraud context
 gumroad admin purchases view <purchase-id> --with-clusters --json --non-interactive --no-input
-gumroad admin purchases search --email buyer@example.com --json --non-interactive --no-input
+gumroad admin purchases search --email buyer@example.com --json --jq '{purchases, has_more, limit}' --non-interactive --no-input
 gumroad admin purchases lookup --stripe-fingerprint fp_abc --limit 25 --json --non-interactive --no-input
-gumroad admin products list --email seller@example.com --json --non-interactive --no-input
+gumroad admin products list --email seller@example.com --page 2 --per-page 25 --json --non-interactive --no-input
 gumroad admin products view <product-id> --with-fraud-context --json --non-interactive --no-input
 
 # Watchlist state does not pause payouts or change user risk state

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -54,6 +54,18 @@ Responses are wrapped in `{"success": true, ...}` with resource-specific keys:
 - `variants list` → `.variants[]`
 - `files upload` / `files complete` → `.file_url`
 - `webhooks list` → `.resource_subscriptions[]`
+- `admin users info` → `.user`
+- `admin users affiliates` → `.affiliates[]`
+- `admin users comments list` → `.comments[]`
+- `admin users comments add` → `.comment`
+- `admin users compliance` → `.compliance_info`, `.info_requests[]`
+- `admin users purchases` → `.purchases[]`
+- `admin users related` → `.related_users[]`
+- `admin purchases view` → `.purchase`
+- `admin purchases search` → `.purchases[]`
+- `admin purchases lookup` → `.purchases[]`
+- `admin products list` → `.products[]`, `admin products view` → `.product`
+- Cursor-paginated admin reads include `.pagination.next`; pass it back with `--cursor`.
 
 ## Commands
 
@@ -80,14 +92,39 @@ gumroad user --json --jq '.user.email' --no-input
 ### admin — Internal admin API
 
 ```sh
-# Inspect user risk, payout, and watchlist state
-gumroad admin users info --email seller@example.com --json --non-interactive
+# Admin commands need internal admin auth.
+# In agents/CI, set GUMROAD_ADMIN_TOKEN and pass --non-interactive.
+
+# Inspect user identity, sign-in, social, risk, payout, and watchlist state
+gumroad admin users info --email seller@example.com --json --non-interactive --no-input
+
+# Review affiliate relationships
+gumroad admin users affiliates --user-id 2245593582708 --direction granted --limit 50 --json --non-interactive --no-input
+gumroad admin users affiliates --email seller@example.com --direction received --cursor cur-next --json --non-interactive --no-input
+
+# Read and add admin comments
+gumroad admin users comments list --user-id 2245593582708 --type note --limit 50 --json --non-interactive --no-input
+gumroad admin users comments add --user-id 2245593582708 --content "VAT exempt confirmed" --yes --json --non-interactive --no-input
+
+# Inspect compliance and buyer history
+gumroad admin users compliance --user-id 2245593582708 --json --non-interactive --no-input
+gumroad admin users purchases --user-id 2245593582708 --status successful --has-early-fraud-warning=false --limit 50 --json --non-interactive --no-input
+
+# Find related accounts by risk signals
+gumroad admin users related --email seller@example.com --signal ip --signal payment_address --json --non-interactive --no-input
+
+# Inspect purchase and product fraud context
+gumroad admin purchases view <purchase-id> --with-clusters --json --non-interactive --no-input
+gumroad admin purchases search --email buyer@example.com --json --non-interactive --no-input
+gumroad admin purchases lookup --stripe-fingerprint fp_abc --limit 25 --json --non-interactive --no-input
+gumroad admin products list --email seller@example.com --json --non-interactive --no-input
+gumroad admin products view <product-id> --with-fraud-context --json --non-interactive --no-input
 
 # Watchlist state does not pause payouts or change user risk state
-gumroad admin users watch --user-id 2245593582708 --expected-email seller@example.com --revenue-threshold 200 --note "Review next buyers" --yes --json --non-interactive
-gumroad admin users update-watch --user-id 2245593582708 --expected-email seller@example.com --revenue-threshold 500 --yes --json --non-interactive
-gumroad admin users update-watch --user-id 2245593582708 --expected-email seller@example.com --revenue-threshold 500 --clear-note --yes --json --non-interactive
-gumroad admin users unwatch --user-id 2245593582708 --expected-email seller@example.com --yes --json --non-interactive
+gumroad admin users watch --user-id 2245593582708 --expected-email seller@example.com --revenue-threshold 200 --note "Review next buyers" --yes --json --non-interactive --no-input
+gumroad admin users update-watch --user-id 2245593582708 --expected-email seller@example.com --revenue-threshold 500 --yes --json --non-interactive --no-input
+gumroad admin users update-watch --user-id 2245593582708 --expected-email seller@example.com --revenue-threshold 500 --clear-note --yes --json --non-interactive --no-input
+gumroad admin users unwatch --user-id 2245593582708 --expected-email seller@example.com --yes --json --non-interactive --no-input
 ```
 
 ### products — Manage products


### PR DESCRIPTION
## What
- Expand the bundled `gumroad` skill to cover the new admin commands and response shapes from the merged rollout.
- Add examples for the new user, purchase, and product admin flows, including cursor-based reads and the fraud-context flags.
- Tighten the embedded skill test so these admin examples stay covered.

## Why
- The shipped skill had drifted behind the CLI after the admin rollout, which made the agent guidance incomplete.
- Keeping the bundled skill current makes the documented command surface match what the CLI now supports.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh.