### PR TITLE
Add sales summary command

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ gumroad sales list --all --json --jq '.sales[] | {email, formatted_total_price}'
 # Export a small filtered sales CSV
 gumroad sales list --after 2024-01-01 --before 2024-01-31 --csv > sales.csv
 
+# Show sales totals
+gumroad sales summary --group-by month --from 2026-01-01 --to 2026-05-21
+
 # Request a larger sales CSV by email
 gumroad sales export --from 2026-01-01 --to 2026-05-21
 gumroad sales export --after 2026-01-01 --before 2026-05-21
@@ -167,6 +170,8 @@ gumroad products update <product_id> --replace-files --keep-file <file_id> --fil
 Paginated commands (`sales list`, `payouts list`, `subscribers list`) accept `--all` to fetch every page. Use `--page-delay 200ms` to pace large fetches.
 
 `gumroad sales list --csv` writes `id,email,product_name,total_cents,currency,refunded,refunded_cents,created_at` for small filtered exports.
+
+`gumroad sales summary` shows gross, net, unit, and refund totals for the server's default 30-day range, or for a filtered range with optional `--group-by product|day|week|month`.
 
 ## AI agents
 

--- a/internal/cmd/sales/sales.go
+++ b/internal/cmd/sales/sales.go
@@ -9,12 +9,14 @@ func NewSalesCmd() *cobra.Command {
 		Use:   "sales",
 		Short: "Manage sales",
 		Example: `  gumroad sales list
+  gumroad sales summary
   gumroad sales export --from 2026-01-01 --to 2026-05-21
   gumroad sales view <id>
   gumroad sales refund <id>`,
 	}
 
 	cmd.AddCommand(newListCmd())
+	cmd.AddCommand(newSummaryCmd())
 	cmd.AddCommand(newExportCmd())
 	cmd.AddCommand(newViewCmd())
 	cmd.AddCommand(newRefundCmd())

--- a/internal/cmd/sales/sales_test.go
+++ b/internal/cmd/sales/sales_test.go
@@ -403,6 +403,235 @@ func TestExport_DryRunSkipsNetwork(t *testing.T) {
 	}
 }
 
+func TestSummary_RequestWithFilters(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotQuery url.Values
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotQuery = r.URL.Query()
+		testutil.JSON(t, w, map[string]any{
+			"success":        true,
+			"gross_cents":    10000,
+			"net_cents":      8500,
+			"units":          12,
+			"refunded_cents": 1500,
+			"refunded_units": 3,
+			"currency":       "usd",
+			"from":           "2026-01-01",
+			"to":             "2026-05-21",
+		})
+	})
+
+	cmd := testutil.Command(newSummaryCmd(), testutil.Quiet(false), testutil.NoColor(true))
+	cmd.SetArgs([]string{"--from", "2026-01-01", "--to", "2026-05-21", "--group-by", "month"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != http.MethodGet || gotPath != "/sales/summary" {
+		t.Fatalf("got %s %s, want GET /sales/summary", gotMethod, gotPath)
+	}
+	for key, want := range map[string]string{
+		"from":     "2026-01-01",
+		"to":       "2026-05-21",
+		"group_by": "month",
+	} {
+		if got := gotQuery.Get(key); got != want {
+			t.Fatalf("got %s=%q, want %q", key, got, want)
+		}
+	}
+	for _, want := range []string{"2026-01-01..2026-05-21", "$100.00", "$85.00", "$15.00", "12", "3"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in %q", want, out)
+		}
+	}
+}
+
+func TestSummary_DefaultsToServerDateRange(t *testing.T) {
+	var gotQuery url.Values
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		testutil.JSON(t, w, map[string]any{
+			"success":        true,
+			"gross_cents":    0,
+			"net_cents":      0,
+			"units":          0,
+			"refunded_cents": 0,
+			"refunded_units": 0,
+			"currency":       "usd",
+			"from":           "2026-04-22",
+			"to":             "2026-05-21",
+		})
+	})
+
+	cmd := testutil.Command(newSummaryCmd())
+	cmd.SetArgs([]string{})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if len(gotQuery) != 0 {
+		t.Fatalf("expected no query params, got %#v", gotQuery)
+	}
+}
+
+func TestSummary_GroupByProductRendersBreakdown(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("group_by"); got != "product" {
+			t.Fatalf("got group_by=%q, want product", got)
+		}
+		testutil.JSON(t, w, map[string]any{
+			"success":        true,
+			"gross_cents":    6000,
+			"net_cents":      5500,
+			"units":          3,
+			"refunded_cents": 500,
+			"refunded_units": 1,
+			"currency":       "usd",
+			"from":           "2026-01-01",
+			"to":             "2026-01-31",
+			"breakdown": []map[string]any{
+				{"key": "prod_1", "label": "Course", "gross_cents": 5000, "net_cents": 4500, "units": 2, "refunded_cents": 500, "refunded_units": 1},
+				{"key": "prod_2", "label": "Book", "gross_cents": 1000, "net_cents": 1000, "units": 1, "refunded_cents": 0, "refunded_units": 0},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newSummaryCmd(), testutil.Quiet(false), testutil.NoColor(true))
+	cmd.SetArgs([]string{"--group-by", "product"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	for _, want := range []string{"PRODUCT", "prod_1", "Course", "$50.00", "$45.00", "prod_2", "Book"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in %q", want, out)
+		}
+	}
+}
+
+func TestSummary_JSON(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"success":        true,
+			"gross_cents":    10000,
+			"net_cents":      8500,
+			"units":          12,
+			"refunded_cents": 1500,
+			"refunded_units": 3,
+			"currency":       "usd",
+			"from":           "2026-01-01",
+			"to":             "2026-05-21",
+		})
+	})
+
+	cmd := testutil.Command(newSummaryCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--from", "2026-01-01"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp struct {
+		Success    bool   `json:"success"`
+		GrossCents int    `json:"gross_cents"`
+		From       string `json:"from"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if !resp.Success || resp.GrossCents != 10000 || resp.From != "2026-01-01" {
+		t.Fatalf("unexpected JSON response: %+v", resp)
+	}
+}
+
+func TestSummary_Plain(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"success":        true,
+			"gross_cents":    6000,
+			"net_cents":      5500,
+			"units":          3,
+			"refunded_cents": 500,
+			"refunded_units": 1,
+			"currency":       "usd",
+			"from":           "2026-01-01",
+			"to":             "2026-01-31",
+			"breakdown": []map[string]any{
+				{"key": "2026-01", "label": "2026-01", "gross_cents": 6000, "net_cents": 5500, "units": 3, "refunded_cents": 500, "refunded_units": 1},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newSummaryCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{"--group-by", "month"})
+	out := strings.TrimSpace(testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) }))
+
+	want := strings.Join([]string{
+		"summary\t2026-01-01..2026-01-31\t\tusd\t6000\t5500\t3\t500\t1",
+		"month\t2026-01\t2026-01\tusd\t6000\t5500\t3\t500\t1",
+	}, "\n")
+	if out != want {
+		t.Fatalf("got plain output %q, want %q", out, want)
+	}
+}
+
+func TestSummary_InvalidDate(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API with invalid date")
+	})
+
+	cmd := newSummaryCmd()
+	cmd.SetArgs([]string{"--from", "2026-13-01"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !strings.Contains(err.Error(), "--from must be a valid date in YYYY-MM-DD format") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSummary_InvalidGroupBy(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API with invalid group-by")
+	})
+
+	cmd := newSummaryCmd()
+	cmd.SetArgs([]string{"--group-by", "email"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !strings.Contains(err.Error(), "--group-by must be one of: product, day, week, month") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSummary_FromAfterToRejected(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API with invalid range")
+	})
+
+	cmd := newSummaryCmd()
+	cmd.SetArgs([]string{"--from", "2026-05-22", "--to", "2026-05-21"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !strings.Contains(err.Error(), "--from must be on or before --to") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSummary_DateRangeTooWideRejected(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API with too-wide range")
+	})
+
+	cmd := newSummaryCmd()
+	cmd.SetArgs([]string{"--from", "2025-01-01", "--to", "2026-05-21"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !strings.Contains(err.Error(), "date range cannot exceed 366 days") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestList_AllFetchesAllPages(t *testing.T) {
 	requests := 0
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
@@ -1216,7 +1445,7 @@ func TestNewSalesCmd_Subcommands(t *testing.T) {
 	if cmd.Use != "sales" {
 		t.Fatalf("got use=%q, want %q", cmd.Use, "sales")
 	}
-	for _, name := range []string{"list", "export", "view", "refund", "ship", "resend-receipt"} {
+	for _, name := range []string{"list", "summary", "export", "view", "refund", "ship", "resend-receipt"} {
 		if child, _, err := cmd.Find([]string{name}); err != nil || child == nil || child.Name() != name {
 			t.Fatalf("expected subcommand %q to be registered, got child=%v err=%v", name, child, err)
 		}

--- a/internal/cmd/sales/sales_test.go
+++ b/internal/cmd/sales/sales_test.go
@@ -632,6 +632,22 @@ func TestSummary_DateRangeTooWideRejected(t *testing.T) {
 	}
 }
 
+func TestSummary_FromOnlyDateRangeTooWideRejected(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API with too-wide range")
+	})
+
+	cmd := newSummaryCmd()
+	cmd.SetArgs([]string{"--from", "2020-01-01"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !strings.Contains(err.Error(), "date range cannot exceed 366 days") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestList_AllFetchesAllPages(t *testing.T) {
 	requests := 0
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {

--- a/internal/cmd/sales/summary.go
+++ b/internal/cmd/sales/summary.go
@@ -98,19 +98,27 @@ func validateSalesSummaryFlags(cmd *cobra.Command, from, to, groupBy string) err
 	if cmd.Flags().Changed("group-by") && !salesSummaryGroups[groupBy] {
 		return cmdutil.UsageErrorf(cmd, "--group-by must be one of: product, day, week, month")
 	}
-	if from == "" || to == "" {
+	if from == "" {
 		return nil
 	}
 
 	fromDate, _ := time.Parse("2006-01-02", from)
-	toDate, _ := time.Parse("2006-01-02", to)
+	toDate := salesSummaryToday()
+	if to != "" {
+		toDate, _ = time.Parse("2006-01-02", to)
+	}
 	if fromDate.After(toDate) {
 		return cmdutil.UsageErrorf(cmd, "--from must be on or before --to")
 	}
-	if int(toDate.Sub(fromDate).Hours()/24) > salesSummaryMaxDateRangeDays {
+	if int(toDate.Sub(fromDate)/(24*time.Hour)) > salesSummaryMaxDateRangeDays {
 		return cmdutil.UsageErrorf(cmd, "date range cannot exceed %d days", salesSummaryMaxDateRangeDays)
 	}
 	return nil
+}
+
+func salesSummaryToday() time.Time {
+	today, _ := time.Parse("2006-01-02", time.Now().Format("2006-01-02"))
+	return today
 }
 
 func renderSalesSummary(opts cmdutil.Options, resp salesSummaryResponse, groupBy string) error {

--- a/internal/cmd/sales/summary.go
+++ b/internal/cmd/sales/summary.go
@@ -1,0 +1,232 @@
+package sales
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+const salesSummaryMaxDateRangeDays = 366
+
+var salesSummaryGroups = map[string]bool{
+	"product": true,
+	"day":     true,
+	"week":    true,
+	"month":   true,
+}
+
+type salesSummaryResponse struct {
+	Success     bool                        `json:"success"`
+	GrossCents  api.JSONInt                 `json:"gross_cents"`
+	NetCents    api.JSONInt                 `json:"net_cents"`
+	Units       api.JSONInt                 `json:"units"`
+	RefundCents api.JSONInt                 `json:"refunded_cents"`
+	RefundUnits api.JSONInt                 `json:"refunded_units"`
+	Currency    string                      `json:"currency"`
+	From        string                      `json:"from"`
+	To          string                      `json:"to"`
+	Breakdown   []salesSummaryBreakdownItem `json:"breakdown,omitempty"`
+}
+
+type salesSummaryBreakdownItem struct {
+	Key         string      `json:"key"`
+	Label       string      `json:"label"`
+	GrossCents  api.JSONInt `json:"gross_cents"`
+	NetCents    api.JSONInt `json:"net_cents"`
+	Units       api.JSONInt `json:"units"`
+	RefundCents api.JSONInt `json:"refunded_cents"`
+	RefundUnits api.JSONInt `json:"refunded_units"`
+}
+
+func newSummaryCmd() *cobra.Command {
+	var from, to, groupBy string
+
+	cmd := &cobra.Command{
+		Use:   "summary",
+		Short: "Show aggregated sales totals",
+		Args:  cmdutil.ExactArgs(0),
+		Example: `  gumroad sales summary
+  gumroad sales summary --from 2026-01-01 --to 2026-05-21
+  gumroad sales summary --group-by product
+  gumroad sales summary --group-by month --from 2025-05-21`,
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			if err := validateSalesSummaryFlags(c, from, to, groupBy); err != nil {
+				return err
+			}
+
+			params := url.Values{}
+			if from != "" {
+				params.Set("from", from)
+			}
+			if to != "" {
+				params.Set("to", to)
+			}
+			if groupBy != "" {
+				params.Set("group_by", groupBy)
+			}
+
+			return cmdutil.RunRequestDecoded[salesSummaryResponse](opts, "Fetching sales summary...", http.MethodGet, "/sales/summary", params, func(resp salesSummaryResponse) error {
+				return renderSalesSummary(opts, resp, groupBy)
+			})
+		},
+	}
+
+	cmd.Flags().StringVar(&from, "from", "", "Summarize sales from date (YYYY-MM-DD)")
+	cmd.Flags().StringVar(&to, "to", "", "Summarize sales to date (YYYY-MM-DD)")
+	cmd.Flags().StringVar(&groupBy, "group-by", "", "Group breakdown by product, day, week, or month")
+
+	return cmd
+}
+
+func validateSalesSummaryFlags(cmd *cobra.Command, from, to, groupBy string) error {
+	if err := cmdutil.RequireDateFlag(cmd, "from", from); err != nil {
+		return err
+	}
+	if err := cmdutil.RequireDateFlag(cmd, "to", to); err != nil {
+		return err
+	}
+	if cmd.Flags().Changed("group-by") && !salesSummaryGroups[groupBy] {
+		return cmdutil.UsageErrorf(cmd, "--group-by must be one of: product, day, week, month")
+	}
+	if from == "" || to == "" {
+		return nil
+	}
+
+	fromDate, _ := time.Parse("2006-01-02", from)
+	toDate, _ := time.Parse("2006-01-02", to)
+	if fromDate.After(toDate) {
+		return cmdutil.UsageErrorf(cmd, "--from must be on or before --to")
+	}
+	if int(toDate.Sub(fromDate).Hours()/24) > salesSummaryMaxDateRangeDays {
+		return cmdutil.UsageErrorf(cmd, "date range cannot exceed %d days", salesSummaryMaxDateRangeDays)
+	}
+	return nil
+}
+
+func renderSalesSummary(opts cmdutil.Options, resp salesSummaryResponse, groupBy string) error {
+	if opts.PlainOutput {
+		return writeSalesSummaryPlain(opts.Out(), resp, groupBy)
+	}
+
+	style := opts.Style()
+	return output.WithPager(opts.Out(), opts.Err(), func(w io.Writer) error {
+		if err := writeSalesSummaryTable(w, style, resp); err != nil {
+			return err
+		}
+		if len(resp.Breakdown) == 0 {
+			return nil
+		}
+		if err := output.Writeln(w, ""); err != nil {
+			return err
+		}
+		return writeSalesSummaryBreakdownTable(w, style, resp, groupBy)
+	})
+}
+
+func writeSalesSummaryTable(w io.Writer, style output.Styler, resp salesSummaryResponse) error {
+	tbl := output.NewStyledTable(style, "RANGE", "GROSS", "NET", "UNITS", "REFUNDS", "REFUNDED")
+	tbl.AddRow(
+		resp.From+".."+resp.To,
+		formatSalesSummaryMoney(resp.GrossCents, resp.Currency),
+		formatSalesSummaryMoney(resp.NetCents, resp.Currency),
+		formatSalesSummaryInt(resp.Units),
+		formatSalesSummaryMoney(resp.RefundCents, resp.Currency),
+		formatSalesSummaryInt(resp.RefundUnits),
+	)
+	return tbl.Render(w)
+}
+
+func writeSalesSummaryBreakdownTable(w io.Writer, style output.Styler, resp salesSummaryResponse, groupBy string) error {
+	if groupBy == "product" {
+		tbl := output.NewStyledTable(style, "PRODUCT", "NAME", "GROSS", "NET", "UNITS", "REFUNDS", "REFUNDED")
+		for _, item := range resp.Breakdown {
+			tbl.AddRow(
+				item.Key,
+				salesSummaryLabel(item.Label),
+				formatSalesSummaryMoney(item.GrossCents, resp.Currency),
+				formatSalesSummaryMoney(item.NetCents, resp.Currency),
+				formatSalesSummaryInt(item.Units),
+				formatSalesSummaryMoney(item.RefundCents, resp.Currency),
+				formatSalesSummaryInt(item.RefundUnits),
+			)
+		}
+		return tbl.Render(w)
+	}
+
+	tbl := output.NewStyledTable(style, "PERIOD", "GROSS", "NET", "UNITS", "REFUNDS", "REFUNDED")
+	for _, item := range resp.Breakdown {
+		tbl.AddRow(
+			item.Key,
+			formatSalesSummaryMoney(item.GrossCents, resp.Currency),
+			formatSalesSummaryMoney(item.NetCents, resp.Currency),
+			formatSalesSummaryInt(item.Units),
+			formatSalesSummaryMoney(item.RefundCents, resp.Currency),
+			formatSalesSummaryInt(item.RefundUnits),
+		)
+	}
+	return tbl.Render(w)
+}
+
+func writeSalesSummaryPlain(w io.Writer, resp salesSummaryResponse, groupBy string) error {
+	rows := [][]string{{
+		"summary",
+		resp.From + ".." + resp.To,
+		"",
+		resp.Currency,
+		formatSalesSummaryInt(resp.GrossCents),
+		formatSalesSummaryInt(resp.NetCents),
+		formatSalesSummaryInt(resp.Units),
+		formatSalesSummaryInt(resp.RefundCents),
+		formatSalesSummaryInt(resp.RefundUnits),
+	}}
+	for _, item := range resp.Breakdown {
+		rows = append(rows, []string{
+			groupBy,
+			item.Key,
+			item.Label,
+			resp.Currency,
+			formatSalesSummaryInt(item.GrossCents),
+			formatSalesSummaryInt(item.NetCents),
+			formatSalesSummaryInt(item.Units),
+			formatSalesSummaryInt(item.RefundCents),
+			formatSalesSummaryInt(item.RefundUnits),
+		})
+	}
+	return output.PrintPlain(w, rows)
+}
+
+func salesSummaryLabel(label string) string {
+	if label == "" {
+		return "-"
+	}
+	return label
+}
+
+func formatSalesSummaryMoney(cents api.JSONInt, currency string) string {
+	amount := cmdutil.FormatMoney(int(cents), currency)
+	code := strings.ToUpper(strings.TrimSpace(currency))
+	if code == "USD" {
+		if strings.HasPrefix(amount, "-") {
+			return "-$" + strings.TrimPrefix(amount, "-")
+		}
+		return "$" + amount
+	}
+	if code == "" {
+		return amount
+	}
+	return fmt.Sprintf("%s %s", amount, code)
+}
+
+func formatSalesSummaryInt(value api.JSONInt) string {
+	return strconv.Itoa(int(value))
+}

--- a/skills/embed_test.go
+++ b/skills/embed_test.go
@@ -46,11 +46,15 @@ func TestSkillMarkdown_ContainsSalesExamples(t *testing.T) {
 	content := string(data)
 	for _, example := range []string{
 		"gumroad sales list --after 2024-01-01 --before 2024-01-31 --csv --no-input",
+		"gumroad sales summary --group-by product --json --no-input",
+		"gumroad sales summary --group-by month --from 2026-01-01 --to 2026-05-21 --json --no-input",
 		"gumroad sales export --from 2026-01-01 --to 2026-05-21 --no-input",
 		"gumroad sales export --after 2026-01-01 --before 2026-05-21 --no-input",
 		"gumroad sales export --product <id> --json --no-input",
+		"`sales summary` → `.gross_cents`, `.net_cents`, `.breakdown[]`",
 		"`sales export` → `.status`, `.recipient_email`",
 		"`--product`, `--order`, `--email`, `--after` (YYYY-MM-DD), `--before` (YYYY-MM-DD), `--all`, `--page-key`, `--csv`",
+		"`--from` (YYYY-MM-DD), `--to` (YYYY-MM-DD), `--group-by` (product|day|week|month)",
 		"`--from`/`--after` (YYYY-MM-DD), `--to`/`--before` (YYYY-MM-DD), `--product`",
 	} {
 		if !strings.Contains(content, example) {

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -47,6 +47,7 @@ Responses are wrapped in `{"success": true, ...}` with resource-specific keys:
 - `sales list` → `.sales[]`
 - `sales view` → `.sale`
 - `sales export` → `.status`, `.recipient_email`
+- `sales summary` → `.gross_cents`, `.net_cents`, `.breakdown[]`
 - `payouts list` → `.payouts[]`, `payouts view/upcoming` → `.payout`
 - `subscribers list` → `.subscribers[]`, `subscribers view` → `.subscriber`
 - `licenses verify` → `.purchase`
@@ -204,6 +205,12 @@ gumroad sales list --after 2024-01-01 --before 2024-01-31 --csv --no-input
 # Find a sale by email
 gumroad sales list --json --jq '.sales[] | select(.email == "user@example.com")' --no-input
 
+# Show sales totals
+gumroad sales summary --json --no-input
+gumroad sales summary --from 2026-01-01 --to 2026-05-21 --json --no-input
+gumroad sales summary --group-by product --json --no-input
+gumroad sales summary --group-by month --from 2026-01-01 --to 2026-05-21 --json --no-input
+
 # Request an emailed CSV export for larger ranges
 gumroad sales export --from 2026-01-01 --to 2026-05-21 --no-input
 gumroad sales export --after 2026-01-01 --before 2026-05-21 --no-input
@@ -221,6 +228,7 @@ gumroad sales resend-receipt <id> --json --no-input
 ```
 
 **List filters/output:** `--product`, `--order`, `--email`, `--after` (YYYY-MM-DD), `--before` (YYYY-MM-DD), `--all`, `--page-key`, `--csv`.
+**Summary filters:** `--from` (YYYY-MM-DD), `--to` (YYYY-MM-DD), `--group-by` (product|day|week|month).
 **Export filters:** `--from`/`--after` (YYYY-MM-DD), `--to`/`--before` (YYYY-MM-DD), `--product`.
 
 ### payouts — View payouts


### PR DESCRIPTION
Ref #97

## What

Adds `gumroad sales summary` so sellers can get aggregated sales totals from the CLI instead of piecing them together themselves. It supports the server’s default 30-day range, optional `--from`/`--to` filters, and `--group-by product|day|week|month` breakdowns.

## Why

The new API endpoint returns the summary data directly, so the CLI can surface it without fetching and aggregating every sale client-side. This keeps the command fast, matches the server contract, and gives sellers a clearer terminal view of revenue, units, and refunds.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new CLI subcommand that hits a new `/sales/summary` endpoint and introduces date-range/grouping validation and rendering logic; main risk is correctness and formatting/flag-validation edge cases rather than security-sensitive behavior.
> 
> **Overview**
> Adds `gumroad sales summary` to fetch aggregated sales totals (gross, net, units, refunds) from `GET /sales/summary`, with optional `--from/--to` filtering and `--group-by product|day|week|month` breakdown output.
> 
> Implements table and `--plain` tabular rendering (including breakdown rows) plus input validation for dates, allowed groupings, and maximum range, and wires the command into `sales` plus docs/skill examples and a comprehensive test suite covering request params, output modes, and validation errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e1e252d70cc939fbe9d0e9d565b06017c9a4a66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->