### PR TITLE
Add the product policy-violation flag admin command

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ gumroad admin users related --email seller@example.com --signal ip --signal paym
 gumroad admin users mark-compliant --user-id 2245593582708 --expected-email seller@example.com --note "Cleared after review"
 gumroad admin users suspend --user-id 2245593582708 --expected-email seller@example.com --note "Chargeback risk confirmed"
 gumroad admin users suspend-for-tos-violation --user-id 2245593582708 --expected-email seller@example.com --note "DMCA takedown notice confirmed"
+gumroad admin products flag-for-tos-violation abc123 --user-id 2245593582708 --expected-email seller@example.com
 gumroad admin purchases lookup --stripe-fingerprint fp_abc --limit 25
 gumroad admin users watch --user-id 2245593582708 --expected-email seller@example.com --revenue-threshold 200 --note "Review next buyers"
 gumroad admin users update-watch --user-id 2245593582708 --expected-email seller@example.com --revenue-threshold 500

--- a/internal/cmd/admin/admin.go
+++ b/internal/cmd/admin/admin.go
@@ -33,7 +33,8 @@ func NewAdminCmd() *cobra.Command {
   gumroad admin payouts list --email <email>
   gumroad admin payouts pause --user-id <user-id> --expected-email <email>
   gumroad admin products list --email <email>
-  gumroad admin products view <product-id>`,
+  gumroad admin products view <product-id>
+  gumroad admin products flag-for-tos-violation <product-id> --user-id <user-id>`,
 	}
 
 	cmd.AddCommand(adminpurchases.NewPurchasesCmd())

--- a/internal/cmd/admin/products/flag_for_tos_violation.go
+++ b/internal/cmd/admin/products/flag_for_tos_violation.go
@@ -1,0 +1,138 @@
+package products
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/antiwork/gumroad-cli/internal/adminapi"
+	"github.com/antiwork/gumroad-cli/internal/admincmd"
+	"github.com/antiwork/gumroad-cli/internal/cmd/admin/users/usertarget"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+const flagForTOSViolationConfirmationMessage = "Flag product %s for a policy violation on user_id %s? This notifies the seller and leaves the rest of the account online."
+
+type flagForTOSViolationRequest struct {
+	UserID        string `json:"user_id"`
+	ProductID     string `json:"product_id"`
+	ExpectedEmail string `json:"expected_email,omitempty"`
+}
+
+type flagForTOSViolationResponse struct {
+	Success   bool   `json:"success"`
+	UserID    string `json:"user_id"`
+	ProductID string `json:"product_id"`
+	Status    string `json:"status"`
+	Message   string `json:"message"`
+}
+
+func newFlagForTOSViolationCmd() *cobra.Command {
+	var targetFlags usertarget.MutationFlags
+
+	cmd := &cobra.Command{
+		Use:   "flag-for-tos-violation <product-id>",
+		Short: "Flag a product for a policy violation as an admin",
+		Long: `Flag a seller for a policy violation with a specific live product as context.
+
+Identify the seller with --user-id. Pass --expected-email as an optional guard
+against acting on an account whose email has changed.
+
+This is a product-level action: the seller is notified and must resolve the
+policy issue, but the account is not suspended and other products stay online.
+The internal API records a standardized product-context comment for this action;
+this command does not send a free-form note.`,
+		Example: `  gumroad admin products flag-for-tos-violation abc123 --user-id 2245593582708
+  gumroad admin products flag-for-tos-violation abc123 --user-id 2245593582708 --expected-email seller@example.com
+  gumroad admin products flag-for-tos-violation abc123 --user-id 2245593582708 --yes`,
+		Args: cmdutil.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			productID := args[0]
+
+			target, err := usertarget.ResolveMutationTarget(c, targetFlags)
+			if err != nil {
+				return err
+			}
+
+			ok, err := cmdutil.ConfirmAction(opts, fmt.Sprintf(flagForTOSViolationConfirmationMessage, productID, target.UserID))
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return cmdutil.PrintCancelledAction(opts, "flag product "+productID+" for a policy violation on user_id "+target.UserID, productID)
+			}
+
+			req := flagForTOSViolationRequest{
+				UserID:        target.UserID,
+				ProductID:     productID,
+				ExpectedEmail: target.ExpectedEmail,
+			}
+			path := "users/flag_for_tos_violation"
+
+			if opts.DryRun {
+				return cmdutil.PrintDryRunRequest(opts, http.MethodPost, adminapi.AdminPath(path), flagForTOSViolationDryRunParams(req))
+			}
+
+			data, err := admincmd.FetchPostJSON(opts, "Flagging product for policy violation...", path, req)
+			if err != nil {
+				return err
+			}
+			if opts.UsesJSONOutput() {
+				return cmdutil.PrintJSONResponse(opts, data)
+			}
+
+			decoded, err := cmdutil.DecodeJSON[flagForTOSViolationResponse](data)
+			if err != nil {
+				return err
+			}
+			userID := usertarget.Fallback(decoded.UserID, target.UserID)
+			return renderFlagForTOSViolation(opts, userID, usertarget.Fallback(decoded.ProductID, productID), decoded)
+		},
+	}
+
+	usertarget.AddMutationFlags(cmd, &targetFlags)
+
+	return cmd
+}
+
+func flagForTOSViolationDryRunParams(req flagForTOSViolationRequest) url.Values {
+	params := url.Values{}
+	params.Set("user_id", req.UserID)
+	params.Set("product_id", req.ProductID)
+	if req.ExpectedEmail != "" {
+		params.Set("expected_email", req.ExpectedEmail)
+	}
+	return params
+}
+
+func renderFlagForTOSViolation(opts cmdutil.Options, userID, productID string, resp flagForTOSViolationResponse) error {
+	message := usertarget.Fallback(resp.Message, resp.Status)
+
+	if opts.PlainOutput {
+		return output.PrintPlain(opts.Out(), [][]string{
+			{"true", message, userID, productID, resp.Status},
+		})
+	}
+
+	if opts.Quiet {
+		return nil
+	}
+
+	style := opts.Style()
+	if err := output.Writeln(opts.Out(), style.Green(message)); err != nil {
+		return err
+	}
+	if err := cmdutil.WriteIdentifierLine(opts.Out(), "User ID", message, userID); err != nil {
+		return err
+	}
+	if err := cmdutil.WriteIdentifierLine(opts.Out(), "Product ID", message, productID); err != nil {
+		return err
+	}
+	if resp.Status != "" {
+		return output.Writef(opts.Out(), "Status: %s\n", resp.Status)
+	}
+	return nil
+}

--- a/internal/cmd/admin/products/flag_for_tos_violation_test.go
+++ b/internal/cmd/admin/products/flag_for_tos_violation_test.go
@@ -1,0 +1,200 @@
+package products
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestFlagForTOSViolationRequiresProductID(t *testing.T) {
+	cmd := newFlagForTOSViolationCmd()
+	cmd.SetArgs([]string{"--user-id", "2245593582708"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected missing product id error")
+	}
+	if !strings.Contains(err.Error(), "missing required argument") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestFlagForTOSViolationRequiresUserID(t *testing.T) {
+	cmd := newFlagForTOSViolationCmd()
+	cmd.SetArgs([]string{"abc123"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected missing user id error")
+	}
+	if !strings.Contains(err.Error(), "missing required flag: --user-id") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestFlagForTOSViolationRequiresConfirmation(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("must not reach API without confirmation")
+	})
+
+	cmd := testutil.Command(newFlagForTOSViolationCmd(), testutil.NoInput(true))
+	cmd.SetArgs([]string{"abc123", "--user-id", "2245593582708"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error without --yes and --no-input")
+	}
+	if !strings.Contains(err.Error(), "--yes") {
+		t.Errorf("error should mention --yes: %v", err)
+	}
+}
+
+func TestFlagForTOSViolationConfirmationMessageDescribesProductFlag(t *testing.T) {
+	got := fmt.Sprintf(flagForTOSViolationConfirmationMessage, "abc123", "2245593582708")
+	for _, want := range []string{
+		"Flag product abc123 for a policy violation on user_id 2245593582708?",
+		"leaves the rest of the account online",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("confirmation message missing %q: %q", want, got)
+		}
+	}
+	if strings.Contains(got, "suspend") {
+		t.Fatalf("confirmation message must not describe a suspension: %q", got)
+	}
+}
+
+func TestFlagForTOSViolationSendsUserIDProductIDAndExpectedEmail(t *testing.T) {
+	var gotMethod, gotPath, gotQuery, gotAuth string
+	var body flagForTOSViolationRequest
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		gotAuth = r.Header.Get("Authorization")
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if err := json.Unmarshal(raw, &body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		testutil.JSON(t, w, map[string]any{
+			"success":    true,
+			"user_id":    "2245593582708",
+			"product_id": "abc123",
+			"status":     "flagged_for_tos_violation",
+			"message":    "User flagged for a policy violation",
+		})
+	})
+
+	cmd := testutil.Command(newFlagForTOSViolationCmd(), testutil.Yes(true), testutil.Quiet(false))
+	cmd.SetArgs([]string{"abc123", "--user-id", "2245593582708", "--expected-email", "seller@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != "POST" || gotPath != "/internal/admin/users/flag_for_tos_violation" {
+		t.Fatalf("got %s %s, want POST /internal/admin/users/flag_for_tos_violation", gotMethod, gotPath)
+	}
+	if gotQuery != "" {
+		t.Fatalf("body fields must not appear in query string, got %q", gotQuery)
+	}
+	if gotAuth != "Bearer admin-token" {
+		t.Fatalf("got auth %q, want Bearer admin-token", gotAuth)
+	}
+	if body.UserID != "2245593582708" || body.ProductID != "abc123" || body.ExpectedEmail != "seller@example.com" {
+		t.Fatalf("unexpected request body: %#v", body)
+	}
+	for _, want := range []string{"User flagged for a policy violation", "User ID: 2245593582708", "Product ID: abc123", "Status: flagged_for_tos_violation"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestFlagForTOSViolationDryRunDoesNotContactEndpoint(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("dry-run must not POST to the flag_for_tos_violation endpoint")
+	})
+
+	cmd := testutil.Command(newFlagForTOSViolationCmd(), testutil.DryRun(true), testutil.NoInput(true))
+	cmd.SetArgs([]string{"abc123", "--user-id", "2245593582708", "--expected-email", "seller@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "POST") || !strings.Contains(out, "/internal/admin/users/flag_for_tos_violation") {
+		t.Errorf("expected dry-run preview to mention POST and the flag_for_tos_violation path, got: %q", out)
+	}
+	for _, want := range []string{"user_id: 2245593582708", "product_id: abc123", "expected_email: seller@example.com"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected dry-run preview to include %q, got: %q", want, out)
+		}
+	}
+}
+
+func TestFlagForTOSViolationJSONPreservesResponse(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"success":    true,
+			"user_id":    "2245593582708",
+			"product_id": "abc123",
+			"status":     "already_flagged",
+			"message":    "User is already flagged for a policy violation",
+		})
+	})
+
+	cmd := testutil.Command(newFlagForTOSViolationCmd(), testutil.Yes(true), testutil.JSONOutput())
+	cmd.SetArgs([]string{"abc123", "--user-id", "2245593582708"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp flagForTOSViolationResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if !resp.Success || resp.UserID != "2245593582708" || resp.ProductID != "abc123" || resp.Status != "already_flagged" || resp.Message != "User is already flagged for a policy violation" {
+		t.Fatalf("unexpected JSON payload: %s", out)
+	}
+}
+
+func TestFlagForTOSViolationPlainOutput(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"success":    true,
+			"user_id":    "2245593582708",
+			"product_id": "abc123",
+			"status":     "flagged_for_tos_violation",
+			"message":    "User flagged for a policy violation",
+		})
+	})
+
+	cmd := testutil.Command(newFlagForTOSViolationCmd(), testutil.Yes(true), testutil.PlainOutput())
+	cmd.SetArgs([]string{"abc123", "--user-id", "2245593582708"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	want := "true\tUser flagged for a policy violation\t2245593582708\tabc123\tflagged_for_tos_violation"
+	if strings.TrimSpace(out) != want {
+		t.Fatalf("unexpected plain output: %q", out)
+	}
+}
+
+func TestFlagForTOSViolationProductMismatchSurfacesMessage(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"success": false,
+			"message": "Product does not belong to user",
+		})
+	})
+
+	cmd := testutil.Command(newFlagForTOSViolationCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"abc123", "--user-id", "2245593582708"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "Product does not belong to user") {
+		t.Fatalf("expected product mismatch error to surface, got: %v", err)
+	}
+}

--- a/internal/cmd/admin/products/products.go
+++ b/internal/cmd/admin/products/products.go
@@ -10,11 +10,13 @@ func NewProductsCmd() *cobra.Command {
   gumroad admin products list --external-id 2245593582708
   gumroad admin products list --email seller@example.com --page 2 --per-page 25
   gumroad admin products list --email seller@example.com --json
-  gumroad admin products view abc123`,
+  gumroad admin products view abc123
+  gumroad admin products flag-for-tos-violation abc123 --user-id 2245593582708`,
 	}
 
 	cmd.AddCommand(newListCmd())
 	cmd.AddCommand(newViewCmd())
+	cmd.AddCommand(newFlagForTOSViolationCmd())
 
 	return cmd
 }

--- a/internal/cmd/admin/products/view_test.go
+++ b/internal/cmd/admin/products/view_test.go
@@ -259,7 +259,7 @@ func TestProductsCmdRegistersSubcommands(t *testing.T) {
 	if cmd.Use != "products" {
 		t.Fatalf("got Use=%q, want products", cmd.Use)
 	}
-	want := map[string]bool{"list": false, "view": false}
+	want := map[string]bool{"list": false, "view": false, "flag-for-tos-violation": false}
 	for _, c := range cmd.Commands() {
 		if _, ok := want[c.Name()]; ok {
 			want[c.Name()] = true

--- a/internal/cmd/admin/users/risk_action.go
+++ b/internal/cmd/admin/users/risk_action.go
@@ -32,7 +32,7 @@ func renderRiskAction(opts cmdutil.Options, label, identifier string, resp riskA
 	if err := output.Writeln(opts.Out(), style.Green(message)); err != nil {
 		return err
 	}
-	if err := writeIdentifierLine(opts.Out(), label, message, identifier); err != nil {
+	if err := cmdutil.WriteIdentifierLine(opts.Out(), label, message, identifier); err != nil {
 		return err
 	}
 	if resp.Status != "" {

--- a/internal/cmd/admin/users/update_email.go
+++ b/internal/cmd/admin/users/update_email.go
@@ -130,7 +130,7 @@ func renderUpdateEmail(opts cmdutil.Options, identifier, newEmail string, resp u
 	if err := output.Writeln(opts.Out(), opts.Style().Green(message)); err != nil {
 		return err
 	}
-	if err := writeIdentifierLine(opts.Out(), "User ID", message, identifier); err != nil {
+	if err := cmdutil.WriteIdentifierLine(opts.Out(), "User ID", message, identifier); err != nil {
 		return err
 	}
 	if resp.PendingConfirmation {

--- a/internal/cmd/admin/users/users.go
+++ b/internal/cmd/admin/users/users.go
@@ -1,12 +1,8 @@
 package users
 
 import (
-	"io"
-	"strings"
-
 	usercomments "github.com/antiwork/gumroad-cli/internal/cmd/admin/users/comments"
 	"github.com/antiwork/gumroad-cli/internal/cmd/admin/users/usertarget"
-	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -58,13 +54,6 @@ func NewUsersCmd() *cobra.Command {
 
 func fallback(value, alt string) string {
 	return usertarget.Fallback(value, alt)
-}
-
-func writeIdentifierLine(w io.Writer, label, message, identifier string) error {
-	if identifier == "" || strings.Contains(message, identifier) {
-		return nil
-	}
-	return output.Writef(w, "%s: %s\n", label, identifier)
 }
 
 type userLookupFlags = usertarget.LookupFlags

--- a/internal/cmd/admin/users/watch.go
+++ b/internal/cmd/admin/users/watch.go
@@ -333,7 +333,7 @@ func renderWatchAction(opts cmdutil.Options, userID, message string, watchedUser
 	if err := output.Writeln(opts.Out(), opts.Style().Green(message)); err != nil {
 		return err
 	}
-	if err := writeIdentifierLine(opts.Out(), "User ID", message, userID); err != nil {
+	if err := cmdutil.WriteIdentifierLine(opts.Out(), "User ID", message, userID); err != nil {
 		return err
 	}
 	return writeWatchedUser(opts.Out(), watchedUser)
@@ -351,7 +351,7 @@ func renderUnwatchAction(opts cmdutil.Options, userID string, resp unwatchRespon
 	if err := output.Writeln(opts.Out(), opts.Style().Green(message)); err != nil {
 		return err
 	}
-	return writeIdentifierLine(opts.Out(), "User ID", message, userID)
+	return cmdutil.WriteIdentifierLine(opts.Out(), "User ID", message, userID)
 }
 
 func writeWatchedUser(w io.Writer, watchedUser *watchedUserInfo) error {

--- a/internal/cmdutil/identifier.go
+++ b/internal/cmdutil/identifier.go
@@ -1,0 +1,15 @@
+package cmdutil
+
+import (
+	"io"
+	"strings"
+
+	"github.com/antiwork/gumroad-cli/internal/output"
+)
+
+func WriteIdentifierLine(w io.Writer, label, message, identifier string) error {
+	if identifier == "" || strings.Contains(message, identifier) {
+		return nil
+	}
+	return output.Writef(w, "%s: %s\n", label, identifier)
+}

--- a/internal/cmdutil/identifier_test.go
+++ b/internal/cmdutil/identifier_test.go
@@ -1,0 +1,41 @@
+package cmdutil
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestWriteIdentifierLineWritesWhenMessageDoesNotContainIdentifier(t *testing.T) {
+	var buf bytes.Buffer
+
+	if err := WriteIdentifierLine(&buf, "User ID", "User flagged", "2245593582708"); err != nil {
+		t.Fatalf("WriteIdentifierLine returned error: %v", err)
+	}
+
+	if got, want := buf.String(), "User ID: 2245593582708\n"; got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestWriteIdentifierLineSkipsEmptyOrAlreadyPresentIdentifier(t *testing.T) {
+	cases := []struct {
+		name       string
+		message    string
+		identifier string
+	}{
+		{name: "empty", message: "User flagged", identifier: ""},
+		{name: "already present", message: "User 2245593582708 flagged", identifier: "2245593582708"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := WriteIdentifierLine(&buf, "User ID", tc.message, tc.identifier); err != nil {
+				t.Fatalf("WriteIdentifierLine returned error: %v", err)
+			}
+			if buf.Len() != 0 {
+				t.Fatalf("expected no output, got %q", buf.String())
+			}
+		})
+	}
+}

--- a/skills/embed_test.go
+++ b/skills/embed_test.go
@@ -122,6 +122,8 @@ func TestSkillMarkdown_ContainsAdminRolloutCommands(t *testing.T) {
 		"gumroad admin users related --email",
 		"gumroad admin users suspend-for-tos-violation --user-id",
 		"`admin users mark-compliant`, `admin users suspend`, `admin users suspend-for-tos-violation` → `.status`, `.message`, `.user_id`",
+		"gumroad admin products flag-for-tos-violation <product-id> --user-id",
+		"`admin products flag-for-tos-violation` → `.status`, `.message`, `.user_id`, `.product_id`",
 		"gumroad admin purchases view <purchase-id> --with-clusters",
 		"gumroad admin purchases search --email",
 		"gumroad admin purchases lookup --stripe-fingerprint",

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -29,7 +29,7 @@ Always follow these rules:
 - **Always** pass `--no-input` to prevent interactive prompts from blocking.
 - **Always** pass `--json` for programmatic access.
 - Use `--json --jq <expr>` together to extract exactly what you need.
-- For operations that can prompt for confirmation (delete, refund, `files abort`, `files complete` replay, or product updates that remove files), add `--yes` to skip confirmation.
+- For operations that can prompt for confirmation (delete, refund, mutating admin actions, `files abort`, `files complete` replay, or product updates that remove files), add `--yes` to skip confirmation.
 - Pass `--quiet` to suppress spinners and status messages.
 - Pass `--dry-run` to preview mutating requests without executing them.
 - Use `--page-delay 200ms` with `--all` to avoid rate limits on large datasets.
@@ -72,6 +72,7 @@ Responses are wrapped in `{"success": true, ...}` with resource-specific keys:
 - `admin users purchases` → `.purchases[]`
 - `admin users related` → `.related_users[]`, `.truncated`, `.per_signal_limit`
 - `admin users mark-compliant`, `admin users suspend`, `admin users suspend-for-tos-violation` → `.status`, `.message`, `.user_id`
+- `admin products flag-for-tos-violation` → `.status`, `.message`, `.user_id`, `.product_id`
 - `admin purchases view` → `.purchase`
 - `admin purchases search` → `.purchases[]`, `.has_more`, `.limit`
 - `admin purchases lookup` → `.purchases[]`
@@ -146,6 +147,7 @@ gumroad admin users related --email seller@example.com --json --jq '{related_use
 gumroad admin users mark-compliant --user-id 2245593582708 --expected-email seller@example.com --note "Cleared after review" --yes --json --non-interactive --no-input
 gumroad admin users suspend --user-id 2245593582708 --expected-email seller@example.com --note "Chargeback risk confirmed" --yes --json --non-interactive --no-input
 gumroad admin users suspend-for-tos-violation --user-id 2245593582708 --expected-email seller@example.com --note "DMCA takedown notice confirmed" --yes --json --non-interactive --no-input
+gumroad admin products flag-for-tos-violation <product-id> --user-id 2245593582708 --expected-email seller@example.com --yes --json --non-interactive --no-input
 
 # Inspect purchase and product fraud context
 gumroad admin purchases view <purchase-id> --with-clusters --json --non-interactive --no-input


### PR DESCRIPTION
Ref antiwork/gumroad/issues/5153

## What

- Adds `gumroad admin products flag-for-tos-violation` so admins can flag a specific product in the context of a seller policy violation.
- Sends the product ID plus the seller ID guard to the internal admin API and preserves the normal confirmation, dry-run, JSON, and plain-output behavior.
- Updates the admin help text, CLI docs, and skill guidance so the command is documented consistently.

## Why

- The CLI was missing the product-level moderation action needed to match the new internal admin API.
- Using the product-specific endpoint keeps this action separate from full account suspension and avoids forcing admins back to the web UI for the flagging step.

---

This PR was implemented with AI assistance using gpt-5.5 xhigh.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a mutating admin moderation action that notifies sellers; mitigated by confirmation, optional email guard, dry-run, and tests, but still affects live seller/product policy state.
> 
> **Overview**
> Adds **`gumroad admin products flag-for-tos-violation`** so admins can flag a seller for a policy violation with a specific product as context, without suspending the account or taking other products offline.
> 
> The command POSTs `user_id`, `product_id`, and optional `expected_email` to the internal **`users/flag_for_tos_violation`** endpoint, with the same confirmation, `--yes`, dry-run, JSON, and plain output behavior as other mutating admin commands. Help text, README, and the agent skill document the new flow and JSON fields (`.status`, `.message`, `.user_id`, `.product_id`).
> 
> **`WriteIdentifierLine`** is moved from the users package into **`cmdutil`** and reused for human output on this command and existing user actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83d3da8034adeaab80d41925dbf8628636b4beb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->