### PR TITLE
Add admin Radar stats command for users

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ gumroad admin users affiliates --user-id 2245593582708 --direction granted --lim
 gumroad admin users comments list --user-id 2245593582708 --type note --limit 50
 gumroad admin users comments add --user-id 2245593582708 --content "VAT exempt confirmed"
 gumroad admin users compliance --user-id 2245593582708
+gumroad admin users radar --user-id 2245593582708 --limit 50
 gumroad admin users purchases --user-id 2245593582708 --status successful --limit 50
 gumroad admin users related --email seller@example.com --signal ip --signal payment_address
 gumroad admin purchases lookup --stripe-fingerprint fp_abc --limit 25

--- a/internal/cmd/admin/admin.go
+++ b/internal/cmd/admin/admin.go
@@ -24,6 +24,7 @@ func NewAdminCmd() *cobra.Command {
   gumroad admin users comments list --user-id <user-id>
   gumroad admin users comments add --user-id <user-id> --content "VAT exempt confirmed"
   gumroad admin users compliance --user-id <user-id>
+  gumroad admin users radar --user-id <user-id>
   gumroad admin users purchases --user-id <user-id> --status successful
   gumroad admin users related --email <email> --signal ip
   gumroad admin users suspension --email <email>

--- a/internal/cmd/admin/users/radar.go
+++ b/internal/cmd/admin/users/radar.go
@@ -1,0 +1,227 @@
+package users
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/antiwork/gumroad-cli/internal/admincmd"
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil/cursor"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+const maxRadarLimit = 100
+
+type radarResponse struct {
+	UserID     string            `json:"user_id"`
+	RadarStats radarStats        `json:"radar_stats"`
+	RecentEFWs []recentEFW       `json:"recent_efws"`
+	Pagination cursor.Pagination `json:"pagination"`
+}
+
+type radarStats struct {
+	SuccessfulPurchases api.JSONInt            `json:"successful_purchases"`
+	EFWCount            api.JSONInt            `json:"efw_count"`
+	EFWByFraudType      map[string]api.JSONInt `json:"efw_by_fraud_type"`
+	EFWWithElevatedRisk api.JSONInt            `json:"efw_with_elevated_risk"`
+	EFWWithHighestRisk  api.JSONInt            `json:"efw_with_highest_risk"`
+	DisputeCount        api.JSONInt            `json:"dispute_count"`
+	DisputeRate         float64                `json:"dispute_rate"`
+}
+
+type recentEFW struct {
+	PurchaseID      string `json:"purchase_id"`
+	FraudType       string `json:"fraud_type"`
+	ChargeRiskLevel string `json:"charge_risk_level"`
+	Resolution      string `json:"resolution"`
+	CreatedAt       string `json:"created_at"`
+}
+
+func newRadarCmd() *cobra.Command {
+	var (
+		lookup userLookupFlags
+		page   cursor.Flags
+	)
+
+	cmd := &cobra.Command{
+		Use:   "radar",
+		Short: "View seller-level Radar and early fraud warning stats",
+		Long: `View seller-level Radar aggregates and recent early fraud warnings.
+
+Identify the seller with --email or --user-id. When both are supplied, the
+server resolves by --user-id.`,
+		Example: `  gumroad admin users radar --user-id 2245593582708
+  gumroad admin users radar --email seller@example.com --limit 50
+  gumroad admin users radar --user-id 2245593582708 --cursor cur-next --json`,
+		Args: cmdutil.ExactArgs(0),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			target, err := resolveUserLookupTarget(c, lookup)
+			if err != nil {
+				return err
+			}
+			if err := cmdutil.RequirePositiveIntFlag(c, "limit", page.Limit); err != nil {
+				return err
+			}
+			if c.Flags().Changed("limit") && page.Limit > maxRadarLimit {
+				return cmdutil.UsageErrorf(c, "--limit must be %d or less", maxRadarLimit)
+			}
+
+			params := target.Values()
+			cursor.Apply(params, page)
+
+			return admincmd.RunGetDecoded[radarResponse](opts, "Fetching Radar stats...", "/users/radar_stats", params, func(resp radarResponse) error {
+				return renderRadar(opts, target.Identifier(), resp)
+			})
+		},
+	}
+
+	addUserLookupFlags(cmd, &lookup)
+	cursor.AddFlags(cmd, &page, cursor.Options{LimitUsage: "Maximum recent EFWs to return (default 20, capped at 100)"})
+
+	return cmd
+}
+
+func renderRadar(opts cmdutil.Options, identifier string, resp radarResponse) error {
+	if opts.PlainOutput {
+		return writeRadarPlain(opts.Out(), identifier, resp)
+	}
+
+	if opts.Quiet {
+		return nil
+	}
+
+	style := opts.Style()
+	return output.WithPager(opts.Out(), opts.Err(), func(w io.Writer) error {
+		if err := writeRadarStatsBlock(w, style, identifier, resp.UserID, resp.RadarStats); err != nil {
+			return err
+		}
+		if len(resp.RecentEFWs) == 0 {
+			if err := output.Writeln(w, "Recent EFWs: none"); err != nil {
+				return err
+			}
+			return cursor.WriteMoreFooter(w, resp.Pagination)
+		}
+		if err := output.Writeln(w, style.Bold("Recent EFWs:")); err != nil {
+			return err
+		}
+		if err := writeRadarEFWTable(w, style, resp.RecentEFWs); err != nil {
+			return err
+		}
+		return cursor.WriteMoreFooter(w, resp.Pagination)
+	})
+}
+
+func writeRadarStatsBlock(w io.Writer, style output.Styler, identifier, userID string, stats radarStats) error {
+	if err := output.Writeln(w, style.Bold("Radar stats for "+identifier)); err != nil {
+		return err
+	}
+	if userID != "" && userID != identifier {
+		if err := output.Writef(w, "User ID: %s\n", userID); err != nil {
+			return err
+		}
+	}
+
+	rows := []struct {
+		label string
+		value string
+	}{
+		{"Successful purchases", formatRadarInt(stats.SuccessfulPurchases)},
+		{"Early fraud warnings", formatRadarInt(stats.EFWCount)},
+		{"EFW by fraud type", radarFraudTypeCountsLabel(stats.EFWByFraudType)},
+		{"Elevated risk EFWs", formatRadarInt(stats.EFWWithElevatedRisk)},
+		{"Highest risk EFWs", formatRadarInt(stats.EFWWithHighestRisk)},
+		{"Disputes", formatRadarInt(stats.DisputeCount)},
+		{"Dispute rate", formatRadarDecimal(stats.DisputeRate) + "%"},
+	}
+	for _, row := range rows {
+		if err := output.Writef(w, "%s: %s\n", row.label, row.value); err != nil {
+			return err
+		}
+	}
+	return output.Writeln(w, "")
+}
+
+func writeRadarEFWTable(w io.Writer, style output.Styler, efws []recentEFW) error {
+	tbl := output.NewStyledTable(style, "PURCHASE/CHARGE", "FRAUD TYPE", "RISK", "RESOLUTION", "CREATED")
+	for _, efw := range efws {
+		tbl.AddRow(radarEFWRow(efw)...)
+	}
+	return tbl.Render(w)
+}
+
+func writeRadarPlain(w io.Writer, identifier string, resp radarResponse) error {
+	capacity := len(resp.RecentEFWs)
+	if capacity == 0 {
+		capacity = 1
+	}
+	rows := make([][]string, 0, capacity)
+	if len(resp.RecentEFWs) == 0 {
+		rows = append(rows, radarPlainRow(identifier, resp.UserID, resp.RadarStats, recentEFW{}))
+	} else {
+		for _, efw := range resp.RecentEFWs {
+			rows = append(rows, radarPlainRow(identifier, resp.UserID, resp.RadarStats, efw))
+		}
+	}
+	return output.PrintPlain(w, rows)
+}
+
+func radarPlainRow(identifier, userID string, stats radarStats, efw recentEFW) []string {
+	return append([]string{
+		identifier,
+		userID,
+		formatRadarInt(stats.SuccessfulPurchases),
+		formatRadarInt(stats.EFWCount),
+		radarFraudTypeCountsLabel(stats.EFWByFraudType),
+		formatRadarInt(stats.EFWWithElevatedRisk),
+		formatRadarInt(stats.EFWWithHighestRisk),
+		formatRadarInt(stats.DisputeCount),
+		formatRadarDecimal(stats.DisputeRate),
+	}, radarEFWRow(efw)...)
+}
+
+func radarEFWRow(efw recentEFW) []string {
+	return []string{
+		efw.PurchaseID,
+		efw.FraudType,
+		efw.ChargeRiskLevel,
+		efw.Resolution,
+		efw.CreatedAt,
+	}
+}
+
+func radarFraudTypeCountsLabel(counts map[string]api.JSONInt) string {
+	if len(counts) == 0 {
+		return "(none)"
+	}
+
+	keys := make([]string, 0, len(counts))
+	for key := range counts {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%s", key, formatRadarInt(counts[key])))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func formatRadarInt(value api.JSONInt) string {
+	return strconv.Itoa(int(value))
+}
+
+func formatRadarDecimal(value float64) string {
+	formatted := strconv.FormatFloat(value, 'f', 2, 64)
+	formatted = strings.TrimRight(strings.TrimRight(formatted, "0"), ".")
+	if formatted == "" || formatted == "-0" {
+		return "0"
+	}
+	return formatted
+}

--- a/internal/cmd/admin/users/radar_test.go
+++ b/internal/cmd/admin/users/radar_test.go
@@ -1,0 +1,229 @@
+package users
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestRadarUsesInternalAdminEndpointAndRendersHumanOutput(t *testing.T) {
+	var gotMethod, gotPath, gotAuth string
+	var gotQuery url.Values
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotQuery = r.URL.Query()
+		testutil.JSON(t, w, radarPayload())
+	})
+
+	cmd := testutil.Command(newRadarCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--email", "seller@example.com", "--limit", "50", "--cursor", "cur-1"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != "GET" || gotPath != "/internal/admin/users/radar_stats" {
+		t.Fatalf("got %s %s, want GET /internal/admin/users/radar_stats", gotMethod, gotPath)
+	}
+	if gotAuth != "Bearer admin-token" {
+		t.Fatalf("got auth %q, want Bearer admin-token", gotAuth)
+	}
+	for key, want := range map[string]string{
+		"email":  "seller@example.com",
+		"limit":  "50",
+		"cursor": "cur-1",
+	} {
+		if got := gotQuery.Get(key); got != want {
+			t.Fatalf("query %s = %q, want %q; full query %s", key, got, want, gotQuery.Encode())
+		}
+	}
+
+	for _, want := range []string{
+		"Radar stats for seller@example.com",
+		"User ID: user_123",
+		"Successful purchases: 3",
+		"Early fraud warnings: 3",
+		"EFW by fraud type: made_with_stolen_card=2, misc=1",
+		"Elevated risk EFWs: 2",
+		"Highest risk EFWs: 1",
+		"Disputes: 1",
+		"Dispute rate: 33.33%",
+		"Recent EFWs:",
+		"purchase_123",
+		"made_with_stolen_card",
+		"highest",
+		"unknown",
+		"2026-05-15T12:00:00Z",
+		"CH-charge_123",
+		"resolved_ignored",
+		"More results: --cursor cur-next",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestRadarPassesUserID(t *testing.T) {
+	var gotEmail, gotUserID string
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotEmail = r.URL.Query().Get("email")
+		gotUserID = r.URL.Query().Get("user_id")
+		testutil.JSON(t, w, emptyRadarPayload())
+	})
+
+	cmd := testutil.Command(newRadarCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--user-id", "user_123"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotEmail != "" || gotUserID != "user_123" {
+		t.Fatalf("got email=%q user_id=%q, want only user_id", gotEmail, gotUserID)
+	}
+	for _, want := range []string{
+		"Radar stats for user_123",
+		"Successful purchases: 0",
+		"EFW by fraud type: (none)",
+		"Recent EFWs: none",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestRadarJSONPreservesResponse(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, radarPayload())
+	})
+
+	cmd := testutil.Command(newRadarCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--user-id", "user_123"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp struct {
+		Success    bool             `json:"success"`
+		UserID     string           `json:"user_id"`
+		RadarStats map[string]any   `json:"radar_stats"`
+		RecentEFWs []map[string]any `json:"recent_efws"`
+		Pagination map[string]any   `json:"pagination"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if !resp.Success || resp.UserID != "user_123" {
+		t.Fatalf("unexpected JSON envelope: %s", out)
+	}
+	if resp.RadarStats["efw_count"] != float64(3) {
+		t.Fatalf("unexpected radar_stats JSON: %s", out)
+	}
+	if len(resp.RecentEFWs) != 2 || resp.RecentEFWs[0]["purchase_id"] != "purchase_123" {
+		t.Fatalf("unexpected recent_efws JSON: %s", out)
+	}
+	if resp.Pagination["next"] != "cur-next" {
+		t.Fatalf("unexpected pagination JSON: %s", out)
+	}
+}
+
+func TestRadarPlainOutput(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, radarPayload())
+	})
+
+	cmd := testutil.Command(newRadarCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{"--email", "seller@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	want := strings.Join([]string{
+		"seller@example.com\tuser_123\t3\t3\tmade_with_stolen_card=2, misc=1\t2\t1\t1\t33.33\tpurchase_123\tmade_with_stolen_card\thighest\tunknown\t2026-05-15T12:00:00Z",
+		"seller@example.com\tuser_123\t3\t3\tmade_with_stolen_card=2, misc=1\t2\t1\t1\t33.33\tCH-charge_123\tmisc\televated\tresolved_ignored\t2026-05-15T11:00:00Z",
+	}, "\n")
+	if strings.TrimSpace(out) != want {
+		t.Fatalf("unexpected plain output:\ngot  %q\nwant %q", strings.TrimSpace(out), want)
+	}
+}
+
+func TestRadarRequiresEmailOrUserID(t *testing.T) {
+	cmd := newRadarCmd()
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "supply --email or --user-id") {
+		t.Fatalf("expected missing identifier error, got %v", err)
+	}
+}
+
+func TestRadarRejectsInvalidLimit(t *testing.T) {
+	t.Run("zero", func(t *testing.T) {
+		cmd := newRadarCmd()
+		cmd.SetArgs([]string{"--user-id", "user_123", "--limit", "0"})
+
+		err := cmd.Execute()
+		if err == nil || !strings.Contains(err.Error(), "--limit must be greater than 0") {
+			t.Fatalf("expected zero limit error, got %v", err)
+		}
+	})
+
+	t.Run("too large", func(t *testing.T) {
+		cmd := newRadarCmd()
+		cmd.SetArgs([]string{"--user-id", "user_123", "--limit", "101"})
+
+		err := cmd.Execute()
+		if err == nil || !strings.Contains(err.Error(), "--limit must be 100 or less") {
+			t.Fatalf("expected max limit error, got %v", err)
+		}
+	})
+}
+
+func radarPayload() map[string]any {
+	payload := emptyRadarPayload()
+	payload["radar_stats"] = map[string]any{
+		"successful_purchases":   3,
+		"efw_count":              3,
+		"efw_by_fraud_type":      map[string]any{"made_with_stolen_card": 2, "misc": 1},
+		"efw_with_elevated_risk": 2,
+		"efw_with_highest_risk":  1,
+		"dispute_count":          1,
+		"dispute_rate":           33.33,
+	}
+	payload["recent_efws"] = []map[string]any{
+		{
+			"purchase_id":       "purchase_123",
+			"fraud_type":        "made_with_stolen_card",
+			"charge_risk_level": "highest",
+			"resolution":        "unknown",
+			"created_at":        "2026-05-15T12:00:00Z",
+		},
+		{
+			"purchase_id":       "CH-charge_123",
+			"fraud_type":        "misc",
+			"charge_risk_level": "elevated",
+			"resolution":        "resolved_ignored",
+			"created_at":        "2026-05-15T11:00:00Z",
+		},
+	}
+	payload["pagination"] = map[string]any{"next": "cur-next", "limit": 50}
+	return payload
+}
+
+func emptyRadarPayload() map[string]any {
+	return map[string]any{
+		"success": true,
+		"user_id": "user_123",
+		"radar_stats": map[string]any{
+			"successful_purchases":   0,
+			"efw_count":              0,
+			"efw_by_fraud_type":      map[string]any{},
+			"efw_with_elevated_risk": 0,
+			"efw_with_highest_risk":  0,
+			"dispute_count":          0,
+			"dispute_rate":           0.0,
+		},
+		"recent_efws": []any{},
+		"pagination":  map[string]any{"next": nil, "limit": 20},
+	}
+}

--- a/internal/cmd/admin/users/users.go
+++ b/internal/cmd/admin/users/users.go
@@ -20,6 +20,7 @@ func NewUsersCmd() *cobra.Command {
   gumroad admin users comments list --user-id 2245593582708
   gumroad admin users comments add --user-id 2245593582708 --content "VAT exempt confirmed"
   gumroad admin users compliance --user-id 2245593582708
+  gumroad admin users radar --user-id 2245593582708
   gumroad admin users purchases --user-id 2245593582708 --status successful
   gumroad admin users related --email user@example.com --signal ip --signal payment_address
   gumroad admin users suspension --email user@example.com
@@ -37,6 +38,7 @@ func NewUsersCmd() *cobra.Command {
 	cmd.AddCommand(newAffiliatesCmd())
 	cmd.AddCommand(usercomments.NewCommentsCmd())
 	cmd.AddCommand(newComplianceCmd())
+	cmd.AddCommand(newRadarCmd())
 	cmd.AddCommand(newPurchasesCmd())
 	cmd.AddCommand(newRelatedCmd())
 	cmd.AddCommand(newSuspensionCmd())

--- a/internal/cmd/admin/users/users_test.go
+++ b/internal/cmd/admin/users/users_test.go
@@ -181,6 +181,7 @@ func TestNewUsersCmdWiresSubcommands(t *testing.T) {
 		"affiliates",
 		"comments",
 		"compliance",
+		"radar",
 		"purchases",
 		"related",
 		"suspension",

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -59,6 +59,7 @@ Responses are wrapped in `{"success": true, ...}` with resource-specific keys:
 - `admin users comments list` → `.comments[]`
 - `admin users comments add` → `.comment`
 - `admin users compliance` → `.compliance_info`, `.info_requests[]`
+- `admin users radar` → `.radar_stats`, `.recent_efws[]`
 - `admin users purchases` → `.purchases[]`
 - `admin users related` → `.related_users[]`, `.truncated`, `.per_signal_limit`
 - `admin purchases view` → `.purchase`
@@ -68,7 +69,7 @@ Responses are wrapped in `{"success": true, ...}` with resource-specific keys:
 
 Admin pagination models differ by command:
 
-- Cursor-paginated: `admin users affiliates`, `admin users comments list`, `admin users purchases`, and `admin purchases lookup` return `.pagination.next` as a cursor string. Pass it back with `--cursor`.
+- Cursor-paginated: `admin users affiliates`, `admin users comments list`, `admin users radar`, `admin users purchases`, and `admin purchases lookup` return `.pagination.next` as a cursor string. Pass it back with `--cursor`.
 - Page-paginated: `admin products list` returns `.pagination.next` as an integer page number. Pass it back with `--page`; use `--per-page` for page size.
 - Capped, not continuable: `admin users related` returns at most 50 related users per signal. Always inspect `.truncated`; when any signal is `true`, the result hit the cap and there is no cursor/page to fetch the rest.
 - Capped, not continuable: `admin purchases search` returns `.has_more` when the server capped results. `--limit` is server-capped at 25 and there is no continuation token.
@@ -112,8 +113,9 @@ gumroad admin users affiliates --email seller@example.com --direction received -
 gumroad admin users comments list --user-id 2245593582708 --type note --limit 50 --json --non-interactive --no-input
 gumroad admin users comments add --user-id 2245593582708 --content "VAT exempt confirmed" --yes --json --non-interactive --no-input
 
-# Inspect compliance and buyer history
+# Inspect compliance, Radar risk, and buyer history
 gumroad admin users compliance --user-id 2245593582708 --json --non-interactive --no-input
+gumroad admin users radar --user-id 2245593582708 --limit 50 --json --non-interactive --no-input
 gumroad admin users purchases --user-id 2245593582708 --status successful --has-early-fraud-warning=false --limit 50 --json --non-interactive --no-input
 
 # Find related accounts by risk signals


### PR DESCRIPTION
Ref antiwork/gumroad-private/issues/362

## What
- Adds `gumroad admin users radar` so the CLI can read seller-level Radar and EFW aggregates from the internal admin API.
- Prints the summary stats and recent EFW rows, with `--cursor` and `--limit` support matching the other cursor-backed admin read commands.
- Updates the admin help text and Gumroad docs so the new command is discoverable.

## Why
- This gives Gumclaw a direct CLI path for the Radar data that the web admin UI already exposes.
- It avoids scraping the UI or running ad hoc Rails checks, while keeping the command shape consistent with the rest of the admin user commands.

---

This PR was implemented with AI assistance using gpt-5.5 xhigh.