### PR TITLE
Fix upload drain timing test

### DIFF
--- a/internal/upload/upload_test.go
+++ b/internal/upload/upload_test.go
@@ -1328,10 +1328,10 @@ func TestUpload_ErrorBodyNotDrained(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	// Three attempts with 1 ms backoff in shortBackoff; each attempt should
-	// close on the 5xx snippet and retry. Total time must be far less than
+	// Three attempts can spend up to errorBodyReadTimeout reading the bounded
+	// snippet before retrying. A drain-to-EOF regression would still take about
 	// 3 s * 3 attempts = 9 s.
-	if elapsed > 2*time.Second {
+	if elapsed > 6*time.Second {
 		t.Errorf("took %s — error body drain appears to be blocking", elapsed)
 	}
 }


### PR DESCRIPTION
Ref https://github.com/antiwork/gumroad-cli/actions/runs/26408671621/job/77737991592

## What

This raises the wall-clock budget for the retrying S3 error-body drain regression test. The test still catches a real drain-to-EOF regression, but no longer fails on macOS runner overhead around the three bounded read attempts.

## Why

The failure was in internal/upload after merging #111, not in the admin command code. The code already bounds each error-body read at 500ms, so three retry attempts need a budget above that floor while staying below the roughly nine-second drain-to-EOF behavior.

---

This PR was implemented with AI assistance using gpt-5.5 xhigh.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad-cli/pr/112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782318054&installation_id=134400930&pr_number=112&repository=antiwork%2Fgumroad-cli&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad-cli%2Fpull%2F112&signature=0ff127488ae1331aacb938371b286bca977a8d3d5a9dd4f51b14ea6104b47365"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timing and comment updates in `internal/upload/upload_test.go`; no production upload behavior changes.
> 
> **Overview**
> Relaxes the timing guard in **`TestUpload_ErrorBodyNotDrained`** so the upload retry regression test stays stable on slower CI (e.g. macOS runners) without weakening what it checks.
> 
> The test still fails if S3 error responses are drained to EOF (~9s across three attempts). The max allowed elapsed time moves from **2s** to **6s**, and comments now describe three retries bounded by **`errorBodyReadTimeout`** (500ms per read) instead of assuming 1ms backoff alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 727ab13f2eeb5890a1b503095dd2cc1648b942c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->