### PR TITLE
Fix variant file attachments for per-variant Content

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,11 +151,14 @@ gumroad products create --name "Art Pack" --price 10.00 --file ./pack.zip --file
 # Add a new file to a product while keeping its current attachments
 gumroad products update <product_id> --file ./pack.zip
 
+# Attach a file to one variant's per-variant Content
+gumroad variants update <variant_id> --product <product_id> --category <cat_id> --file ./license.pdf
+
 # Replace the current file set, preserving only the IDs you keep explicitly
 gumroad products update <product_id> --replace-files --keep-file <file_id> --file ./new-pack.zip
 ```
 
-`gumroad files upload` and `gumroad files complete` both print the canonical `file_url`. Product create/update accept repeatable `--file` flags, with matching `--file-name` and `--file-description` values when you need custom attachment metadata. `gumroad products update` also supports `--remove-file`, and `--replace-files` with `--keep-file`, when you need to remove existing attachments.
+`gumroad files upload` and `gumroad files complete` both print the canonical `file_url`. Product create/update and variant update accept repeatable `--file` flags, with matching `--file-name` and `--file-description` values when you need custom attachment metadata. For products that use per-variant Content, use `gumroad variants update ... --file`; product-level `--file` is for shared Content. `gumroad products update` also supports `--remove-file`, and `--replace-files` with `--keep-file`, when you need to remove existing attachments.
 
 ## Output modes
 

--- a/internal/cmd/products/file_updates.go
+++ b/internal/cmd/products/file_updates.go
@@ -39,13 +39,23 @@ type productFileUpdatePlan struct {
 }
 
 type productFileUpdateState struct {
-	Files       []existingProductFile `json:"files"`
-	RichContent []map[string]any      `json:"rich_content"`
+	Files                            []existingProductFile        `json:"files"`
+	RichContent                      []map[string]any             `json:"rich_content"`
+	HasSameRichContentForAllVariants bool                         `json:"has_same_rich_content_for_all_variants"`
+	Variants                         *[]productVariantCategoryRef `json:"variants"`
 }
 
 type productFileSelections struct {
 	Keep   map[string]struct{}
 	Remove map[string]struct{}
+}
+
+type productVariantCategoryRef struct {
+	Options []productVariantOptionRef `json:"options"`
+}
+
+type productVariantOptionRef struct {
+	Name string `json:"name"`
 }
 
 type productFilesResponse struct {
@@ -109,6 +119,25 @@ func fetchExistingProductFileState(client *api.Client, productID string) (produc
 		return productFileUpdateState{}, err
 	}
 	return resp.Product, nil
+}
+
+func productUsesPerVariantRichContent(state productFileUpdateState) bool {
+	if state.HasSameRichContentForAllVariants {
+		return false
+	}
+	if state.Variants == nil {
+		return true
+	}
+	return productHasVariants(*state.Variants)
+}
+
+func productHasVariants(variants []productVariantCategoryRef) bool {
+	for _, category := range variants {
+		if len(category.Options) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func planProductFileUpdate(

--- a/internal/cmd/products/rich_content.go
+++ b/internal/cmd/products/rich_content.go
@@ -107,25 +107,6 @@ func fileEmbedIDs(richContent []map[string]any) []string {
 	return richcontent.FileEmbedIDs(richContent)
 }
 
-func collectFileEmbedIDs(node any, ids *[]string) {
-	current, ok := node.(map[string]any)
-	if !ok {
-		return
-	}
-	if current["type"] == "fileEmbed" {
-		if attrs, ok := current["attrs"].(map[string]any); ok {
-			if id, ok := attrs["id"].(string); ok && id != "" {
-				*ids = append(*ids, id)
-			}
-		}
-	}
-	if children, ok := current["content"].([]any); ok {
-		for _, child := range children {
-			collectFileEmbedIDs(child, ids)
-		}
-	}
-}
-
 func replaceFileEmbedID(richContent []map[string]any, oldID, newID string) {
 	richcontent.ReplaceFileEmbedID(richContent, oldID, newID)
 }

--- a/internal/cmd/products/rich_content.go
+++ b/internal/cmd/products/rich_content.go
@@ -1,62 +1,23 @@
 package products
 
 import (
-	"crypto/rand"
-	"encoding/json"
-	"fmt"
 	"sort"
 
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/richcontent"
 	"github.com/spf13/cobra"
 )
 
-const defaultFileRichContentTitle = "Page 1"
+const defaultFileRichContentTitle = richcontent.DefaultFileTitle
 
-type richContentFileRef struct {
-	FileID   string
-	EmbedUID string
-}
+type richContentFileRef = richcontent.FileRef
 
 func newRichContentFileRefs(count int) ([]richContentFileRef, error) {
-	refs := make([]richContentFileRef, count)
-	for i := range refs {
-		fileUUID, err := newUUIDV4()
-		if err != nil {
-			return nil, fmt.Errorf("could not generate file id: %w", err)
-		}
-		embedUUID, err := newUUIDV4()
-		if err != nil {
-			return nil, fmt.Errorf("could not generate file embed id: %w", err)
-		}
-		refs[i] = richContentFileRef{
-			FileID:   "cli-upload-" + fileUUID,
-			EmbedUID: embedUUID,
-		}
-	}
-	return refs, nil
+	return richcontent.NewFileRefs(count)
 }
 
 func buildFileRichContent(fileRefs []richContentFileRef) []map[string]any {
-	content := make([]map[string]any, 0, len(fileRefs)+1)
-	for _, ref := range fileRefs {
-		content = append(content, map[string]any{
-			"type": "fileEmbed",
-			"attrs": map[string]any{
-				"id":        ref.FileID,
-				"uid":       ref.EmbedUID,
-				"collapsed": false,
-			},
-		})
-	}
-	content = append(content, map[string]any{"type": "paragraph"})
-
-	return []map[string]any{{
-		"title": defaultFileRichContentTitle,
-		"description": map[string]any{
-			"type":    "doc",
-			"content": content,
-		},
-	}}
+	return richcontent.BuildFileRichContent(fileRefs)
 }
 
 func buildProductUpdateRichContent(
@@ -127,141 +88,23 @@ func removedFileEmbedIDs(richContent []map[string]any, removed []existingProduct
 }
 
 func appendFileEmbeds(richContent []map[string]any, preserved []existingProductFile, fileRefs []richContentFileRef) ([]map[string]any, error) {
-	if len(fileRefs) == 0 {
-		return cloneRichContent(richContent)
-	}
-	if len(richContent) == 0 {
-		preservedRefs, err := richContentRefsForExistingFiles(preserved)
-		if err != nil {
-			return nil, err
-		}
-		return buildFileRichContent(append(preservedRefs, fileRefs...)), nil
-	}
-
-	cloned, err := cloneRichContent(richContent)
-	if err != nil {
-		return nil, err
-	}
-
-	page := cloned[appendFileEmbedPage(cloned)]
-	description, ok := page["description"].(map[string]any)
-	if !ok {
-		description = map[string]any{"type": "doc"}
-		page["description"] = description
-	}
-	content, _ := description["content"].([]any)
-	if group := fileEmbedGroupForAppend(content); group != nil {
-		groupContent, _ := group["content"].([]any)
-		group["content"] = append(groupContent, fileEmbedNodes(fileRefs)...)
-	} else {
-		content = appendFileEmbedsToContent(content, fileRefs)
-	}
-	description["type"] = "doc"
-	description["content"] = content
-	return cloned, nil
+	return richcontent.AppendFileEmbeds(richContent, preservedProductFileIDs(preserved), fileRefs)
 }
 
-func richContentRefsForExistingFiles(files []existingProductFile) ([]richContentFileRef, error) {
-	refs := make([]richContentFileRef, len(files))
+func preservedProductFileIDs(files []existingProductFile) []string {
+	ids := make([]string, len(files))
 	for i, file := range files {
-		embedUUID, err := newUUIDV4()
-		if err != nil {
-			return nil, fmt.Errorf("could not generate file embed id: %w", err)
-		}
-		refs[i] = richContentFileRef{
-			FileID:   file.ID,
-			EmbedUID: embedUUID,
-		}
+		ids[i] = file.ID
 	}
-	return refs, nil
-}
-
-func appendFileEmbedPage(richContent []map[string]any) int {
-	target := len(richContent) - 1
-	for i, page := range richContent {
-		if richContentPageHasFileEmbed(page) {
-			target = i
-		}
-	}
-	return target
-}
-
-func richContentPageHasFileEmbed(page map[string]any) bool {
-	var ids []string
-	collectFileEmbedIDs(page["description"], &ids)
-	return len(ids) > 0
-}
-
-func fileEmbedGroupForAppend(content []any) map[string]any {
-	var target map[string]any
-	for _, child := range content {
-		childMap, ok := child.(map[string]any)
-		if !ok {
-			continue
-		}
-		if childMap["type"] == "fileEmbed" {
-			return nil
-		}
-
-		var ids []string
-		collectFileEmbedIDs(childMap, &ids)
-		if len(ids) == 0 {
-			continue
-		}
-		if childMap["type"] != "fileEmbedGroup" || target != nil {
-			return nil
-		}
-		target = childMap
-	}
-	return target
-}
-
-func appendFileEmbedsToContent(content []any, fileRefs []richContentFileRef) []any {
-	var trailingParagraph any
-	if len(content) > 0 && nodeHasType(content[len(content)-1], "paragraph") {
-		trailingParagraph = content[len(content)-1]
-		content = content[:len(content)-1]
-	}
-	content = append(content, fileEmbedNodes(fileRefs)...)
-	if trailingParagraph == nil {
-		trailingParagraph = map[string]any{"type": "paragraph"}
-	}
-	return append(content, trailingParagraph)
+	return ids
 }
 
 func cloneRichContent(richContent []map[string]any) ([]map[string]any, error) {
-	data, err := json.Marshal(richContent)
-	if err != nil {
-		return nil, fmt.Errorf("could not encode rich_content: %w", err)
-	}
-	var cloned []map[string]any
-	if err := json.Unmarshal(data, &cloned); err != nil {
-		return nil, fmt.Errorf("could not decode rich_content: %w", err)
-	}
-	return cloned, nil
-}
-
-func fileEmbedNodes(fileRefs []richContentFileRef) []any {
-	nodes := make([]any, len(fileRefs))
-	for i, ref := range fileRefs {
-		nodes[i] = map[string]any{
-			"type": "fileEmbed",
-			"attrs": map[string]any{
-				"id":        ref.FileID,
-				"uid":       ref.EmbedUID,
-				"collapsed": false,
-			},
-		}
-	}
-	return nodes
+	return richcontent.Clone(richContent)
 }
 
 func fileEmbedIDs(richContent []map[string]any) []string {
-	var ids []string
-	for _, page := range richContent {
-		collectFileEmbedIDs(page["description"], &ids)
-	}
-	return ids
+	return richcontent.FileEmbedIDs(richContent)
 }
 
 func collectFileEmbedIDs(node any, ids *[]string) {
@@ -284,105 +127,9 @@ func collectFileEmbedIDs(node any, ids *[]string) {
 }
 
 func replaceFileEmbedID(richContent []map[string]any, oldID, newID string) {
-	for _, page := range richContent {
-		replaceFileEmbedIDInNode(page["description"], oldID, newID)
-	}
+	richcontent.ReplaceFileEmbedID(richContent, oldID, newID)
 }
 
 func stripFileEmbedIDs(richContent []map[string]any, ids []string) {
-	if len(ids) == 0 {
-		return
-	}
-	idSet := make(map[string]struct{}, len(ids))
-	for _, id := range ids {
-		idSet[id] = struct{}{}
-	}
-	for _, page := range richContent {
-		if description, ok := page["description"].(map[string]any); ok {
-			stripFileEmbedIDsInNode(description, idSet)
-			ensureRichContentDescriptionContent(description)
-		}
-	}
-}
-
-func stripFileEmbedIDsInNode(node any, ids map[string]struct{}) {
-	current, ok := node.(map[string]any)
-	if !ok {
-		return
-	}
-	children, ok := current["content"].([]any)
-	if !ok {
-		return
-	}
-
-	kept := make([]any, 0, len(children))
-	for _, child := range children {
-		if childMap, ok := child.(map[string]any); ok {
-			if childMap["type"] == "fileEmbed" {
-				if attrs, ok := childMap["attrs"].(map[string]any); ok {
-					if id, ok := attrs["id"].(string); ok {
-						if _, remove := ids[id]; remove {
-							continue
-						}
-					}
-				}
-			}
-			stripFileEmbedIDsInNode(childMap, ids)
-			if isEmptyFileEmbedGroup(childMap) {
-				continue
-			}
-		}
-		kept = append(kept, child)
-	}
-	current["content"] = kept
-}
-
-func isEmptyFileEmbedGroup(node map[string]any) bool {
-	if node["type"] != "fileEmbedGroup" {
-		return false
-	}
-	children, ok := node["content"].([]any)
-	return !ok || len(children) == 0
-}
-
-func ensureRichContentDescriptionContent(description map[string]any) {
-	content, ok := description["content"].([]any)
-	if ok && len(content) > 0 {
-		return
-	}
-	description["content"] = []any{map[string]any{"type": "paragraph"}}
-}
-
-func nodeHasType(node any, typ string) bool {
-	nodeMap, ok := node.(map[string]any)
-	return ok && nodeMap["type"] == typ
-}
-
-func replaceFileEmbedIDInNode(node any, oldID, newID string) {
-	current, ok := node.(map[string]any)
-	if !ok {
-		return
-	}
-	if current["type"] == "fileEmbed" {
-		if attrs, ok := current["attrs"].(map[string]any); ok && attrs["id"] == oldID {
-			attrs["id"] = newID
-		}
-	}
-	if children, ok := current["content"].([]any); ok {
-		for _, child := range children {
-			replaceFileEmbedIDInNode(child, oldID, newID)
-		}
-	}
-}
-
-func newUUIDV4() (string, error) {
-	var b [16]byte
-	if _, err := rand.Read(b[:]); err != nil {
-		return "", err
-	}
-
-	b[6] = (b[6] & 0x0f) | 0x40
-	b[8] = (b[8] & 0x3f) | 0x80
-
-	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:]), nil
+	richcontent.StripFileEmbedIDs(richContent, ids)
 }

--- a/internal/cmd/products/update.go
+++ b/internal/cmd/products/update.go
@@ -126,7 +126,6 @@ func newUpdateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-
 			plannedUploads, err := describeProductUploads(requestedUploads)
 			if err != nil {
 				return err
@@ -150,6 +149,11 @@ func newUpdateCmd() *cobra.Command {
 			fileRefs, err := newRichContentFileRefs(len(plannedUploads))
 			if err != nil {
 				return err
+			}
+			if len(fileRefs) > 0 && productUsesPerVariantRichContent(existingState) {
+				return cmdutil.UsageErrorf(c,
+					"product %s uses per-variant content, so product-level --file cannot update rich_content; use gumroad variants update <variant_id> --product %s --category <cat_id> --file <path>",
+					args[0], args[0])
 			}
 
 			richContent, includeRichContent, err := buildProductUpdateRichContent(c, existingState.RichContent, filePlan, fileRefs)

--- a/internal/cmd/products/update_files_test.go
+++ b/internal/cmd/products/update_files_test.go
@@ -19,8 +19,10 @@ import (
 )
 
 type productUpdateFileServers struct {
-	existingFiles       []existingProductFile
-	existingRichContent []map[string]any
+	existingFiles                    []existingProductFile
+	existingRichContent              []map[string]any
+	hasSameRichContentForAllVariants bool
+	variants                         []map[string]any
 
 	s3 *httptest.Server
 
@@ -42,7 +44,8 @@ func newProductUpdateFileServers(t *testing.T) *productUpdateFileServers {
 	t.Helper()
 
 	s := &productUpdateFileServers{
-		presignBody: map[string]string{},
+		hasSameRichContentForAllVariants: true,
+		presignBody:                      map[string]string{},
 	}
 	s.s3 = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		s.s3Calls.Add(1)
@@ -75,9 +78,11 @@ func (s *productUpdateFileServers) dispatch(t *testing.T) http.HandlerFunc {
 				s.getCalls.Add(1)
 				testutil.JSON(t, w, map[string]any{
 					"product": map[string]any{
-						"id":           "prod1",
-						"files":        s.existingFiles,
-						"rich_content": s.existingRichContent,
+						"id":                                     "prod1",
+						"files":                                  s.existingFiles,
+						"rich_content":                           s.existingRichContent,
+						"has_same_rich_content_for_all_variants": s.hasSameRichContentForAllVariants,
+						"variants":                               s.variants,
 					},
 				})
 			case http.MethodPut:
@@ -370,6 +375,70 @@ func TestUpdate_FilePreservesExistingByDefault(t *testing.T) {
 	}
 	if ids := richContentFileEmbedIDsFromBody(t, srv.putJSON); !reflect.DeepEqual(ids, []string{"file_a", "file_b", newFileID}) {
 		t.Fatalf("rich_content fileEmbed ids = %#v, want preserved files and new upload", ids)
+	}
+}
+
+func TestUpdate_FileRejectsPerVariantContentWithoutAttachFlag(t *testing.T) {
+	srv := newProductUpdateFileServers(t)
+	srv.hasSameRichContentForAllVariants = false
+	srv.variants = []map[string]any{{
+		"title":   "Size",
+		"options": []map[string]any{{"name": "Large"}},
+	}}
+	testutil.Setup(t, srv.dispatch(t))
+
+	path := writeProductUploadFixture(t, "license bytes")
+	cmd := testutil.Command(newUpdateCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{
+		"prod1",
+		"--file", path,
+		"--file-name", "License.pdf",
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected per-variant content error")
+	}
+	if !strings.Contains(err.Error(), "per-variant content") || !strings.Contains(err.Error(), "gumroad variants update") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if srv.s3Calls.Load() != 0 {
+		t.Fatalf("S3 calls = %d, want 0", srv.s3Calls.Load())
+	}
+	if srv.putCalls.Load() != 0 {
+		t.Fatalf("PUT calls = %d, want 0", srv.putCalls.Load())
+	}
+}
+
+func TestProductUsesPerVariantRichContentIsConservativeWhenVariantsOmitted(t *testing.T) {
+	state := productFileUpdateState{
+		HasSameRichContentForAllVariants: false,
+	}
+	if !productUsesPerVariantRichContent(state) {
+		t.Fatal("expected omitted variants to be treated as per-variant content")
+	}
+}
+
+func TestProductUsesPerVariantRichContentAllowsExplicitEmptyVariants(t *testing.T) {
+	variants := []productVariantCategoryRef{}
+	state := productFileUpdateState{
+		HasSameRichContentForAllVariants: false,
+		Variants:                         &variants,
+	}
+	if productUsesPerVariantRichContent(state) {
+		t.Fatal("expected explicit empty variants to allow product-level content")
+	}
+}
+
+func TestProductUsesPerVariantRichContentDetectsVariantOptions(t *testing.T) {
+	variants := []productVariantCategoryRef{{
+		Options: []productVariantOptionRef{{Name: "Large"}},
+	}}
+	state := productFileUpdateState{
+		HasSameRichContentForAllVariants: false,
+		Variants:                         &variants,
+	}
+	if !productUsesPerVariantRichContent(state) {
+		t.Fatal("expected variant options to require variant-level content")
 	}
 }
 

--- a/internal/cmd/products/update_files_test.go
+++ b/internal/cmd/products/update_files_test.go
@@ -845,8 +845,7 @@ func TestUpdate_FileAppendsInsideExistingFileEmbedGroup(t *testing.T) {
 	if !ok || group["type"] != "fileEmbedGroup" {
 		t.Fatalf("first rich_content node = %#v, want fileEmbedGroup", content[0])
 	}
-	var groupIDs []string
-	collectFileEmbedIDs(group, &groupIDs)
+	groupIDs := fileEmbedIDs([]map[string]any{{"description": group}})
 	if !reflect.DeepEqual(groupIDs, []string{"file_a", "file_b", newFileID}) {
 		t.Fatalf("fileEmbedGroup ids = %#v, want existing files then new upload", groupIDs)
 	}

--- a/internal/cmd/variants/file_updates.go
+++ b/internal/cmd/variants/file_updates.go
@@ -126,7 +126,7 @@ func alignVariantUploadValues(cmd *cobra.Command, flagName string, values []stri
 
 func runVariantUpdateWithFiles(
 	opts cmdutil.Options,
-	productID, categoryID, variantID, variantPath string,
+	productID, variantID, variantPath string,
 	params url.Values,
 	requestedUploads []requestedVariantUpload,
 ) error {

--- a/internal/cmd/variants/file_updates.go
+++ b/internal/cmd/variants/file_updates.go
@@ -1,0 +1,466 @@
+package variants
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/config"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/richcontent"
+	"github.com/antiwork/gumroad-cli/internal/upload"
+	"github.com/antiwork/gumroad-cli/internal/uploadui"
+	"github.com/spf13/cobra"
+)
+
+// s3HTTPClientForTesting redirects multipart PUTs at a test TLS server. Tests
+// in this package must not use t.Parallel while mutating this hook.
+var s3HTTPClientForTesting *http.Client
+
+type requestedVariantUpload struct {
+	Path        string
+	DisplayName string
+	Description string
+}
+
+type plannedVariantUpload struct {
+	requestedVariantUpload
+	Plan upload.Plan
+}
+
+type variantExistingProductFile struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type variantProductFileState struct {
+	Files                            []variantExistingProductFile `json:"files"`
+	HasSameRichContentForAllVariants bool                         `json:"has_same_rich_content_for_all_variants"`
+}
+
+type variantProductFilesResponse struct {
+	Product variantProductFileState `json:"product"`
+}
+
+type variantRichContentState struct {
+	ID          string           `json:"id"`
+	Name        string           `json:"name"`
+	RichContent []map[string]any `json:"rich_content"`
+}
+
+type variantRichContentResponse struct {
+	Variant variantRichContentState `json:"variant"`
+}
+
+type variantFileAttachRequest struct {
+	Method string         `json:"method"`
+	Path   string         `json:"path"`
+	Body   map[string]any `json:"body"`
+}
+
+type variantFileAttachDryRun struct {
+	DryRun         bool                        `json:"dry_run"`
+	Uploads        []variantDryRunUpload       `json:"uploads"`
+	Preserved      []variantDryRunExistingFile `json:"preserved"`
+	ProductRequest variantFileAttachRequest    `json:"product_request"`
+	VariantRequest variantFileAttachRequest    `json:"variant_request"`
+}
+
+type variantDryRunUpload struct {
+	Action    string `json:"action"`
+	Path      string `json:"path"`
+	Filename  string `json:"filename"`
+	Size      int64  `json:"size"`
+	PartSize  int64  `json:"part_size"`
+	PartCount int    `json:"part_count"`
+}
+
+type variantDryRunExistingFile struct {
+	ID   string `json:"id"`
+	Name string `json:"name,omitempty"`
+}
+
+func collectRequestedVariantUploads(cmd *cobra.Command, paths, names, descriptions []string) ([]requestedVariantUpload, error) {
+	if len(paths) == 0 {
+		return nil, nil
+	}
+
+	alignedNames, err := alignVariantUploadValues(cmd, "--file-name", names, len(paths))
+	if err != nil {
+		return nil, err
+	}
+	alignedDescriptions, err := alignVariantUploadValues(cmd, "--file-description", descriptions, len(paths))
+	if err != nil {
+		return nil, err
+	}
+
+	uploads := make([]requestedVariantUpload, len(paths))
+	for i, path := range paths {
+		uploads[i] = requestedVariantUpload{
+			Path:        path,
+			DisplayName: strings.TrimSpace(alignedNames[i]),
+			Description: alignedDescriptions[i],
+		}
+	}
+	return uploads, nil
+}
+
+func alignVariantUploadValues(cmd *cobra.Command, flagName string, values []string, count int) ([]string, error) {
+	switch len(values) {
+	case 0:
+		return make([]string, count), nil
+	case count:
+		aligned := make([]string, count)
+		copy(aligned, values)
+		return aligned, nil
+	default:
+		return nil, cmdutil.UsageErrorf(cmd, "%s must be provided zero times or exactly once per --file (got %d values for %d files)", flagName, len(values), count)
+	}
+}
+
+func runVariantUpdateWithFiles(
+	opts cmdutil.Options,
+	productID, categoryID, variantID, variantPath string,
+	params url.Values,
+	requestedUploads []requestedVariantUpload,
+) error {
+	plannedUploads, err := describeVariantUploads(requestedUploads)
+	if err != nil {
+		return err
+	}
+
+	token, err := config.Token()
+	if err != nil {
+		return err
+	}
+	client := cmdutil.NewAPIClient(opts, token)
+
+	productState, err := fetchVariantProductFileState(client, productID)
+	if err != nil {
+		return err
+	}
+	if productState.HasSameRichContentForAllVariants {
+		return fmt.Errorf("cannot attach files to variant content while product %s uses shared content; use gumroad products update %s --file <path> instead, or switch the product to per-variant content first", productID, productID)
+	}
+
+	variantState, err := fetchVariantRichContentState(client, variantPath)
+	if err != nil {
+		return err
+	}
+
+	fileRefs, err := richcontent.NewFileRefs(len(plannedUploads))
+	if err != nil {
+		return err
+	}
+	richContent, err := richcontent.AppendFileEmbeds(variantState.RichContent, nil, fileRefs)
+	if err != nil {
+		return err
+	}
+
+	productPath := cmdutil.JoinPath("products", productID)
+	productBody := map[string]any{
+		"files": buildVariantProductFilesPayload(productState.Files, plannedUploads, placeholderVariantUploadURLs(len(plannedUploads)), fileRefs),
+	}
+	variantBody := buildVariantUpdateJSONBody(params, richContent)
+
+	if opts.DryRun {
+		return renderVariantFileAttachDryRun(opts, productPath, variantPath, productState.Files, plannedUploads, productBody, variantBody)
+	}
+
+	uploadedURLs, err := uploadVariantBatch(opts, client, plannedUploads)
+	if err != nil {
+		return err
+	}
+	productBody["files"] = buildVariantProductFilesPayload(productState.Files, plannedUploads, uploadedURLs, fileRefs)
+
+	if _, err := client.PutJSON(productPath, productBody); err != nil {
+		return wrapVariantPartialUploadError(err, uploadedURLs)
+	}
+	data, err := client.PutJSON(variantPath, variantBody)
+	if err != nil {
+		return wrapVariantPartialUploadError(err, uploadedURLs)
+	}
+	return cmdutil.PrintMutationSuccess(opts, data, variantID, "Variant "+variantID+" updated.")
+}
+
+func describeVariantUploads(uploads []requestedVariantUpload) ([]plannedVariantUpload, error) {
+	planned := make([]plannedVariantUpload, len(uploads))
+	for i, requested := range uploads {
+		plan, err := upload.Describe(requested.Path, upload.Options{Filename: requested.DisplayName})
+		if err != nil {
+			return nil, err
+		}
+
+		planned[i] = plannedVariantUpload{
+			requestedVariantUpload: requested,
+			Plan:                   plan,
+		}
+	}
+	return planned, nil
+}
+
+func fetchVariantProductFileState(client *api.Client, productID string) (variantProductFileState, error) {
+	data, err := client.Get(cmdutil.JoinPath("products", productID), url.Values{})
+	if err != nil {
+		return variantProductFileState{}, err
+	}
+	resp, err := cmdutil.DecodeJSON[variantProductFilesResponse](data)
+	if err != nil {
+		return variantProductFileState{}, err
+	}
+	return resp.Product, nil
+}
+
+func fetchVariantRichContentState(client *api.Client, variantPath string) (variantRichContentState, error) {
+	data, err := client.Get(variantPath, url.Values{})
+	if err != nil {
+		return variantRichContentState{}, err
+	}
+	resp, err := cmdutil.DecodeJSON[variantRichContentResponse](data)
+	if err != nil {
+		return variantRichContentState{}, err
+	}
+	return resp.Variant, nil
+}
+
+func buildVariantProductFilesPayload(
+	existing []variantExistingProductFile,
+	uploads []plannedVariantUpload,
+	uploadURLs []string,
+	fileRefs []richcontent.FileRef,
+) []map[string]any {
+	files := make([]map[string]any, 0, len(existing)+len(uploads))
+	for _, file := range existing {
+		files = append(files, map[string]any{"id": file.ID})
+	}
+	for i, planned := range uploads {
+		entry := map[string]any{
+			"external_id": fileRefs[i].FileID,
+			"url":         uploadURLs[i],
+		}
+		if planned.DisplayName != "" {
+			entry["display_name"] = planned.DisplayName
+		}
+		if planned.Description != "" {
+			entry["description"] = planned.Description
+		}
+		files = append(files, entry)
+	}
+	return files
+}
+
+func buildVariantUpdateJSONBody(params url.Values, richContent []map[string]any) map[string]any {
+	body := valuesToJSONBody(params)
+	body["rich_content"] = richContent
+	return body
+}
+
+func valuesToJSONBody(params url.Values) map[string]any {
+	body := make(map[string]any, len(params))
+	keys := make([]string, 0, len(params))
+	for key := range params {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		values := append([]string(nil), params[key]...)
+		if len(values) == 1 {
+			body[key] = values[0]
+		} else if len(values) > 1 {
+			body[key] = values
+		}
+	}
+	return body
+}
+
+func placeholderVariantUploadURLs(count int) []string {
+	urls := make([]string, count)
+	for i := 0; i < count; i++ {
+		urls[i] = fmt.Sprintf("<uploaded:file:%d>", i)
+	}
+	return urls
+}
+
+func uploadVariantBatch(opts cmdutil.Options, client *api.Client, uploads []plannedVariantUpload) ([]string, error) {
+	urls := make([]string, len(uploads))
+	for i, current := range uploads {
+		statusLabel := current.Plan.Filename
+		if len(uploads) > 1 {
+			statusLabel = fmt.Sprintf("%s (%d/%d)", current.Plan.Filename, i+1, len(uploads))
+		}
+
+		fileURL, err := uploadui.UploadFile(opts, client, current.Path, current.Plan, s3HTTPClientForTesting, statusLabel)
+		if err != nil {
+			return nil, wrapVariantPartialUploadError(err, urls[:i])
+		}
+		urls[i] = fileURL
+	}
+	return urls, nil
+}
+
+type variantPartialUploadError struct {
+	cause        error
+	uploadedURLs []string
+}
+
+func (e *variantPartialUploadError) Error() string {
+	if len(e.uploadedURLs) == 0 {
+		return e.cause.Error()
+	}
+	return fmt.Sprintf("%v (previously uploaded file URLs: %s)", e.cause, strings.Join(e.uploadedURLs, ", "))
+}
+
+func (e *variantPartialUploadError) Unwrap() error {
+	return e.cause
+}
+
+func wrapVariantPartialUploadError(err error, uploadedURLs []string) error {
+	if err == nil {
+		return nil
+	}
+	if len(uploadedURLs) == 0 {
+		return err
+	}
+	copied := append([]string(nil), uploadedURLs...)
+	return &variantPartialUploadError{
+		cause:        err,
+		uploadedURLs: copied,
+	}
+}
+
+func renderVariantFileAttachDryRun(
+	opts cmdutil.Options,
+	productPath, variantPath string,
+	existingFiles []variantExistingProductFile,
+	uploads []plannedVariantUpload,
+	productBody, variantBody map[string]any,
+) error {
+	payload := variantFileAttachDryRun{
+		DryRun:    true,
+		Uploads:   make([]variantDryRunUpload, 0, len(uploads)),
+		Preserved: make([]variantDryRunExistingFile, 0, len(existingFiles)),
+		ProductRequest: variantFileAttachRequest{
+			Method: http.MethodPut,
+			Path:   productPath,
+			Body:   productBody,
+		},
+		VariantRequest: variantFileAttachRequest{
+			Method: http.MethodPut,
+			Path:   variantPath,
+			Body:   variantBody,
+		},
+	}
+	for _, planned := range uploads {
+		payload.Uploads = append(payload.Uploads, dryRunVariantUpload(planned.Plan))
+	}
+	for _, current := range existingFiles {
+		payload.Preserved = append(payload.Preserved, variantDryRunExistingFile(current))
+	}
+
+	switch {
+	case opts.UsesJSONOutput():
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("could not encode dry-run output: %w", err)
+		}
+		return output.PrintJSON(opts.Out(), data, opts.JQExpr)
+	case opts.PlainOutput:
+		return renderVariantFileAttachDryRunPlain(opts, payload)
+	default:
+		return renderVariantFileAttachDryRunHuman(opts, payload)
+	}
+}
+
+func dryRunVariantUpload(plan upload.Plan) variantDryRunUpload {
+	return variantDryRunUpload{
+		Action:    "upload",
+		Path:      plan.Path,
+		Filename:  plan.Filename,
+		Size:      plan.Size,
+		PartSize:  plan.PartSize,
+		PartCount: plan.PartCount,
+	}
+}
+
+func renderVariantFileAttachDryRunPlain(opts cmdutil.Options, payload variantFileAttachDryRun) error {
+	for _, current := range payload.Preserved {
+		if err := output.PrintPlain(opts.Out(), [][]string{{"preserve", current.ID, current.Name}}); err != nil {
+			return err
+		}
+	}
+	for _, planned := range payload.Uploads {
+		if err := output.PrintPlain(opts.Out(), [][]string{{
+			"upload",
+			planned.Path,
+			planned.Filename,
+			strconv.FormatInt(planned.Size, 10),
+			strconv.Itoa(planned.PartCount),
+		}}); err != nil {
+			return err
+		}
+	}
+	for _, request := range []variantFileAttachRequest{payload.ProductRequest, payload.VariantRequest} {
+		data, err := json.Marshal(request.Body)
+		if err != nil {
+			return fmt.Errorf("could not encode dry-run output: %w", err)
+		}
+		if err := output.PrintPlain(opts.Out(), [][]string{{request.Method, request.Path, string(data)}}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func renderVariantFileAttachDryRunHuman(opts cmdutil.Options, payload variantFileAttachDryRun) error {
+	for _, current := range payload.Preserved {
+		if err := output.Writeln(opts.Out(), "Preserve existing file: "+formatVariantExistingFileLabel(current)); err != nil {
+			return err
+		}
+	}
+	for _, planned := range payload.Uploads {
+		if err := output.Writeln(opts.Out(), opts.Style().Yellow("Dry run")+": upload "+planned.Path); err != nil {
+			return err
+		}
+		if err := output.Writef(opts.Out(), "Filename: %s\n", planned.Filename); err != nil {
+			return err
+		}
+		parts := "1 part"
+		if planned.PartCount != 1 {
+			parts = fmt.Sprintf("%d parts", planned.PartCount)
+		}
+		if err := output.Writef(opts.Out(), "Size: %s (%s)\n", uploadui.HumanBytes(planned.Size), parts); err != nil {
+			return err
+		}
+	}
+	for _, request := range []variantFileAttachRequest{payload.ProductRequest, payload.VariantRequest} {
+		if err := output.Writeln(opts.Out(), opts.Style().Yellow("Dry run")+": "+request.Method+" "+request.Path); err != nil {
+			return err
+		}
+		data, err := json.MarshalIndent(request.Body, "", "  ")
+		if err != nil {
+			return fmt.Errorf("could not encode dry-run output: %w", err)
+		}
+		if err := output.Writeln(opts.Out(), string(data)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func formatVariantExistingFileLabel(file variantDryRunExistingFile) string {
+	name := strings.TrimSpace(file.Name)
+	switch {
+	case name == "":
+		return file.ID
+	case name == file.ID:
+		return name
+	default:
+		return fmt.Sprintf("%s (%s)", name, file.ID)
+	}
+}

--- a/internal/cmd/variants/update.go
+++ b/internal/cmd/variants/update.go
@@ -11,12 +11,16 @@ import (
 func newUpdateCmd() *cobra.Command {
 	var product, category, name, description, priceDifference string
 	var maxPurchaseCount int
+	var files []string
+	var fileNames []string
+	var fileDescriptions []string
 
 	cmd := &cobra.Command{
 		Use:   "update <variant_id>",
 		Short: "Update a variant",
 		Args:  cmdutil.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
 			if err := cmdutil.RequireNonNegativeIntFlag(c, "max-purchase-count", maxPurchaseCount); err != nil {
 				return err
 			}
@@ -26,11 +30,19 @@ func newUpdateCmd() *cobra.Command {
 			if category == "" {
 				return cmdutil.MissingFlagError(c, "--category")
 			}
-			if err := cmdutil.RequireAnyFlagChanged(c, "name", "description", "price-difference", "max-purchase-count"); err != nil {
+			if err := cmdutil.RequireAnyFlagChanged(c,
+				"name", "description", "price-difference", "max-purchase-count",
+				"file", "file-name", "file-description",
+			); err != nil {
 				return err
 			}
 
 			flags := c.Flags()
+			requestedUploads, err := collectRequestedVariantUploads(c, files, fileNames, fileDescriptions)
+			if err != nil {
+				return err
+			}
+
 			params := url.Values{}
 			if flags.Changed("name") {
 				if name == "" {
@@ -53,7 +65,17 @@ func newUpdateCmd() *cobra.Command {
 			}
 
 			path := cmdutil.JoinPath("products", product, "variant_categories", category, "variants", args[0])
-			return cmdutil.RunRequestWithSuccess(cmdutil.OptionsFrom(c), "Updating variant...", "PUT", path, params, args[0], "Variant "+args[0]+" updated.")
+			fileFlagsChanged := flags.Changed("file") ||
+				flags.Changed("file-name") ||
+				flags.Changed("file-description")
+			if !fileFlagsChanged {
+				return cmdutil.RunRequestWithSuccess(opts, "Updating variant...", "PUT", path, params, args[0], "Variant "+args[0]+" updated.")
+			}
+			if len(requestedUploads) == 0 {
+				return cmdutil.UsageErrorf(c, "--file-name and --file-description require at least one --file")
+			}
+
+			return runVariantUpdateWithFiles(opts, product, category, args[0], path, params, requestedUploads)
 		},
 	}
 
@@ -63,6 +85,9 @@ func newUpdateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&description, "description", "", "New description")
 	cmd.Flags().StringVar(&priceDifference, "price-difference", "", "New price difference (e.g. 5.00, -1.50)")
 	cmd.Flags().IntVar(&maxPurchaseCount, "max-purchase-count", 0, "New max purchase count")
+	cmd.Flags().StringArrayVar(&files, "file", nil, "Attach a new local file to this variant's content (repeatable)")
+	cmd.Flags().StringArrayVar(&fileNames, "file-name", nil, "Display name for the matching --file (repeatable)")
+	cmd.Flags().StringArrayVar(&fileDescriptions, "file-description", nil, "Description for the matching --file (repeatable)")
 
 	return cmd
 }

--- a/internal/cmd/variants/update.go
+++ b/internal/cmd/variants/update.go
@@ -75,7 +75,7 @@ func newUpdateCmd() *cobra.Command {
 				return cmdutil.UsageErrorf(c, "--file-name and --file-description require at least one --file")
 			}
 
-			return runVariantUpdateWithFiles(opts, product, category, args[0], path, params, requestedUploads)
+			return runVariantUpdateWithFiles(opts, product, args[0], path, params, requestedUploads)
 		},
 	}
 

--- a/internal/cmd/variants/variants.go
+++ b/internal/cmd/variants/variants.go
@@ -9,7 +9,8 @@ func NewVariantsCmd() *cobra.Command {
 		Use:   "variants",
 		Short: "Manage variants",
 		Example: `  gumroad variants list --product <id> --category <cat_id>
-  gumroad variants create --product <id> --category <cat_id> --name "Large"`,
+  gumroad variants create --product <id> --category <cat_id> --name "Large"
+  gumroad variants update <variant_id> --product <id> --category <cat_id> --file ./license.pdf`,
 	}
 
 	cmd.AddCommand(newListCmd())

--- a/internal/cmd/variants/variants_test.go
+++ b/internal/cmd/variants/variants_test.go
@@ -3,11 +3,20 @@ package variants
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/richcontent"
 	"github.com/antiwork/gumroad-cli/internal/testutil"
 )
 
@@ -30,6 +39,196 @@ func variantHandler(t *testing.T) http.HandlerFunc {
 				"price_difference_cents": 500, "max_purchase_count": 5,
 			},
 		})
+	}
+}
+
+type variantFileAttachServers struct {
+	s3 *httptest.Server
+
+	sharedContent      bool
+	productJSON        map[string]any
+	variantJSON        map[string]any
+	variantRichContent []map[string]any
+
+	productGetCalls atomic.Int32
+	productPutCalls atomic.Int32
+	variantGetCalls atomic.Int32
+	variantPutCalls atomic.Int32
+	s3Calls         atomic.Int32
+	completeSeq     atomic.Int32
+}
+
+func newVariantFileAttachServers(t *testing.T) *variantFileAttachServers {
+	t.Helper()
+
+	s := &variantFileAttachServers{
+		variantRichContent: []map[string]any{{
+			"id":    "page_1",
+			"title": "Existing page",
+			"description": map[string]any{
+				"type": "doc",
+				"content": []any{
+					map[string]any{"type": "fileEmbed", "attrs": map[string]any{"id": "file_existing", "uid": "old-uid"}},
+					map[string]any{"type": "paragraph"},
+				},
+			},
+		}},
+	}
+	s.s3 = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.s3Calls.Add(1)
+		if r.Method != http.MethodPut {
+			t.Errorf("S3 got %s, want PUT", r.Method)
+			http.Error(w, "bad method", http.StatusBadRequest)
+			return
+		}
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.Header().Set("ETag", `"etag-1"`)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(s.s3.Close)
+
+	prev := s3HTTPClientForTesting
+	s3HTTPClientForTesting = s.s3.Client()
+	t.Cleanup(func() { s3HTTPClientForTesting = prev })
+
+	return s
+}
+
+func (s *variantFileAttachServers) dispatch(t *testing.T) http.HandlerFunc {
+	t.Helper()
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/products/p1":
+			switch r.Method {
+			case http.MethodGet:
+				s.productGetCalls.Add(1)
+				testutil.JSON(t, w, map[string]any{
+					"product": map[string]any{
+						"id": "p1",
+						"files": []map[string]any{
+							{"id": "file_existing", "name": "Existing.pdf"},
+						},
+						"has_same_rich_content_for_all_variants": s.sharedContent,
+					},
+				})
+			case http.MethodPut:
+				s.productPutCalls.Add(1)
+				if err := json.NewDecoder(r.Body).Decode(&s.productJSON); err != nil {
+					t.Fatalf("decode product JSON body: %v", err)
+				}
+				testutil.JSON(t, w, map[string]any{"product": map[string]any{"id": "p1"}})
+			default:
+				t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+				http.Error(w, "unexpected", http.StatusMethodNotAllowed)
+			}
+		case "/products/p1/variant_categories/vc1/variants/v1":
+			switch r.Method {
+			case http.MethodGet:
+				s.variantGetCalls.Add(1)
+				testutil.JSON(t, w, map[string]any{
+					"variant": map[string]any{
+						"id":           "v1",
+						"name":         "Large",
+						"rich_content": s.variantRichContent,
+					},
+				})
+			case http.MethodPut:
+				s.variantPutCalls.Add(1)
+				if err := json.NewDecoder(r.Body).Decode(&s.variantJSON); err != nil {
+					t.Fatalf("decode variant JSON body: %v", err)
+				}
+				testutil.JSON(t, w, map[string]any{"variant": map[string]any{"id": "v1"}})
+			default:
+				t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+				http.Error(w, "unexpected", http.StatusMethodNotAllowed)
+			}
+		case "/files/presign":
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm failed: %v", err)
+			}
+			testutil.JSON(t, w, map[string]any{
+				"upload_id": "up-1",
+				"key":       "attachments/u/k/original/upload.bin",
+				"file_url":  "https://example.com/attachments/u/k/original/upload.bin",
+				"parts": []map[string]any{
+					{"part_number": 1, "presigned_url": s.s3.URL + "/part/1"},
+				},
+			})
+		case "/files/complete":
+			seq := s.completeSeq.Add(1)
+			testutil.JSON(t, w, map[string]any{
+				"file_url": fmt.Sprintf("https://example.com/attachments/u/k/original/upload-%d.bin", seq),
+			})
+		case "/files/abort":
+			testutil.JSON(t, w, map[string]any{})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected", http.StatusNotFound)
+		}
+	}
+}
+
+func writeVariantUploadFixture(t *testing.T, contents string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "fixture.bin")
+	if err := os.WriteFile(path, []byte(contents), 0600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+func variantUpdateJSONFiles(t *testing.T, body map[string]any) []map[string]any {
+	t.Helper()
+
+	raw, ok := body["files"].([]any)
+	if !ok {
+		t.Fatalf("files payload has wrong type: %T", body["files"])
+	}
+	files := make([]map[string]any, len(raw))
+	for i, current := range raw {
+		file, ok := current.(map[string]any)
+		if !ok {
+			t.Fatalf("files[%d] has wrong type: %T", i, current)
+		}
+		files[i] = file
+	}
+	return files
+}
+
+func variantUpdateJSONRichContent(t *testing.T, body map[string]any) []map[string]any {
+	t.Helper()
+
+	rawRichContent, ok := body["rich_content"].([]any)
+	if !ok {
+		t.Fatalf("variant rich_content has wrong type: %T", body["rich_content"])
+	}
+	richContentPages := make([]map[string]any, len(rawRichContent))
+	for i, raw := range rawRichContent {
+		page, ok := raw.(map[string]any)
+		if !ok {
+			t.Fatalf("rich_content[%d] has wrong type: %T", i, raw)
+		}
+		richContentPages[i] = page
+	}
+	return richContentPages
+}
+
+func TestNewVariantsCmdIncludesSubcommands(t *testing.T) {
+	cmd := NewVariantsCmd()
+	if cmd.Use != "variants" {
+		t.Fatalf("Use = %q, want variants", cmd.Use)
+	}
+
+	names := map[string]bool{}
+	for _, subcmd := range cmd.Commands() {
+		names[subcmd.Name()] = true
+	}
+	for _, name := range []string{"list", "view", "create", "update", "delete"} {
+		if !names[name] {
+			t.Fatalf("missing subcommand %q", name)
+		}
 	}
 }
 
@@ -763,6 +962,272 @@ func TestUpdate_MaxPurchaseCountZero(t *testing.T) {
 
 	if gotParam != "0" {
 		t.Errorf("got max_purchase_count=%q, want 0", gotParam)
+	}
+}
+
+func TestUpdate_FileAttachesToVariantRichContent(t *testing.T) {
+	srv := newVariantFileAttachServers(t)
+	testutil.Setup(t, srv.dispatch(t))
+
+	path := writeVariantUploadFixture(t, "license bytes")
+	cmd := testutil.Command(newUpdateCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{
+		"v1",
+		"--product", "p1",
+		"--category", "vc1",
+		"--file", path,
+		"--file-name", "License.pdf",
+	})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if srv.productPutCalls.Load() != 1 {
+		t.Fatalf("product PUT calls = %d, want 1", srv.productPutCalls.Load())
+	}
+	if srv.variantPutCalls.Load() != 1 {
+		t.Fatalf("variant PUT calls = %d, want 1", srv.variantPutCalls.Load())
+	}
+	if srv.s3Calls.Load() != 1 {
+		t.Fatalf("S3 calls = %d, want 1", srv.s3Calls.Load())
+	}
+	if _, ok := srv.productJSON["rich_content"]; ok {
+		t.Fatalf("product update unexpectedly sent rich_content: %#v", srv.productJSON["rich_content"])
+	}
+
+	files := variantUpdateJSONFiles(t, srv.productJSON)
+	if len(files) != 2 {
+		t.Fatalf("files payload len = %d, want 2", len(files))
+	}
+	if files[0]["id"] != "file_existing" {
+		t.Fatalf("files[0].id = %#v, want file_existing", files[0]["id"])
+	}
+	newFileID, ok := files[1]["external_id"].(string)
+	if !ok || !strings.HasPrefix(newFileID, "cli-upload-") {
+		t.Fatalf("files[1].external_id = %#v, want generated id", files[1]["external_id"])
+	}
+	if files[1]["url"] != "https://example.com/attachments/u/k/original/upload-1.bin" {
+		t.Fatalf("files[1].url = %#v", files[1]["url"])
+	}
+
+	richContentPages := variantUpdateJSONRichContent(t, srv.variantJSON)
+	if ids := richcontent.FileEmbedIDs(richContentPages); !reflect.DeepEqual(ids, []string{"file_existing", newFileID}) {
+		t.Fatalf("variant rich_content fileEmbed ids = %#v, want existing file then new upload", ids)
+	}
+}
+
+func TestUpdate_FileCreatesVariantRichContentWhenEmpty(t *testing.T) {
+	srv := newVariantFileAttachServers(t)
+	srv.variantRichContent = []map[string]any{}
+	testutil.Setup(t, srv.dispatch(t))
+
+	path := writeVariantUploadFixture(t, "license bytes")
+	cmd := testutil.Command(newUpdateCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{
+		"v1",
+		"--product", "p1",
+		"--category", "vc1",
+		"--file", path,
+		"--file-name", "License.pdf",
+	})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	files := variantUpdateJSONFiles(t, srv.productJSON)
+	if len(files) != 2 {
+		t.Fatalf("files payload len = %d, want 2", len(files))
+	}
+	if files[0]["id"] != "file_existing" {
+		t.Fatalf("files[0].id = %#v, want file_existing", files[0]["id"])
+	}
+	newFileID, ok := files[1]["external_id"].(string)
+	if !ok || !strings.HasPrefix(newFileID, "cli-upload-") {
+		t.Fatalf("files[1].external_id = %#v, want generated id", files[1]["external_id"])
+	}
+
+	richContentPages := variantUpdateJSONRichContent(t, srv.variantJSON)
+	if ids := richcontent.FileEmbedIDs(richContentPages); !reflect.DeepEqual(ids, []string{newFileID}) {
+		t.Fatalf("variant rich_content fileEmbed ids = %#v, want new upload only", ids)
+	}
+}
+
+func TestUpdate_FileRejectsSharedContentBeforeUpload(t *testing.T) {
+	srv := newVariantFileAttachServers(t)
+	srv.sharedContent = true
+	testutil.Setup(t, srv.dispatch(t))
+
+	path := writeVariantUploadFixture(t, "license bytes")
+	cmd := testutil.Command(newUpdateCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{
+		"v1",
+		"--product", "p1",
+		"--category", "vc1",
+		"--file", path,
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected shared content error")
+	}
+	if !strings.Contains(err.Error(), "shared content") || !strings.Contains(err.Error(), "products update") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if srv.variantGetCalls.Load() != 0 {
+		t.Fatalf("variant GET calls = %d, want 0", srv.variantGetCalls.Load())
+	}
+	if srv.s3Calls.Load() != 0 {
+		t.Fatalf("S3 calls = %d, want 0", srv.s3Calls.Load())
+	}
+	if srv.productPutCalls.Load() != 0 || srv.variantPutCalls.Load() != 0 {
+		t.Fatalf("unexpected PUT calls: product=%d variant=%d", srv.productPutCalls.Load(), srv.variantPutCalls.Load())
+	}
+}
+
+func TestUpdate_FileDryRunJSONShowsProductAndVariantRequests(t *testing.T) {
+	srv := newVariantFileAttachServers(t)
+	testutil.Setup(t, srv.dispatch(t))
+
+	path := writeVariantUploadFixture(t, "license bytes")
+	cmd := testutil.Command(newUpdateCmd(), testutil.DryRun(true), testutil.JSONOutput())
+	cmd.SetArgs([]string{
+		"v1",
+		"--product", "p1",
+		"--category", "vc1",
+		"--file", path,
+		"--file-name", "License.pdf",
+		"--description", "Updated variant",
+	})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var payload struct {
+		DryRun         bool `json:"dry_run"`
+		Uploads        []any
+		Preserved      []any
+		ProductRequest struct {
+			Method string         `json:"method"`
+			Path   string         `json:"path"`
+			Body   map[string]any `json:"body"`
+		} `json:"product_request"`
+		VariantRequest struct {
+			Method string         `json:"method"`
+			Path   string         `json:"path"`
+			Body   map[string]any `json:"body"`
+		} `json:"variant_request"`
+	}
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("dry-run output is not JSON: %v", err)
+	}
+	if !payload.DryRun {
+		t.Fatal("dry_run = false, want true")
+	}
+	if len(payload.Uploads) != 1 {
+		t.Fatalf("uploads len = %d, want 1", len(payload.Uploads))
+	}
+	if len(payload.Preserved) != 1 {
+		t.Fatalf("preserved len = %d, want 1", len(payload.Preserved))
+	}
+	if payload.ProductRequest.Method != "PUT" || payload.ProductRequest.Path != "/products/p1" {
+		t.Fatalf("product request = %s %s", payload.ProductRequest.Method, payload.ProductRequest.Path)
+	}
+	if payload.VariantRequest.Method != "PUT" || payload.VariantRequest.Path != "/products/p1/variant_categories/vc1/variants/v1" {
+		t.Fatalf("variant request = %s %s", payload.VariantRequest.Method, payload.VariantRequest.Path)
+	}
+	if payload.VariantRequest.Body["description"] != "Updated variant" {
+		t.Fatalf("variant description = %#v, want Updated variant", payload.VariantRequest.Body["description"])
+	}
+	if srv.s3Calls.Load() != 0 {
+		t.Fatalf("S3 calls = %d, want 0", srv.s3Calls.Load())
+	}
+	if srv.productPutCalls.Load() != 0 || srv.variantPutCalls.Load() != 0 {
+		t.Fatalf("unexpected PUT calls: product=%d variant=%d", srv.productPutCalls.Load(), srv.variantPutCalls.Load())
+	}
+}
+
+func TestUpdate_FileDryRunPlainShowsRequests(t *testing.T) {
+	srv := newVariantFileAttachServers(t)
+	testutil.Setup(t, srv.dispatch(t))
+
+	path := writeVariantUploadFixture(t, "license bytes")
+	cmd := testutil.Command(newUpdateCmd(), testutil.DryRun(true), testutil.PlainOutput())
+	cmd.SetArgs([]string{
+		"v1",
+		"--product", "p1",
+		"--category", "vc1",
+		"--file", path,
+	})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	for _, expected := range []string{
+		"preserve\tfile_existing\tExisting.pdf",
+		"upload\t" + output.EscapePlainField(path),
+		"PUT\t/products/p1\t",
+		"PUT\t/products/p1/variant_categories/vc1/variants/v1\t",
+	} {
+		if !strings.Contains(out, expected) {
+			t.Fatalf("plain dry-run output missing %q: %q", expected, out)
+		}
+	}
+}
+
+func TestUpdate_FileDryRunHumanShowsRequests(t *testing.T) {
+	srv := newVariantFileAttachServers(t)
+	testutil.Setup(t, srv.dispatch(t))
+
+	path := writeVariantUploadFixture(t, "license bytes")
+	cmd := testutil.Command(newUpdateCmd(), testutil.DryRun(true))
+	cmd.SetArgs([]string{
+		"v1",
+		"--product", "p1",
+		"--category", "vc1",
+		"--file", path,
+	})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	for _, expected := range []string{
+		"Preserve existing file: Existing.pdf (file_existing)",
+		"Dry run: upload " + path,
+		"Dry run: PUT /products/p1",
+		"Dry run: PUT /products/p1/variant_categories/vc1/variants/v1",
+	} {
+		if !strings.Contains(out, expected) {
+			t.Fatalf("human dry-run output missing %q: %q", expected, out)
+		}
+	}
+}
+
+func TestVariantPartialUploadErrorIncludesUploadedURLs(t *testing.T) {
+	cause := errors.New("update failed")
+	err := wrapVariantPartialUploadError(cause, []string{"https://example.com/file-a"})
+	if !errors.Is(err, cause) {
+		t.Fatalf("wrapped error does not unwrap to cause: %v", err)
+	}
+	if !strings.Contains(err.Error(), "previously uploaded file URLs: https://example.com/file-a") {
+		t.Fatalf("error missing uploaded URLs: %v", err)
+	}
+}
+
+func TestVariantPartialUploadErrorNoUploadedURLsReturnsCause(t *testing.T) {
+	cause := errors.New("update failed")
+	if err := wrapVariantPartialUploadError(cause, nil); !errors.Is(err, cause) {
+		t.Fatalf("error = %v, want original cause", err)
+	}
+	if err := wrapVariantPartialUploadError(nil, []string{"https://example.com/file-a"}); err != nil {
+		t.Fatalf("nil error wrapped to %v", err)
+	}
+}
+
+func TestFormatVariantExistingFileLabel(t *testing.T) {
+	tests := []struct {
+		name string
+		file variantDryRunExistingFile
+		want string
+	}{
+		{name: "id only", file: variantDryRunExistingFile{ID: "file_1"}, want: "file_1"},
+		{name: "name equals id", file: variantDryRunExistingFile{ID: "file_1", Name: "file_1"}, want: "file_1"},
+		{name: "name and id", file: variantDryRunExistingFile{ID: "file_1", Name: "License.pdf"}, want: "License.pdf (file_1)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatVariantExistingFileLabel(tt.file); got != tt.want {
+				t.Fatalf("label = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/richcontent/files.go
+++ b/internal/richcontent/files.go
@@ -1,0 +1,317 @@
+package richcontent
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+)
+
+const DefaultFileTitle = "Page 1"
+
+type FileRef struct {
+	FileID   string
+	EmbedUID string
+}
+
+func NewFileRefs(count int) ([]FileRef, error) {
+	refs := make([]FileRef, count)
+	for i := range refs {
+		fileUUID, err := newUUIDV4()
+		if err != nil {
+			return nil, fmt.Errorf("could not generate file id: %w", err)
+		}
+		embedUUID, err := newUUIDV4()
+		if err != nil {
+			return nil, fmt.Errorf("could not generate file embed id: %w", err)
+		}
+		refs[i] = FileRef{
+			FileID:   "cli-upload-" + fileUUID,
+			EmbedUID: embedUUID,
+		}
+	}
+	return refs, nil
+}
+
+func BuildFileRichContent(fileRefs []FileRef) []map[string]any {
+	content := make([]map[string]any, 0, len(fileRefs)+1)
+	for _, ref := range fileRefs {
+		content = append(content, map[string]any{
+			"type": "fileEmbed",
+			"attrs": map[string]any{
+				"id":        ref.FileID,
+				"uid":       ref.EmbedUID,
+				"collapsed": false,
+			},
+		})
+	}
+	content = append(content, map[string]any{"type": "paragraph"})
+
+	return []map[string]any{{
+		"title": DefaultFileTitle,
+		"description": map[string]any{
+			"type":    "doc",
+			"content": content,
+		},
+	}}
+}
+
+func AppendFileEmbeds(richContent []map[string]any, preservedFileIDs []string, fileRefs []FileRef) ([]map[string]any, error) {
+	if len(fileRefs) == 0 {
+		return Clone(richContent)
+	}
+	if len(richContent) == 0 {
+		preservedRefs, err := refsForExistingFiles(preservedFileIDs)
+		if err != nil {
+			return nil, err
+		}
+		return BuildFileRichContent(append(preservedRefs, fileRefs...)), nil
+	}
+
+	cloned, err := Clone(richContent)
+	if err != nil {
+		return nil, err
+	}
+
+	page := cloned[appendFileEmbedPage(cloned)]
+	description, ok := page["description"].(map[string]any)
+	if !ok {
+		description = map[string]any{"type": "doc"}
+		page["description"] = description
+	}
+	content, _ := description["content"].([]any)
+	if group := fileEmbedGroupForAppend(content); group != nil {
+		groupContent, _ := group["content"].([]any)
+		group["content"] = append(groupContent, fileEmbedNodes(fileRefs)...)
+	} else {
+		content = appendFileEmbedsToContent(content, fileRefs)
+	}
+	description["type"] = "doc"
+	description["content"] = content
+	return cloned, nil
+}
+
+func Clone(richContent []map[string]any) ([]map[string]any, error) {
+	data, err := json.Marshal(richContent)
+	if err != nil {
+		return nil, fmt.Errorf("could not encode rich_content: %w", err)
+	}
+	var cloned []map[string]any
+	if err := json.Unmarshal(data, &cloned); err != nil {
+		return nil, fmt.Errorf("could not decode rich_content: %w", err)
+	}
+	return cloned, nil
+}
+
+func FileEmbedIDs(richContent []map[string]any) []string {
+	var ids []string
+	for _, page := range richContent {
+		collectFileEmbedIDs(page["description"], &ids)
+	}
+	return ids
+}
+
+func ReplaceFileEmbedID(richContent []map[string]any, oldID, newID string) {
+	for _, page := range richContent {
+		replaceFileEmbedIDInNode(page["description"], oldID, newID)
+	}
+}
+
+func StripFileEmbedIDs(richContent []map[string]any, ids []string) {
+	if len(ids) == 0 {
+		return
+	}
+	idSet := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		idSet[id] = struct{}{}
+	}
+	for _, page := range richContent {
+		if description, ok := page["description"].(map[string]any); ok {
+			stripFileEmbedIDsInNode(description, idSet)
+			ensureDescriptionContent(description)
+		}
+	}
+}
+
+func refsForExistingFiles(fileIDs []string) ([]FileRef, error) {
+	refs := make([]FileRef, len(fileIDs))
+	for i, fileID := range fileIDs {
+		embedUUID, err := newUUIDV4()
+		if err != nil {
+			return nil, fmt.Errorf("could not generate file embed id: %w", err)
+		}
+		refs[i] = FileRef{
+			FileID:   fileID,
+			EmbedUID: embedUUID,
+		}
+	}
+	return refs, nil
+}
+
+func appendFileEmbedPage(richContent []map[string]any) int {
+	target := len(richContent) - 1
+	for i, page := range richContent {
+		if pageHasFileEmbed(page) {
+			target = i
+		}
+	}
+	return target
+}
+
+func pageHasFileEmbed(page map[string]any) bool {
+	var ids []string
+	collectFileEmbedIDs(page["description"], &ids)
+	return len(ids) > 0
+}
+
+func fileEmbedGroupForAppend(content []any) map[string]any {
+	var target map[string]any
+	for _, child := range content {
+		childMap, ok := child.(map[string]any)
+		if !ok {
+			continue
+		}
+		if childMap["type"] == "fileEmbed" {
+			return nil
+		}
+
+		var ids []string
+		collectFileEmbedIDs(childMap, &ids)
+		if len(ids) == 0 {
+			continue
+		}
+		if childMap["type"] != "fileEmbedGroup" || target != nil {
+			return nil
+		}
+		target = childMap
+	}
+	return target
+}
+
+func appendFileEmbedsToContent(content []any, fileRefs []FileRef) []any {
+	var trailingParagraph any
+	if len(content) > 0 && nodeHasType(content[len(content)-1], "paragraph") {
+		trailingParagraph = content[len(content)-1]
+		content = content[:len(content)-1]
+	}
+	content = append(content, fileEmbedNodes(fileRefs)...)
+	if trailingParagraph == nil {
+		trailingParagraph = map[string]any{"type": "paragraph"}
+	}
+	return append(content, trailingParagraph)
+}
+
+func fileEmbedNodes(fileRefs []FileRef) []any {
+	nodes := make([]any, len(fileRefs))
+	for i, ref := range fileRefs {
+		nodes[i] = map[string]any{
+			"type": "fileEmbed",
+			"attrs": map[string]any{
+				"id":        ref.FileID,
+				"uid":       ref.EmbedUID,
+				"collapsed": false,
+			},
+		}
+	}
+	return nodes
+}
+
+func collectFileEmbedIDs(node any, ids *[]string) {
+	current, ok := node.(map[string]any)
+	if !ok {
+		return
+	}
+	if current["type"] == "fileEmbed" {
+		if attrs, ok := current["attrs"].(map[string]any); ok {
+			if id, ok := attrs["id"].(string); ok && id != "" {
+				*ids = append(*ids, id)
+			}
+		}
+	}
+	if children, ok := current["content"].([]any); ok {
+		for _, child := range children {
+			collectFileEmbedIDs(child, ids)
+		}
+	}
+}
+
+func replaceFileEmbedIDInNode(node any, oldID, newID string) {
+	current, ok := node.(map[string]any)
+	if !ok {
+		return
+	}
+	if current["type"] == "fileEmbed" {
+		if attrs, ok := current["attrs"].(map[string]any); ok && attrs["id"] == oldID {
+			attrs["id"] = newID
+		}
+	}
+	if children, ok := current["content"].([]any); ok {
+		for _, child := range children {
+			replaceFileEmbedIDInNode(child, oldID, newID)
+		}
+	}
+}
+
+func stripFileEmbedIDsInNode(node any, ids map[string]struct{}) {
+	current, ok := node.(map[string]any)
+	if !ok {
+		return
+	}
+	children, ok := current["content"].([]any)
+	if !ok {
+		return
+	}
+
+	kept := make([]any, 0, len(children))
+	for _, child := range children {
+		if childMap, ok := child.(map[string]any); ok {
+			if childMap["type"] == "fileEmbed" {
+				if attrs, ok := childMap["attrs"].(map[string]any); ok {
+					if id, ok := attrs["id"].(string); ok {
+						if _, remove := ids[id]; remove {
+							continue
+						}
+					}
+				}
+			}
+			stripFileEmbedIDsInNode(childMap, ids)
+			if isEmptyFileEmbedGroup(childMap) {
+				continue
+			}
+		}
+		kept = append(kept, child)
+	}
+	current["content"] = kept
+}
+
+func isEmptyFileEmbedGroup(node map[string]any) bool {
+	if node["type"] != "fileEmbedGroup" {
+		return false
+	}
+	children, ok := node["content"].([]any)
+	return !ok || len(children) == 0
+}
+
+func ensureDescriptionContent(description map[string]any) {
+	content, ok := description["content"].([]any)
+	if ok && len(content) > 0 {
+		return
+	}
+	description["content"] = []any{map[string]any{"type": "paragraph"}}
+}
+
+func nodeHasType(node any, typ string) bool {
+	nodeMap, ok := node.(map[string]any)
+	return ok && nodeMap["type"] == typ
+}
+
+func newUUIDV4() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:]), nil
+}

--- a/skills/embed_test.go
+++ b/skills/embed_test.go
@@ -63,6 +63,24 @@ func TestSkillMarkdown_ContainsSalesExamples(t *testing.T) {
 	}
 }
 
+func TestSkillMarkdown_ContainsVariantFileAttachExamples(t *testing.T) {
+	data, err := SkillMarkdown()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	content := string(data)
+	for _, example := range []string{
+		"gumroad variants update <var_id> --product <id> --category <cat_id> --file ./license.pdf --json --no-input",
+		"`products update --file` for shared product Content",
+		"`variants update --file` only for products with per-variant Content",
+	} {
+		if !strings.Contains(content, example) {
+			t.Errorf("expected skill to mention variant file attach example %q", example)
+		}
+	}
+}
+
 func TestSkillMarkdown_ContainsAdminRolloutCommands(t *testing.T) {
 	data, err := SkillMarkdown()
 	if err != nil {

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -8,7 +8,7 @@ description: >
   Also trigger on "check my Gumroad", "look up a sale", "verify a license",
   "list my products", "how much have I made", "who bought", "recent sales",
   "refund a sale", "create a product", "upload a file", "attach a file to a product",
-  "finish a failed upload", "abort an upload", "manage webhooks",
+  "attach a file to a variant", "finish a failed upload", "abort an upload", "manage webhooks",
   "check my earnings", "see my revenue", "who subscribed", "manage my store",
   "discount code", "coupon", "shipping status", "payout schedule", or any
   request to query or act on Gumroad data — even if the user doesn't say
@@ -175,6 +175,8 @@ gumroad products skus <id> --json --no-input
 
 **Update flags:** `--file` (repeatable), `--file-name`, `--file-description`, `--remove-file` (repeatable), `--replace-files`, `--keep-file` (repeatable with `--replace-files`). Updates preserve existing files by default unless `--replace-files` is set.
 
+Use `products update --file` for shared product Content. For products with per-variant Content, use `variants update ... --file` for the specific variant you want to change.
+
 ### files — Upload and recover file attachments
 
 ```sh
@@ -321,10 +323,13 @@ gumroad variants create --product <id> --category <cat_id> --name "Large" --json
 gumroad variants create --product <id> --category <cat_id> --name "XL" --price-difference 5.00 --json --no-input
 gumroad variants view <var_id> --product <id> --category <cat_id> --json --no-input
 gumroad variants update <var_id> --product <id> --category <cat_id> --name "Medium" --json --no-input
+gumroad variants update <var_id> --product <id> --category <cat_id> --file ./license.pdf --json --no-input
 gumroad variants delete <var_id> --product <id> --category <cat_id> --yes --json --no-input
 ```
 
 **All subcommands require** `--product` and `--category`.
+
+**Update flags:** `--name`, `--description`, `--price-difference`, `--max-purchase-count`, `--file` (repeatable), `--file-name`, `--file-description`. Use `variants update --file` only for products with per-variant Content; for shared Content, attach at the product level with `products update --file`.
 
 ### custom-fields — Manage custom fields
 


### PR DESCRIPTION
Ref #100

## What

This fixes file attachment for products that use per-variant Content by keeping `products update --file` scoped to shared product Content. When a product uses per-variant Content, the product command now refuses with a clear error and points to `variants update --file`.

The PR adds file attachment support to `variants update`, updates the CLI examples and embedded skill guidance, and covers the product guard and variant attachment path with tests.

## Why

The broken behavior came from sending product-level rich content for a product whose files belong in variant rich content. The correct CLI model is to target the variant explicitly instead of hiding a bulk mutation behind a product update command.

---

This PR was implemented with AI assistance using gpt-5.5 xhigh.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new multi-step mutation flow (upload + product PUT + variant PUT) and changes behavior of `products update --file` to hard-fail for per-variant content, which could impact existing automation and requires careful API contract alignment.
> 
> **Overview**
> Fixes per-variant Content file attachment by **preventing `gumroad products update --file` from running when a product uses per-variant `rich_content`**, returning a clear usage error that points users to `gumroad variants update ... --file`.
> 
> Adds **file attachment support to `gumroad variants update`** via new `--file`/`--file-name`/`--file-description` flags: it uploads files, updates the product `files` list with new `external_id` entries, and updates the variant’s `rich_content` to embed the new files, with dry-run output showing both requests.
> 
> Refactors rich-content file-embed utilities into a new shared `internal/richcontent` package, and updates README/skill docs plus tests to cover the new guardrails and variant-attachment behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cae595ac5cee639a6256782a12ab253e00c5e4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->