### PR TITLE
Tighten radar plain output

### DIFF
--- a/internal/cmd/admin/users/radar.go
+++ b/internal/cmd/admin/users/radar.go
@@ -156,23 +156,11 @@ func writeRadarEFWTable(w io.Writer, style output.Styler, efws []recentEFW) erro
 }
 
 func writeRadarPlain(w io.Writer, identifier string, resp radarResponse) error {
-	capacity := len(resp.RecentEFWs)
-	if capacity == 0 {
-		capacity = 1
-	}
-	rows := make([][]string, 0, capacity)
-	if len(resp.RecentEFWs) == 0 {
-		rows = append(rows, radarPlainRow(identifier, resp.UserID, resp.RadarStats, recentEFW{}))
-	} else {
-		for _, efw := range resp.RecentEFWs {
-			rows = append(rows, radarPlainRow(identifier, resp.UserID, resp.RadarStats, efw))
-		}
-	}
-	return output.PrintPlain(w, rows)
+	return output.PrintPlain(w, [][]string{radarPlainRow(identifier, resp.UserID, resp.RadarStats)})
 }
 
-func radarPlainRow(identifier, userID string, stats radarStats, efw recentEFW) []string {
-	return append([]string{
+func radarPlainRow(identifier, userID string, stats radarStats) []string {
+	return []string{
 		identifier,
 		userID,
 		formatRadarInt(stats.SuccessfulPurchases),
@@ -182,7 +170,7 @@ func radarPlainRow(identifier, userID string, stats radarStats, efw recentEFW) [
 		formatRadarInt(stats.EFWWithHighestRisk),
 		formatRadarInt(stats.DisputeCount),
 		formatRadarDecimal(stats.DisputeRate),
-	}, radarEFWRow(efw)...)
+	}
 }
 
 func radarEFWRow(efw recentEFW) []string {
@@ -220,7 +208,7 @@ func formatRadarInt(value api.JSONInt) string {
 func formatRadarDecimal(value float64) string {
 	formatted := strconv.FormatFloat(value, 'f', 2, 64)
 	formatted = strings.TrimRight(strings.TrimRight(formatted, "0"), ".")
-	if formatted == "" || formatted == "-0" {
+	if formatted == "-0" {
 		return "0"
 	}
 	return formatted

--- a/internal/cmd/admin/users/radar_test.go
+++ b/internal/cmd/admin/users/radar_test.go
@@ -138,12 +138,24 @@ func TestRadarPlainOutput(t *testing.T) {
 	cmd.SetArgs([]string{"--email", "seller@example.com"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	want := strings.Join([]string{
-		"seller@example.com\tuser_123\t3\t3\tmade_with_stolen_card=2, misc=1\t2\t1\t1\t33.33\tpurchase_123\tmade_with_stolen_card\thighest\tunknown\t2026-05-15T12:00:00Z",
-		"seller@example.com\tuser_123\t3\t3\tmade_with_stolen_card=2, misc=1\t2\t1\t1\t33.33\tCH-charge_123\tmisc\televated\tresolved_ignored\t2026-05-15T11:00:00Z",
-	}, "\n")
+	want := "seller@example.com\tuser_123\t3\t3\tmade_with_stolen_card=2, misc=1\t2\t1\t1\t33.33"
 	if strings.TrimSpace(out) != want {
 		t.Fatalf("unexpected plain output:\ngot  %q\nwant %q", strings.TrimSpace(out), want)
+	}
+}
+
+func TestRadarPlainOutputWithoutRecentEFWs(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, emptyRadarPayload())
+	})
+
+	cmd := testutil.Command(newRadarCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{"--user-id", "user_123"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	want := "user_123\tuser_123\t0\t0\t(none)\t0\t0\t0\t0"
+	if strings.TrimSpace(out) != want {
+		t.Fatalf("unexpected empty plain output:\ngot  %q\nwant %q", strings.TrimSpace(out), want)
 	}
 }
 


### PR DESCRIPTION
Ref antiwork/gumroad-private#362

## What

Tighten the follow-up behavior for the new admin Radar command. Plain output now emits one aggregate stats row instead of repeating the same summary fields once per recent EFW, while JSON and human output still include the recent EFW details.

## Why

The command returns both summary data and a paginated detail list. Keeping plain output as a single stats row avoids locking in a mixed tabular contract that no other admin user command uses, and the added empty-result coverage protects that shape.

---

This PR was implemented with AI assistance using gpt-5.5 xhigh.
