### PR TITLE
Add sales CSV export support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ gumroad products view abc123
 # Fetch all sales, filter with jq
 gumroad sales list --all --json --jq '.sales[] | {email, formatted_total_price}'
 
+# Export a small filtered sales CSV
+gumroad sales list --after 2024-01-01 --before 2024-01-31 --csv > sales.csv
+
 # Preview a refund without executing it
 gumroad sales refund abc123 --amount 5.00 --dry-run
 ```
@@ -158,6 +161,8 @@ gumroad products update <product_id> --replace-files --keep-file <file_id> --fil
 | `--quiet` | Minimal | Scripts |
 
 Paginated commands (`sales list`, `payouts list`, `subscribers list`) accept `--all` to fetch every page. Use `--page-delay 200ms` to pace large fetches.
+
+`gumroad sales list --csv` writes `id,email,product_name,total_cents,currency,refunded,refunded_cents,created_at` for small filtered exports.
 
 ## AI agents
 

--- a/internal/cmd/sales/list.go
+++ b/internal/cmd/sales/list.go
@@ -115,7 +115,10 @@ func validateSalesCSVOutput(cmd *cobra.Command, opts cmdutil.Options, csvOutput 
 
 func renderSalesList(opts cmdutil.Options, resp salesListResponse, product, email, orderID, before, after string, csvOutput bool) error {
 	if csvOutput {
-		return writeSalesCSV(opts.Out(), resp.Sales)
+		if err := writeSalesCSV(opts.Out(), resp.Sales); err != nil {
+			return err
+		}
+		return renderSalesCSVPageHint(opts, product, email, orderID, before, after, resp.NextPageKey)
 	}
 
 	if len(resp.Sales) == 0 {
@@ -137,6 +140,15 @@ func renderSalesList(opts cmdutil.Options, resp salesListResponse, product, emai
 		}
 		return nil
 	})
+}
+
+func renderSalesCSVPageHint(opts cmdutil.Options, product, email, orderID, before, after, nextPageKey string) error {
+	if nextPageKey == "" || opts.Quiet {
+		return nil
+	}
+
+	hint := salesCSVAllHint(product, email, orderID, before, after)
+	return output.Writeln(opts.Err(), opts.Style().Dim("More results available: "+hint))
 }
 
 func streamSalesListAll(opts cmdutil.Options, params url.Values, csvOutput bool) error {
@@ -314,5 +326,17 @@ func salesPaginationHint(product, email, orderID, before, after, nextPageKey str
 		cmdutil.CommandArg{Flag: "--before", Value: before},
 		cmdutil.CommandArg{Flag: "--after", Value: after},
 		cmdutil.CommandArg{Flag: "--page-key", Value: nextPageKey},
+	)
+}
+
+func salesCSVAllHint(product, email, orderID, before, after string) string {
+	return cmdutil.ReplayCommand("gumroad sales list",
+		cmdutil.CommandArg{Flag: "--product", Value: product},
+		cmdutil.CommandArg{Flag: "--email", Value: email},
+		cmdutil.CommandArg{Flag: "--order", Value: orderID},
+		cmdutil.CommandArg{Flag: "--before", Value: before},
+		cmdutil.CommandArg{Flag: "--after", Value: after},
+		cmdutil.CommandArg{Flag: "--all", Boolean: true},
+		cmdutil.CommandArg{Flag: "--csv", Boolean: true},
 	)
 }

--- a/internal/cmd/sales/list.go
+++ b/internal/cmd/sales/list.go
@@ -1,6 +1,7 @@
 package sales
 
 import (
+	"bytes"
 	"encoding/csv"
 	"io"
 	"net/url"
@@ -21,19 +22,45 @@ type saleListItem struct {
 	FormattedTotal      string       `json:"formatted_total_price"`
 	CreatedAt           string       `json:"created_at"`
 	Refunded            bool         `json:"refunded"`
-	TotalCents          *api.JSONInt `json:"total_cents"`
-	Price               *api.JSONInt `json:"price"`
+	TotalCents          *nullableInt `json:"total_cents"`
+	Price               *nullableInt `json:"price"`
 	Currency            string       `json:"currency"`
 	CurrencyType        string       `json:"currency_type"`
 	PriceCurrencyType   string       `json:"price_currency_type"`
-	RefundedCents       *api.JSONInt `json:"refunded_cents"`
-	AmountRefundedCents *api.JSONInt `json:"amount_refunded_cents"`
+	RefundedCents       *nullableInt `json:"refunded_cents"`
+	AmountRefundedCents *nullableInt `json:"amount_refunded_cents"`
 }
 
 type salesListResponse struct {
 	Success     bool           `json:"success"`
 	Sales       []saleListItem `json:"sales"`
 	NextPageKey string         `json:"next_page_key,omitempty"`
+}
+
+type nullableInt struct {
+	value api.JSONInt
+	valid bool
+}
+
+func (n *nullableInt) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		n.valid = false
+		n.value = 0
+		return nil
+	}
+
+	if err := n.value.UnmarshalJSON(data); err != nil {
+		return err
+	}
+	n.valid = true
+	return nil
+}
+
+func (n nullableInt) MarshalJSON() ([]byte, error) {
+	if !n.valid {
+		return []byte("null"), nil
+	}
+	return []byte(strconv.Itoa(int(n.value))), nil
 }
 
 func newListCmd() *cobra.Command {
@@ -254,10 +281,10 @@ func writeSalesCSVRows(cw *csv.Writer, sales []saleListItem) error {
 			s.ID,
 			s.Email,
 			s.ProductName,
-			formatJSONInt(firstJSONInt(s.TotalCents, s.Price)),
+			formatNullableInt(firstNullableInt(s.TotalCents, s.Price)),
 			s.csvCurrency(),
 			strconv.FormatBool(s.Refunded),
-			formatJSONInt(firstJSONInt(s.RefundedCents, s.AmountRefundedCents)),
+			formatNullableInt(firstNullableInt(s.RefundedCents, s.AmountRefundedCents)),
 			s.CreatedAt,
 		}); err != nil {
 			return err
@@ -275,20 +302,20 @@ func (s saleListItem) csvCurrency() string {
 	return ""
 }
 
-func firstJSONInt(values ...*api.JSONInt) *api.JSONInt {
+func firstNullableInt(values ...*nullableInt) *nullableInt {
 	for _, value := range values {
-		if value != nil {
+		if value != nil && value.valid {
 			return value
 		}
 	}
 	return nil
 }
 
-func formatJSONInt(value *api.JSONInt) string {
+func formatNullableInt(value *nullableInt) string {
 	if value == nil {
 		return "0"
 	}
-	return strconv.Itoa(int(*value))
+	return strconv.Itoa(int(value.value))
 }
 
 func writeSalesTable(w io.Writer, style output.Styler, sales []saleListItem) error {

--- a/internal/cmd/sales/list.go
+++ b/internal/cmd/sales/list.go
@@ -1,8 +1,11 @@
 package sales
 
 import (
+	"encoding/csv"
 	"io"
 	"net/url"
+	"strconv"
+	"strings"
 
 	"github.com/antiwork/gumroad-cli/internal/api"
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
@@ -12,12 +15,19 @@ import (
 )
 
 type saleListItem struct {
-	ID             string `json:"id"`
-	Email          string `json:"email"`
-	ProductName    string `json:"product_name"`
-	FormattedTotal string `json:"formatted_total_price"`
-	CreatedAt      string `json:"created_at"`
-	Refunded       bool   `json:"refunded"`
+	ID                  string       `json:"id"`
+	Email               string       `json:"email"`
+	ProductName         string       `json:"product_name"`
+	FormattedTotal      string       `json:"formatted_total_price"`
+	CreatedAt           string       `json:"created_at"`
+	Refunded            bool         `json:"refunded"`
+	TotalCents          *api.JSONInt `json:"total_cents"`
+	Price               *api.JSONInt `json:"price"`
+	Currency            string       `json:"currency"`
+	CurrencyType        string       `json:"currency_type"`
+	PriceCurrencyType   string       `json:"price_currency_type"`
+	RefundedCents       *api.JSONInt `json:"refunded_cents"`
+	AmountRefundedCents *api.JSONInt `json:"amount_refunded_cents"`
 }
 
 type salesListResponse struct {
@@ -28,7 +38,7 @@ type salesListResponse struct {
 
 func newListCmd() *cobra.Command {
 	var product, email, orderID, before, after, pageKey string
-	var all bool
+	var all, csvOutput bool
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -36,10 +46,14 @@ func newListCmd() *cobra.Command {
 		Args:  cmdutil.ExactArgs(0),
 		Example: `  gumroad sales list
   gumroad sales list --product <id> --after 2024-01-01
+  gumroad sales list --after 2024-01-01 --csv
   gumroad sales list --all
   gumroad sales list --json --jq '.sales[0].id'`,
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
+			if err := validateSalesCSVOutput(c, opts, csvOutput); err != nil {
+				return err
+			}
 			if err := cmdutil.RequireDateFlag(c, "before", before); err != nil {
 				return err
 			}
@@ -67,11 +81,11 @@ func newListCmd() *cobra.Command {
 				params.Set("page_key", pageKey)
 			}
 			if all {
-				return streamSalesListAll(opts, params)
+				return streamSalesListAll(opts, params, csvOutput)
 			}
 
 			return cmdutil.RunRequestDecoded[salesListResponse](opts, "Fetching sales...", "GET", "/sales", params, func(resp salesListResponse) error {
-				return renderSalesList(opts, resp, product, email, orderID, before, after)
+				return renderSalesList(opts, resp, product, email, orderID, before, after, csvOutput)
 			})
 		},
 	}
@@ -83,12 +97,27 @@ func newListCmd() *cobra.Command {
 	cmd.Flags().StringVar(&after, "after", "", "Filter sales after date (YYYY-MM-DD)")
 	cmd.Flags().StringVar(&pageKey, "page-key", "", "Pagination cursor")
 	cmd.Flags().BoolVar(&all, "all", false, "Fetch all pages")
+	cmd.Flags().BoolVar(&csvOutput, "csv", false, "Output as CSV")
 	cmd.MarkFlagsMutuallyExclusive("all", "page-key")
 
 	return cmd
 }
 
-func renderSalesList(opts cmdutil.Options, resp salesListResponse, product, email, orderID, before, after string) error {
+func validateSalesCSVOutput(cmd *cobra.Command, opts cmdutil.Options, csvOutput bool) error {
+	if !csvOutput {
+		return nil
+	}
+	if opts.JSONOutput || opts.JQExpr != "" || opts.PlainOutput {
+		return cmdutil.NewUsageError(cmd, "--csv cannot be combined with --json, --jq, or --plain")
+	}
+	return nil
+}
+
+func renderSalesList(opts cmdutil.Options, resp salesListResponse, product, email, orderID, before, after string, csvOutput bool) error {
+	if csvOutput {
+		return writeSalesCSV(opts.Out(), resp.Sales)
+	}
+
 	if len(resp.Sales) == 0 {
 		return renderEmptySalesList(opts, product, email, orderID, before, after, resp.NextPageKey)
 	}
@@ -110,7 +139,7 @@ func renderSalesList(opts cmdutil.Options, resp salesListResponse, product, emai
 	})
 }
 
-func streamSalesListAll(opts cmdutil.Options, params url.Values) error {
+func streamSalesListAll(opts cmdutil.Options, params url.Values, csvOutput bool) error {
 	token, err := config.Token()
 	if err != nil {
 		return err
@@ -126,6 +155,10 @@ func streamSalesListAll(opts cmdutil.Options, params url.Values) error {
 	style := opts.Style()
 	walkPages := func(visit cmdutil.PageVisitor[salesListResponse]) error {
 		return walkSalesPages(opts, client, params, visit)
+	}
+
+	if csvOutput {
+		return streamSalesCSV(opts.Out(), walkPages)
 	}
 
 	return cmdutil.StreamPaginatedPages(opts, cmdutil.PaginatedPageOutputConfig[salesListResponse]{
@@ -168,6 +201,82 @@ func writeSalesPlain(w io.Writer, sales []saleListItem) error {
 		rows = append(rows, []string{s.ID, s.Email, s.ProductName, s.FormattedTotal, s.CreatedAt})
 	}
 	return output.PrintPlain(w, rows)
+}
+
+var salesCSVHeader = []string{"id", "email", "product_name", "total_cents", "currency", "refunded", "refunded_cents", "created_at"}
+
+func writeSalesCSV(w io.Writer, sales []saleListItem) error {
+	cw := csv.NewWriter(w)
+	if err := writeSalesCSVHeader(cw); err != nil {
+		return err
+	}
+	if err := writeSalesCSVRows(cw, sales); err != nil {
+		return err
+	}
+	cw.Flush()
+	return cw.Error()
+}
+
+func streamSalesCSV(w io.Writer, walkPages func(cmdutil.PageVisitor[salesListResponse]) error) error {
+	cw := csv.NewWriter(w)
+	if err := writeSalesCSVHeader(cw); err != nil {
+		return err
+	}
+	err := walkPages(func(page salesListResponse) (bool, error) {
+		return false, writeSalesCSVRows(cw, page.Sales)
+	})
+	cw.Flush()
+	if err != nil {
+		return err
+	}
+	return cw.Error()
+}
+
+func writeSalesCSVHeader(cw *csv.Writer) error {
+	return cw.Write(salesCSVHeader)
+}
+
+func writeSalesCSVRows(cw *csv.Writer, sales []saleListItem) error {
+	for _, s := range sales {
+		if err := cw.Write([]string{
+			s.ID,
+			s.Email,
+			s.ProductName,
+			formatJSONInt(firstJSONInt(s.TotalCents, s.Price)),
+			s.csvCurrency(),
+			strconv.FormatBool(s.Refunded),
+			formatJSONInt(firstJSONInt(s.RefundedCents, s.AmountRefundedCents)),
+			s.CreatedAt,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s saleListItem) csvCurrency() string {
+	for _, value := range []string{s.Currency, s.CurrencyType, s.PriceCurrencyType} {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func firstJSONInt(values ...*api.JSONInt) *api.JSONInt {
+	for _, value := range values {
+		if value != nil {
+			return value
+		}
+	}
+	return nil
+}
+
+func formatJSONInt(value *api.JSONInt) string {
+	if value == nil {
+		return "0"
+	}
+	return strconv.Itoa(int(*value))
 }
 
 func writeSalesTable(w io.Writer, style output.Styler, sales []saleListItem) error {

--- a/internal/cmd/sales/sales_test.go
+++ b/internal/cmd/sales/sales_test.go
@@ -179,6 +179,38 @@ func TestList_CSVOutputUsesCurrentSalesAPIFields(t *testing.T) {
 	}
 }
 
+func TestList_CSVOutputSkipsNullPrimaryNumericFields(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"sales": []map[string]any{
+				{
+					"id":                    "s1",
+					"email":                 "a@b.com",
+					"product_name":          "Art",
+					"total_cents":           nil,
+					"price":                 1000,
+					"currency":              "usd",
+					"refunded":              true,
+					"refunded_cents":        nil,
+					"amount_refunded_cents": 250,
+					"created_at":            "2024-01-15T10:00:00Z",
+				},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newListCmd())
+	cmd.SetArgs([]string{"--csv"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	records := readCSVRecords(t, out)
+	want := [][]string{
+		{"id", "email", "product_name", "total_cents", "currency", "refunded", "refunded_cents", "created_at"},
+		{"s1", "a@b.com", "Art", "1000", "usd", "true", "250", "2024-01-15T10:00:00Z"},
+	}
+	assertCSVRecords(t, records, want)
+}
+
 func TestList_EmptyCSVOutputWritesHeader(t *testing.T) {
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
 		testutil.JSON(t, w, map[string]any{"sales": []any{}})

--- a/internal/cmd/sales/sales_test.go
+++ b/internal/cmd/sales/sales_test.go
@@ -1,15 +1,36 @@
 package sales
 
 import (
+	"encoding/csv"
 	"encoding/json"
 	"errors"
 	"net/http"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/testutil"
+	"github.com/spf13/cobra"
 )
+
+func readCSVRecords(t *testing.T, value string) [][]string {
+	t.Helper()
+
+	records, err := csv.NewReader(strings.NewReader(value)).ReadAll()
+	if err != nil {
+		t.Fatalf("read CSV output: %v\n%s", err, value)
+	}
+	return records
+}
+
+func assertCSVRecords(t *testing.T, got, want [][]string) {
+	t.Helper()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected CSV records:\ngot  %#v\nwant %#v", got, want)
+	}
+}
 
 func TestList_AllFilters(t *testing.T) {
 	var gotQuery string
@@ -64,6 +85,84 @@ func TestList_Pagination(t *testing.T) {
 	}
 }
 
+func TestList_CSVOutput(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"sales": []map[string]any{
+				{
+					"id":             "s1",
+					"email":          "a@b.com",
+					"product_name":   "Art, Pack",
+					"total_cents":    1000,
+					"currency":       "usd",
+					"refunded":       true,
+					"refunded_cents": 250,
+					"created_at":     "2024-01-15T10:00:00Z",
+				},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newListCmd())
+	cmd.SetArgs([]string{"--csv"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	records := readCSVRecords(t, out)
+	want := [][]string{
+		{"id", "email", "product_name", "total_cents", "currency", "refunded", "refunded_cents", "created_at"},
+		{"s1", "a@b.com", "Art, Pack", "1000", "usd", "true", "250", "2024-01-15T10:00:00Z"},
+	}
+	assertCSVRecords(t, records, want)
+}
+
+func TestList_CSVOutputUsesCurrentSalesAPIFields(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"sales": []map[string]any{
+				{
+					"id":                    "s1",
+					"email":                 "a@b.com",
+					"product_name":          "Art",
+					"price":                 1000,
+					"currency_type":         "usd",
+					"refunded":              false,
+					"amount_refunded_cents": 0,
+					"created_at":            "2024-01-15T10:00:00Z",
+				},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newListCmd())
+	cmd.SetArgs([]string{"--csv"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	records := readCSVRecords(t, out)
+	if got := records[1][3]; got != "1000" {
+		t.Fatalf("got total_cents %q, want 1000", got)
+	}
+	if got := records[1][4]; got != "usd" {
+		t.Fatalf("got currency %q, want usd", got)
+	}
+	if got := records[1][6]; got != "0" {
+		t.Fatalf("got refunded_cents %q, want 0", got)
+	}
+}
+
+func TestList_EmptyCSVOutputWritesHeader(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{"sales": []any{}})
+	})
+
+	cmd := testutil.Command(newListCmd())
+	cmd.SetArgs([]string{"--csv"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	records := readCSVRecords(t, out)
+	want := [][]string{{"id", "email", "product_name", "total_cents", "currency", "refunded", "refunded_cents", "created_at"}}
+	assertCSVRecords(t, records, want)
+}
+
 func TestList_AllFetchesAllPages(t *testing.T) {
 	requests := 0
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
@@ -105,6 +204,45 @@ func TestList_AllFetchesAllPages(t *testing.T) {
 	}
 }
 
+func TestList_AllCSVOutputStreamsAllPages(t *testing.T) {
+	requests := 0
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		switch r.URL.Query().Get("page_key") {
+		case "":
+			testutil.JSON(t, w, map[string]any{
+				"sales": []map[string]any{
+					{"id": "s1", "email": "a@b.com", "product_name": "Art", "price": 1000, "currency_type": "usd", "created_at": "2024-01-15"},
+				},
+				"next_page_key": "cursor123",
+			})
+		case "cursor123":
+			testutil.JSON(t, w, map[string]any{
+				"sales": []map[string]any{
+					{"id": "s2", "email": "b@c.com", "product_name": "Book", "price": 1200, "currency_type": "usd", "refunded": true, "amount_refunded_cents": 1200, "created_at": "2024-01-16"},
+				},
+			})
+		default:
+			t.Fatalf("unexpected page_key %q", r.URL.Query().Get("page_key"))
+		}
+	})
+
+	cmd := testutil.Command(newListCmd())
+	cmd.SetArgs([]string{"--all", "--csv"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	records := readCSVRecords(t, out)
+	want := [][]string{
+		{"id", "email", "product_name", "total_cents", "currency", "refunded", "refunded_cents", "created_at"},
+		{"s1", "a@b.com", "Art", "1000", "usd", "false", "0", "2024-01-15"},
+		{"s2", "b@c.com", "Book", "1200", "usd", "true", "1200", "2024-01-16"},
+	}
+	assertCSVRecords(t, records, want)
+	if requests != 2 {
+		t.Fatalf("got %d requests, want 2", requests)
+	}
+}
+
 func TestList_SinglePageDoesNotWalkPages(t *testing.T) {
 	requests := 0
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
@@ -139,6 +277,34 @@ func TestList_SinglePageDoesNotWalkPages(t *testing.T) {
 	}
 	if resp.NextPageKey != "cursor123" {
 		t.Fatalf("got next_page_key=%q, want cursor123", resp.NextPageKey)
+	}
+}
+
+func TestList_CSVRejectsOtherOutputModes(t *testing.T) {
+	tests := []struct {
+		name    string
+		command *cobra.Command
+	}{
+		{"json", testutil.Command(newListCmd(), testutil.JSONOutput())},
+		{"jq", testutil.Command(newListCmd(), testutil.JQ(".sales"))},
+		{"plain", testutil.Command(newListCmd(), testutil.PlainOutput())},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+				t.Error("should not reach API with conflicting output flags")
+			})
+
+			tt.command.SetArgs([]string{"--csv"})
+			err := tt.command.Execute()
+			if err == nil {
+				t.Fatal("expected conflicting output mode error")
+			}
+			if !strings.Contains(err.Error(), "--csv cannot be combined with --json, --jq, or --plain") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/cmd/sales/sales_test.go
+++ b/internal/cmd/sales/sales_test.go
@@ -115,6 +115,36 @@ func TestList_CSVOutput(t *testing.T) {
 	assertCSVRecords(t, records, want)
 }
 
+func TestList_CSVOutputWarnsWhenMorePagesExist(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"sales": []map[string]any{
+				{"id": "s1", "email": "a@b.com", "product_name": "Art", "price": 1000, "currency_type": "usd", "created_at": "2024-01-15"},
+			},
+			"next_page_key": "cursor123",
+		})
+	})
+
+	cmd := testutil.Command(newListCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--product", "p1", "--after", "2024-01-01", "--csv"})
+	stdout, stderr := testutil.CaptureOutput(func() { testutil.MustExecute(t, cmd) })
+
+	records := readCSVRecords(t, stdout)
+	want := [][]string{
+		{"id", "email", "product_name", "total_cents", "currency", "refunded", "refunded_cents", "created_at"},
+		{"s1", "a@b.com", "Art", "1000", "usd", "false", "0", "2024-01-15"},
+	}
+	assertCSVRecords(t, records, want)
+	if strings.Contains(stdout, "More results available") {
+		t.Fatalf("CSV stdout must not include pagination warning, got %q", stdout)
+	}
+
+	wantHint := "More results available: gumroad sales list --product p1 --after 2024-01-01 --all --csv"
+	if !strings.Contains(stderr, wantHint) {
+		t.Fatalf("stderr missing pagination hint %q in %q", wantHint, stderr)
+	}
+}
+
 func TestList_CSVOutputUsesCurrentSalesAPIFields(t *testing.T) {
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
 		testutil.JSON(t, w, map[string]any{

--- a/skills/embed_test.go
+++ b/skills/embed_test.go
@@ -37,6 +37,23 @@ func TestSkillMarkdown_ContainsAllCommands(t *testing.T) {
 	}
 }
 
+func TestSkillMarkdown_ContainsSalesCSVExample(t *testing.T) {
+	data, err := SkillMarkdown()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	content := string(data)
+	for _, example := range []string{
+		"gumroad sales list --after 2024-01-01 --before 2024-01-31 --csv --no-input",
+		"`--product`, `--order`, `--email`, `--after` (YYYY-MM-DD), `--before` (YYYY-MM-DD), `--all`, `--page-key`, `--csv`",
+	} {
+		if !strings.Contains(content, example) {
+			t.Errorf("expected skill to mention sales CSV example %q", example)
+		}
+	}
+}
+
 func TestSkillMarkdown_ContainsAdminRolloutCommands(t *testing.T) {
 	data, err := SkillMarkdown()
 	if err != nil {

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -198,6 +198,7 @@ gumroad sales list --json --no-input
 gumroad sales list --product <id> --after 2024-01-01 --json --no-input
 gumroad sales list --email user@example.com --json --no-input
 gumroad sales list --all --json --no-input
+gumroad sales list --after 2024-01-01 --before 2024-01-31 --csv --no-input
 
 # Find a sale by email
 gumroad sales list --json --jq '.sales[] | select(.email == "user@example.com")' --no-input
@@ -213,7 +214,7 @@ gumroad sales refund <id> --amount 5.00 --yes --json --no-input
 gumroad sales resend-receipt <id> --json --no-input
 ```
 
-**List filters:** `--product`, `--order`, `--email`, `--after` (YYYY-MM-DD), `--before` (YYYY-MM-DD), `--all`, `--page-key`.
+**List filters/output:** `--product`, `--order`, `--email`, `--after` (YYYY-MM-DD), `--before` (YYYY-MM-DD), `--all`, `--page-key`, `--csv`.
 
 ### payouts — View payouts
 


### PR DESCRIPTION
Ref #97

## What

- Added `gumroad sales list --csv` for small filtered exports.
- The CSV output uses raw cent values and includes refunded amount data instead of human-formatted prices.
- `--csv` works with normal filtered listing and `--all`, and it is rejected alongside `--json`, `--jq`, and `--plain`.
- Updated the bundled Gumroad skill and docs so the new flag and example stay in sync with the CLI.

## Why

- This gives sellers a quick terminal-friendly export path without waiting for the larger async export flow.
- Keeping the skill and docs aligned matters here because this command is meant to be used directly from the terminal and by agents.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad-cli/pr/105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781995868&installation_id=134400930&pr_number=105&repository=antiwork%2Fgumroad-cli&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad-cli%2Fpull%2F105&signature=5c6fd86e803d634fcb6eb498675559de8de29d49b60276d335a26c0f3c7f20a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->