### PR TITLE
Add sales export support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ gumroad sales list --all --json --jq '.sales[] | {email, formatted_total_price}'
 # Export a small filtered sales CSV
 gumroad sales list --after 2024-01-01 --before 2024-01-31 --csv > sales.csv
 
+# Request a larger sales CSV by email
+gumroad sales export --from 2026-01-01 --to 2026-05-21
+
 # Preview a refund without executing it
 gumroad sales refund abc123 --amount 5.00 --dry-run
 ```
@@ -92,7 +95,7 @@ gumroad auth          login, status, logout
 gumroad admin         Internal admin API commands
 gumroad user          View your account info
 gumroad products      create, update, list, view, delete, publish, unpublish, skus
-gumroad sales         list, view, refund, ship, resend-receipt
+gumroad sales         list, export, view, refund, ship, resend-receipt
 gumroad payouts       list, view, upcoming
 gumroad subscribers   list, view
 gumroad licenses      verify, enable, disable, decrement, rotate

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ gumroad sales list --after 2024-01-01 --before 2024-01-31 --csv > sales.csv
 
 # Request a larger sales CSV by email
 gumroad sales export --from 2026-01-01 --to 2026-05-21
+gumroad sales export --after 2026-01-01 --before 2026-05-21
 
 # Preview a refund without executing it
 gumroad sales refund abc123 --amount 5.00 --dry-run

--- a/internal/cmd/sales/export.go
+++ b/internal/cmd/sales/export.go
@@ -17,30 +17,34 @@ type salesExportResponse struct {
 }
 
 func newExportCmd() *cobra.Command {
-	var from, to, product string
+	var from, to, after, before, product string
 
 	cmd := &cobra.Command{
 		Use:   "export",
 		Short: "Request an emailed sales CSV export",
 		Args:  cmdutil.ExactArgs(0),
 		Example: `  gumroad sales export --from 2026-01-01 --to 2026-05-21
+  gumroad sales export --after 2026-01-01 --before 2026-05-21
   gumroad sales export --product <id>
   gumroad sales export --json`,
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
-			if err := cmdutil.RequireDateFlag(c, "from", from); err != nil {
+
+			startDate, err := salesExportDateValue(c, "from", from, "after", after)
+			if err != nil {
 				return err
 			}
-			if err := cmdutil.RequireDateFlag(c, "to", to); err != nil {
+			endDate, err := salesExportDateValue(c, "to", to, "before", before)
+			if err != nil {
 				return err
 			}
 
 			params := url.Values{}
-			if from != "" {
-				params.Set("from", from)
+			if startDate != "" {
+				params.Set("from", startDate)
 			}
-			if to != "" {
-				params.Set("to", to)
+			if endDate != "" {
+				params.Set("to", endDate)
 			}
 			if product != "" {
 				params.Set("product_id", product)
@@ -54,9 +58,29 @@ func newExportCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&from, "from", "", "Export sales from date (YYYY-MM-DD)")
 	cmd.Flags().StringVar(&to, "to", "", "Export sales to date (YYYY-MM-DD)")
+	cmd.Flags().StringVar(&after, "after", "", "Alias for --from")
+	cmd.Flags().StringVar(&before, "before", "", "Alias for --to")
 	cmd.Flags().StringVar(&product, "product", "", "Filter by product ID")
 
 	return cmd
+}
+
+func salesExportDateValue(cmd *cobra.Command, primaryFlag, primaryValue, aliasFlag, aliasValue string) (string, error) {
+	primaryChanged := cmd.Flags().Changed(primaryFlag)
+	aliasChanged := cmd.Flags().Changed(aliasFlag)
+	if primaryChanged && aliasChanged {
+		return "", cmdutil.UsageErrorf(cmd, "--%s cannot be combined with --%s", aliasFlag, primaryFlag)
+	}
+	if err := cmdutil.RequireDateFlag(cmd, primaryFlag, primaryValue); err != nil {
+		return "", err
+	}
+	if err := cmdutil.RequireDateFlag(cmd, aliasFlag, aliasValue); err != nil {
+		return "", err
+	}
+	if aliasChanged {
+		return aliasValue, nil
+	}
+	return primaryValue, nil
 }
 
 func renderSalesExport(opts cmdutil.Options, resp salesExportResponse) error {

--- a/internal/cmd/sales/export.go
+++ b/internal/cmd/sales/export.go
@@ -1,0 +1,74 @@
+package sales
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+type salesExportResponse struct {
+	Success        bool   `json:"success"`
+	Status         string `json:"status"`
+	RecipientEmail string `json:"recipient_email"`
+}
+
+func newExportCmd() *cobra.Command {
+	var from, to, product string
+
+	cmd := &cobra.Command{
+		Use:   "export",
+		Short: "Request an emailed sales CSV export",
+		Args:  cmdutil.ExactArgs(0),
+		Example: `  gumroad sales export --from 2026-01-01 --to 2026-05-21
+  gumroad sales export --product <id>
+  gumroad sales export --json`,
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			if err := cmdutil.RequireDateFlag(c, "from", from); err != nil {
+				return err
+			}
+			if err := cmdutil.RequireDateFlag(c, "to", to); err != nil {
+				return err
+			}
+
+			params := url.Values{}
+			if from != "" {
+				params.Set("from", from)
+			}
+			if to != "" {
+				params.Set("to", to)
+			}
+			if product != "" {
+				params.Set("product_id", product)
+			}
+
+			return cmdutil.RunRequestDecoded[salesExportResponse](opts, "Requesting sales export...", http.MethodPost, "/sales/exports", params, func(resp salesExportResponse) error {
+				return renderSalesExport(opts, resp)
+			})
+		},
+	}
+
+	cmd.Flags().StringVar(&from, "from", "", "Export sales from date (YYYY-MM-DD)")
+	cmd.Flags().StringVar(&to, "to", "", "Export sales to date (YYYY-MM-DD)")
+	cmd.Flags().StringVar(&product, "product", "", "Filter by product ID")
+
+	return cmd
+}
+
+func renderSalesExport(opts cmdutil.Options, resp salesExportResponse) error {
+	if opts.PlainOutput {
+		return output.PrintPlain(opts.Out(), [][]string{{resp.Status, resp.RecipientEmail}})
+	}
+	return cmdutil.PrintSuccess(opts, salesExportQueuedMessage(resp.RecipientEmail))
+}
+
+func salesExportQueuedMessage(email string) string {
+	if email == "" {
+		return "Sales export queued."
+	}
+	return fmt.Sprintf("CSV will be emailed to %s when ready.", email)
+}

--- a/internal/cmd/sales/sales.go
+++ b/internal/cmd/sales/sales.go
@@ -9,11 +9,13 @@ func NewSalesCmd() *cobra.Command {
 		Use:   "sales",
 		Short: "Manage sales",
 		Example: `  gumroad sales list
+  gumroad sales export --from 2026-01-01 --to 2026-05-21
   gumroad sales view <id>
   gumroad sales refund <id>`,
 	}
 
 	cmd.AddCommand(newListCmd())
+	cmd.AddCommand(newExportCmd())
 	cmd.AddCommand(newViewCmd())
 	cmd.AddCommand(newRefundCmd())
 	cmd.AddCommand(newShipCmd())

--- a/internal/cmd/sales/sales_test.go
+++ b/internal/cmd/sales/sales_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"net/url"
 	"reflect"
 	"strings"
 	"testing"
@@ -223,6 +224,139 @@ func TestList_EmptyCSVOutputWritesHeader(t *testing.T) {
 	records := readCSVRecords(t, out)
 	want := [][]string{{"id", "email", "product_name", "total_cents", "currency", "refunded", "refunded_cents", "created_at"}}
 	assertCSVRecords(t, records, want)
+}
+
+func TestExport_QueuesSalesExportWithFilters(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotForm url.Values
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm failed: %v", err)
+		}
+		gotForm = r.PostForm
+		testutil.JSON(t, w, map[string]any{
+			"status":          "queued",
+			"recipient_email": "seller@example.com",
+		})
+	})
+
+	cmd := testutil.Command(newExportCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--from", "2026-01-01", "--to", "2026-05-21", "--product", "prod_123"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != http.MethodPost || gotPath != "/sales/exports" {
+		t.Fatalf("got %s %s, want POST /sales/exports", gotMethod, gotPath)
+	}
+	for key, want := range map[string]string{
+		"from":       "2026-01-01",
+		"to":         "2026-05-21",
+		"product_id": "prod_123",
+	} {
+		if got := gotForm.Get(key); got != want {
+			t.Fatalf("got %s=%q, want %q", key, got, want)
+		}
+	}
+	if !strings.Contains(out, "CSV will be emailed to seller@example.com when ready.") {
+		t.Fatalf("unexpected output: %q", out)
+	}
+}
+
+func TestExport_QueuesSalesExportWithoutFilters(t *testing.T) {
+	var gotForm url.Values
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm failed: %v", err)
+		}
+		gotForm = r.PostForm
+		testutil.JSON(t, w, map[string]any{
+			"status":          "queued",
+			"recipient_email": "seller@example.com",
+		})
+	})
+
+	cmd := testutil.Command(newExportCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if len(gotForm) != 0 {
+		t.Fatalf("expected no form filters, got %#v", gotForm)
+	}
+}
+
+func TestExport_JSON(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"status":          "queued",
+			"recipient_email": "seller@example.com",
+		})
+	})
+
+	cmd := testutil.Command(newExportCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--from", "2026-01-01"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp struct {
+		Success        bool   `json:"success"`
+		Status         string `json:"status"`
+		RecipientEmail string `json:"recipient_email"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if !resp.Success || resp.Status != "queued" || resp.RecipientEmail != "seller@example.com" {
+		t.Fatalf("unexpected JSON response: %+v", resp)
+	}
+}
+
+func TestExport_Plain(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"status":          "queued",
+			"recipient_email": "seller@example.com",
+		})
+	})
+
+	cmd := testutil.Command(newExportCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if strings.TrimSpace(out) != "queued\tseller@example.com" {
+		t.Fatalf("unexpected plain output: %q", out)
+	}
+}
+
+func TestExport_InvalidDate(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API with invalid date")
+	})
+
+	cmd := newExportCmd()
+	cmd.SetArgs([]string{"--from", "2026-13-01"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !strings.Contains(err.Error(), "--from must be a valid date in YYYY-MM-DD format") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestExport_DryRunSkipsNetwork(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("dry-run should not reach API")
+	})
+
+	cmd := testutil.Command(newExportCmd(), testutil.DryRun(true))
+	cmd.SetArgs([]string{"--from", "2026-01-01", "--to", "2026-05-21", "--product", "prod_123"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	for _, want := range []string{"Dry run", "POST /sales/exports", "from: 2026-01-01", "to: 2026-05-21", "product_id: prod_123"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in %q", want, out)
+		}
+	}
 }
 
 func TestList_AllFetchesAllPages(t *testing.T) {
@@ -1038,7 +1172,7 @@ func TestNewSalesCmd_Subcommands(t *testing.T) {
 	if cmd.Use != "sales" {
 		t.Fatalf("got use=%q, want %q", cmd.Use, "sales")
 	}
-	for _, name := range []string{"list", "view", "refund", "ship", "resend-receipt"} {
+	for _, name := range []string{"list", "export", "view", "refund", "ship", "resend-receipt"} {
 		if child, _, err := cmd.Find([]string{name}); err != nil || child == nil || child.Name() != name {
 			t.Fatalf("expected subcommand %q to be registered, got child=%v err=%v", name, child, err)
 		}

--- a/internal/cmd/sales/sales_test.go
+++ b/internal/cmd/sales/sales_test.go
@@ -285,6 +285,34 @@ func TestExport_QueuesSalesExportWithoutFilters(t *testing.T) {
 	}
 }
 
+func TestExport_AcceptsListStyleDateAliases(t *testing.T) {
+	var gotForm url.Values
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm failed: %v", err)
+		}
+		gotForm = r.PostForm
+		testutil.JSON(t, w, map[string]any{
+			"status":          "queued",
+			"recipient_email": "seller@example.com",
+		})
+	})
+
+	cmd := testutil.Command(newExportCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--after", "2026-01-01", "--before", "2026-05-21"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if got := gotForm.Get("from"); got != "2026-01-01" {
+		t.Fatalf("got from=%q, want 2026-01-01", got)
+	}
+	if got := gotForm.Get("to"); got != "2026-05-21" {
+		t.Fatalf("got to=%q, want 2026-05-21", got)
+	}
+	if gotForm.Has("after") || gotForm.Has("before") {
+		t.Fatalf("alias flags must not be sent to the server, got %#v", gotForm)
+	}
+}
+
 func TestExport_JSON(t *testing.T) {
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
 		testutil.JSON(t, w, map[string]any{
@@ -339,6 +367,22 @@ func TestExport_InvalidDate(t *testing.T) {
 		t.Fatal("expected validation error")
 	}
 	if !strings.Contains(err.Error(), "--from must be a valid date in YYYY-MM-DD format") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestExport_DuplicateDateAliasesRejected(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API with duplicate date flags")
+	})
+
+	cmd := newExportCmd()
+	cmd.SetArgs([]string{"--from", "2026-01-01", "--after", "2026-01-02"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected duplicate date flag error")
+	}
+	if !strings.Contains(err.Error(), "--after cannot be combined with --from") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/skills/embed_test.go
+++ b/skills/embed_test.go
@@ -47,10 +47,11 @@ func TestSkillMarkdown_ContainsSalesExamples(t *testing.T) {
 	for _, example := range []string{
 		"gumroad sales list --after 2024-01-01 --before 2024-01-31 --csv --no-input",
 		"gumroad sales export --from 2026-01-01 --to 2026-05-21 --no-input",
+		"gumroad sales export --after 2026-01-01 --before 2026-05-21 --no-input",
 		"gumroad sales export --product <id> --json --no-input",
 		"`sales export` → `.status`, `.recipient_email`",
 		"`--product`, `--order`, `--email`, `--after` (YYYY-MM-DD), `--before` (YYYY-MM-DD), `--all`, `--page-key`, `--csv`",
-		"`--from` (YYYY-MM-DD), `--to` (YYYY-MM-DD), `--product`",
+		"`--from`/`--after` (YYYY-MM-DD), `--to`/`--before` (YYYY-MM-DD), `--product`",
 	} {
 		if !strings.Contains(content, example) {
 			t.Errorf("expected skill to mention sales example %q", example)

--- a/skills/embed_test.go
+++ b/skills/embed_test.go
@@ -37,7 +37,7 @@ func TestSkillMarkdown_ContainsAllCommands(t *testing.T) {
 	}
 }
 
-func TestSkillMarkdown_ContainsSalesCSVExample(t *testing.T) {
+func TestSkillMarkdown_ContainsSalesExamples(t *testing.T) {
 	data, err := SkillMarkdown()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -46,10 +46,14 @@ func TestSkillMarkdown_ContainsSalesCSVExample(t *testing.T) {
 	content := string(data)
 	for _, example := range []string{
 		"gumroad sales list --after 2024-01-01 --before 2024-01-31 --csv --no-input",
+		"gumroad sales export --from 2026-01-01 --to 2026-05-21 --no-input",
+		"gumroad sales export --product <id> --json --no-input",
+		"`sales export` → `.status`, `.recipient_email`",
 		"`--product`, `--order`, `--email`, `--after` (YYYY-MM-DD), `--before` (YYYY-MM-DD), `--all`, `--page-key`, `--csv`",
+		"`--from` (YYYY-MM-DD), `--to` (YYYY-MM-DD), `--product`",
 	} {
 		if !strings.Contains(content, example) {
-			t.Errorf("expected skill to mention sales CSV example %q", example)
+			t.Errorf("expected skill to mention sales example %q", example)
 		}
 	}
 }

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -206,6 +206,7 @@ gumroad sales list --json --jq '.sales[] | select(.email == "user@example.com")'
 
 # Request an emailed CSV export for larger ranges
 gumroad sales export --from 2026-01-01 --to 2026-05-21 --no-input
+gumroad sales export --after 2026-01-01 --before 2026-05-21 --no-input
 gumroad sales export --product <id> --json --no-input
 
 # View a sale
@@ -220,7 +221,7 @@ gumroad sales resend-receipt <id> --json --no-input
 ```
 
 **List filters/output:** `--product`, `--order`, `--email`, `--after` (YYYY-MM-DD), `--before` (YYYY-MM-DD), `--all`, `--page-key`, `--csv`.
-**Export filters:** `--from` (YYYY-MM-DD), `--to` (YYYY-MM-DD), `--product`.
+**Export filters:** `--from`/`--after` (YYYY-MM-DD), `--to`/`--before` (YYYY-MM-DD), `--product`.
 
 ### payouts — View payouts
 

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -46,6 +46,7 @@ Responses are wrapped in `{"success": true, ...}` with resource-specific keys:
 - `products view` → `.product`
 - `sales list` → `.sales[]`
 - `sales view` → `.sale`
+- `sales export` → `.status`, `.recipient_email`
 - `payouts list` → `.payouts[]`, `payouts view/upcoming` → `.payout`
 - `subscribers list` → `.subscribers[]`, `subscribers view` → `.subscriber`
 - `licenses verify` → `.purchase`
@@ -203,6 +204,10 @@ gumroad sales list --after 2024-01-01 --before 2024-01-31 --csv --no-input
 # Find a sale by email
 gumroad sales list --json --jq '.sales[] | select(.email == "user@example.com")' --no-input
 
+# Request an emailed CSV export for larger ranges
+gumroad sales export --from 2026-01-01 --to 2026-05-21 --no-input
+gumroad sales export --product <id> --json --no-input
+
 # View a sale
 gumroad sales view <id> --json --no-input
 
@@ -215,6 +220,7 @@ gumroad sales resend-receipt <id> --json --no-input
 ```
 
 **List filters/output:** `--product`, `--order`, `--email`, `--after` (YYYY-MM-DD), `--before` (YYYY-MM-DD), `--all`, `--page-key`, `--csv`.
+**Export filters:** `--from` (YYYY-MM-DD), `--to` (YYYY-MM-DD), `--product`.
 
 ### payouts — View payouts
 


### PR DESCRIPTION
Ref #97

## What

Adds a sales export flow so users can request the server-generated sales CSV from the CLI. The command supports product and date filters, including both `--from`/`--to` and the `sales list`-style `--after`/`--before` aliases.

## Why

The server now owns larger sales CSV exports, so the CLI needs a direct way to start that job. Keeping `--after`/`--before` aligned with `sales list` makes the export path easier to discover while still sending the API's `from`/`to` parameters.

## Before/After

Terminal recording: [animated SVG](https://gist.githubusercontent.com/gianfrancopiana/baa508fe280c7170edc516fd897f8849/raw/84a98c536a795d284ed7fc3dcb2c33350e80fc94/sales-export-terminal.svg) ([gist](https://gist.github.com/gianfrancopiana/baa508fe280c7170edc516fd897f8849))

![Sales export terminal recording](https://gist.githubusercontent.com/gianfrancopiana/baa508fe280c7170edc516fd897f8849/raw/84a98c536a795d284ed7fc3dcb2c33350e80fc94/sales-export-terminal.svg)

## Test Results

```sh
go test ./internal/cmd/sales ./skills
go test ./...
make test-cover
make lint
git diff --check
```

---

This PR was implemented with AI assistance using gpt-5.5 xhigh.

Prompts given:
- "merged the PR, plus the server side part needed for part 2 of the plan. can we now implement what remains for part 2 in a new branch?"
- "push"
- "see PR feedback and address it"

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad-cli/pr/106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781998482&installation_id=134400930&pr_number=106&repository=antiwork%2Fgumroad-cli&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad-cli%2Fpull%2F106&signature=a2b8852abee3b1564fb4f51bfa182cf1c17b90643d668f389eb62bfa3ac2a5fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
