### PR TITLE
Add product media upload commands to the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ For CI and agents, set `GUMROAD_ACCESS_TOKEN` instead — it takes precedence ov
 gumroad auth          login, status, logout
 gumroad admin         Internal admin API commands
 gumroad user          View your account info
-gumroad products      create, update, list, view, delete, publish, unpublish, skus
+gumroad products      create, update, list, view, delete, publish, unpublish, covers, thumbnail, skus
 gumroad sales         list, export, view, refund, ship, resend-receipt
 gumroad payouts       list, view, upcoming
 gumroad subscribers   list, view
@@ -159,6 +159,26 @@ gumroad products update <product_id> --replace-files --keep-file <file_id> --fil
 ```
 
 `gumroad files upload` and `gumroad files complete` both print the canonical `file_url`. Product create/update and variant update accept repeatable `--file` flags, with matching `--file-name` and `--file-description` values when you need custom attachment metadata. For products that use per-variant Content, use `gumroad variants update ... --file`; product-level `--file` is for shared Content. `gumroad products update` also supports `--remove-file`, and `--replace-files` with `--keep-file`, when you need to remove existing attachments.
+
+## Product media
+
+```sh
+# Create a draft product, then attach cover and thumbnail images
+gumroad products create --name "Art Pack" --price 10.00 --cover-image ./cover.jpg --thumbnail ./thumb.jpg
+
+# Add preview/gallery images to an existing product
+gumroad products update <product_id> --preview-image ./gallery-1.jpg --preview-image ./gallery-2.jpg
+
+# Full-control resource commands
+gumroad products covers add <product_id> --image ./cover.jpg
+gumroad products covers add <product_id> --url https://www.youtube.com/watch?v=qKebcV1jv3A
+gumroad products covers reorder <product_id> <cover_id> <cover_id>
+gumroad products covers remove <product_id> <cover_id> --yes
+gumroad products thumbnail set <product_id> --image ./thumb.jpg
+gumroad products thumbnail remove <product_id> --yes
+```
+
+Product media upload supports JPEG, PNG, and GIF. WebP is rejected client-side because the Gumroad API does not accept it for product media.
 
 ## Output modes
 

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -58,10 +58,17 @@ func parseAPIError(statusCode int, body []byte) error {
 	var resp struct {
 		Success bool   `json:"success"`
 		Message string `json:"message"`
+		Error   string `json:"error"`
 	}
-	if err := json.Unmarshal(body, &resp); err == nil && resp.Message != "" {
-		msg, hint := rewriteError(statusCode, resp.Message)
-		return &APIError{StatusCode: statusCode, Message: msg, Hint: hint}
+	if err := json.Unmarshal(body, &resp); err == nil {
+		message := resp.Message
+		if message == "" {
+			message = resp.Error
+		}
+		if message != "" {
+			msg, hint := rewriteError(statusCode, message)
+			return &APIError{StatusCode: statusCode, Message: msg, Hint: hint}
+		}
 	}
 
 	msg, hint := rewriteError(statusCode, "")

--- a/internal/cmd/products/covers.go
+++ b/internal/cmd/products/covers.go
@@ -1,0 +1,131 @@
+package products
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func newCoversCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "covers",
+		Short: "Manage product cover images",
+		Example: `  gumroad products covers add <product_id> --image ./cover.jpg
+  gumroad products covers add <product_id> --url https://www.youtube.com/watch?v=qKebcV1jv3A
+  gumroad products covers remove <product_id> <cover_id>
+  gumroad products covers reorder <product_id> <cover_id> <cover_id>`,
+	}
+
+	cmd.AddCommand(newCoversAddCmd())
+	cmd.AddCommand(newCoversRemoveCmd())
+	cmd.AddCommand(newCoversReorderCmd())
+	return cmd
+}
+
+func newCoversAddCmd() *cobra.Command {
+	var imagePath, coverURL string
+
+	cmd := &cobra.Command{
+		Use:   "add <product_id>",
+		Short: "Add a cover to a product",
+		Args:  cmdutil.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			flags := c.Flags()
+			if !flags.Changed("image") && !flags.Changed("url") {
+				return cmdutil.UsageErrorf(c, "provide --image or --url")
+			}
+			if flags.Changed("image") && flags.Changed("url") {
+				return cmdutil.UsageErrorf(c, "--image and --url cannot be used together")
+			}
+			productID := args[0]
+			path := productMediaAttachPath(productID, productMediaCover)
+
+			if flags.Changed("url") {
+				if err := cmdutil.RequireHTTPURLFlag(c, "url", coverURL); err != nil {
+					return err
+				}
+				params := url.Values{}
+				params.Set("url", coverURL)
+				return cmdutil.RunRequestWithSuccess(opts, "Adding cover...", http.MethodPost, path, params, productID, "Cover added to product "+productID+".")
+			}
+
+			media, err := describeProductMedia([]requestedProductMedia{{Kind: productMediaCover, Path: imagePath}})
+			if err != nil {
+				return err
+			}
+			if opts.DryRun {
+				return renderStandaloneProductMediaDryRun(opts, media, productMediaDryRunRequests(productID, media))
+			}
+
+			token, err := config.Token()
+			if err != nil {
+				return err
+			}
+			client := cmdutil.NewAPIClient(opts, token)
+			results, err := uploadAndAttachProductMedia(opts, client, productID, media, "")
+			if err != nil {
+				return err
+			}
+			data, err := json.Marshal(map[string]any{"media": results})
+			if err != nil {
+				return fmt.Errorf("could not encode response: %w", err)
+			}
+			return cmdutil.PrintMutationSuccess(opts, data, productID, "Cover added to product "+productID+".")
+		},
+	}
+	cmd.Flags().StringVar(&imagePath, "image", "", "Local JPEG, PNG, or GIF image to upload as a cover")
+	cmd.Flags().StringVar(&coverURL, "url", "", "Remote http(s) URL to add as a cover")
+	return cmd
+}
+
+func newCoversRemoveCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "remove <product_id> <cover_id>",
+		Short: "Remove a product cover",
+		Args:  cmdutil.ExactArgs(2),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			productID, coverID := args[0], args[1]
+			ok, err := cmdutil.ConfirmAction(opts, "Remove cover "+coverID+" from product "+productID+"?")
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return cmdutil.PrintCancelledAction(opts, "remove cover "+coverID, coverID)
+			}
+			path := cmdutil.JoinPath("products", productID, "covers", coverID)
+			return cmdutil.RunRequestWithSuccess(opts, "Removing cover...", http.MethodDelete, path, nil, coverID, "Cover "+coverID+" removed.")
+		},
+	}
+	return cmd
+}
+
+func newCoversReorderCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "reorder <product_id> <cover_id>...",
+		Short: "Reorder product covers",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 2 {
+				return cmdutil.UsageErrorf(cmd, "provide a product ID and at least one cover ID")
+			}
+			return nil
+		},
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			productID := args[0]
+			params := url.Values{}
+			for _, coverID := range args[1:] {
+				params.Add("cover_ids[]", coverID)
+			}
+			path := cmdutil.JoinPath("products", productID)
+			return cmdutil.RunRequestWithSuccess(opts, "Reordering covers...", http.MethodPut, path, params, productID, "Covers reordered for product "+productID+".")
+		},
+	}
+	return cmd
+}

--- a/internal/cmd/products/covers.go
+++ b/internal/cmd/products/covers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/config"
@@ -42,6 +43,9 @@ func newCoversAddCmd() *cobra.Command {
 			}
 			if flags.Changed("image") && flags.Changed("url") {
 				return cmdutil.UsageErrorf(c, "--image and --url cannot be used together")
+			}
+			if flags.Changed("image") && strings.TrimSpace(imagePath) == "" {
+				return cmdutil.UsageErrorf(c, "--image cannot be empty")
 			}
 			productID := args[0]
 			path := productMediaAttachPath(productID, productMediaCover)

--- a/internal/cmd/products/covers.go
+++ b/internal/cmd/products/covers.go
@@ -1,8 +1,6 @@
 package products
 
 import (
-	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -76,9 +74,9 @@ func newCoversAddCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			data, err := json.Marshal(map[string]any{"media": results})
+			data, err := productMediaSingleAttachResult(results)
 			if err != nil {
-				return fmt.Errorf("could not encode response: %w", err)
+				return err
 			}
 			return cmdutil.PrintMutationSuccess(opts, data, productID, "Cover added to product "+productID+".")
 		},

--- a/internal/cmd/products/create.go
+++ b/internal/cmd/products/create.go
@@ -53,12 +53,15 @@ type createUploadInput struct {
 }
 
 type dryRunCreateUpload struct {
-	Action    string `json:"action"`
-	Path      string `json:"path"`
-	Filename  string `json:"filename"`
-	Size      int64  `json:"size"`
-	PartSize  int64  `json:"part_size"`
-	PartCount int    `json:"part_count"`
+	Action      string `json:"action"`
+	Kind        string `json:"kind,omitempty"`
+	Path        string `json:"path"`
+	Filename    string `json:"filename"`
+	Size        int64  `json:"size"`
+	PartSize    int64  `json:"part_size"`
+	PartCount   int    `json:"part_count"`
+	ContentType string `json:"content_type,omitempty"`
+	Checksum    string `json:"checksum,omitempty"`
 }
 
 type dryRunCreateRequest struct {
@@ -68,9 +71,10 @@ type dryRunCreateRequest struct {
 }
 
 type dryRunCreatePayload struct {
-	DryRun  bool                 `json:"dry_run"`
-	Uploads []dryRunCreateUpload `json:"uploads"`
-	Request dryRunCreateRequest  `json:"request"`
+	DryRun           bool                  `json:"dry_run"`
+	Uploads          []dryRunCreateUpload  `json:"uploads"`
+	Request          dryRunCreateRequest   `json:"request"`
+	FollowUpRequests []dryRunCreateRequest `json:"follow_up_requests,omitempty"`
 }
 
 func newCreateCmd() *cobra.Command {
@@ -81,12 +85,15 @@ func newCreateCmd() *cobra.Command {
 	var payWhatYouWant bool
 	var tags []string
 	var files, fileNames, fileDescriptions []string
+	var coverImage, thumbnail string
+	var previewImages []string
 
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a new product (as draft)",
 		Example: `  gumroad products create --name "Art Pack" --price 10.00
   gumroad products create --name "Art Pack" --file ./pack.zip --file-name "Art Pack.zip"
+  gumroad products create --name "Art Pack" --cover-image ./cover.jpg --thumbnail ./thumb.jpg
   gumroad products create --name "Newsletter" --type membership --subscription-duration monthly
   gumroad products create --name "E-Book" --type ebook --price 5 --tag art --tag digital`,
 		Args: cmdutil.ExactArgs(0),
@@ -116,6 +123,13 @@ func newCreateCmd() *cobra.Command {
 			}
 
 			plannedUploads, err := planCreateUploads(c, files, fileNames, fileDescriptions)
+			if err != nil {
+				return err
+			}
+			if err := validateProductMediaFlagPaths(c, coverImage, previewImages, thumbnail); err != nil {
+				return err
+			}
+			media, err := describeProductMedia(collectProductMedia(coverImage, previewImages, thumbnail))
 			if err != nil {
 				return err
 			}
@@ -169,20 +183,26 @@ func newCreateCmd() *cobra.Command {
 				params.Add("tags[]", t)
 			}
 
-			if len(plannedUploads) > 0 {
+			if len(plannedUploads) > 0 || len(media) > 0 {
 				fileRefs, err := newRichContentFileRefs(len(plannedUploads))
 				if err != nil {
 					return err
 				}
 
+				var filesPayload []map[string]any
 				if opts.DryRun {
-					fileURLs := make([]string, len(plannedUploads))
-					for i := range plannedUploads {
-						fileURLs[i] = dryRunFilePlaceholder(i)
+					if len(plannedUploads) > 0 {
+						fileURLs := make([]string, len(plannedUploads))
+						for i := range plannedUploads {
+							fileURLs[i] = dryRunFilePlaceholder(i)
+						}
+						filesPayload = buildCreateUploadFilesPayload(plannedUploads, fileURLs, fileRefs)
 					}
-					body := buildProductJSONBody(params, buildCreateUploadFilesPayload(plannedUploads, fileURLs, fileRefs))
-					body["rich_content"] = buildFileRichContent(fileRefs)
-					return renderCreateDryRun(opts, plannedUploads, body)
+					body := buildProductJSONBody(params, filesPayload)
+					if len(fileRefs) > 0 {
+						body["rich_content"] = buildFileRichContent(fileRefs)
+					}
+					return renderCreateDryRun(opts, plannedUploads, media, body, productMediaDryRunRequests("created-product-id", media))
 				}
 
 				token, err := config.Token()
@@ -190,12 +210,18 @@ func newCreateCmd() *cobra.Command {
 					return err
 				}
 				client := cmdutil.NewAPIClient(opts, token)
-				fileURLs, err := uploadBatch(opts, client, createBatchUploadInputs(plannedUploads))
-				if err != nil {
-					return err
+				var fileURLs []string
+				if len(plannedUploads) > 0 {
+					fileURLs, err = uploadBatch(opts, client, createBatchUploadInputs(plannedUploads))
+					if err != nil {
+						return err
+					}
+					filesPayload = buildCreateUploadFilesPayload(plannedUploads, fileURLs, fileRefs)
 				}
-				body := buildProductJSONBody(params, buildCreateUploadFilesPayload(plannedUploads, fileURLs, fileRefs))
-				body["rich_content"] = buildFileRichContent(fileRefs)
+				body := buildProductJSONBody(params, filesPayload)
+				if len(fileRefs) > 0 {
+					body["rich_content"] = buildFileRichContent(fileRefs)
+				}
 				data, err := cmdutil.RunWithTokenData(opts, token, "Creating product...",
 					func(client *api.Client) (json.RawMessage, error) {
 						return client.PostJSON("/products", body)
@@ -203,12 +229,20 @@ func newCreateCmd() *cobra.Command {
 				if err != nil {
 					return wrapPartialUploadError(err, fileURLs)
 				}
-				if opts.UsesJSONOutput() {
-					return cmdutil.PrintJSONResponse(opts, data)
-				}
 				resp, err := cmdutil.DecodeJSON[createProductResponse](data)
 				if err != nil {
 					return err
+				}
+				mediaResults, err := uploadAndAttachProductMedia(opts, client, resp.Product.ID, media, "product create")
+				if err != nil {
+					return err
+				}
+				if opts.UsesJSONOutput() {
+					data, err = mergeProductMediaResult(data, mediaResults)
+					if err != nil {
+						return err
+					}
+					return cmdutil.PrintJSONResponse(opts, data)
 				}
 				return renderCreateProductResult(opts, resp)
 			}
@@ -238,6 +272,9 @@ func newCreateCmd() *cobra.Command {
 	cmd.Flags().StringArrayVar(&files, "file", nil, "Attach a local file to the new product (repeatable)")
 	cmd.Flags().StringArrayVar(&fileNames, "file-name", nil, "Display filename for the matching --file upload (repeatable; use an empty string to skip a slot)")
 	cmd.Flags().StringArrayVar(&fileDescriptions, "file-description", nil, "Description for the matching --file upload (repeatable; use an empty string to skip a slot)")
+	cmd.Flags().StringVar(&coverImage, "cover-image", "", "Local JPEG, PNG, or GIF cover image to upload after creating the product")
+	cmd.Flags().StringArrayVar(&previewImages, "preview-image", nil, "Additional local JPEG, PNG, or GIF preview image to upload as a product cover (repeatable)")
+	cmd.Flags().StringVar(&thumbnail, "thumbnail", "", "Local JPEG, PNG, or GIF thumbnail image to upload after creating the product")
 
 	return cmd
 }
@@ -346,11 +383,12 @@ func renderProductUploadDryRunPlain(opts cmdutil.Options, plan upload.Plan) erro
 	}})
 }
 
-func renderCreateDryRun(opts cmdutil.Options, uploads []createUploadInput, body map[string]any) error {
+func renderCreateDryRun(opts cmdutil.Options, uploads []createUploadInput, media []plannedProductMedia, body map[string]any, followUps []dryRunCreateRequest) error {
 	if opts.UsesJSONOutput() {
 		payload := dryRunCreatePayload{
-			DryRun:  true,
-			Uploads: make([]dryRunCreateUpload, 0, len(uploads)),
+			DryRun:           true,
+			Uploads:          make([]dryRunCreateUpload, 0, len(uploads)+len(media)),
+			FollowUpRequests: followUps,
 			Request: dryRunCreateRequest{
 				Method: "POST",
 				Path:   "/products",
@@ -360,6 +398,7 @@ func renderCreateDryRun(opts cmdutil.Options, uploads []createUploadInput, body 
 		for _, planned := range uploads {
 			payload.Uploads = append(payload.Uploads, dryRunProductUpload(planned.Plan))
 		}
+		payload.Uploads = append(payload.Uploads, productMediaDryRunUploads(media)...)
 		data, err := json.Marshal(payload)
 		if err != nil {
 			return fmt.Errorf("could not encode dry-run output: %w", err)
@@ -373,15 +412,28 @@ func renderCreateDryRun(opts cmdutil.Options, uploads []createUploadInput, body 
 				return err
 			}
 		}
+		for _, planned := range media {
+			if err := renderProductMediaDryRunPlain(opts, planned); err != nil {
+				return err
+			}
+		}
 		data, err := json.Marshal(body)
 		if err != nil {
 			return fmt.Errorf("could not encode dry-run output: %w", err)
 		}
-		return output.PrintPlain(opts.Out(), [][]string{{"POST", "/products", string(data)}})
+		if err := output.PrintPlain(opts.Out(), [][]string{{"POST", "/products", string(data)}}); err != nil {
+			return err
+		}
+		return renderDryRunRequestsPlain(opts, followUps)
 	}
 
 	for _, planned := range uploads {
 		if err := renderProductUploadDryRun(opts, planned.Plan); err != nil {
+			return err
+		}
+	}
+	for _, planned := range media {
+		if err := renderProductMediaDryRun(opts, planned); err != nil {
 			return err
 		}
 	}
@@ -393,7 +445,10 @@ func renderCreateDryRun(opts cmdutil.Options, uploads []createUploadInput, body 
 	if err != nil {
 		return fmt.Errorf("could not encode dry-run output: %w", err)
 	}
-	return output.Writeln(opts.Out(), string(data))
+	if err := output.Writeln(opts.Out(), string(data)); err != nil {
+		return err
+	}
+	return renderDryRunRequestsHuman(opts, followUps)
 }
 
 func renderProductUploadDryRun(opts cmdutil.Options, plan upload.Plan) error {

--- a/internal/cmd/products/create.go
+++ b/internal/cmd/products/create.go
@@ -218,16 +218,27 @@ func newCreateCmd() *cobra.Command {
 					}
 					filesPayload = buildCreateUploadFilesPayload(plannedUploads, fileURLs, fileRefs)
 				}
-				body := buildProductJSONBody(params, filesPayload)
-				if len(fileRefs) > 0 {
-					body["rich_content"] = buildFileRichContent(fileRefs)
-				}
-				data, err := cmdutil.RunWithTokenData(opts, token, "Creating product...",
-					func(client *api.Client) (json.RawMessage, error) {
-						return client.PostJSON("/products", body)
-					})
-				if err != nil {
-					return wrapPartialUploadError(err, fileURLs)
+				var data json.RawMessage
+				if len(plannedUploads) > 0 {
+					body := buildProductJSONBody(params, filesPayload)
+					if len(fileRefs) > 0 {
+						body["rich_content"] = buildFileRichContent(fileRefs)
+					}
+					data, err = cmdutil.RunWithTokenData(opts, token, "Creating product...",
+						func(client *api.Client) (json.RawMessage, error) {
+							return client.PostJSON("/products", body)
+						})
+					if err != nil {
+						return wrapPartialUploadError(err, fileURLs)
+					}
+				} else {
+					data, err = cmdutil.RunWithTokenData(opts, token, "Creating product...",
+						func(client *api.Client) (json.RawMessage, error) {
+							return client.Post("/products", params)
+						})
+					if err != nil {
+						return err
+					}
 				}
 				resp, err := cmdutil.DecodeJSON[createProductResponse](data)
 				if err != nil {

--- a/internal/cmd/products/create.go
+++ b/internal/cmd/products/create.go
@@ -238,9 +238,11 @@ func newCreateCmd() *cobra.Command {
 					return err
 				}
 				if opts.UsesJSONOutput() {
-					data, err = mergeProductMediaResult(data, mediaResults)
-					if err != nil {
-						return err
+					if len(mediaResults) > 0 {
+						data, err = mergeProductMediaResult(data, mediaResults)
+						if err != nil {
+							return err
+						}
 					}
 					return cmdutil.PrintJSONResponse(opts, data)
 				}

--- a/internal/cmd/products/create_files_test.go
+++ b/internal/cmd/products/create_files_test.go
@@ -22,6 +22,7 @@ type createUploadServers struct {
 	mu               sync.Mutex
 	presignFilenames []string
 	productJSON      map[string]any
+	productResponse  json.RawMessage
 	productStatus    int
 	s3Calls          int
 	completeCalls    int
@@ -113,6 +114,17 @@ func (srv *createUploadServers) dispatch(t *testing.T) http.HandlerFunc {
 			srv.mu.Unlock()
 			if status != 0 {
 				http.Error(w, "product failed", status)
+				return
+			}
+
+			srv.mu.Lock()
+			response := append(json.RawMessage(nil), srv.productResponse...)
+			srv.mu.Unlock()
+			if len(response) > 0 {
+				w.Header().Set("Content-Type", "application/json")
+				if _, err := w.Write(response); err != nil {
+					t.Fatalf("write product response: %v", err)
+				}
 				return
 			}
 
@@ -299,6 +311,28 @@ func TestCreate_WithFiles_UploadsAndPostsIndexedFields(t *testing.T) {
 	}
 	if !strings.Contains(out, "Created draft product:") || !strings.Contains(out, "prod-upload") {
 		t.Fatalf("unexpected output: %q", out)
+	}
+}
+
+func TestCreate_WithFilesJSONPreservesRawProductResponseWithoutMedia(t *testing.T) {
+	srv := newCreateUploadServers(t)
+	srv.productResponse = json.RawMessage(`{"product":{"id":"prod-upload","rank":1.0}}`)
+	testutil.Setup(t, srv.dispatch(t))
+
+	firstPath := writeCreateFixture(t, "first")
+	cmd := testutil.Command(newCreateCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{
+		"--name", "Art Pack",
+		"--price", "10.00",
+		"--file", firstPath,
+	})
+
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if !strings.Contains(out, `"rank": 1.0`) {
+		t.Fatalf("expected raw numeric formatting to be preserved, got:\n%s", out)
+	}
+	if strings.Contains(out, `"media"`) {
+		t.Fatalf("file-only create should not add media output, got:\n%s", out)
 	}
 }
 

--- a/internal/cmd/products/file_updates.go
+++ b/internal/cmd/products/file_updates.go
@@ -63,11 +63,12 @@ type productFilesResponse struct {
 }
 
 type dryRunUpdateBody struct {
-	DryRun    bool                 `json:"dry_run"`
-	Uploads   []dryRunCreateUpload `json:"uploads"`
-	Preserved []dryRunExistingFile `json:"preserved"`
-	Removed   []dryRunExistingFile `json:"removed"`
-	Request   dryRunCreateRequest  `json:"request"`
+	DryRun           bool                  `json:"dry_run"`
+	Uploads          []dryRunCreateUpload  `json:"uploads"`
+	Preserved        []dryRunExistingFile  `json:"preserved"`
+	Removed          []dryRunExistingFile  `json:"removed"`
+	Request          dryRunCreateRequest   `json:"request"`
+	FollowUpRequests []dryRunCreateRequest `json:"follow_up_requests,omitempty"`
 }
 
 type dryRunExistingFile struct {
@@ -312,13 +313,25 @@ func renderProductUpdateDryRun(
 	uploads []plannedProductUpload,
 	body map[string]any,
 ) error {
+	return renderProductUpdateDryRunWithMedia(opts, path, plan, uploads, body, nil, nil)
+}
+
+func renderProductUpdateDryRunWithMedia(
+	opts cmdutil.Options,
+	path string,
+	plan productFileUpdatePlan,
+	uploads []plannedProductUpload,
+	body map[string]any,
+	media []plannedProductMedia,
+	followUps []dryRunCreateRequest,
+) error {
 	switch {
 	case opts.UsesJSONOutput():
-		return renderProductUpdateDryRunJSON(opts, path, plan, uploads, body)
+		return renderProductUpdateDryRunJSONWithMedia(opts, path, plan, uploads, body, media, followUps)
 	case opts.PlainOutput:
-		return renderProductUpdateDryRunPlain(opts, path, plan, uploads, body)
+		return renderProductUpdateDryRunPlainWithMedia(opts, path, plan, uploads, body, media, followUps)
 	default:
-		return renderProductUpdateDryRunHuman(opts, path, plan, uploads, body)
+		return renderProductUpdateDryRunHumanWithMedia(opts, path, plan, uploads, body, media, followUps)
 	}
 }
 
@@ -329,11 +342,42 @@ func renderProductUpdateDryRunJSON(
 	uploads []plannedProductUpload,
 	body map[string]any,
 ) error {
+	return renderProductUpdateDryRunJSONWithMedia(opts, path, plan, uploads, body, nil, nil)
+}
+
+func renderProductUpdateMediaOnlyDryRunJSON(opts cmdutil.Options, media []plannedProductMedia, requests []dryRunCreateRequest) error {
 	payload := dryRunUpdateBody{
 		DryRun:    true,
-		Uploads:   make([]dryRunCreateUpload, 0, len(uploads)),
-		Preserved: make([]dryRunExistingFile, 0, len(plan.Preserved)),
-		Removed:   make([]dryRunExistingFile, 0, len(plan.Removed)),
+		Uploads:   productMediaDryRunUploads(media),
+		Preserved: []dryRunExistingFile{},
+		Removed:   []dryRunExistingFile{},
+	}
+	if len(requests) > 0 {
+		payload.Request = requests[0]
+		payload.FollowUpRequests = requests[1:]
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("could not encode dry-run output: %w", err)
+	}
+	return output.PrintJSON(opts.Out(), data, opts.JQExpr)
+}
+
+func renderProductUpdateDryRunJSONWithMedia(
+	opts cmdutil.Options,
+	path string,
+	plan productFileUpdatePlan,
+	uploads []plannedProductUpload,
+	body map[string]any,
+	media []plannedProductMedia,
+	followUps []dryRunCreateRequest,
+) error {
+	payload := dryRunUpdateBody{
+		DryRun:           true,
+		Uploads:          make([]dryRunCreateUpload, 0, len(uploads)+len(media)),
+		Preserved:        make([]dryRunExistingFile, 0, len(plan.Preserved)),
+		Removed:          make([]dryRunExistingFile, 0, len(plan.Removed)),
+		FollowUpRequests: followUps,
 		Request: dryRunCreateRequest{
 			Method: http.MethodPut,
 			Path:   path,
@@ -343,6 +387,7 @@ func renderProductUpdateDryRunJSON(
 	for _, planned := range uploads {
 		payload.Uploads = append(payload.Uploads, dryRunProductUpload(planned.Plan))
 	}
+	payload.Uploads = append(payload.Uploads, productMediaDryRunUploads(media)...)
 	for _, current := range plan.Preserved {
 		payload.Preserved = append(payload.Preserved, dryRunExistingProductFile(current))
 	}
@@ -356,12 +401,14 @@ func renderProductUpdateDryRunJSON(
 	return output.PrintJSON(opts.Out(), data, opts.JQExpr)
 }
 
-func renderProductUpdateDryRunPlain(
+func renderProductUpdateDryRunPlainWithMedia(
 	opts cmdutil.Options,
 	path string,
 	plan productFileUpdatePlan,
 	uploads []plannedProductUpload,
 	body map[string]any,
+	media []plannedProductMedia,
+	followUps []dryRunCreateRequest,
 ) error {
 	for _, current := range plan.Preserved {
 		if err := output.PrintPlain(opts.Out(), [][]string{{
@@ -386,23 +433,33 @@ func renderProductUpdateDryRunPlain(
 			return err
 		}
 	}
+	for _, planned := range media {
+		if err := renderProductMediaDryRunPlain(opts, planned); err != nil {
+			return err
+		}
+	}
 	data, err := json.Marshal(body)
 	if err != nil {
 		return fmt.Errorf("could not encode dry-run output: %w", err)
 	}
-	return output.PrintPlain(opts.Out(), [][]string{{
+	if err := output.PrintPlain(opts.Out(), [][]string{{
 		http.MethodPut,
 		path,
 		string(data),
-	}})
+	}}); err != nil {
+		return err
+	}
+	return renderDryRunRequestsPlain(opts, followUps)
 }
 
-func renderProductUpdateDryRunHuman(
+func renderProductUpdateDryRunHumanWithMedia(
 	opts cmdutil.Options,
 	path string,
 	plan productFileUpdatePlan,
 	uploads []plannedProductUpload,
 	body map[string]any,
+	media []plannedProductMedia,
+	followUps []dryRunCreateRequest,
 ) error {
 	for _, current := range plan.Preserved {
 		if err := output.Writeln(opts.Out(), "Preserve existing file: "+formatExistingProductFileLabel(current)); err != nil {
@@ -419,6 +476,11 @@ func renderProductUpdateDryRunHuman(
 			return err
 		}
 	}
+	for _, planned := range media {
+		if err := renderProductMediaDryRun(opts, planned); err != nil {
+			return err
+		}
+	}
 	style := opts.Style()
 	if err := output.Writeln(opts.Out(), style.Yellow("Dry run")+": "+http.MethodPut+" "+path); err != nil {
 		return err
@@ -428,16 +490,19 @@ func renderProductUpdateDryRunHuman(
 	if err != nil {
 		return fmt.Errorf("could not encode dry-run output: %w", err)
 	}
-	return output.Writeln(opts.Out(), string(data))
+	if err := output.Writeln(opts.Out(), string(data)); err != nil {
+		return err
+	}
+	return renderDryRunRequestsHuman(opts, followUps)
 }
 
-func runProductUpdateJSON(
+func runProductUpdateJSONData(
 	opts cmdutil.Options,
 	client *api.Client,
-	path, productID string,
+	path string,
 	body map[string]any,
 	uploadedURLs []string,
-) error {
+) (json.RawMessage, error) {
 	var sp *output.Spinner
 	if cmdutil.ShouldShowSpinner(opts) {
 		sp = output.NewSpinnerTo("Updating product...", opts.Err())
@@ -447,12 +512,12 @@ func runProductUpdateJSON(
 
 	data, err := client.PutJSON(path, body)
 	if err != nil {
-		return wrapPartialUploadError(err, uploadedURLs)
+		return nil, wrapPartialUploadError(err, uploadedURLs)
 	}
 	if sp != nil {
 		sp.Stop()
 	}
-	return cmdutil.PrintMutationSuccess(opts, data, productID, "Product "+productID+" updated.")
+	return data, nil
 }
 
 func confirmProductFileRemoval(opts cmdutil.Options, productID string, removed []existingProductFile) (bool, error) {

--- a/internal/cmd/products/file_updates.go
+++ b/internal/cmd/products/file_updates.go
@@ -335,16 +335,6 @@ func renderProductUpdateDryRunWithMedia(
 	}
 }
 
-func renderProductUpdateDryRunJSON(
-	opts cmdutil.Options,
-	path string,
-	plan productFileUpdatePlan,
-	uploads []plannedProductUpload,
-	body map[string]any,
-) error {
-	return renderProductUpdateDryRunJSONWithMedia(opts, path, plan, uploads, body, nil, nil)
-}
-
 func renderProductUpdateMediaOnlyDryRunJSON(opts cmdutil.Options, media []plannedProductMedia, requests []dryRunCreateRequest) error {
 	payload := dryRunUpdateBody{
 		DryRun:    true,

--- a/internal/cmd/products/file_updates.go
+++ b/internal/cmd/products/file_updates.go
@@ -503,6 +503,30 @@ func runProductUpdateJSONData(
 	body map[string]any,
 	uploadedURLs []string,
 ) (json.RawMessage, error) {
+	data, err := runProductUpdateData(opts, func() (json.RawMessage, error) {
+		return client.PutJSON(path, body)
+	})
+	if err != nil {
+		return nil, wrapPartialUploadError(err, uploadedURLs)
+	}
+	return data, nil
+}
+
+func runProductUpdateFormData(
+	opts cmdutil.Options,
+	client *api.Client,
+	path string,
+	params url.Values,
+) (json.RawMessage, error) {
+	return runProductUpdateData(opts, func() (json.RawMessage, error) {
+		return client.Put(path, params)
+	})
+}
+
+func runProductUpdateData(
+	opts cmdutil.Options,
+	run func() (json.RawMessage, error),
+) (json.RawMessage, error) {
 	var sp *output.Spinner
 	if cmdutil.ShouldShowSpinner(opts) {
 		sp = output.NewSpinnerTo("Updating product...", opts.Err())
@@ -510,9 +534,9 @@ func runProductUpdateJSONData(
 		defer sp.Stop()
 	}
 
-	data, err := client.PutJSON(path, body)
+	data, err := run()
 	if err != nil {
-		return nil, wrapPartialUploadError(err, uploadedURLs)
+		return nil, err
 	}
 	if sp != nil {
 		sp.Stop()

--- a/internal/cmd/products/product_media.go
+++ b/internal/cmd/products/product_media.go
@@ -2,10 +2,7 @@ package products
 
 import (
 	"encoding/json"
-	"net/http"
 )
-
-var directUploadHTTPClientForTesting *http.Client
 
 type productMediaKind string
 

--- a/internal/cmd/products/product_media.go
+++ b/internal/cmd/products/product_media.go
@@ -1,0 +1,46 @@
+package products
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+var directUploadHTTPClientForTesting *http.Client
+
+type productMediaKind string
+
+const (
+	productMediaCover     productMediaKind = "cover"
+	productMediaPreview   productMediaKind = "preview"
+	productMediaThumbnail productMediaKind = "thumbnail"
+
+	maxDirectUploadErrorBody = 4 * 1024
+)
+
+type requestedProductMedia struct {
+	Kind productMediaKind
+	Path string
+}
+
+type plannedProductMedia struct {
+	requestedProductMedia
+	Filename    string
+	ContentType string
+	Checksum    string
+	Size        int64
+}
+
+type directUploadResponse struct {
+	SignedID     string `json:"signed_id"`
+	DirectUpload struct {
+		URL     string            `json:"url"`
+		Headers map[string]string `json:"headers"`
+	} `json:"direct_upload"`
+}
+
+type productMediaAttachmentResult struct {
+	Kind     string          `json:"kind"`
+	Path     string          `json:"path"`
+	Endpoint string          `json:"endpoint"`
+	Response json.RawMessage `json:"response"`
+}

--- a/internal/cmd/products/product_media_attach.go
+++ b/internal/cmd/products/product_media_attach.go
@@ -12,17 +12,26 @@ import (
 )
 
 type productMediaAttachError struct {
-	cause           error
-	productID       string
-	completedAction string
-	retryCommand    string
+	cause                error
+	productID            string
+	completedAction      string
+	partialMediaAttached bool
+	retryCommands        []string
 }
 
 func (e *productMediaAttachError) Error() string {
-	if e.completedAction == "" {
-		return e.cause.Error()
+	retry := strings.Join(e.retryCommands, "; ")
+	if e.completedAction != "" {
+		context := fmt.Sprintf("%s completed for product %s", e.completedAction, e.productID)
+		if e.partialMediaAttached {
+			context += "; some media was already attached"
+		}
+		return fmt.Sprintf("%v (%s; retry remaining media with: %s)", e.cause, context, retry)
 	}
-	return fmt.Sprintf("%v (%s completed for product %s; retry media with: %s)", e.cause, e.completedAction, e.productID, e.retryCommand)
+	if e.partialMediaAttached {
+		return fmt.Sprintf("%v (some media was already attached to product %s; retry remaining media with: %s)", e.cause, e.productID, retry)
+	}
+	return e.cause.Error()
 }
 
 func (e *productMediaAttachError) Unwrap() error {
@@ -37,10 +46,10 @@ func uploadAndAttachProductMedia(
 	completedAction string,
 ) ([]productMediaAttachmentResult, error) {
 	results := make([]productMediaAttachmentResult, 0, len(media))
-	for _, current := range media {
+	for i, current := range media {
 		signedID, err := directUploadProductMedia(opts, client, current)
 		if err != nil {
-			return results, wrapProductMediaAttachError(err, productID, completedAction, current)
+			return results, wrapProductMediaAttachError(err, productID, completedAction, len(results) > 0, media[i:])
 		}
 
 		path := productMediaAttachPath(productID, current.Kind)
@@ -48,7 +57,7 @@ func uploadAndAttachProductMedia(
 		params.Set("signed_blob_id", signedID)
 		data, err := client.Post(path, params)
 		if err != nil {
-			return results, wrapProductMediaAttachError(err, productID, completedAction, current)
+			return results, wrapProductMediaAttachError(err, productID, completedAction, len(results) > 0, media[i:])
 		}
 		results = append(results, productMediaAttachmentResult{
 			Kind:     string(current.Kind),
@@ -60,15 +69,20 @@ func uploadAndAttachProductMedia(
 	return results, nil
 }
 
-func wrapProductMediaAttachError(err error, productID, completedAction string, media plannedProductMedia) error {
-	if completedAction == "" {
+func wrapProductMediaAttachError(err error, productID, completedAction string, partialMediaAttached bool, media []plannedProductMedia) error {
+	if completedAction == "" && !partialMediaAttached {
+		return err
+	}
+	retryCommands := productMediaRetryCommands(productID, media)
+	if len(retryCommands) == 0 {
 		return err
 	}
 	return &productMediaAttachError{
-		cause:           err,
-		productID:       productID,
-		completedAction: completedAction,
-		retryCommand:    productMediaRetryCommand(productID, media),
+		cause:                err,
+		productID:            productID,
+		completedAction:      completedAction,
+		partialMediaAttached: partialMediaAttached,
+		retryCommands:        retryCommands,
 	}
 }
 
@@ -89,6 +103,14 @@ func productMediaRetryCommand(productID string, media plannedProductMedia) strin
 	default:
 		return fmt.Sprintf("gumroad products covers add %s --image %s", productID, quotedPath)
 	}
+}
+
+func productMediaRetryCommands(productID string, media []plannedProductMedia) []string {
+	commands := make([]string, 0, len(media))
+	for _, current := range media {
+		commands = append(commands, productMediaRetryCommand(productID, current))
+	}
+	return commands
 }
 
 func shellQuote(value string) string {

--- a/internal/cmd/products/product_media_attach.go
+++ b/internal/cmd/products/product_media_attach.go
@@ -140,6 +140,13 @@ func mergeProductMediaResult(data json.RawMessage, media []productMediaAttachmen
 	return json.Marshal(body)
 }
 
+func productMediaOnlyUpdateResult(productID string) (json.RawMessage, error) {
+	return json.Marshal(map[string]any{
+		"success": true,
+		"product": map[string]string{"id": productID},
+	})
+}
+
 func normalizeJSONForEmbedding(data json.RawMessage) json.RawMessage {
 	if len(bytes.TrimSpace(data)) == 0 {
 		return json.RawMessage("null")

--- a/internal/cmd/products/product_media_attach.go
+++ b/internal/cmd/products/product_media_attach.go
@@ -1,0 +1,126 @@
+package products
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+)
+
+type productMediaAttachError struct {
+	cause           error
+	productID       string
+	completedAction string
+	retryCommand    string
+}
+
+func (e *productMediaAttachError) Error() string {
+	if e.completedAction == "" {
+		return e.cause.Error()
+	}
+	return fmt.Sprintf("%v (%s completed for product %s; retry media with: %s)", e.cause, e.completedAction, e.productID, e.retryCommand)
+}
+
+func (e *productMediaAttachError) Unwrap() error {
+	return e.cause
+}
+
+func uploadAndAttachProductMedia(
+	opts cmdutil.Options,
+	client *api.Client,
+	productID string,
+	media []plannedProductMedia,
+	completedAction string,
+) ([]productMediaAttachmentResult, error) {
+	results := make([]productMediaAttachmentResult, 0, len(media))
+	for _, current := range media {
+		signedID, err := directUploadProductMedia(opts, client, current)
+		if err != nil {
+			return results, wrapProductMediaAttachError(err, productID, completedAction, current)
+		}
+
+		path := productMediaAttachPath(productID, current.Kind)
+		params := url.Values{}
+		params.Set("signed_blob_id", signedID)
+		data, err := client.Post(path, params)
+		if err != nil {
+			return results, wrapProductMediaAttachError(err, productID, completedAction, current)
+		}
+		results = append(results, productMediaAttachmentResult{
+			Kind:     string(current.Kind),
+			Path:     current.Path,
+			Endpoint: path,
+			Response: normalizeJSONForEmbedding(data),
+		})
+	}
+	return results, nil
+}
+
+func wrapProductMediaAttachError(err error, productID, completedAction string, media plannedProductMedia) error {
+	if completedAction == "" {
+		return err
+	}
+	return &productMediaAttachError{
+		cause:           err,
+		productID:       productID,
+		completedAction: completedAction,
+		retryCommand:    productMediaRetryCommand(productID, media),
+	}
+}
+
+func productMediaAttachPath(productID string, kind productMediaKind) string {
+	switch kind {
+	case productMediaThumbnail:
+		return cmdutil.JoinPath("products", productID, "thumbnail")
+	default:
+		return cmdutil.JoinPath("products", productID, "covers")
+	}
+}
+
+func productMediaRetryCommand(productID string, media plannedProductMedia) string {
+	quotedPath := shellQuote(media.Path)
+	switch media.Kind {
+	case productMediaThumbnail:
+		return fmt.Sprintf("gumroad products thumbnail set %s --image %s", productID, quotedPath)
+	default:
+		return fmt.Sprintf("gumroad products covers add %s --image %s", productID, quotedPath)
+	}
+}
+
+func shellQuote(value string) string {
+	if value == "" {
+		return "''"
+	}
+	if strings.IndexFunc(value, func(r rune) bool {
+		return !(r == '/' || r == '.' || r == '_' || r == '-' || r == ':' || r == '@' || r == '+' || r == '=' ||
+			(r >= '0' && r <= '9') || (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z'))
+	}) == -1 {
+		return value
+	}
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}
+
+func mergeProductMediaResult(data json.RawMessage, media []productMediaAttachmentResult) (json.RawMessage, error) {
+	body := map[string]any{}
+	normalized := normalizeJSONForEmbedding(data)
+	if len(normalized) > 0 && string(normalized) != "null" {
+		if err := json.Unmarshal(normalized, &body); err != nil {
+			return nil, fmt.Errorf("could not parse response: %w", err)
+		}
+	}
+	if len(media) > 0 {
+		body["media"] = media
+	}
+	return json.Marshal(body)
+}
+
+func normalizeJSONForEmbedding(data json.RawMessage) json.RawMessage {
+	if len(bytes.TrimSpace(data)) == 0 {
+		return json.RawMessage("null")
+	}
+	return data
+}

--- a/internal/cmd/products/product_media_attach.go
+++ b/internal/cmd/products/product_media_attach.go
@@ -127,17 +127,56 @@ func shellQuote(value string) string {
 }
 
 func mergeProductMediaResult(data json.RawMessage, media []productMediaAttachmentResult) (json.RawMessage, error) {
-	body := map[string]any{}
 	normalized := normalizeJSONForEmbedding(data)
-	if len(normalized) > 0 && string(normalized) != "null" {
-		if err := json.Unmarshal(normalized, &body); err != nil {
-			return nil, fmt.Errorf("could not parse response: %w", err)
+	if len(media) == 0 {
+		return normalized, nil
+	}
+
+	mediaData, err := json.Marshal(media)
+	if err != nil {
+		return nil, fmt.Errorf("could not encode media response: %w", err)
+	}
+	trimmed := bytes.TrimSpace(normalized)
+	if len(trimmed) == 0 || string(trimmed) == "null" {
+		return appendJSONField(nil, "media", mediaData)
+	}
+	return appendJSONField(trimmed, "media", mediaData)
+}
+
+func appendJSONField(object json.RawMessage, key string, value json.RawMessage) (json.RawMessage, error) {
+	if len(object) == 0 {
+		keyData, err := json.Marshal(key)
+		if err != nil {
+			return nil, fmt.Errorf("could not encode response key: %w", err)
 		}
+		out := make([]byte, 0, len(keyData)+len(value)+4)
+		out = append(out, '{')
+		out = append(out, keyData...)
+		out = append(out, ':')
+		out = append(out, value...)
+		out = append(out, '}')
+		return out, nil
 	}
-	if len(media) > 0 {
-		body["media"] = media
+
+	if !json.Valid(object) || len(object) < 2 || object[0] != '{' || object[len(object)-1] != '}' {
+		return nil, fmt.Errorf("could not parse response: expected JSON object")
 	}
-	return json.Marshal(body)
+	keyData, err := json.Marshal(key)
+	if err != nil {
+		return nil, fmt.Errorf("could not encode response key: %w", err)
+	}
+	inner := bytes.TrimSpace(object[1 : len(object)-1])
+	out := make([]byte, 0, len(object)+len(keyData)+len(value)+2)
+	out = append(out, '{')
+	if len(inner) > 0 {
+		out = append(out, inner...)
+		out = append(out, ',')
+	}
+	out = append(out, keyData...)
+	out = append(out, ':')
+	out = append(out, value...)
+	out = append(out, '}')
+	return out, nil
 }
 
 func productMediaOnlyUpdateResult(productID string) (json.RawMessage, error) {

--- a/internal/cmd/products/product_media_attach.go
+++ b/internal/cmd/products/product_media_attach.go
@@ -143,6 +143,14 @@ func mergeProductMediaResult(data json.RawMessage, media []productMediaAttachmen
 	return appendJSONField(trimmed, "media", mediaData)
 }
 
+func productMediaSingleAttachResult(media []productMediaAttachmentResult) (json.RawMessage, error) {
+	var data json.RawMessage
+	if len(media) == 1 {
+		data = media[0].Response
+	}
+	return mergeProductMediaResult(data, media)
+}
+
 func appendJSONField(object json.RawMessage, key string, value json.RawMessage) (json.RawMessage, error) {
 	if len(object) == 0 {
 		keyData, err := json.Marshal(key)

--- a/internal/cmd/products/product_media_direct_upload.go
+++ b/internal/cmd/products/product_media_direct_upload.go
@@ -1,0 +1,83 @@
+package products
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+)
+
+func directUploadProductMedia(opts cmdutil.Options, client *api.Client, media plannedProductMedia) (string, error) {
+	params := url.Values{}
+	params.Set("blob[filename]", media.Filename)
+	params.Set("blob[byte_size]", strconv.FormatInt(media.Size, 10))
+	params.Set("blob[checksum]", media.Checksum)
+	params.Set("blob[content_type]", media.ContentType)
+
+	data, err := client.Post("/direct_uploads", params)
+	if err != nil {
+		return "", err
+	}
+	resp, err := cmdutil.DecodeJSON[directUploadResponse](data)
+	if err != nil {
+		return "", err
+	}
+	if resp.SignedID == "" {
+		return "", fmt.Errorf("direct upload response did not include signed_id")
+	}
+	if resp.DirectUpload.URL == "" {
+		return "", fmt.Errorf("direct upload response did not include upload URL")
+	}
+	if err := putDirectUpload(opts, media, resp.DirectUpload.URL, resp.DirectUpload.Headers); err != nil {
+		return "", err
+	}
+	return resp.SignedID, nil
+}
+
+func putDirectUpload(opts cmdutil.Options, media plannedProductMedia, uploadURL string, headers map[string]string) error {
+	file, err := os.Open(media.Path)
+	if err != nil {
+		return fmt.Errorf("could not open %s image: %w", media.Kind, err)
+	}
+	defer func() { _ = file.Close() }()
+
+	req, err := http.NewRequestWithContext(opts.Context, http.MethodPut, uploadURL, file)
+	if err != nil {
+		return fmt.Errorf("could not create direct upload request: %w", err)
+	}
+	req.ContentLength = media.Size
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+	if req.Header.Get("Content-Type") == "" {
+		req.Header.Set("Content-Type", media.ContentType)
+	}
+	if req.Header.Get("Content-MD5") == "" {
+		req.Header.Set("Content-MD5", media.Checksum)
+	}
+
+	httpClient := directUploadHTTPClientForTesting
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("direct upload failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxDirectUploadErrorBody))
+		message := strings.TrimSpace(string(body))
+		if message == "" {
+			message = resp.Status
+		}
+		return fmt.Errorf("direct upload failed with HTTP %d: %s", resp.StatusCode, message)
+	}
+	return nil
+}

--- a/internal/cmd/products/product_media_direct_upload.go
+++ b/internal/cmd/products/product_media_direct_upload.go
@@ -62,11 +62,7 @@ func putDirectUpload(opts cmdutil.Options, media plannedProductMedia, uploadURL 
 		req.Header.Set("Content-MD5", media.Checksum)
 	}
 
-	httpClient := directUploadHTTPClientForTesting
-	if httpClient == nil {
-		httpClient = http.DefaultClient
-	}
-	resp, err := httpClient.Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("direct upload failed: %w", err)
 	}

--- a/internal/cmd/products/product_media_dry_run.go
+++ b/internal/cmd/products/product_media_dry_run.go
@@ -1,0 +1,147 @@
+package products
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/uploadui"
+)
+
+func productMediaDryRunUploads(media []plannedProductMedia) []dryRunCreateUpload {
+	uploads := make([]dryRunCreateUpload, 0, len(media))
+	for _, current := range media {
+		uploads = append(uploads, dryRunCreateUpload{
+			Action:      "direct_upload",
+			Kind:        string(current.Kind),
+			Path:        current.Path,
+			Filename:    current.Filename,
+			Size:        current.Size,
+			PartSize:    current.Size,
+			PartCount:   1,
+			ContentType: current.ContentType,
+			Checksum:    current.Checksum,
+		})
+	}
+	return uploads
+}
+
+func productMediaDryRunRequests(productID string, media []plannedProductMedia) []dryRunCreateRequest {
+	requests := make([]dryRunCreateRequest, 0, len(media)*2)
+	for i, current := range media {
+		requests = append(requests, dryRunCreateRequest{
+			Method: http.MethodPost,
+			Path:   "/direct_uploads",
+			Body: map[string]any{
+				"blob": map[string]any{
+					"filename":     current.Filename,
+					"byte_size":    current.Size,
+					"checksum":     current.Checksum,
+					"content_type": current.ContentType,
+				},
+			},
+		})
+		requests = append(requests, dryRunCreateRequest{
+			Method: http.MethodPost,
+			Path:   productMediaAttachPath(productID, current.Kind),
+			Body: map[string]any{
+				"signed_blob_id": dryRunSignedBlobPlaceholder(current.Kind, i),
+			},
+		})
+	}
+	return requests
+}
+
+func dryRunSignedBlobPlaceholder(kind productMediaKind, index int) string {
+	return fmt.Sprintf("<signed_blob:%s:%d>", kind, index)
+}
+
+func renderProductMediaDryRunPlain(opts cmdutil.Options, media plannedProductMedia) error {
+	return output.PrintPlain(opts.Out(), [][]string{{
+		"direct_upload",
+		string(media.Kind),
+		media.Path,
+		media.Filename,
+		strconv.FormatInt(media.Size, 10),
+		media.ContentType,
+	}})
+}
+
+func renderProductMediaDryRun(opts cmdutil.Options, media plannedProductMedia) error {
+	style := opts.Style()
+	if err := output.Writeln(opts.Out(), style.Yellow("Dry run")+": direct upload "+media.Path); err != nil {
+		return err
+	}
+	if err := output.Writef(opts.Out(), "Filename: %s\n", media.Filename); err != nil {
+		return err
+	}
+	if err := output.Writef(opts.Out(), "Content type: %s\n", media.ContentType); err != nil {
+		return err
+	}
+	return output.Writef(opts.Out(), "Size: %s\n", uploadui.HumanBytes(media.Size))
+}
+
+func renderStandaloneProductMediaDryRun(opts cmdutil.Options, media []plannedProductMedia, requests []dryRunCreateRequest) error {
+	if opts.UsesJSONOutput() {
+		payload := dryRunCreatePayload{
+			DryRun:  true,
+			Uploads: productMediaDryRunUploads(media),
+		}
+		if len(requests) > 0 {
+			payload.Request = requests[0]
+			payload.FollowUpRequests = requests[1:]
+		}
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("could not encode dry-run output: %w", err)
+		}
+		return output.PrintJSON(opts.Out(), data, opts.JQExpr)
+	}
+	if opts.PlainOutput {
+		for _, planned := range media {
+			if err := renderProductMediaDryRunPlain(opts, planned); err != nil {
+				return err
+			}
+		}
+		return renderDryRunRequestsPlain(opts, requests)
+	}
+	for _, planned := range media {
+		if err := renderProductMediaDryRun(opts, planned); err != nil {
+			return err
+		}
+	}
+	return renderDryRunRequestsHuman(opts, requests)
+}
+
+func renderDryRunRequestsPlain(opts cmdutil.Options, requests []dryRunCreateRequest) error {
+	for _, request := range requests {
+		data, err := json.Marshal(request.Body)
+		if err != nil {
+			return fmt.Errorf("could not encode dry-run output: %w", err)
+		}
+		if err := output.PrintPlain(opts.Out(), [][]string{{request.Method, request.Path, string(data)}}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func renderDryRunRequestsHuman(opts cmdutil.Options, requests []dryRunCreateRequest) error {
+	style := opts.Style()
+	for _, request := range requests {
+		if err := output.Writeln(opts.Out(), style.Yellow("Dry run")+": "+request.Method+" "+request.Path); err != nil {
+			return err
+		}
+		data, err := json.MarshalIndent(request.Body, "", "  ")
+		if err != nil {
+			return fmt.Errorf("could not encode dry-run output: %w", err)
+		}
+		if err := output.Writeln(opts.Out(), string(data)); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/cmd/products/product_media_plan.go
+++ b/internal/cmd/products/product_media_plan.go
@@ -1,7 +1,7 @@
 package products
 
 import (
-	"crypto/md5" // #nosec G501 -- Rails Active Storage direct uploads require a base64 Content-MD5 checksum.
+	"crypto/md5" // #nosec G501
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -163,7 +163,7 @@ func checksumFileMD5(file *os.File) (string, error) {
 	if _, err := file.Seek(0, io.SeekStart); err != nil {
 		return "", err
 	}
-	hash := md5.New() // #nosec G401 -- Rails Active Storage direct uploads require Content-MD5, not a security hash.
+	hash := md5.New() // #nosec G401
 	if _, err := io.Copy(hash, file); err != nil {
 		return "", err
 	}

--- a/internal/cmd/products/product_media_plan.go
+++ b/internal/cmd/products/product_media_plan.go
@@ -1,0 +1,174 @@
+package products
+
+import (
+	"crypto/md5" // #nosec G501 -- Rails Active Storage direct uploads require a base64 Content-MD5 checksum.
+	"encoding/base64"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+func collectProductMedia(coverImage string, previewImages []string, thumbnail string) []requestedProductMedia {
+	var media []requestedProductMedia
+	if coverImage != "" {
+		media = append(media, requestedProductMedia{Kind: productMediaCover, Path: coverImage})
+	}
+	for _, path := range previewImages {
+		media = append(media, requestedProductMedia{Kind: productMediaPreview, Path: path})
+	}
+	if thumbnail != "" {
+		media = append(media, requestedProductMedia{Kind: productMediaThumbnail, Path: thumbnail})
+	}
+	return media
+}
+
+func validateProductMediaFlagPaths(cmd *cobra.Command, coverImage string, previewImages []string, thumbnail string) error {
+	if cmd.Flags().Changed("cover-image") && strings.TrimSpace(coverImage) == "" {
+		return cmdutil.UsageErrorf(cmd, "--cover-image cannot be empty")
+	}
+	if cmd.Flags().Changed("thumbnail") && strings.TrimSpace(thumbnail) == "" {
+		return cmdutil.UsageErrorf(cmd, "--thumbnail cannot be empty")
+	}
+	for _, path := range previewImages {
+		if strings.TrimSpace(path) == "" {
+			return cmdutil.UsageErrorf(cmd, "--preview-image cannot be empty")
+		}
+	}
+	return nil
+}
+
+func describeProductMedia(media []requestedProductMedia) ([]plannedProductMedia, error) {
+	planned := make([]plannedProductMedia, len(media))
+	for i, current := range media {
+		plan, err := describeSingleProductMedia(current)
+		if err != nil {
+			return nil, err
+		}
+		planned[i] = plan
+	}
+	return planned, nil
+}
+
+func describeSingleProductMedia(media requestedProductMedia) (plannedProductMedia, error) {
+	file, err := os.Open(media.Path)
+	if err != nil {
+		return plannedProductMedia{}, fmt.Errorf("could not open %s image: %w", media.Kind, err)
+	}
+	defer func() { _ = file.Close() }()
+
+	info, err := file.Stat()
+	if err != nil {
+		return plannedProductMedia{}, fmt.Errorf("could not stat %s image: %w", media.Kind, err)
+	}
+	if info.IsDir() {
+		return plannedProductMedia{}, fmt.Errorf("%s is a directory", media.Path)
+	}
+	if !info.Mode().IsRegular() {
+		return plannedProductMedia{}, fmt.Errorf("%s is not a regular file", media.Path)
+	}
+	if info.Size() == 0 {
+		return plannedProductMedia{}, fmt.Errorf("%s is empty", media.Path)
+	}
+	if info.Size() > uploadMaxProductMediaFileSize() {
+		return plannedProductMedia{}, fmt.Errorf("%s size %d bytes exceeds maximum of %d bytes (50 MB)", media.Path, info.Size(), uploadMaxProductMediaFileSize())
+	}
+
+	contentType, err := detectProductImageContentType(media.Path, file)
+	if err != nil {
+		return plannedProductMedia{}, err
+	}
+	checksum, err := checksumFileMD5(file)
+	if err != nil {
+		return plannedProductMedia{}, fmt.Errorf("could not checksum %s image: %w", media.Kind, err)
+	}
+
+	return plannedProductMedia{
+		requestedProductMedia: media,
+		Filename:              filepath.Base(media.Path),
+		ContentType:           contentType,
+		Checksum:              checksum,
+		Size:                  info.Size(),
+	}, nil
+}
+
+func uploadMaxProductMediaFileSize() int64 {
+	return 50 * 1024 * 1024
+}
+
+func detectProductImageContentType(path string, file *os.File) (string, error) {
+	ext := strings.ToLower(filepath.Ext(path))
+	if ext == ".webp" {
+		return "", fmt.Errorf("WebP images are not supported for product media; use JPEG, PNG, or GIF")
+	}
+
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return "", err
+	}
+	var sample [512]byte
+	n, err := file.Read(sample[:])
+	if err != nil && err != io.EOF {
+		return "", err
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return "", err
+	}
+
+	if isWebPImage(sample[:n]) {
+		return "", fmt.Errorf("WebP images are not supported for product media; use JPEG, PNG, or GIF")
+	}
+	rawDetected := strings.ToLower(strings.TrimSpace(strings.Split(http.DetectContentType(sample[:n]), ";")[0]))
+	if rawDetected == "image/webp" {
+		return "", fmt.Errorf("WebP images are not supported for product media; use JPEG, PNG, or GIF")
+	}
+	detected := normalizeImageContentType(rawDetected)
+	if detected != "" {
+		return detected, nil
+	}
+
+	if byExt := normalizeImageContentType(mime.TypeByExtension(ext)); byExt != "" {
+		return byExt, nil
+	}
+
+	return "", fmt.Errorf("unsupported product media type for %s; use a JPEG, PNG, or GIF image", path)
+}
+
+func isWebPImage(sample []byte) bool {
+	return len(sample) >= 12 &&
+		string(sample[0:4]) == "RIFF" &&
+		string(sample[8:12]) == "WEBP"
+}
+
+func normalizeImageContentType(contentType string) string {
+	contentType = strings.ToLower(strings.TrimSpace(strings.Split(contentType, ";")[0]))
+	switch contentType {
+	case "image/jpeg", "image/jpg":
+		return "image/jpeg"
+	case "image/png":
+		return "image/png"
+	case "image/gif":
+		return "image/gif"
+	default:
+		return ""
+	}
+}
+
+func checksumFileMD5(file *os.File) (string, error) {
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return "", err
+	}
+	hash := md5.New() // #nosec G401 -- Rails Active Storage direct uploads require Content-MD5, not a security hash.
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", err
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(hash.Sum(nil)), nil
+}

--- a/internal/cmd/products/product_media_plan.go
+++ b/internal/cmd/products/product_media_plan.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"mime"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -130,10 +129,6 @@ func detectProductImageContentType(path string, file *os.File) (string, error) {
 	detected := normalizeImageContentType(rawDetected)
 	if detected != "" {
 		return detected, nil
-	}
-
-	if byExt := normalizeImageContentType(mime.TypeByExtension(ext)); byExt != "" {
-		return byExt, nil
 	}
 
 	return "", fmt.Errorf("unsupported product media type for %s; use a JPEG, PNG, or GIF image", path)

--- a/internal/cmd/products/product_media_test.go
+++ b/internal/cmd/products/product_media_test.go
@@ -578,6 +578,22 @@ func TestCoversAdd_WithURLSendsURL(t *testing.T) {
 	}
 }
 
+func TestCoversAdd_WithEmptyImageReturnsUsageError(t *testing.T) {
+	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
+		t.Fatal("empty image must not reach the API")
+	})
+
+	cmd := testutil.Command(newCoversAddCmd())
+	cmd.SetArgs([]string{"prod1", "--image", ""})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected empty image error")
+	}
+	if !strings.Contains(err.Error(), "--image cannot be empty") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestCoversRemoveAndThumbnailRemove(t *testing.T) {
 	srv := newProductMediaServers(t)
 	testutil.Setup(t, srv.dispatch(t))
@@ -614,6 +630,22 @@ func TestThumbnailSet_WithImageUploadsAndAttaches(t *testing.T) {
 	}
 	if !reflect.DeepEqual(signedIDs, []string{"signed-1"}) {
 		t.Fatalf("attached signed IDs = %#v", signedIDs)
+	}
+}
+
+func TestThumbnailSet_WithEmptyImageReturnsUsageError(t *testing.T) {
+	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
+		t.Fatal("empty image must not reach the API")
+	})
+
+	cmd := testutil.Command(newThumbnailSetCmd())
+	cmd.SetArgs([]string{"prod1", "--image", ""})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected empty image error")
+	}
+	if !strings.Contains(err.Error(), "--image cannot be empty") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/cmd/products/product_media_test.go
+++ b/internal/cmd/products/product_media_test.go
@@ -1,0 +1,590 @@
+package products
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/config"
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+type productMediaServers struct {
+	direct *httptest.Server
+
+	mu               sync.Mutex
+	apiSequence      []string
+	directUploadForm []map[string]string
+	directPUTHeaders []http.Header
+	attachSignedIDs  []string
+	productPUTCalls  int
+}
+
+func newProductMediaServers(t *testing.T) *productMediaServers {
+	t.Helper()
+
+	s := &productMediaServers{}
+	s.direct = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("direct upload got %s, want PUT", r.Method)
+			http.Error(w, "bad method", http.StatusMethodNotAllowed)
+			return
+		}
+		_, _ = io.Copy(io.Discard, r.Body)
+		s.mu.Lock()
+		s.directPUTHeaders = append(s.directPUTHeaders, r.Header.Clone())
+		s.mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(s.direct.Close)
+	return s
+}
+
+func (s *productMediaServers) dispatch(t *testing.T) http.HandlerFunc {
+	t.Helper()
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		s.mu.Lock()
+		s.apiSequence = append(s.apiSequence, r.Method+" "+r.URL.Path)
+		s.mu.Unlock()
+
+		switch r.URL.Path {
+		case "/products":
+			if r.Method != http.MethodPost {
+				t.Errorf("/products got %s, want POST", r.Method)
+			}
+			testutil.JSON(t, w, map[string]any{
+				"product": map[string]any{
+					"id":              "prod-media",
+					"name":            "Art Pack",
+					"formatted_price": "$10",
+				},
+			})
+		case "/products/prod1":
+			if r.Method != http.MethodPut {
+				t.Errorf("/products/prod1 got %s, want PUT", r.Method)
+			}
+			s.mu.Lock()
+			s.productPUTCalls++
+			s.mu.Unlock()
+			testutil.JSON(t, w, map[string]any{"success": true})
+		case "/direct_uploads":
+			if r.Method != http.MethodPost {
+				t.Errorf("/direct_uploads got %s, want POST", r.Method)
+			}
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm: %v", err)
+			}
+			s.mu.Lock()
+			n := len(s.directUploadForm) + 1
+			form := map[string]string{
+				"filename":     r.PostForm.Get("blob[filename]"),
+				"byte_size":    r.PostForm.Get("blob[byte_size]"),
+				"checksum":     r.PostForm.Get("blob[checksum]"),
+				"content_type": r.PostForm.Get("blob[content_type]"),
+			}
+			s.directUploadForm = append(s.directUploadForm, form)
+			s.mu.Unlock()
+			testutil.JSON(t, w, map[string]any{
+				"signed_id":    "signed-" + strconv.Itoa(n),
+				"filename":     form["filename"],
+				"byte_size":    form["byte_size"],
+				"checksum":     form["checksum"],
+				"content_type": form["content_type"],
+				"direct_upload": map[string]any{
+					"url": s.direct.URL + "/upload/" + strconv.Itoa(n),
+					"headers": map[string]string{
+						"Content-Type": form["content_type"],
+						"Content-MD5":  form["checksum"],
+					},
+				},
+			})
+		case "/products/prod-media/covers", "/products/prod-media/thumbnail", "/products/prod1/covers", "/products/prod1/thumbnail", "/products/prod1/covers/cover-1":
+			if r.Method == http.MethodDelete {
+				testutil.JSON(t, w, map[string]any{"success": true})
+				return
+			}
+			if r.Method != http.MethodPost {
+				t.Errorf("%s got %s, want POST or DELETE", r.URL.Path, r.Method)
+			}
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm: %v", err)
+			}
+			s.mu.Lock()
+			s.attachSignedIDs = append(s.attachSignedIDs, r.PostForm.Get("signed_blob_id"))
+			s.mu.Unlock()
+			switch {
+			case strings.HasSuffix(r.URL.Path, "/thumbnail"):
+				testutil.JSON(t, w, map[string]any{
+					"success":   true,
+					"thumbnail": map[string]any{"guid": "thumb-1"},
+				})
+			default:
+				testutil.JSON(t, w, map[string]any{
+					"success":       true,
+					"covers":        []map[string]any{{"id": "cover-1"}},
+					"main_cover_id": "cover-1",
+				})
+			}
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected", http.StatusNotFound)
+		}
+	}
+}
+
+func (s *productMediaServers) snapshot() ([]string, []map[string]string, []http.Header, []string, int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.apiSequence...),
+		append([]map[string]string(nil), s.directUploadForm...),
+		append([]http.Header(nil), s.directPUTHeaders...),
+		append([]string(nil), s.attachSignedIDs...),
+		s.productPUTCalls
+}
+
+func writeMediaFixture(t *testing.T, name, contents string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(contents), 0600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+func webPFixtureContents() string {
+	return string([]byte{'R', 'I', 'F', 'F', 0, 0, 0, 0, 'W', 'E', 'B', 'P', 'V', 'P', '8', ' '})
+}
+
+func TestCreate_WithCoverAndThumbnail_CreatesThenUploadsAndAttachesMedia(t *testing.T) {
+	srv := newProductMediaServers(t)
+	testutil.Setup(t, srv.dispatch(t))
+
+	coverPath := writeMediaFixture(t, "cover.jpg", "cover bytes")
+	thumbPath := writeMediaFixture(t, "thumb.png", "thumb bytes")
+
+	cmd := testutil.Command(newCreateCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{
+		"--name", "Art Pack",
+		"--price", "10.00",
+		"--cover-image", coverPath,
+		"--thumbnail", thumbPath,
+	})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	sequence, forms, puts, signedIDs, _ := srv.snapshot()
+	wantSequence := []string{
+		"POST /products",
+		"POST /direct_uploads",
+		"POST /products/prod-media/covers",
+		"POST /direct_uploads",
+		"POST /products/prod-media/thumbnail",
+	}
+	if !reflect.DeepEqual(sequence, wantSequence) {
+		t.Fatalf("API sequence = %#v, want %#v", sequence, wantSequence)
+	}
+	if len(forms) != 2 {
+		t.Fatalf("direct uploads = %d, want 2", len(forms))
+	}
+	if forms[0]["filename"] != "cover.jpg" || forms[0]["content_type"] != "image/jpeg" {
+		t.Fatalf("cover direct upload form = %#v", forms[0])
+	}
+	if forms[1]["filename"] != "thumb.png" || forms[1]["content_type"] != "image/png" {
+		t.Fatalf("thumbnail direct upload form = %#v", forms[1])
+	}
+	if len(puts) != 2 || puts[0].Get("Content-MD5") == "" || puts[1].Get("Content-MD5") == "" {
+		t.Fatalf("direct upload PUT headers = %#v", puts)
+	}
+	if !reflect.DeepEqual(signedIDs, []string{"signed-1", "signed-2"}) {
+		t.Fatalf("attached signed IDs = %#v", signedIDs)
+	}
+
+	var payload struct {
+		Product struct {
+			ID string `json:"id"`
+		} `json:"product"`
+		Media []productMediaAttachmentResult `json:"media"`
+	}
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("parse JSON output: %v\n%s", err, out)
+	}
+	if payload.Product.ID != "prod-media" || len(payload.Media) != 2 {
+		t.Fatalf("unexpected output payload: %+v", payload)
+	}
+}
+
+func TestUpdate_WithPreviewImageOnly_DoesNotPutProduct(t *testing.T) {
+	srv := newProductMediaServers(t)
+	testutil.Setup(t, srv.dispatch(t))
+
+	previewPath := writeMediaFixture(t, "preview.gif", "gif bytes")
+	cmd := testutil.Command(newUpdateCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"prod1", "--preview-image", previewPath})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	sequence, forms, _, signedIDs, productPUTCalls := srv.snapshot()
+	wantSequence := []string{
+		"POST /direct_uploads",
+		"POST /products/prod1/covers",
+	}
+	if !reflect.DeepEqual(sequence, wantSequence) {
+		t.Fatalf("API sequence = %#v, want %#v", sequence, wantSequence)
+	}
+	if productPUTCalls != 0 {
+		t.Fatalf("product PUT calls = %d, want 0", productPUTCalls)
+	}
+	if len(forms) != 1 || forms[0]["content_type"] != "image/gif" {
+		t.Fatalf("direct upload form = %#v", forms)
+	}
+	if !reflect.DeepEqual(signedIDs, []string{"signed-1"}) {
+		t.Fatalf("attached signed IDs = %#v", signedIDs)
+	}
+	if !strings.Contains(out, `"media"`) {
+		t.Fatalf("expected media result in JSON output, got %s", out)
+	}
+}
+
+func TestUpdate_WithPreviewImageDryRunJSONShowsDirectUploadAndAttachRequests(t *testing.T) {
+	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
+		t.Fatal("dry run must not reach the API")
+	})
+
+	previewPath := writeMediaFixture(t, "preview.jpg", "preview bytes")
+	cmd := testutil.Command(newUpdateCmd(), testutil.DryRun(true), testutil.JSONOutput())
+	cmd.SetArgs([]string{"prod1", "--preview-image", previewPath})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var payload dryRunUpdateBody
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("parse JSON dry-run output: %v\n%s", err, out)
+	}
+	if len(payload.Uploads) != 1 {
+		t.Fatalf("uploads = %d, want 1", len(payload.Uploads))
+	}
+	if payload.Uploads[0].Action != "direct_upload" || payload.Uploads[0].Kind != "preview" || payload.Uploads[0].ContentType != "image/jpeg" {
+		t.Fatalf("unexpected upload plan: %+v", payload.Uploads[0])
+	}
+	if len(payload.Preserved) != 0 || len(payload.Removed) != 0 {
+		t.Fatalf("unexpected file update delta: preserved=%+v removed=%+v", payload.Preserved, payload.Removed)
+	}
+	requests := append([]dryRunCreateRequest{payload.Request}, payload.FollowUpRequests...)
+	if len(requests) != 2 {
+		t.Fatalf("requests = %d, want 2", len(requests))
+	}
+	if requests[0].Path != "/direct_uploads" || requests[1].Path != "/products/prod1/covers" {
+		t.Fatalf("unexpected requests: %+v", requests)
+	}
+}
+
+func TestCreate_WithMediaDryRunPlainAndHumanShowsDirectUploadFlow(t *testing.T) {
+	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
+		t.Fatal("dry run must not reach the API")
+	})
+
+	for _, tc := range []struct {
+		name     string
+		mutators []testutil.OptionsMutator
+		want     []string
+	}{
+		{
+			name:     "plain",
+			mutators: []testutil.OptionsMutator{testutil.DryRun(true), testutil.PlainOutput()},
+			want:     []string{"direct_upload", "POST\t/direct_uploads", "POST\t/products/created-product-id/covers"},
+		},
+		{
+			name:     "human",
+			mutators: []testutil.OptionsMutator{testutil.DryRun(true)},
+			want:     []string{"Dry run: direct upload", "Content type: image/jpeg", "Dry run: POST /direct_uploads", "Dry run: POST /products/created-product-id/covers"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeMediaFixture(t, "cover.jpg", "cover bytes")
+			cmd := testutil.Command(newCreateCmd(), tc.mutators...)
+			cmd.SetArgs([]string{"--name", "Art Pack", "--cover-image", path})
+			out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+			for _, want := range tc.want {
+				if !strings.Contains(out, want) {
+					t.Fatalf("expected %q in output:\n%s", want, out)
+				}
+			}
+		})
+	}
+}
+
+func TestProductMediaRejectsWebPClientSide(t *testing.T) {
+	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
+		t.Fatal("unsupported media must not reach the API")
+	})
+
+	path := writeMediaFixture(t, "cover.webp", "webp bytes")
+	cmd := testutil.Command(newCreateCmd())
+	cmd.SetArgs([]string{"--name", "Art Pack", "--cover-image", path})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected WebP validation error")
+	}
+	if !strings.Contains(err.Error(), "WebP images are not supported") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestProductMediaRejectsRenamedWebPClientSide(t *testing.T) {
+	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
+		t.Fatal("unsupported media must not reach the API")
+	})
+
+	path := writeMediaFixture(t, "cover.jpg", webPFixtureContents())
+	cmd := testutil.Command(newCreateCmd())
+	cmd.SetArgs([]string{"--name", "Art Pack", "--cover-image", path})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected WebP validation error")
+	}
+	if !strings.Contains(err.Error(), "WebP images are not supported") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestProductMediaRejectsOversizedImagesClientSide(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "huge.jpg")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create fixture: %v", err)
+	}
+	if err := file.Truncate(uploadMaxProductMediaFileSize() + 1); err != nil {
+		t.Fatalf("truncate fixture: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close fixture: %v", err)
+	}
+
+	_, err = describeSingleProductMedia(requestedProductMedia{Kind: productMediaCover, Path: path})
+	if err == nil {
+		t.Fatal("expected image size validation error")
+	}
+	if !strings.Contains(err.Error(), "50 MB") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestProductMediaPlanningAndRetryHelpers(t *testing.T) {
+	collected := collectProductMedia("cover.jpg", []string{"preview-a.jpg", "preview-b.jpg"}, "thumb.jpg")
+	if len(collected) != 4 || collected[0].Kind != productMediaCover || collected[3].Kind != productMediaThumbnail {
+		t.Fatalf("unexpected collected media: %+v", collected)
+	}
+
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--name", "Art Pack", "--preview-image", ""})
+	if err := cmd.ParseFlags([]string{"--preview-image", ""}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	if err := validateProductMediaFlagPaths(cmd, "", []string{""}, ""); err == nil || !strings.Contains(err.Error(), "--preview-image cannot be empty") {
+		t.Fatalf("expected empty preview-image error, got %v", err)
+	}
+
+	if got := productMediaRetryCommand("prod1", plannedProductMedia{requestedProductMedia: requestedProductMedia{Kind: productMediaThumbnail, Path: "thumb one.jpg"}}); got != "gumroad products thumbnail set prod1 --image 'thumb one.jpg'" {
+		t.Fatalf("thumbnail retry command = %q", got)
+	}
+	if got := productMediaRetryCommand("prod1", plannedProductMedia{requestedProductMedia: requestedProductMedia{Kind: productMediaCover, Path: "cover.jpg"}}); got != "gumroad products covers add prod1 --image cover.jpg" {
+		t.Fatalf("cover retry command = %q", got)
+	}
+	wrapped := wrapProductMediaAttachError(fmt.Errorf("upload failed"), "prod1", "product create", plannedProductMedia{
+		requestedProductMedia: requestedProductMedia{Kind: productMediaCover, Path: "cover.jpg"},
+	})
+	if !strings.Contains(wrapped.Error(), "product create completed for product prod1") {
+		t.Fatalf("wrapped error did not include retry context: %v", wrapped)
+	}
+}
+
+func TestDetectProductImageContentTypeSniffsExtensionlessImages(t *testing.T) {
+	path := writeMediaFixture(t, "cover", "GIF89a0000000000")
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open fixture: %v", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	contentType, err := detectProductImageContentType(path, file)
+	if err != nil {
+		t.Fatalf("detectProductImageContentType: %v", err)
+	}
+	if contentType != "image/gif" {
+		t.Fatalf("content type = %q, want image/gif", contentType)
+	}
+}
+
+func TestDirectUploadProductMediaRejectsIncompleteServerResponses(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/direct_uploads" {
+			t.Fatalf("unexpected request: %s", r.URL.Path)
+		}
+		testutil.JSON(t, w, map[string]any{
+			"direct_upload": map[string]any{"url": "https://example.com/upload"},
+		})
+	})
+
+	path := writeMediaFixture(t, "cover.jpg", "cover bytes")
+	media, err := describeSingleProductMedia(requestedProductMedia{Kind: productMediaCover, Path: path})
+	if err != nil {
+		t.Fatalf("describeSingleProductMedia: %v", err)
+	}
+	_, err = directUploadProductMedia(testutil.TestOptions(), testutilClient(t), media)
+	if err == nil || !strings.Contains(err.Error(), "signed_id") {
+		t.Fatalf("expected missing signed_id error, got %v", err)
+	}
+}
+
+func TestPutDirectUploadReportsServerBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "storage unavailable", http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	path := writeMediaFixture(t, "cover.jpg", "cover bytes")
+	media, err := describeSingleProductMedia(requestedProductMedia{Kind: productMediaCover, Path: path})
+	if err != nil {
+		t.Fatalf("describeSingleProductMedia: %v", err)
+	}
+	err = putDirectUpload(testutil.TestOptions(), media, server.URL, nil)
+	if err == nil || !strings.Contains(err.Error(), "storage unavailable") {
+		t.Fatalf("expected direct upload server error, got %v", err)
+	}
+}
+
+func TestCoversAdd_WithImageUploadsAndAttaches(t *testing.T) {
+	srv := newProductMediaServers(t)
+	testutil.Setup(t, srv.dispatch(t))
+
+	path := writeMediaFixture(t, "cover.jpg", "cover bytes")
+	cmd := testutil.Command(newCoversAddCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"prod1", "--image", path})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	sequence, forms, _, signedIDs, _ := srv.snapshot()
+	if !reflect.DeepEqual(sequence, []string{"POST /direct_uploads", "POST /products/prod1/covers"}) {
+		t.Fatalf("API sequence = %#v", sequence)
+	}
+	if len(forms) != 1 || forms[0]["filename"] != "cover.jpg" {
+		t.Fatalf("direct upload form = %#v", forms)
+	}
+	if !reflect.DeepEqual(signedIDs, []string{"signed-1"}) {
+		t.Fatalf("attached signed IDs = %#v", signedIDs)
+	}
+}
+
+func TestCoversAdd_WithURLSendsURL(t *testing.T) {
+	var gotForm urlValues
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/products/prod1/covers" {
+			t.Fatalf("got %s %s, want POST /products/prod1/covers", r.Method, r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		gotForm = urlValues(r.PostForm)
+		testutil.JSON(t, w, map[string]any{"success": true, "covers": []map[string]any{{"id": "cover-url"}}})
+	})
+
+	cmd := testutil.Command(newCoversAddCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"prod1", "--url", "https://www.youtube.com/watch?v=qKebcV1jv3A"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotForm.Get("url") != "https://www.youtube.com/watch?v=qKebcV1jv3A" {
+		t.Fatalf("url = %q", gotForm.Get("url"))
+	}
+}
+
+func TestCoversRemoveAndThumbnailRemove(t *testing.T) {
+	srv := newProductMediaServers(t)
+	testutil.Setup(t, srv.dispatch(t))
+
+	coverCmd := testutil.Command(newCoversRemoveCmd(), testutil.Yes(true), testutil.JSONOutput())
+	coverCmd.SetArgs([]string{"prod1", "cover-1"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, coverCmd) })
+
+	thumbnailCmd := testutil.Command(newThumbnailRemoveCmd(), testutil.Yes(true), testutil.JSONOutput())
+	thumbnailCmd.SetArgs([]string{"prod1"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, thumbnailCmd) })
+
+	sequence, _, _, _, _ := srv.snapshot()
+	if !reflect.DeepEqual(sequence, []string{"DELETE /products/prod1/covers/cover-1", "DELETE /products/prod1/thumbnail"}) {
+		t.Fatalf("API sequence = %#v", sequence)
+	}
+}
+
+func TestThumbnailSet_WithImageUploadsAndAttaches(t *testing.T) {
+	srv := newProductMediaServers(t)
+	testutil.Setup(t, srv.dispatch(t))
+
+	path := writeMediaFixture(t, "thumb.png", "thumb bytes")
+	cmd := testutil.Command(newThumbnailSetCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"prod1", "--image", path})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	sequence, forms, _, signedIDs, _ := srv.snapshot()
+	if !reflect.DeepEqual(sequence, []string{"POST /direct_uploads", "POST /products/prod1/thumbnail"}) {
+		t.Fatalf("API sequence = %#v", sequence)
+	}
+	if len(forms) != 1 || forms[0]["filename"] != "thumb.png" || forms[0]["content_type"] != "image/png" {
+		t.Fatalf("direct upload form = %#v", forms)
+	}
+	if !reflect.DeepEqual(signedIDs, []string{"signed-1"}) {
+		t.Fatalf("attached signed IDs = %#v", signedIDs)
+	}
+}
+
+func TestCoversReorder_SendsCoverIDs(t *testing.T) {
+	var gotForm urlValues
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/products/prod1" {
+			t.Fatalf("got %s %s, want PUT /products/prod1", r.Method, r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		gotForm = urlValues(r.PostForm)
+		testutil.JSON(t, w, map[string]any{"success": true})
+	})
+
+	cmd := testutil.Command(newCoversReorderCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"prod1", "cover_b", "cover_a"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !reflect.DeepEqual(gotForm["cover_ids[]"], []string{"cover_b", "cover_a"}) {
+		t.Fatalf("cover_ids[] = %#v", gotForm["cover_ids[]"])
+	}
+}
+
+type urlValues map[string][]string
+
+func (v urlValues) Get(key string) string {
+	if len(v[key]) == 0 {
+		return ""
+	}
+	return v[key][0]
+}
+
+func (v urlValues) String() string {
+	return fmt.Sprint(map[string][]string(v))
+}
+
+func testutilClient(t *testing.T) *api.Client {
+	t.Helper()
+	token, err := config.Token()
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	return cmdutil.NewAPIClient(testutil.TestOptions(), token)
+}

--- a/internal/cmd/products/product_media_test.go
+++ b/internal/cmd/products/product_media_test.go
@@ -251,8 +251,20 @@ func TestUpdate_WithPreviewImageOnly_DoesNotPutProduct(t *testing.T) {
 	if !reflect.DeepEqual(signedIDs, []string{"signed-1"}) {
 		t.Fatalf("attached signed IDs = %#v", signedIDs)
 	}
-	if !strings.Contains(out, `"media"`) {
-		t.Fatalf("expected media result in JSON output, got %s", out)
+	var payload struct {
+		Result struct {
+			Success bool `json:"success"`
+			Product struct {
+				ID string `json:"id"`
+			} `json:"product"`
+			Media []productMediaAttachmentResult `json:"media"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("parse JSON output: %v\n%s", err, out)
+	}
+	if !payload.Result.Success || payload.Result.Product.ID != "prod1" || len(payload.Result.Media) != 1 {
+		t.Fatalf("unexpected JSON output: %+v", payload)
 	}
 }
 

--- a/internal/cmd/products/product_media_test.go
+++ b/internal/cmd/products/product_media_test.go
@@ -283,6 +283,49 @@ func TestMergeProductMediaResultPreservesRawResponseFormatting(t *testing.T) {
 	}
 }
 
+func TestMergeProductMediaResultHandlesEmptyAndInvalidResponses(t *testing.T) {
+	media := []productMediaAttachmentResult{{
+		Kind:     "cover",
+		Path:     "cover.jpg",
+		Endpoint: "/products/prod-media/covers",
+		Response: json.RawMessage(`{"success":true}`),
+	}}
+
+	withoutMedia, err := mergeProductMediaResult(json.RawMessage(`{"product":{"rank":1.0}}`), nil)
+	if err != nil {
+		t.Fatalf("merge without media: %v", err)
+	}
+	if string(withoutMedia) != `{"product":{"rank":1.0}}` {
+		t.Fatalf("expected response without media to stay unchanged, got:\n%s", withoutMedia)
+	}
+
+	fromNil, err := mergeProductMediaResult(nil, media)
+	if err != nil {
+		t.Fatalf("merge nil response: %v", err)
+	}
+	if !json.Valid(fromNil) || !strings.Contains(string(fromNil), `"media":[`) {
+		t.Fatalf("expected nil response to become a media object, got:\n%s", fromNil)
+	}
+
+	fromEmptyObject, err := mergeProductMediaResult(json.RawMessage(`{}`), media)
+	if err != nil {
+		t.Fatalf("merge empty object response: %v", err)
+	}
+	if string(fromEmptyObject) == `{}` || !strings.Contains(string(fromEmptyObject), `"media":[`) {
+		t.Fatalf("expected media to be appended to empty object, got:\n%s", fromEmptyObject)
+	}
+
+	_, err = mergeProductMediaResult(json.RawMessage(`[]`), media)
+	if err == nil || !strings.Contains(err.Error(), "expected JSON object") {
+		t.Fatalf("expected non-object response error, got %v", err)
+	}
+
+	_, err = mergeProductMediaResult(json.RawMessage(`{`), media)
+	if err == nil || !strings.Contains(err.Error(), "expected JSON object") {
+		t.Fatalf("expected invalid response error, got %v", err)
+	}
+}
+
 func TestUpdate_WithPreviewImageOnly_DoesNotPutProduct(t *testing.T) {
 	srv := newProductMediaServers(t)
 	testutil.Setup(t, srv.dispatch(t))

--- a/internal/cmd/products/product_media_test.go
+++ b/internal/cmd/products/product_media_test.go
@@ -177,6 +177,18 @@ func writeMediaFixture(t *testing.T, name, contents string) string {
 	return path
 }
 
+func jpegFixtureContents() string {
+	return string([]byte{0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 'J', 'F', 'I', 'F', 0x00, 0x01})
+}
+
+func pngFixtureContents() string {
+	return string([]byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n', 0x00, 0x00, 0x00, 0x0d})
+}
+
+func gifFixtureContents() string {
+	return "GIF89a0000000000"
+}
+
 func webPFixtureContents() string {
 	return string([]byte{'R', 'I', 'F', 'F', 0, 0, 0, 0, 'W', 'E', 'B', 'P', 'V', 'P', '8', ' '})
 }
@@ -185,8 +197,8 @@ func TestCreate_WithCoverAndThumbnail_CreatesThenUploadsAndAttachesMedia(t *test
 	srv := newProductMediaServers(t)
 	testutil.Setup(t, srv.dispatch(t))
 
-	coverPath := writeMediaFixture(t, "cover.jpg", "cover bytes")
-	thumbPath := writeMediaFixture(t, "thumb.png", "thumb bytes")
+	coverPath := writeMediaFixture(t, "cover.jpg", jpegFixtureContents())
+	thumbPath := writeMediaFixture(t, "thumb.png", pngFixtureContents())
 
 	cmd := testutil.Command(newCreateCmd(), testutil.JSONOutput())
 	cmd.SetArgs([]string{
@@ -247,11 +259,35 @@ func TestCreate_WithCoverAndThumbnail_CreatesThenUploadsAndAttachesMedia(t *test
 	}
 }
 
+func TestMergeProductMediaResultPreservesRawResponseFormatting(t *testing.T) {
+	data := json.RawMessage(`{"product":{"id":"prod-media","rank":1.0}}`)
+	media := []productMediaAttachmentResult{{
+		Kind:     "cover",
+		Path:     "cover.jpg",
+		Endpoint: "/products/prod-media/covers",
+		Response: json.RawMessage(`{"success":true}`),
+	}}
+
+	merged, err := mergeProductMediaResult(data, media)
+	if err != nil {
+		t.Fatalf("mergeProductMediaResult: %v", err)
+	}
+	if !json.Valid(merged) {
+		t.Fatalf("merged result is not valid JSON: %s", merged)
+	}
+	if !strings.Contains(string(merged), `"rank":1.0`) {
+		t.Fatalf("expected raw numeric formatting to be preserved, got:\n%s", merged)
+	}
+	if !strings.Contains(string(merged), `"media":[`) {
+		t.Fatalf("expected media to be appended, got:\n%s", merged)
+	}
+}
+
 func TestUpdate_WithPreviewImageOnly_DoesNotPutProduct(t *testing.T) {
 	srv := newProductMediaServers(t)
 	testutil.Setup(t, srv.dispatch(t))
 
-	previewPath := writeMediaFixture(t, "preview.gif", "gif bytes")
+	previewPath := writeMediaFixture(t, "preview.gif", gifFixtureContents())
 	cmd := testutil.Command(newUpdateCmd(), testutil.JSONOutput())
 	cmd.SetArgs([]string{"prod1", "--preview-image", previewPath})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
@@ -300,7 +336,7 @@ func TestUpdate_WithPreviewImageOnlyFailureDoesNotClaimProductUpdateCompleted(t 
 		http.Error(w, "direct upload unavailable", http.StatusBadGateway)
 	})
 
-	previewPath := writeMediaFixture(t, "preview.gif", "gif bytes")
+	previewPath := writeMediaFixture(t, "preview.gif", gifFixtureContents())
 	cmd := testutil.Command(newUpdateCmd(), testutil.JSONOutput())
 	cmd.SetArgs([]string{"prod1", "--preview-image", previewPath})
 	err := cmd.Execute()
@@ -331,8 +367,8 @@ func TestCreate_WithMultipleMediaFailureShowsRetryForFailedAndSkippedMedia(t *te
 		}
 	})
 
-	coverPath := writeMediaFixture(t, "cover.jpg", "cover bytes")
-	thumbPath := writeMediaFixture(t, "thumb.png", "thumb bytes")
+	coverPath := writeMediaFixture(t, "cover.jpg", jpegFixtureContents())
+	thumbPath := writeMediaFixture(t, "thumb.png", pngFixtureContents())
 	cmd := testutil.Command(newCreateCmd(), testutil.JSONOutput())
 	cmd.SetArgs([]string{
 		"--name", "Art Pack",
@@ -363,7 +399,7 @@ func TestUpdate_WithPreviewImageDryRunJSONShowsDirectUploadAndAttachRequests(t *
 		t.Fatal("dry run must not reach the API")
 	})
 
-	previewPath := writeMediaFixture(t, "preview.jpg", "preview bytes")
+	previewPath := writeMediaFixture(t, "preview.jpg", jpegFixtureContents())
 	cmd := testutil.Command(newUpdateCmd(), testutil.DryRun(true), testutil.JSONOutput())
 	cmd.SetArgs([]string{"prod1", "--preview-image", previewPath})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
@@ -412,7 +448,7 @@ func TestCreate_WithMediaDryRunPlainAndHumanShowsDirectUploadFlow(t *testing.T) 
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			path := writeMediaFixture(t, "cover.jpg", "cover bytes")
+			path := writeMediaFixture(t, "cover.jpg", jpegFixtureContents())
 			cmd := testutil.Command(newCreateCmd(), tc.mutators...)
 			cmd.SetArgs([]string{"--name", "Art Pack", "--cover-image", path})
 			out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
@@ -455,6 +491,23 @@ func TestProductMediaRejectsRenamedWebPClientSide(t *testing.T) {
 		t.Fatal("expected WebP validation error")
 	}
 	if !strings.Contains(err.Error(), "WebP images are not supported") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestProductMediaRejectsRenamedNonImageClientSide(t *testing.T) {
+	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
+		t.Fatal("unsupported media must not reach the API")
+	})
+
+	path := writeMediaFixture(t, "cover.jpg", "%PDF-1.7\nnot an image")
+	cmd := testutil.Command(newCreateCmd())
+	cmd.SetArgs([]string{"--name", "Art Pack", "--cover-image", path})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected non-image validation error")
+	}
+	if !strings.Contains(err.Error(), "unsupported product media type") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -515,7 +568,7 @@ func TestProductMediaPlanningAndRetryHelpers(t *testing.T) {
 }
 
 func TestDetectProductImageContentTypeSniffsExtensionlessImages(t *testing.T) {
-	path := writeMediaFixture(t, "cover", "GIF89a0000000000")
+	path := writeMediaFixture(t, "cover", gifFixtureContents())
 	file, err := os.Open(path)
 	if err != nil {
 		t.Fatalf("open fixture: %v", err)
@@ -541,7 +594,7 @@ func TestDirectUploadProductMediaRejectsIncompleteServerResponses(t *testing.T) 
 		})
 	})
 
-	path := writeMediaFixture(t, "cover.jpg", "cover bytes")
+	path := writeMediaFixture(t, "cover.jpg", jpegFixtureContents())
 	media, err := describeSingleProductMedia(requestedProductMedia{Kind: productMediaCover, Path: path})
 	if err != nil {
 		t.Fatalf("describeSingleProductMedia: %v", err)
@@ -558,7 +611,7 @@ func TestPutDirectUploadReportsServerBody(t *testing.T) {
 	}))
 	defer server.Close()
 
-	path := writeMediaFixture(t, "cover.jpg", "cover bytes")
+	path := writeMediaFixture(t, "cover.jpg", jpegFixtureContents())
 	media, err := describeSingleProductMedia(requestedProductMedia{Kind: productMediaCover, Path: path})
 	if err != nil {
 		t.Fatalf("describeSingleProductMedia: %v", err)
@@ -573,7 +626,7 @@ func TestCoversAdd_WithImageUploadsAndAttaches(t *testing.T) {
 	srv := newProductMediaServers(t)
 	testutil.Setup(t, srv.dispatch(t))
 
-	path := writeMediaFixture(t, "cover.jpg", "cover bytes")
+	path := writeMediaFixture(t, "cover.jpg", jpegFixtureContents())
 	cmd := testutil.Command(newCoversAddCmd(), testutil.JSONOutput())
 	cmd.SetArgs([]string{"prod1", "--image", path})
 	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
@@ -650,7 +703,7 @@ func TestThumbnailSet_WithImageUploadsAndAttaches(t *testing.T) {
 	srv := newProductMediaServers(t)
 	testutil.Setup(t, srv.dispatch(t))
 
-	path := writeMediaFixture(t, "thumb.png", "thumb bytes")
+	path := writeMediaFixture(t, "thumb.png", pngFixtureContents())
 	cmd := testutil.Command(newThumbnailSetCmd(), testutil.JSONOutput())
 	cmd.SetArgs([]string{"prod1", "--image", path})
 	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })

--- a/internal/cmd/products/product_media_test.go
+++ b/internal/cmd/products/product_media_test.go
@@ -672,7 +672,7 @@ func TestCoversAdd_WithImageUploadsAndAttaches(t *testing.T) {
 	path := writeMediaFixture(t, "cover.jpg", jpegFixtureContents())
 	cmd := testutil.Command(newCoversAddCmd(), testutil.JSONOutput())
 	cmd.SetArgs([]string{"prod1", "--image", path})
-	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
 	sequence, forms, _, signedIDs, _, _ := srv.snapshot()
 	if !reflect.DeepEqual(sequence, []string{"POST /direct_uploads", "POST /products/prod1/covers"}) {
@@ -683,6 +683,24 @@ func TestCoversAdd_WithImageUploadsAndAttaches(t *testing.T) {
 	}
 	if !reflect.DeepEqual(signedIDs, []string{"signed-1"}) {
 		t.Fatalf("attached signed IDs = %#v", signedIDs)
+	}
+	var payload struct {
+		Result struct {
+			Covers []struct {
+				ID string `json:"id"`
+			} `json:"covers"`
+			MainCoverID string                         `json:"main_cover_id"`
+			Media       []productMediaAttachmentResult `json:"media"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("parse JSON output: %v\n%s", err, out)
+	}
+	if len(payload.Result.Covers) != 1 || payload.Result.Covers[0].ID != "cover-1" || payload.Result.MainCoverID != "cover-1" {
+		t.Fatalf("expected cover attach response fields, got %+v", payload.Result)
+	}
+	if len(payload.Result.Media) != 1 || payload.Result.Media[0].Kind != "cover" {
+		t.Fatalf("expected media metadata, got %+v", payload.Result.Media)
 	}
 }
 

--- a/internal/cmd/products/product_media_test.go
+++ b/internal/cmd/products/product_media_test.go
@@ -256,6 +256,31 @@ func TestUpdate_WithPreviewImageOnly_DoesNotPutProduct(t *testing.T) {
 	}
 }
 
+func TestUpdate_WithPreviewImageOnlyFailureDoesNotClaimProductUpdateCompleted(t *testing.T) {
+	var sequence []string
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		sequence = append(sequence, r.Method+" "+r.URL.Path)
+		if r.URL.Path == "/products/prod1" {
+			t.Fatal("media-only update must not PUT product fields")
+		}
+		http.Error(w, "direct upload unavailable", http.StatusBadGateway)
+	})
+
+	previewPath := writeMediaFixture(t, "preview.gif", "gif bytes")
+	cmd := testutil.Command(newUpdateCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"prod1", "--preview-image", previewPath})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected direct upload error")
+	}
+	if strings.Contains(err.Error(), "product update completed") {
+		t.Fatalf("unexpected completed product update context: %v", err)
+	}
+	if !reflect.DeepEqual(sequence, []string{"POST /direct_uploads"}) {
+		t.Fatalf("API sequence = %#v", sequence)
+	}
+}
+
 func TestUpdate_WithPreviewImageDryRunJSONShowsDirectUploadAndAttachRequests(t *testing.T) {
 	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
 		t.Fatal("dry run must not reach the API")

--- a/internal/cmd/products/product_media_test.go
+++ b/internal/cmd/products/product_media_test.go
@@ -281,6 +281,49 @@ func TestUpdate_WithPreviewImageOnlyFailureDoesNotClaimProductUpdateCompleted(t 
 	}
 }
 
+func TestCreate_WithMultipleMediaFailureShowsRetryForFailedAndSkippedMedia(t *testing.T) {
+	var sequence []string
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		sequence = append(sequence, r.Method+" "+r.URL.Path)
+		switch r.URL.Path {
+		case "/products":
+			testutil.JSON(t, w, map[string]any{
+				"product": map[string]any{"id": "prod-media"},
+			})
+		case "/direct_uploads":
+			http.Error(w, "direct upload unavailable", http.StatusBadGateway)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	})
+
+	coverPath := writeMediaFixture(t, "cover.jpg", "cover bytes")
+	thumbPath := writeMediaFixture(t, "thumb.png", "thumb bytes")
+	cmd := testutil.Command(newCreateCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{
+		"--name", "Art Pack",
+		"--cover-image", coverPath,
+		"--thumbnail", thumbPath,
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected direct upload error")
+	}
+	for _, want := range []string{
+		"product create completed for product prod-media",
+		"retry remaining media with:",
+		"gumroad products covers add prod-media --image",
+		"gumroad products thumbnail set prod-media --image",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected %q in error: %v", want, err)
+		}
+	}
+	if !reflect.DeepEqual(sequence, []string{"POST /products", "POST /direct_uploads"}) {
+		t.Fatalf("API sequence = %#v", sequence)
+	}
+}
+
 func TestUpdate_WithPreviewImageDryRunJSONShowsDirectUploadAndAttachRequests(t *testing.T) {
 	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
 		t.Fatal("dry run must not reach the API")
@@ -425,11 +468,15 @@ func TestProductMediaPlanningAndRetryHelpers(t *testing.T) {
 	if got := productMediaRetryCommand("prod1", plannedProductMedia{requestedProductMedia: requestedProductMedia{Kind: productMediaCover, Path: "cover.jpg"}}); got != "gumroad products covers add prod1 --image cover.jpg" {
 		t.Fatalf("cover retry command = %q", got)
 	}
-	wrapped := wrapProductMediaAttachError(fmt.Errorf("upload failed"), "prod1", "product create", plannedProductMedia{
-		requestedProductMedia: requestedProductMedia{Kind: productMediaCover, Path: "cover.jpg"},
+	wrapped := wrapProductMediaAttachError(fmt.Errorf("upload failed"), "prod1", "product create", false, []plannedProductMedia{
+		{requestedProductMedia: requestedProductMedia{Kind: productMediaCover, Path: "cover.jpg"}},
+		{requestedProductMedia: requestedProductMedia{Kind: productMediaThumbnail, Path: "thumb.jpg"}},
 	})
 	if !strings.Contains(wrapped.Error(), "product create completed for product prod1") {
 		t.Fatalf("wrapped error did not include retry context: %v", wrapped)
+	}
+	if !strings.Contains(wrapped.Error(), "gumroad products thumbnail set prod1 --image thumb.jpg") {
+		t.Fatalf("wrapped error did not include skipped media retry context: %v", wrapped)
 	}
 }
 

--- a/internal/cmd/products/product_media_test.go
+++ b/internal/cmd/products/product_media_test.go
@@ -23,12 +23,13 @@ import (
 type productMediaServers struct {
 	direct *httptest.Server
 
-	mu               sync.Mutex
-	apiSequence      []string
-	directUploadForm []map[string]string
-	directPUTHeaders []http.Header
-	attachSignedIDs  []string
-	productPUTCalls  int
+	mu                sync.Mutex
+	apiSequence       []string
+	productCreateForm []map[string]string
+	directUploadForm  []map[string]string
+	directPUTHeaders  []http.Header
+	attachSignedIDs   []string
+	productPUTCalls   int
 }
 
 func newProductMediaServers(t *testing.T) *productMediaServers {
@@ -64,6 +65,17 @@ func (s *productMediaServers) dispatch(t *testing.T) http.HandlerFunc {
 			if r.Method != http.MethodPost {
 				t.Errorf("/products got %s, want POST", r.Method)
 			}
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm: %v", err)
+			}
+			s.mu.Lock()
+			s.productCreateForm = append(s.productCreateForm, map[string]string{
+				"content_type": r.Header.Get("Content-Type"),
+				"name":         r.PostForm.Get("name"),
+				"price":        r.PostForm.Get("price"),
+				"native_type":  r.PostForm.Get("native_type"),
+			})
+			s.mu.Unlock()
 			testutil.JSON(t, w, map[string]any{
 				"product": map[string]any{
 					"id":              "prod-media",
@@ -144,14 +156,15 @@ func (s *productMediaServers) dispatch(t *testing.T) http.HandlerFunc {
 	}
 }
 
-func (s *productMediaServers) snapshot() ([]string, []map[string]string, []http.Header, []string, int) {
+func (s *productMediaServers) snapshot() ([]string, []map[string]string, []http.Header, []string, int, []map[string]string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return append([]string(nil), s.apiSequence...),
 		append([]map[string]string(nil), s.directUploadForm...),
 		append([]http.Header(nil), s.directPUTHeaders...),
 		append([]string(nil), s.attachSignedIDs...),
-		s.productPUTCalls
+		s.productPUTCalls,
+		append([]map[string]string(nil), s.productCreateForm...)
 }
 
 func writeMediaFixture(t *testing.T, name, contents string) string {
@@ -184,7 +197,7 @@ func TestCreate_WithCoverAndThumbnail_CreatesThenUploadsAndAttachesMedia(t *test
 	})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	sequence, forms, puts, signedIDs, _ := srv.snapshot()
+	sequence, forms, puts, signedIDs, _, productCreateForms := srv.snapshot()
 	wantSequence := []string{
 		"POST /products",
 		"POST /direct_uploads",
@@ -210,6 +223,15 @@ func TestCreate_WithCoverAndThumbnail_CreatesThenUploadsAndAttachesMedia(t *test
 	if !reflect.DeepEqual(signedIDs, []string{"signed-1", "signed-2"}) {
 		t.Fatalf("attached signed IDs = %#v", signedIDs)
 	}
+	if len(productCreateForms) != 1 {
+		t.Fatalf("product create forms = %d, want 1", len(productCreateForms))
+	}
+	if !strings.HasPrefix(productCreateForms[0]["content_type"], "application/x-www-form-urlencoded") {
+		t.Fatalf("product create content type = %q, want form encoded", productCreateForms[0]["content_type"])
+	}
+	if productCreateForms[0]["name"] != "Art Pack" || productCreateForms[0]["price"] != "1000" || productCreateForms[0]["native_type"] != "digital" {
+		t.Fatalf("product create form = %#v", productCreateForms[0])
+	}
 
 	var payload struct {
 		Product struct {
@@ -234,7 +256,7 @@ func TestUpdate_WithPreviewImageOnly_DoesNotPutProduct(t *testing.T) {
 	cmd.SetArgs([]string{"prod1", "--preview-image", previewPath})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	sequence, forms, _, signedIDs, productPUTCalls := srv.snapshot()
+	sequence, forms, _, signedIDs, productPUTCalls, _ := srv.snapshot()
 	wantSequence := []string{
 		"POST /direct_uploads",
 		"POST /products/prod1/covers",
@@ -556,7 +578,7 @@ func TestCoversAdd_WithImageUploadsAndAttaches(t *testing.T) {
 	cmd.SetArgs([]string{"prod1", "--image", path})
 	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	sequence, forms, _, signedIDs, _ := srv.snapshot()
+	sequence, forms, _, signedIDs, _, _ := srv.snapshot()
 	if !reflect.DeepEqual(sequence, []string{"POST /direct_uploads", "POST /products/prod1/covers"}) {
 		t.Fatalf("API sequence = %#v", sequence)
 	}
@@ -618,7 +640,7 @@ func TestCoversRemoveAndThumbnailRemove(t *testing.T) {
 	thumbnailCmd.SetArgs([]string{"prod1"})
 	testutil.CaptureStdout(func() { testutil.MustExecute(t, thumbnailCmd) })
 
-	sequence, _, _, _, _ := srv.snapshot()
+	sequence, _, _, _, _, _ := srv.snapshot()
 	if !reflect.DeepEqual(sequence, []string{"DELETE /products/prod1/covers/cover-1", "DELETE /products/prod1/thumbnail"}) {
 		t.Fatalf("API sequence = %#v", sequence)
 	}
@@ -633,7 +655,7 @@ func TestThumbnailSet_WithImageUploadsAndAttaches(t *testing.T) {
 	cmd.SetArgs([]string{"prod1", "--image", path})
 	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	sequence, forms, _, signedIDs, _ := srv.snapshot()
+	sequence, forms, _, signedIDs, _, _ := srv.snapshot()
 	if !reflect.DeepEqual(sequence, []string{"POST /direct_uploads", "POST /products/prod1/thumbnail"}) {
 		t.Fatalf("API sequence = %#v", sequence)
 	}

--- a/internal/cmd/products/products.go
+++ b/internal/cmd/products/products.go
@@ -15,7 +15,11 @@ func NewProductsCmd() *cobra.Command {
 		Example: `  gumroad products list
   gumroad products create --name "Art Pack" --price 10.00
   gumroad products create --name "Art Pack" --file ./pack.zip --file-name "Art Pack.zip"
+  gumroad products create --name "Art Pack" --cover-image ./cover.jpg --thumbnail ./thumb.jpg
   gumroad products update <product_id> --name "New Name"
+  gumroad products update <product_id> --preview-image ./gallery.jpg
+  gumroad products covers add <product_id> --image ./cover.jpg
+  gumroad products thumbnail set <product_id> --image ./thumb.jpg
   gumroad products update <product_id> --file ./pack.zip
   gumroad products update <product_id> --replace-files --keep-file file_123 --file ./new-pack.zip
   gumroad products view <id>
@@ -32,6 +36,8 @@ func NewProductsCmd() *cobra.Command {
 	cmd.AddCommand(newDeleteCmd())
 	cmd.AddCommand(newPublishCmd())
 	cmd.AddCommand(newUnpublishCmd())
+	cmd.AddCommand(newCoversCmd())
+	cmd.AddCommand(newThumbnailCmd())
 	cmd.AddCommand(skus.NewProductSKUsCmd())
 
 	return cmd

--- a/internal/cmd/products/thumbnail.go
+++ b/internal/cmd/products/thumbnail.go
@@ -1,0 +1,87 @@
+package products
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func newThumbnailCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "thumbnail",
+		Short: "Manage a product thumbnail",
+		Example: `  gumroad products thumbnail set <product_id> --image ./thumb.jpg
+  gumroad products thumbnail remove <product_id>`,
+	}
+
+	cmd.AddCommand(newThumbnailSetCmd())
+	cmd.AddCommand(newThumbnailRemoveCmd())
+	return cmd
+}
+
+func newThumbnailSetCmd() *cobra.Command {
+	var imagePath string
+
+	cmd := &cobra.Command{
+		Use:   "set <product_id>",
+		Short: "Set a product thumbnail",
+		Args:  cmdutil.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			if !c.Flags().Changed("image") {
+				return cmdutil.MissingFlagError(c, "--image")
+			}
+			productID := args[0]
+			media, err := describeProductMedia([]requestedProductMedia{{Kind: productMediaThumbnail, Path: imagePath}})
+			if err != nil {
+				return err
+			}
+			if opts.DryRun {
+				return renderStandaloneProductMediaDryRun(opts, media, productMediaDryRunRequests(productID, media))
+			}
+
+			token, err := config.Token()
+			if err != nil {
+				return err
+			}
+			client := cmdutil.NewAPIClient(opts, token)
+			results, err := uploadAndAttachProductMedia(opts, client, productID, media, "")
+			if err != nil {
+				return err
+			}
+			data, err := json.Marshal(map[string]any{"media": results})
+			if err != nil {
+				return fmt.Errorf("could not encode response: %w", err)
+			}
+			return cmdutil.PrintMutationSuccess(opts, data, productID, "Thumbnail set for product "+productID+".")
+		},
+	}
+	cmd.Flags().StringVar(&imagePath, "image", "", "Local JPEG, PNG, or GIF image to upload as the thumbnail")
+	return cmd
+}
+
+func newThumbnailRemoveCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "remove <product_id>",
+		Short: "Remove a product thumbnail",
+		Args:  cmdutil.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			productID := args[0]
+			ok, err := cmdutil.ConfirmAction(opts, "Remove thumbnail from product "+productID+"?")
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return cmdutil.PrintCancelledAction(opts, "remove thumbnail from product "+productID, productID)
+			}
+			path := productMediaAttachPath(productID, productMediaThumbnail)
+			return cmdutil.RunRequestWithSuccess(opts, "Removing thumbnail...", http.MethodDelete, path, nil, productID, "Thumbnail removed from product "+productID+".")
+		},
+	}
+	return cmd
+}

--- a/internal/cmd/products/thumbnail.go
+++ b/internal/cmd/products/thumbnail.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/config"
@@ -34,6 +35,9 @@ func newThumbnailSetCmd() *cobra.Command {
 			opts := cmdutil.OptionsFrom(c)
 			if !c.Flags().Changed("image") {
 				return cmdutil.MissingFlagError(c, "--image")
+			}
+			if strings.TrimSpace(imagePath) == "" {
+				return cmdutil.UsageErrorf(c, "--image cannot be empty")
 			}
 			productID := args[0]
 			media, err := describeProductMedia([]requestedProductMedia{{Kind: productMediaThumbnail, Path: imagePath}})

--- a/internal/cmd/products/update.go
+++ b/internal/cmd/products/update.go
@@ -146,7 +146,7 @@ func newUpdateCmd() *cobra.Command {
 					var data []byte
 					completedAction := ""
 					if productFieldsChanged {
-						data, err = client.Put(path, params)
+						data, err = runProductUpdateFormData(opts, client, path, params)
 						if err != nil {
 							return err
 						}

--- a/internal/cmd/products/update.go
+++ b/internal/cmd/products/update.go
@@ -23,6 +23,8 @@ func newUpdateCmd() *cobra.Command {
 	var keepFileIDs []string
 	var removeFileIDs []string
 	var replaceFiles bool
+	var coverImage, thumbnail string
+	var previewImages []string
 
 	cmd := &cobra.Command{
 		Use:   "update <product_id>",
@@ -30,6 +32,8 @@ func newUpdateCmd() *cobra.Command {
 		Example: `  gumroad products update <id> --name "New Name"
   gumroad products update <id> --price 15.00 --currency eur
   gumroad products update <id> --tag art --tag digital
+  gumroad products update <id> --cover-image ./cover.jpg
+  gumroad products update <id> --preview-image ./gallery-1.jpg --preview-image ./gallery-2.jpg
   gumroad products update <id> --file ./pack.zip
   gumroad products update <id> --replace-files --keep-file file_123 --file ./new-pack.zip`,
 		Args: cmdutil.ExactArgs(1),
@@ -44,6 +48,7 @@ func newUpdateCmd() *cobra.Command {
 				"taxonomy-id", "tag",
 				"file", "file-name", "file-description",
 				"keep-file", "remove-file", "replace-files",
+				"cover-image", "preview-image", "thumbnail",
 			); err != nil {
 				return err
 			}
@@ -55,6 +60,13 @@ func newUpdateCmd() *cobra.Command {
 				return err
 			}
 			requestedUploads, err := collectRequestedProductUploads(c, files, fileNames, fileDescriptions)
+			if err != nil {
+				return err
+			}
+			if err := validateProductMediaFlagPaths(c, coverImage, previewImages, thumbnail); err != nil {
+				return err
+			}
+			media, err := describeProductMedia(collectProductMedia(coverImage, previewImages, thumbnail))
 			if err != nil {
 				return err
 			}
@@ -107,6 +119,7 @@ func newUpdateCmd() *cobra.Command {
 			}
 
 			path := cmdutil.JoinPath("products", args[0])
+			productFieldsChanged := productUpdateFieldFlagsChanged(c)
 			fileFlagsChanged := flags.Changed("file") ||
 				flags.Changed("file-name") ||
 				flags.Changed("file-description") ||
@@ -114,6 +127,39 @@ func newUpdateCmd() *cobra.Command {
 				flags.Changed("remove-file") ||
 				flags.Changed("replace-files")
 			if !fileFlagsChanged {
+				if len(media) > 0 {
+					if opts.DryRun {
+						requests := productMediaDryRunRequests(args[0], media)
+						if !productFieldsChanged {
+							if opts.UsesJSONOutput() {
+								return renderProductUpdateMediaOnlyDryRunJSON(opts, media, requests)
+							}
+							return renderStandaloneProductMediaDryRun(opts, media, requests)
+						}
+						return renderProductUpdateDryRunWithMedia(opts, path, productFileUpdatePlan{}, nil, buildProductJSONBody(params, nil), media, requests)
+					}
+					token, err := config.Token()
+					if err != nil {
+						return err
+					}
+					client := cmdutil.NewAPIClient(opts, token)
+					var data []byte
+					if productFieldsChanged {
+						data, err = client.Put(path, params)
+						if err != nil {
+							return err
+						}
+					}
+					mediaResults, err := uploadAndAttachProductMedia(opts, client, args[0], media, "product update")
+					if err != nil {
+						return err
+					}
+					data, err = mergeProductMediaResult(data, mediaResults)
+					if err != nil {
+						return err
+					}
+					return cmdutil.PrintMutationSuccess(opts, data, args[0], "Product "+args[0]+" updated.")
+				}
 				if opts.DryRun && opts.UsesJSONOutput() {
 					return renderProductUpdateDryRun(opts, path, productFileUpdatePlan{}, nil, buildProductJSONBody(params, nil))
 				}
@@ -171,7 +217,7 @@ func newUpdateCmd() *cobra.Command {
 
 			if opts.DryRun {
 				payload := buildProductUpdateJSONBody(params, filePlan, placeholderUploadURLs(len(plannedUploads)), fileRefs, richContent, includeRichContent)
-				return renderProductUpdateDryRun(opts, path, filePlan, plannedUploads, payload)
+				return renderProductUpdateDryRunWithMedia(opts, path, filePlan, plannedUploads, payload, media, productMediaDryRunRequests(args[0], media))
 			}
 
 			uploadedURLs, err := uploadBatch(opts, client, productBatchUploadInputs(plannedUploads))
@@ -179,7 +225,19 @@ func newUpdateCmd() *cobra.Command {
 				return err
 			}
 			payload := buildProductUpdateJSONBody(params, filePlan, uploadedURLs, fileRefs, richContent, includeRichContent)
-			return runProductUpdateJSON(opts, client, path, args[0], payload, uploadedURLs)
+			data, err := runProductUpdateJSONData(opts, client, path, payload, uploadedURLs)
+			if err != nil {
+				return err
+			}
+			mediaResults, err := uploadAndAttachProductMedia(opts, client, args[0], media, "product update")
+			if err != nil {
+				return err
+			}
+			data, err = mergeProductMediaResult(data, mediaResults)
+			if err != nil {
+				return err
+			}
+			return cmdutil.PrintMutationSuccess(opts, data, args[0], "Product "+args[0]+" updated.")
 		},
 	}
 
@@ -201,6 +259,23 @@ func newUpdateCmd() *cobra.Command {
 	cmd.Flags().StringArrayVar(&keepFileIDs, "keep-file", nil, "Existing file ID to preserve when using --replace-files (repeatable)")
 	cmd.Flags().StringArrayVar(&removeFileIDs, "remove-file", nil, "Existing file ID to remove (repeatable)")
 	cmd.Flags().BoolVar(&replaceFiles, "replace-files", false, "Replace the current file set instead of preserving existing files by default")
+	cmd.Flags().StringVar(&coverImage, "cover-image", "", "Local JPEG, PNG, or GIF cover image to upload")
+	cmd.Flags().StringArrayVar(&previewImages, "preview-image", nil, "Additional local JPEG, PNG, or GIF preview image to upload as a product cover (repeatable)")
+	cmd.Flags().StringVar(&thumbnail, "thumbnail", "", "Local JPEG, PNG, or GIF thumbnail image to upload")
 
 	return cmd
+}
+
+func productUpdateFieldFlagsChanged(cmd *cobra.Command) bool {
+	for _, flag := range []string{
+		"name", "price", "currency", "description",
+		"custom-permalink", "custom-summary", "custom-receipt",
+		"pay-what-you-want", "suggested-price", "max-purchase-count",
+		"taxonomy-id", "tag",
+	} {
+		if cmd.Flags().Changed(flag) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/cmd/products/update.go
+++ b/internal/cmd/products/update.go
@@ -144,13 +144,15 @@ func newUpdateCmd() *cobra.Command {
 					}
 					client := cmdutil.NewAPIClient(opts, token)
 					var data []byte
+					completedAction := ""
 					if productFieldsChanged {
 						data, err = client.Put(path, params)
 						if err != nil {
 							return err
 						}
+						completedAction = "product update"
 					}
-					mediaResults, err := uploadAndAttachProductMedia(opts, client, args[0], media, "product update")
+					mediaResults, err := uploadAndAttachProductMedia(opts, client, args[0], media, completedAction)
 					if err != nil {
 						return err
 					}

--- a/internal/cmd/products/update.go
+++ b/internal/cmd/products/update.go
@@ -156,6 +156,12 @@ func newUpdateCmd() *cobra.Command {
 					if err != nil {
 						return err
 					}
+					if !productFieldsChanged {
+						data, err = productMediaOnlyUpdateResult(args[0])
+						if err != nil {
+							return err
+						}
+					}
 					data, err = mergeProductMediaResult(data, mediaResults)
 					if err != nil {
 						return err

--- a/internal/cmd/products/update.go
+++ b/internal/cmd/products/update.go
@@ -241,9 +241,11 @@ func newUpdateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			data, err = mergeProductMediaResult(data, mediaResults)
-			if err != nil {
-				return err
+			if len(mediaResults) > 0 {
+				data, err = mergeProductMediaResult(data, mediaResults)
+				if err != nil {
+					return err
+				}
 			}
 			return cmdutil.PrintMutationSuccess(opts, data, args[0], "Product "+args[0]+" updated.")
 		},

--- a/internal/cmd/products/update_files_test.go
+++ b/internal/cmd/products/update_files_test.go
@@ -35,9 +35,10 @@ type productUpdateFileServers struct {
 	putStatus            int
 	rejectUnknownFileIDs bool
 
-	putForm     url.Values
-	putJSON     map[string]any
-	presignBody map[string]string
+	putForm         url.Values
+	putJSON         map[string]any
+	putJSONResponse json.RawMessage
+	presignBody     map[string]string
 }
 
 func newProductUpdateFileServers(t *testing.T) *productUpdateFileServers {
@@ -103,6 +104,10 @@ func (s *productUpdateFileServers) dispatch(t *testing.T) http.HandlerFunc {
 				}
 				if s.putStatus != 0 {
 					http.Error(w, "update failed", s.putStatus)
+					return
+				}
+				if len(s.putJSONResponse) > 0 {
+					testutil.RawJSON(t, w, string(s.putJSONResponse))
 					return
 				}
 				testutil.JSON(t, w, map[string]any{})
@@ -375,6 +380,24 @@ func TestUpdate_FilePreservesExistingByDefault(t *testing.T) {
 	}
 	if ids := richContentFileEmbedIDsFromBody(t, srv.putJSON); !reflect.DeepEqual(ids, []string{"file_a", "file_b", newFileID}) {
 		t.Fatalf("rich_content fileEmbed ids = %#v, want preserved files and new upload", ids)
+	}
+}
+
+func TestUpdate_WithFilesJSONPreservesRawProductResponseWithoutMedia(t *testing.T) {
+	srv := newProductUpdateFileServers(t)
+	srv.putJSONResponse = json.RawMessage(`{"success":true,"product":{"id":"prod1","rank":1.0}}`)
+	testutil.Setup(t, srv.dispatch(t))
+
+	path := writeProductUploadFixture(t, "fresh bytes")
+	cmd := testutil.Command(newUpdateCmd(), testutil.Yes(true), testutil.JSONOutput())
+	cmd.SetArgs([]string{"prod1", "--file", path})
+
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if !strings.Contains(out, `"rank": 1.0`) {
+		t.Fatalf("expected raw numeric formatting to be preserved, got:\n%s", out)
+	}
+	if strings.Contains(out, `"media"`) {
+		t.Fatalf("file-only update should not add media output, got:\n%s", out)
 	}
 }
 

--- a/internal/cmd/products/update_files_test.go
+++ b/internal/cmd/products/update_files_test.go
@@ -1500,13 +1500,13 @@ func TestProductFileRemovalMessageIncludesNames(t *testing.T) {
 	}
 }
 
-func TestRenderProductUpdateDryRunJSON_Direct(t *testing.T) {
+func TestRenderProductUpdateDryRun_JSONDirect(t *testing.T) {
 	var buf bytes.Buffer
 	opts := testutil.TestOptions(testutil.Stdout(&buf), testutil.JSONOutput())
 	body := map[string]any{"files": []map[string]any{}}
 
-	if err := renderProductUpdateDryRunJSON(opts, "/products/prod1", productFileUpdatePlan{}, nil, body); err != nil {
-		t.Fatalf("renderProductUpdateDryRunJSON: %v", err)
+	if err := renderProductUpdateDryRun(opts, "/products/prod1", productFileUpdatePlan{}, nil, body); err != nil {
+		t.Fatalf("renderProductUpdateDryRun: %v", err)
 	}
 	var payload dryRunUpdateBody
 	if err := json.Unmarshal(buf.Bytes(), &payload); err != nil {

--- a/skills/embed_test.go
+++ b/skills/embed_test.go
@@ -94,6 +94,8 @@ func TestSkillMarkdown_ContainsProductMediaAndBulkGuidance(t *testing.T) {
 		"gumroad products covers add <id> --image ./cover.jpg --json --no-input",
 		"gumroad products thumbnail set <id> --image ./thumb.jpg --json --no-input",
 		"WebP is not supported by the API",
+		"`products update` with media flags → mutation envelope with `.result.media[]`",
+		"`products covers add --url` → `.result.covers[]`, `.result.main_cover_id`",
 		"Check existing products and permalinks first",
 		"Continue past per-product errors",
 	} {

--- a/skills/embed_test.go
+++ b/skills/embed_test.go
@@ -81,6 +81,28 @@ func TestSkillMarkdown_ContainsVariantFileAttachExamples(t *testing.T) {
 	}
 }
 
+func TestSkillMarkdown_ContainsProductMediaAndBulkGuidance(t *testing.T) {
+	data, err := SkillMarkdown()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	content := string(data)
+	for _, example := range []string{
+		"gumroad products create --name \"Art Pack\" --price 10.00 --cover-image ./cover.jpg --thumbnail ./thumb.jpg --json --no-input",
+		"gumroad products update <id> --preview-image ./gallery-1.jpg --preview-image ./gallery-2.jpg --json --no-input",
+		"gumroad products covers add <id> --image ./cover.jpg --json --no-input",
+		"gumroad products thumbnail set <id> --image ./thumb.jpg --json --no-input",
+		"WebP is not supported by the API",
+		"Check existing products and permalinks first",
+		"Continue past per-product errors",
+	} {
+		if !strings.Contains(content, example) {
+			t.Errorf("expected skill to mention product media or bulk guidance %q", example)
+		}
+	}
+}
+
 func TestSkillMarkdown_ContainsAdminRolloutCommands(t *testing.T) {
 	data, err := SkillMarkdown()
 	if err != nil {

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -59,8 +59,9 @@ Responses are wrapped in `{"success": true, ...}` with resource-specific keys:
 - `files upload` / `files complete` → `.file_url`
 - `products create` with media flags → `.product` plus `.media[]`
 - `products update` with media flags → mutation envelope with `.result.media[]`
-- `products covers add --image`, `products thumbnail set` → `.result.media[].response`
+- `products covers add --image` → `.result.covers[]`, `.result.main_cover_id`, plus `.result.media[]`
 - `products covers add --url` → `.result.covers[]`, `.result.main_cover_id`
+- `products thumbnail set` → `.result.media[].response`
 - `webhooks list` → `.resource_subscriptions[]`
 - `admin users info` → `.user`
 - `admin users affiliates` → `.affiliates[]`

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -8,6 +8,7 @@ description: >
   Also trigger on "check my Gumroad", "look up a sale", "verify a license",
   "list my products", "how much have I made", "who bought", "recent sales",
   "refund a sale", "create a product", "upload a file", "attach a file to a product",
+  "add a cover image", "set a product thumbnail", "upload product media",
   "attach a file to a variant", "finish a failed upload", "abort an upload", "manage webhooks",
   "check my earnings", "see my revenue", "who subscribed", "manage my store",
   "discount code", "coupon", "shipping status", "payout schedule", or any
@@ -34,6 +35,7 @@ Always follow these rules:
 - Use `--page-delay 200ms` with `--all` to avoid rate limits on large datasets.
 - Prices are in whole currency units (e.g. `--price 10.00` for $10), not cents. The CLI converts internally. Use `--currency eur` to change currency.
 - Products are created as drafts — use `gumroad products publish <id>` to make them live.
+- Product cover and thumbnail uploads support JPEG, PNG, and GIF. WebP is not supported by the API and the CLI rejects it before upload.
 - If a command fails with a seller auth error, tell the user to run `gumroad auth login` interactively — agents cannot do this step.
 - For admin commands in agents/CI, pass `--non-interactive` and set `GUMROAD_ADMIN_TOKEN`; interactive shells can store an admin token with `gumroad auth login`.
 
@@ -55,6 +57,8 @@ Responses are wrapped in `{"success": true, ...}` with resource-specific keys:
 - `variant-categories list` → `.variant_categories[]`
 - `variants list` → `.variants[]`
 - `files upload` / `files complete` → `.file_url`
+- `products create/update` with media flags → `.product`/mutation result plus `.media[]`
+- `products covers add`, `products thumbnail set` → `.result.media[].response`
 - `webhooks list` → `.resource_subscriptions[]`
 - `admin users info` → `.user`
 - `admin users affiliates` → `.affiliates[]`
@@ -75,6 +79,16 @@ Admin pagination models differ by command:
 - Page-paginated: `admin products list` returns `.pagination.next` as an integer page number. Pass it back with `--page`; use `--per-page` for page size.
 - Capped, not continuable: `admin users related` returns at most 50 related users per signal. Always inspect `.truncated`; when any signal is `true`, the result hit the cap and there is no cursor/page to fetch the rest.
 - Capped, not continuable: `admin purchases search` returns `.has_more` when the server capped results. `--limit` is server-capped at 25 and there is no continuation token.
+
+## Bulk operations
+
+When creating or updating many products:
+
+- Check existing products and permalinks first, then skip duplicates on re-runs.
+- Derive custom permalinks deterministically from source data so retries are idempotent.
+- Use `--dry-run --json` to preview generated requests, and ask the user to confirm before mutating more than 5 products.
+- Continue past per-product errors, collect each failure with its product/permalink, and summarize successes and failures at the end.
+- For product media failures after creation, retry with the command printed in the error, such as `gumroad products covers add <id> --image ./cover.jpg`.
 
 ## Commands
 
@@ -150,6 +164,7 @@ gumroad products view <id> --json --no-input
 # Create a product (created as draft)
 gumroad products create --name "Art Pack" --price 10.00 --json --no-input
 gumroad products create --name "Art Pack" --price 10.00 --file ./pack.zip --file-name "Art Pack.zip" --json --no-input
+gumroad products create --name "Art Pack" --price 10.00 --cover-image ./cover.jpg --thumbnail ./thumb.jpg --json --no-input
 gumroad products create --name "Newsletter" --type membership --subscription-duration monthly --json --no-input
 gumroad products create --name "E-Book" --type ebook --price 5 --tag art --tag digital --json --no-input
 
@@ -157,8 +172,19 @@ gumroad products create --name "E-Book" --type ebook --price 5 --tag art --tag d
 gumroad products update <id> --name "New Name" --json --no-input
 gumroad products update <id> --price 15.00 --currency eur --json --no-input
 gumroad products update <id> --file ./pack.zip --json --no-input
+gumroad products update <id> --cover-image ./cover.jpg --json --no-input
+gumroad products update <id> --preview-image ./gallery-1.jpg --preview-image ./gallery-2.jpg --json --no-input
+gumroad products update <id> --thumbnail ./thumb.jpg --json --no-input
 gumroad products update <id> --replace-files --keep-file file_123 --file ./new-pack.zip --yes --json --no-input
 gumroad products update <id> --remove-file file_456 --yes --json --no-input
+
+# Product covers and thumbnail
+gumroad products covers add <id> --image ./cover.jpg --json --no-input
+gumroad products covers add <id> --url https://www.youtube.com/watch?v=qKebcV1jv3A --json --no-input
+gumroad products covers reorder <id> <cover_id> <cover_id> --json --no-input
+gumroad products covers remove <id> <cover_id> --yes --json --no-input
+gumroad products thumbnail set <id> --image ./thumb.jpg --json --no-input
+gumroad products thumbnail remove <id> --yes --json --no-input
 
 # Publish / unpublish
 gumroad products publish <id> --json --no-input
@@ -171,11 +197,13 @@ gumroad products delete <id> --yes --json --no-input
 gumroad products skus <id> --json --no-input
 ```
 
-**Create flags:** `--name` (required), `--price`, `--type` (digital|course|ebook|membership|bundle|coffee|call|commission), `--currency`, `--pay-what-you-want`, `--suggested-price`, `--description`, `--custom-summary`, `--custom-permalink`, `--custom-receipt`, `--max-purchase-count`, `--taxonomy-id`, `--tag` (repeatable), `--file` (repeatable), `--file-name` (repeatable, aligned to `--file`), `--file-description` (repeatable, aligned to `--file`).
+**Create flags:** `--name` (required), `--price`, `--type` (digital|course|ebook|membership|bundle|coffee|call|commission), `--currency`, `--pay-what-you-want`, `--suggested-price`, `--description`, `--custom-summary`, `--custom-permalink`, `--custom-receipt`, `--max-purchase-count`, `--taxonomy-id`, `--tag` (repeatable), `--file` (repeatable), `--file-name` (repeatable, aligned to `--file`), `--file-description` (repeatable, aligned to `--file`), `--cover-image`, `--preview-image` (repeatable), `--thumbnail`.
 
-**Update flags:** `--file` (repeatable), `--file-name`, `--file-description`, `--remove-file` (repeatable), `--replace-files`, `--keep-file` (repeatable with `--replace-files`). Updates preserve existing files by default unless `--replace-files` is set.
+**Update flags:** `--name`, `--price`, `--currency`, `--description`, `--custom-summary`, `--custom-permalink`, `--custom-receipt`, `--max-purchase-count`, `--taxonomy-id`, `--tag` (repeatable), `--file` (repeatable), `--file-name`, `--file-description`, `--remove-file` (repeatable), `--replace-files`, `--keep-file` (repeatable with `--replace-files`), `--cover-image`, `--preview-image` (repeatable), `--thumbnail`. Updates preserve existing files by default unless `--replace-files` is set.
 
 Use `products update --file` for shared product Content. For products with per-variant Content, use `variants update ... --file` for the specific variant you want to change.
+
+Use `--cover-image` for the primary cover, repeat `--preview-image` for additional gallery/preview images, and `--thumbnail` for the card/library thumbnail. These media flags run the required two-step API flow: direct upload first, then attach by signed blob ID.
 
 ### files — Upload and recover file attachments
 

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -57,8 +57,10 @@ Responses are wrapped in `{"success": true, ...}` with resource-specific keys:
 - `variant-categories list` → `.variant_categories[]`
 - `variants list` → `.variants[]`
 - `files upload` / `files complete` → `.file_url`
-- `products create/update` with media flags → `.product`/mutation result plus `.media[]`
-- `products covers add`, `products thumbnail set` → `.result.media[].response`
+- `products create` with media flags → `.product` plus `.media[]`
+- `products update` with media flags → mutation envelope with `.result.media[]`
+- `products covers add --image`, `products thumbnail set` → `.result.media[].response`
+- `products covers add --url` → `.result.covers[]`, `.result.main_cover_id`
 - `webhooks list` → `.resource_subscriptions[]`
 - `admin users info` → `.user`
 - `admin users affiliates` → `.affiliates[]`


### PR DESCRIPTION
Ref #95

## What
- Adds CLI support for uploading and attaching product cover images, preview images, and thumbnails through the product workflow.
- Supports both shortcut flags on `products create` / `products update` and dedicated `products covers` and `products thumbnail` commands for direct control.
- Rejects unsupported WebP media client-side and keeps the two-step upload-and-attach flow explicit.
- Updates the public CLI docs and embedded skill guidance so the new media workflow is discoverable and consistent for users and agents.

## Why
- Product media needed a CLI path that matches the server-side API flow instead of relying on browser-only upload behavior.
- The new commands make the media workflow easier to repeat, while still preserving a lower-level path for users who want to manage covers and thumbnails directly.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new product media upload/attach flows (direct uploads + follow-up API calls) and new CLI subcommands, which could impact product create/update behavior and error handling. Risk is mitigated by extensive tests and client-side validation (type/size/WebP rejection).
> 
> **Overview**
> Adds **product media support** to the CLI: `products create`/`products update` gain `--cover-image`, repeatable `--preview-image`, and `--thumbnail` flags that perform the two-step *direct upload → attach* flow and include media activity in `--dry-run` output.
> 
> Introduces dedicated resource commands `products covers` (add via `--image` direct upload or `--url`, remove, reorder) and `products thumbnail` (set/remove), plus richer error wrapping with retry commands when media attachment partially succeeds.
> 
> Updates JSON/dry-run payload shapes to include media uploads and `follow_up_requests`, preserves raw JSON response formatting when appending media results, broadens API error parsing to accept `error` fields, and refreshes README + embedded skill docs/tests to document the new workflow and WebP rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbd25b5ff06a695c5797e4545713b775bb8f07c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->