### PR TITLE
Add the TOS suspension admin command

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ gumroad admin users compliance --user-id 2245593582708
 gumroad admin users radar --user-id 2245593582708 --limit 50
 gumroad admin users purchases --user-id 2245593582708 --status successful --limit 50
 gumroad admin users related --email seller@example.com --signal ip --signal payment_address
+gumroad admin users mark-compliant --user-id 2245593582708 --expected-email seller@example.com --note "Cleared after review"
+gumroad admin users suspend --user-id 2245593582708 --expected-email seller@example.com --note "Chargeback risk confirmed"
+gumroad admin users suspend-for-tos-violation --user-id 2245593582708 --expected-email seller@example.com --note "DMCA takedown notice confirmed"
 gumroad admin purchases lookup --stripe-fingerprint fp_abc --limit 25
 gumroad admin users watch --user-id 2245593582708 --expected-email seller@example.com --revenue-threshold 200 --note "Review next buyers"
 gumroad admin users update-watch --user-id 2245593582708 --expected-email seller@example.com --revenue-threshold 500

--- a/internal/cmd/admin/admin.go
+++ b/internal/cmd/admin/admin.go
@@ -28,6 +28,7 @@ func NewAdminCmd() *cobra.Command {
   gumroad admin users purchases --user-id <user-id> --status successful
   gumroad admin users related --email <email> --signal ip
   gumroad admin users suspension --email <email>
+  gumroad admin users suspend-for-tos-violation --user-id <user-id> --expected-email <email>
   gumroad admin users watch --user-id <user-id> --expected-email <email> --revenue-threshold 200
   gumroad admin payouts list --email <email>
   gumroad admin payouts pause --user-id <user-id> --expected-email <email>

--- a/internal/cmd/admin/users/suspend_for_tos_violation.go
+++ b/internal/cmd/admin/users/suspend_for_tos_violation.go
@@ -1,0 +1,83 @@
+package users
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/antiwork/gumroad-cli/internal/adminapi"
+	"github.com/antiwork/gumroad-cli/internal/admincmd"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+const suspendForTOSViolationConfirmationMessage = "Suspend user_id %s for a policy violation? This freezes payouts and disables the seller's products, but does not block them from buying as a customer."
+
+func newSuspendForTOSViolationCmd() *cobra.Command {
+	var (
+		targetFlags userMutationFlags
+		note        string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "suspend-for-tos-violation",
+		Short: "Suspend a user for a policy violation as an admin",
+		Long: `Suspend a user for a policy violation through the internal admin API.
+
+Identify the user with --user-id. Pass --expected-email as an optional guard
+against acting on an account whose email has changed.
+
+This is distinct from fraud suspension: payouts and seller products are stopped,
+but the user is not blocked from buying as a customer.`,
+		Example: `  gumroad admin users suspend-for-tos-violation --user-id 2245593582708
+  gumroad admin users suspend-for-tos-violation --user-id 2245593582708 --expected-email seller@example.com
+  gumroad admin users suspend-for-tos-violation --user-id 2245593582708 --note "DMCA takedown notice confirmed"`,
+		Args: cmdutil.ExactArgs(0),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+
+			target, err := resolveUserMutationTarget(c, targetFlags)
+			if err != nil {
+				return err
+			}
+
+			identifier := target.Identifier()
+			ok, err := cmdutil.ConfirmAction(opts, fmt.Sprintf(suspendForTOSViolationConfirmationMessage, identifier))
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return cmdutil.PrintCancelledAction(opts, "suspend user_id "+identifier+" for a policy violation", identifier)
+			}
+
+			req := suspendRequest{
+				UserID:         target.UserID,
+				ExpectedEmail:  target.ExpectedEmail,
+				SuspensionNote: note,
+			}
+			path := "users/suspend_for_tos_violation"
+
+			if opts.DryRun {
+				return cmdutil.PrintDryRunRequest(opts, http.MethodPost, adminapi.AdminPath(path), suspendDryRunParams(req))
+			}
+
+			data, err := admincmd.FetchPostJSON(opts, "Suspending user for policy violation...", path, req)
+			if err != nil {
+				return err
+			}
+			if opts.UsesJSONOutput() {
+				return cmdutil.PrintJSONResponse(opts, data)
+			}
+
+			decoded, err := cmdutil.DecodeJSON[riskActionResponse](data)
+			if err != nil {
+				return err
+			}
+			return renderRiskAction(opts, "User ID", fallback(decoded.UserID, identifier), decoded)
+		},
+	}
+
+	addUserMutationFlags(cmd, &targetFlags)
+	cmd.Flags().StringVar(&note, "note", "", "Optional suspension note")
+
+	return cmd
+}

--- a/internal/cmd/admin/users/suspend_for_tos_violation_test.go
+++ b/internal/cmd/admin/users/suspend_for_tos_violation_test.go
@@ -1,0 +1,164 @@
+package users
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestSuspendForTOSViolationRequiresUserID(t *testing.T) {
+	cmd := newSuspendForTOSViolationCmd()
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected missing identifier error")
+	}
+	if !strings.Contains(err.Error(), "missing required flag: --user-id") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSuspendForTOSViolationRequiresConfirmation(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("must not reach API without confirmation")
+	})
+
+	cmd := testutil.Command(newSuspendForTOSViolationCmd(), testutil.NoInput(true))
+	cmd.SetArgs([]string{"--user-id", "2245593582708"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error without --yes and --no-input")
+	}
+	if !strings.Contains(err.Error(), "--yes") {
+		t.Errorf("error should mention --yes: %v", err)
+	}
+}
+
+func TestSuspendForTOSViolationConfirmationMessageDescribesPolicySuspension(t *testing.T) {
+	got := fmt.Sprintf(suspendForTOSViolationConfirmationMessage, "2245593582708")
+	for _, want := range []string{
+		"Suspend user_id 2245593582708 for a policy violation?",
+		"does not block them from buying as a customer",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("confirmation message missing %q: %q", want, got)
+		}
+	}
+	if strings.Contains(got, "fraud") {
+		t.Fatalf("confirmation message must not call this fraud: %q", got)
+	}
+}
+
+func TestSuspendForTOSViolationSendsUserIDExpectedEmailAndSuspensionNote(t *testing.T) {
+	var gotMethod, gotPath, gotQuery, gotAuth string
+	var body suspendRequest
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		gotAuth = r.Header.Get("Authorization")
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if err := json.Unmarshal(raw, &body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		testutil.JSON(t, w, map[string]any{
+			"success": true,
+			"user_id": "2245593582708",
+			"status":  "suspended_for_tos_violation",
+			"message": "User suspended for a policy violation",
+		})
+	})
+
+	cmd := testutil.Command(newSuspendForTOSViolationCmd(), testutil.Yes(true), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--expected-email", "seller@example.com", "--note", "DMCA takedown notice confirmed"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != "POST" || gotPath != "/internal/admin/users/suspend_for_tos_violation" {
+		t.Fatalf("got %s %s, want POST /internal/admin/users/suspend_for_tos_violation", gotMethod, gotPath)
+	}
+	if gotQuery != "" {
+		t.Fatalf("body fields must not appear in query string, got %q", gotQuery)
+	}
+	if gotAuth != "Bearer admin-token" {
+		t.Fatalf("got auth %q, want Bearer admin-token", gotAuth)
+	}
+	if body.UserID != "2245593582708" || body.ExpectedEmail != "seller@example.com" || body.SuspensionNote != "DMCA takedown notice confirmed" {
+		t.Fatalf("unexpected request body: %#v", body)
+	}
+	for _, want := range []string{"User suspended for a policy violation", "User ID: 2245593582708", "Status: suspended_for_tos_violation"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestSuspendForTOSViolationDryRunDoesNotContactEndpoint(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("dry-run must not POST to the suspend_for_tos_violation endpoint")
+	})
+
+	cmd := testutil.Command(newSuspendForTOSViolationCmd(), testutil.DryRun(true), testutil.NoInput(true))
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--expected-email", "seller@example.com", "--note", "DMCA takedown notice confirmed"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "POST") || !strings.Contains(out, "/internal/admin/users/suspend_for_tos_violation") {
+		t.Errorf("expected dry-run preview to mention POST and the suspend_for_tos_violation path, got: %q", out)
+	}
+	if !strings.Contains(out, "user_id: 2245593582708") || !strings.Contains(out, "expected_email: seller@example.com") || !strings.Contains(out, "suspension_note: DMCA takedown notice confirmed") {
+		t.Errorf("expected dry-run preview to include user_id, expected_email, and suspension_note, got: %q", out)
+	}
+}
+
+func TestSuspendForTOSViolationJSONPreservesResponse(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"success": true,
+			"user_id": "2245593582708",
+			"status":  "already_suspended",
+			"message": "User is already suspended for a policy violation",
+		})
+	})
+
+	cmd := testutil.Command(newSuspendForTOSViolationCmd(), testutil.Yes(true), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--user-id", "2245593582708"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp riskActionResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if !resp.Success || resp.UserID != "2245593582708" || resp.Status != "already_suspended" || resp.Message != "User is already suspended for a policy violation" {
+		t.Fatalf("unexpected JSON payload: %s", out)
+	}
+}
+
+func TestSuspendForTOSViolationPlainOutput(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"success": true,
+			"user_id": "2245593582708",
+			"status":  "suspended_for_tos_violation",
+			"message": "User suspended for a policy violation",
+		})
+	})
+
+	cmd := testutil.Command(newSuspendForTOSViolationCmd(), testutil.Yes(true), testutil.PlainOutput())
+	cmd.SetArgs([]string{"--user-id", "2245593582708"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	want := "true\tUser suspended for a policy violation\t2245593582708\tsuspended_for_tos_violation"
+	if strings.TrimSpace(out) != want {
+		t.Fatalf("unexpected plain output: %q", out)
+	}
+}

--- a/internal/cmd/admin/users/users.go
+++ b/internal/cmd/admin/users/users.go
@@ -29,6 +29,7 @@ func NewUsersCmd() *cobra.Command {
   gumroad admin users update-watch --user-id 2245593582708 --revenue-threshold 500
   gumroad admin users unwatch --user-id 2245593582708
   gumroad admin users suspend --user-id 2245593582708 --note "Chargeback risk confirmed"
+  gumroad admin users suspend-for-tos-violation --user-id 2245593582708 --note "DMCA takedown notice confirmed"
   gumroad admin users reset-password --user-id 2245593582708
   gumroad admin users update-email --user-id 2245593582708 --new-email new@example.com
   gumroad admin users two-factor disable --user-id 2245593582708`,
@@ -47,6 +48,7 @@ func NewUsersCmd() *cobra.Command {
 	cmd.AddCommand(newUpdateWatchCmd())
 	cmd.AddCommand(newUnwatchCmd())
 	cmd.AddCommand(newSuspendCmd())
+	cmd.AddCommand(newSuspendForTOSViolationCmd())
 	cmd.AddCommand(newResetPasswordCmd())
 	cmd.AddCommand(newUpdateEmailCmd())
 	cmd.AddCommand(newTwoFactorCmd())

--- a/internal/cmd/admin/users/users_test.go
+++ b/internal/cmd/admin/users/users_test.go
@@ -190,6 +190,7 @@ func TestNewUsersCmdWiresSubcommands(t *testing.T) {
 		"update-watch",
 		"unwatch",
 		"suspend",
+		"suspend-for-tos-violation",
 		"reset-password",
 		"update-email",
 		"two-factor",

--- a/skills/embed_test.go
+++ b/skills/embed_test.go
@@ -120,6 +120,8 @@ func TestSkillMarkdown_ContainsAdminRolloutCommands(t *testing.T) {
 		"gumroad admin users compliance --user-id",
 		"gumroad admin users purchases --user-id",
 		"gumroad admin users related --email",
+		"gumroad admin users suspend-for-tos-violation --user-id",
+		"`admin users mark-compliant`, `admin users suspend`, `admin users suspend-for-tos-violation` → `.status`, `.message`, `.user_id`",
 		"gumroad admin purchases view <purchase-id> --with-clusters",
 		"gumroad admin purchases search --email",
 		"gumroad admin purchases lookup --stripe-fingerprint",

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -71,6 +71,7 @@ Responses are wrapped in `{"success": true, ...}` with resource-specific keys:
 - `admin users radar` → `.radar_stats`, `.recent_efws[]`
 - `admin users purchases` → `.purchases[]`
 - `admin users related` → `.related_users[]`, `.truncated`, `.per_signal_limit`
+- `admin users mark-compliant`, `admin users suspend`, `admin users suspend-for-tos-violation` → `.status`, `.message`, `.user_id`
 - `admin purchases view` → `.purchase`
 - `admin purchases search` → `.purchases[]`, `.has_more`, `.limit`
 - `admin purchases lookup` → `.purchases[]`
@@ -140,6 +141,11 @@ gumroad admin users purchases --user-id 2245593582708 --status successful --has-
 # Find related accounts by risk signals
 gumroad admin users related --email seller@example.com --signal ip --signal payment_address --json --non-interactive --no-input
 gumroad admin users related --email seller@example.com --json --jq '{related_users, truncated, per_signal_limit}' --non-interactive --no-input
+
+# Mutate user compliance and suspension state
+gumroad admin users mark-compliant --user-id 2245593582708 --expected-email seller@example.com --note "Cleared after review" --yes --json --non-interactive --no-input
+gumroad admin users suspend --user-id 2245593582708 --expected-email seller@example.com --note "Chargeback risk confirmed" --yes --json --non-interactive --no-input
+gumroad admin users suspend-for-tos-violation --user-id 2245593582708 --expected-email seller@example.com --note "DMCA takedown notice confirmed" --yes --json --non-interactive --no-input
 
 # Inspect purchase and product fraud context
 gumroad admin purchases view <purchase-id> --with-clusters --json --non-interactive --no-input


### PR DESCRIPTION
Ref antiwork/gumroad/issues/5153

## What

Adds `gumroad admin users suspend-for-tos-violation` so admins can suspend a user for a policy violation through the CLI instead of falling back to the web UI.

## Why

This matches the merged Gumroad API contract for TOS suspension and keeps the CLI aligned with the server-side behavior. It gives admins the correct suspension path for policy violations without using the fraud flow or incorrect messaging.

---

This PR was implemented with AI assistance using gpt-5.5 xhigh.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a mutating admin action that changes seller suspension state; behavior is gated by confirmation and mirrors existing suspend flows, but wrong use has real account impact.
> 
> **Overview**
> Adds **`gumroad admin users suspend-for-tos-violation`**, a new admin CLI path for **policy/TOS suspension** (distinct from fraud **`suspend`**). It POSTs to `users/suspend_for_tos_violation` with `--user-id`, optional `--expected-email`, and `--note`, uses the same confirmation/dry-run/JSON/plain output patterns as other user risk mutations, and documents that payouts and seller products are stopped while the user can still buy as a customer.
> 
> Wiring and docs: the command is registered under `admin users`, covered by focused tests (validation, confirmation copy, request body, dry-run, output modes), and examples are added in **README**, admin help, and the **gumroad** skill (including response shape alongside `mark-compliant` and `suspend`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a53969ae7d9e44f9800001a4470b53349fb88d25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->