### PR TITLE
Add admin refund-balance CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Run `gumroad <command> --help` for usage details and examples.
 
 Admin commands use a separate internal token. Run `gumroad auth login` and check the admin box to store one locally. Mutating admin commands use that stored token in normal interactive runs so the acting admin can be shown before the request; CI and agents can pass `--non-interactive` with `GUMROAD_ADMIN_TOKEN`. For local testing, set `GUMROAD_ADMIN_API_BASE_URL`.
 
+`admin users refund-balance --dry-run` still calls the unpaid-balance preview endpoint, but skips the guarded refund POST.
+
 ```sh
 gumroad admin users info --email seller@example.com --json
 gumroad admin users affiliates --user-id 2245593582708 --direction granted --limit 50
@@ -132,6 +134,8 @@ gumroad admin users suspend-for-tos-violation --user-id 2245593582708 --expected
 gumroad admin products flag-for-tos-violation abc123 --user-id 2245593582708 --expected-email seller@example.com
 gumroad admin payouts scheduled create --user-id 2245593582708 --expected-email seller@example.com --processor stripe --payout-date 2026-06-15
 gumroad admin payouts scheduled list --status pending --user-id 2245593582708
+gumroad admin users refund-balance --user-id 2245593582708 --expected-email seller@example.com --dry-run
+gumroad admin users refund-balance --user-id 2245593582708 --expected-email seller@example.com
 gumroad admin purchases lookup --stripe-fingerprint fp_abc --limit 25
 gumroad admin users watch --user-id 2245593582708 --expected-email seller@example.com --revenue-threshold 200 --note "Review next buyers"
 gumroad admin users update-watch --user-id 2245593582708 --expected-email seller@example.com --revenue-threshold 500

--- a/internal/admincmd/read.go
+++ b/internal/admincmd/read.go
@@ -88,6 +88,16 @@ func FetchPostJSON(opts cmdutil.Options, spinnerMessage, path string, payload an
 	})
 }
 
+// ResolveMutationToken resolves the token policy used by mutating admin commands.
+func ResolveMutationToken(opts cmdutil.Options) (adminconfig.TokenInfo, error) {
+	return resolveMutationToken(opts)
+}
+
+// WriteActorBanner prints the stored admin actor banner for mutating commands.
+func WriteActorBanner(opts cmdutil.Options, info adminconfig.TokenInfo) error {
+	return writeActorBanner(opts, info)
+}
+
 func runAuthenticatedData(opts cmdutil.Options, spinnerMessage string, run ClientRunner) (json.RawMessage, error) {
 	info, err := adminconfig.ResolveToken()
 	if err != nil {

--- a/internal/cmd/admin/users/refund_balance.go
+++ b/internal/cmd/admin/users/refund_balance.go
@@ -1,0 +1,263 @@
+package users
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/antiwork/gumroad-cli/internal/adminapi"
+	"github.com/antiwork/gumroad-cli/internal/admincmd"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+const refundBalanceConfirmationMessage = "Refund %d unpaid purchase(s) totaling %s for user_id %s? This queues refunds to buyers and cannot be undone once processors accept them."
+
+type unpaidBalanceResponse struct {
+	Success          bool   `json:"success"`
+	UserID           string `json:"user_id"`
+	Count            int    `json:"count"`
+	Total            int    `json:"total"`
+	TotalAmountCents int    `json:"total_amount_cents"`
+	Currency         string `json:"currency"`
+}
+
+type refundBalanceRequest struct {
+	UserID                   string `json:"user_id"`
+	ExpectedEmail            string `json:"expected_email"`
+	ExpectedPurchaseCount    int    `json:"expected_purchase_count"`
+	ExpectedTotalAmountCents int    `json:"expected_total_amount_cents"`
+}
+
+type refundBalanceResponse struct {
+	Success          bool   `json:"success"`
+	UserID           string `json:"user_id"`
+	Status           string `json:"status"`
+	Message          string `json:"message"`
+	Count            int    `json:"count"`
+	Total            int    `json:"total"`
+	TotalAmountCents int    `json:"total_amount_cents"`
+	Currency         string `json:"currency"`
+}
+
+func newRefundBalanceCmd() *cobra.Command {
+	var targetFlags userMutationFlags
+
+	cmd := &cobra.Command{
+		Use:   "refund-balance",
+		Short: "Refund unpaid purchases for a suspended user",
+		Long: `Preview and queue refunds for all refundable purchases still in Gumroad-held unpaid balance.
+
+The command first reads /users/unpaid_balance, then sends the returned count and
+total cents back to /users/refund_balance as stale-state guards. --expected-email
+is required because this is an irreversible money-moving workflow.
+
+Pass --dry-run to run the preview GET and print the guarded POST that would be
+sent without queueing refunds.`,
+		Example: `  gumroad admin users refund-balance --user-id 2245593582708 --expected-email seller@example.com --dry-run
+  gumroad admin users refund-balance --user-id 2245593582708 --expected-email seller@example.com --yes`,
+		Args: cmdutil.ExactArgs(0),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+
+			target, err := resolveUserMutationTarget(c, targetFlags)
+			if err != nil {
+				return err
+			}
+			if target.ExpectedEmail == "" {
+				return cmdutil.MissingFlagError(c, "--expected-email")
+			}
+
+			path := "users/refund_balance"
+
+			if opts.DryRun {
+				preview, err := fetchRefundBalanceDryRunPreview(opts, target.UserID)
+				if err != nil {
+					return err
+				}
+				req := refundBalanceRequest{
+					UserID:                   target.UserID,
+					ExpectedEmail:            target.ExpectedEmail,
+					ExpectedPurchaseCount:    preview.Count,
+					ExpectedTotalAmountCents: preview.TotalAmountCents,
+				}
+				if err := renderRefundBalancePreview(opts, fallback(preview.UserID, target.UserID), preview); err != nil {
+					return err
+				}
+				return cmdutil.PrintDryRunRequest(opts, http.MethodPost, adminapi.AdminPath(path), refundBalanceDryRunParams(req))
+			}
+
+			info, err := admincmd.ResolveMutationToken(opts)
+			if err != nil {
+				return err
+			}
+			if err := admincmd.WriteActorBanner(opts, info); err != nil {
+				return err
+			}
+			client := admincmd.NewAPIClient(opts, info.Value)
+			preview, err := fetchRefundBalancePreview(opts, client, target.UserID)
+			if err != nil {
+				return err
+			}
+			req := refundBalanceRequest{
+				UserID:                   target.UserID,
+				ExpectedEmail:            target.ExpectedEmail,
+				ExpectedPurchaseCount:    preview.Count,
+				ExpectedTotalAmountCents: preview.TotalAmountCents,
+			}
+
+			ok, err := cmdutil.ConfirmAction(opts, fmt.Sprintf(
+				refundBalanceConfirmationMessage,
+				preview.Count,
+				formatRefundBalanceAmount(preview.TotalAmountCents, preview.Currency),
+				target.UserID,
+			))
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return cmdutil.PrintCancelledAction(opts, "refund unpaid balance for user_id "+target.UserID, target.UserID)
+			}
+
+			data, err := postRefundBalance(opts, client, path, req)
+			if err != nil {
+				return err
+			}
+			if opts.UsesJSONOutput() {
+				return cmdutil.PrintJSONResponse(opts, data)
+			}
+
+			decoded, err := cmdutil.DecodeJSON[refundBalanceResponse](data)
+			if err != nil {
+				return err
+			}
+			return renderRefundBalanceResult(opts, fallback(decoded.UserID, target.UserID), decoded)
+		},
+	}
+
+	addUserMutationFlags(cmd, &targetFlags)
+
+	return cmd
+}
+
+func fetchRefundBalanceDryRunPreview(opts cmdutil.Options, userID string) (unpaidBalanceResponse, error) {
+	return admincmd.FetchGetDecoded[unpaidBalanceResponse](opts, "Checking unpaid balance...", "users/unpaid_balance", refundBalancePreviewParams(userID))
+}
+
+func fetchRefundBalancePreview(opts cmdutil.Options, client *adminapi.Client, userID string) (unpaidBalanceResponse, error) {
+	data, err := runRefundBalanceAdminRequest(opts, "Checking unpaid balance...", func() (json.RawMessage, error) {
+		return client.Get("users/unpaid_balance", refundBalancePreviewParams(userID))
+	})
+	if err != nil {
+		return unpaidBalanceResponse{}, err
+	}
+	return cmdutil.DecodeJSON[unpaidBalanceResponse](data)
+}
+
+func postRefundBalance(opts cmdutil.Options, client *adminapi.Client, path string, req refundBalanceRequest) (json.RawMessage, error) {
+	return runRefundBalanceAdminRequest(opts, "Queueing refund balance...", func() (json.RawMessage, error) {
+		return client.PostJSON(path, req)
+	})
+}
+
+func runRefundBalanceAdminRequest(opts cmdutil.Options, spinnerMessage string, run func() (json.RawMessage, error)) (json.RawMessage, error) {
+	if cmdutil.ShouldShowSpinner(opts) {
+		sp := output.NewSpinnerTo(spinnerMessage, opts.Err())
+		sp.Start()
+		defer sp.Stop()
+	}
+	return run()
+}
+
+func refundBalancePreviewParams(userID string) url.Values {
+	params := url.Values{}
+	params.Set("user_id", userID)
+	return params
+}
+
+func refundBalanceDryRunParams(req refundBalanceRequest) url.Values {
+	params := url.Values{}
+	params.Set("user_id", req.UserID)
+	params.Set("expected_email", req.ExpectedEmail)
+	params.Set("expected_purchase_count", strconv.Itoa(req.ExpectedPurchaseCount))
+	params.Set("expected_total_amount_cents", strconv.Itoa(req.ExpectedTotalAmountCents))
+	return params
+}
+
+func renderRefundBalancePreview(opts cmdutil.Options, userID string, preview unpaidBalanceResponse) error {
+	if opts.UsesJSONOutput() || opts.PlainOutput || opts.Quiet {
+		return nil
+	}
+
+	style := opts.Style()
+	if err := output.Writeln(opts.Out(), style.Yellow("Refund balance preview")); err != nil {
+		return err
+	}
+	if err := output.Writef(opts.Out(), "User ID: %s\n", userID); err != nil {
+		return err
+	}
+	if err := output.Writef(opts.Out(), "Purchases: %d\n", preview.Count); err != nil {
+		return err
+	}
+	if err := output.Writef(opts.Out(), "Amount: %s\n", formatRefundBalanceAmount(preview.TotalAmountCents, preview.Currency)); err != nil {
+		return err
+	}
+	if preview.Currency != "" {
+		return output.Writef(opts.Out(), "Currency: %s\n", preview.Currency)
+	}
+	return nil
+}
+
+func renderRefundBalanceResult(opts cmdutil.Options, userID string, resp refundBalanceResponse) error {
+	message := fallback(resp.Message, resp.Status)
+
+	if opts.PlainOutput {
+		return output.PrintPlain(opts.Out(), [][]string{{
+			strconv.FormatBool(resp.Success),
+			message,
+			userID,
+			resp.Status,
+			strconv.Itoa(resp.Count),
+			strconv.Itoa(resp.TotalAmountCents),
+			resp.Currency,
+		}})
+	}
+
+	if opts.Quiet {
+		return nil
+	}
+
+	style := opts.Style()
+	if err := output.Writeln(opts.Out(), style.Green(message)); err != nil {
+		return err
+	}
+	if err := cmdutil.WriteIdentifierLine(opts.Out(), "User ID", message, userID); err != nil {
+		return err
+	}
+	if resp.Status != "" {
+		if err := output.Writef(opts.Out(), "Status: %s\n", resp.Status); err != nil {
+			return err
+		}
+	}
+	if err := output.Writef(opts.Out(), "Purchases: %d\n", resp.Count); err != nil {
+		return err
+	}
+	if err := output.Writef(opts.Out(), "Amount: %s\n", formatRefundBalanceAmount(resp.TotalAmountCents, resp.Currency)); err != nil {
+		return err
+	}
+	if resp.Currency != "" {
+		return output.Writef(opts.Out(), "Currency: %s\n", resp.Currency)
+	}
+	return nil
+}
+
+func formatRefundBalanceAmount(cents int, currency string) string {
+	if currency == "" {
+		return fmt.Sprintf("%d cents", cents)
+	}
+	return fmt.Sprintf("%d %s cents", cents, strings.ToUpper(currency))
+}

--- a/internal/cmd/admin/users/refund_balance.go
+++ b/internal/cmd/admin/users/refund_balance.go
@@ -231,6 +231,14 @@ func renderNoRefundBalance(opts cmdutil.Options, userID string, preview unpaidBa
 func renderRefundBalanceResult(opts cmdutil.Options, userID string, resp refundBalanceResponse) error {
 	message := fallback(resp.Message, resp.Status)
 
+	if opts.UsesJSONOutput() {
+		data, err := json.Marshal(resp)
+		if err != nil {
+			return fmt.Errorf("could not encode refund balance response: %w", err)
+		}
+		return output.PrintJSON(opts.Out(), data, opts.JQExpr)
+	}
+
 	if opts.PlainOutput {
 		return output.PrintPlain(opts.Out(), [][]string{{
 			strconv.FormatBool(resp.Success),

--- a/internal/cmd/admin/users/refund_balance.go
+++ b/internal/cmd/admin/users/refund_balance.go
@@ -21,7 +21,6 @@ type unpaidBalanceResponse struct {
 	Success          bool   `json:"success"`
 	UserID           string `json:"user_id"`
 	Count            int    `json:"count"`
-	Total            int    `json:"total"`
 	TotalAmountCents int    `json:"total_amount_cents"`
 	Currency         string `json:"currency"`
 }
@@ -39,7 +38,6 @@ type refundBalanceResponse struct {
 	Status           string `json:"status"`
 	Message          string `json:"message"`
 	Count            int    `json:"count"`
-	Total            int    `json:"total"`
 	TotalAmountCents int    `json:"total_amount_cents"`
 	Currency         string `json:"currency"`
 }
@@ -79,6 +77,9 @@ sent without queueing refunds.`,
 				if err != nil {
 					return err
 				}
+				if preview.Count == 0 {
+					return renderNoRefundBalance(opts, fallback(preview.UserID, target.UserID), preview)
+				}
 				req := refundBalanceRequest{
 					UserID:                   target.UserID,
 					ExpectedEmail:            target.ExpectedEmail,
@@ -102,6 +103,9 @@ sent without queueing refunds.`,
 			preview, err := fetchRefundBalancePreview(opts, client, target.UserID)
 			if err != nil {
 				return err
+			}
+			if preview.Count == 0 {
+				return renderNoRefundBalance(opts, fallback(preview.UserID, target.UserID), preview)
 			}
 			req := refundBalanceRequest{
 				UserID:                   target.UserID,
@@ -210,6 +214,18 @@ func renderRefundBalancePreview(opts cmdutil.Options, userID string, preview unp
 		return output.Writef(opts.Out(), "Currency: %s\n", preview.Currency)
 	}
 	return nil
+}
+
+func renderNoRefundBalance(opts cmdutil.Options, userID string, preview unpaidBalanceResponse) error {
+	return renderRefundBalanceResult(opts, userID, refundBalanceResponse{
+		Success:          true,
+		UserID:           userID,
+		Status:           "skipped",
+		Message:          "No unpaid purchases to refund",
+		Count:            preview.Count,
+		TotalAmountCents: preview.TotalAmountCents,
+		Currency:         preview.Currency,
+	})
 }
 
 func renderRefundBalanceResult(opts cmdutil.Options, userID string, resp refundBalanceResponse) error {

--- a/internal/cmd/admin/users/refund_balance.go
+++ b/internal/cmd/admin/users/refund_balance.go
@@ -72,26 +72,6 @@ sent without queueing refunds.`,
 
 			path := "users/refund_balance"
 
-			if opts.DryRun {
-				preview, err := fetchRefundBalanceDryRunPreview(opts, target.UserID)
-				if err != nil {
-					return err
-				}
-				if preview.Count == 0 {
-					return renderNoRefundBalance(opts, fallback(preview.UserID, target.UserID), preview)
-				}
-				req := refundBalanceRequest{
-					UserID:                   target.UserID,
-					ExpectedEmail:            target.ExpectedEmail,
-					ExpectedPurchaseCount:    preview.Count,
-					ExpectedTotalAmountCents: preview.TotalAmountCents,
-				}
-				if err := renderRefundBalancePreview(opts, fallback(preview.UserID, target.UserID), preview); err != nil {
-					return err
-				}
-				return cmdutil.PrintDryRunRequest(opts, http.MethodPost, adminapi.AdminPath(path), refundBalanceDryRunParams(req))
-			}
-
 			info, err := admincmd.ResolveMutationToken(opts)
 			if err != nil {
 				return err
@@ -112,6 +92,12 @@ sent without queueing refunds.`,
 				ExpectedEmail:            target.ExpectedEmail,
 				ExpectedPurchaseCount:    preview.Count,
 				ExpectedTotalAmountCents: preview.TotalAmountCents,
+			}
+			if opts.DryRun {
+				if err := renderRefundBalancePreview(opts, fallback(preview.UserID, target.UserID), preview); err != nil {
+					return err
+				}
+				return cmdutil.PrintDryRunRequest(opts, http.MethodPost, adminapi.AdminPath(path), refundBalanceDryRunParams(req))
 			}
 
 			ok, err := cmdutil.ConfirmAction(opts, fmt.Sprintf(
@@ -146,10 +132,6 @@ sent without queueing refunds.`,
 	addUserMutationFlags(cmd, &targetFlags)
 
 	return cmd
-}
-
-func fetchRefundBalanceDryRunPreview(opts cmdutil.Options, userID string) (unpaidBalanceResponse, error) {
-	return admincmd.FetchGetDecoded[unpaidBalanceResponse](opts, "Checking unpaid balance...", "users/unpaid_balance", refundBalancePreviewParams(userID))
 }
 
 func fetchRefundBalancePreview(opts cmdutil.Options, client *adminapi.Client, userID string) (unpaidBalanceResponse, error) {

--- a/internal/cmd/admin/users/refund_balance_test.go
+++ b/internal/cmd/admin/users/refund_balance_test.go
@@ -171,6 +171,74 @@ func TestRefundBalanceSkipsZeroBalanceWithoutConfirmationOrPost(t *testing.T) {
 	}
 }
 
+func TestRefundBalanceSkipsZeroBalanceWithJSONOutput(t *testing.T) {
+	var requests []string
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Method+" "+r.URL.Path)
+		if r.Method == http.MethodPost {
+			t.Error("must not POST when preview has no unpaid purchases")
+		}
+		testutil.JSON(t, w, map[string]any{
+			"user_id":            "2245593582708",
+			"count":              0,
+			"total":              0,
+			"total_amount_cents": 0,
+			"currency":           "usd",
+		})
+	})
+
+	cmd := testutil.Command(newRefundBalanceCmd(), testutil.NoInput(true), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--expected-email", "seller@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if strings.Join(requests, ",") != "GET /internal/admin/users/unpaid_balance" {
+		t.Fatalf("unexpected request sequence: %v", requests)
+	}
+
+	var resp refundBalanceResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if !resp.Success || resp.UserID != "2245593582708" || resp.Status != "skipped" || resp.Message != "No unpaid purchases to refund" || resp.Count != 0 || resp.TotalAmountCents != 0 || resp.Currency != "usd" {
+		t.Fatalf("unexpected JSON payload: %s", out)
+	}
+}
+
+func TestRefundBalanceDryRunSkipsZeroBalanceWithJSONOutput(t *testing.T) {
+	var requests []string
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Method+" "+r.URL.Path)
+		if r.Method == http.MethodPost {
+			t.Error("dry-run must not POST when preview has no unpaid purchases")
+		}
+		testutil.JSON(t, w, map[string]any{
+			"user_id":            "2245593582708",
+			"count":              0,
+			"total":              0,
+			"total_amount_cents": 0,
+			"currency":           "usd",
+		})
+	})
+
+	cmd := testutil.Command(newRefundBalanceCmd(), testutil.DryRun(true), testutil.NoInput(true), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--expected-email", "seller@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if strings.Join(requests, ",") != "GET /internal/admin/users/unpaid_balance" {
+		t.Fatalf("unexpected request sequence: %v", requests)
+	}
+
+	var resp refundBalanceResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if !resp.Success || resp.UserID != "2245593582708" || resp.Status != "skipped" || resp.Message != "No unpaid purchases to refund" {
+		t.Fatalf("unexpected JSON payload: %s", out)
+	}
+}
+
 func TestRefundBalanceDryRunPreviewsOnly(t *testing.T) {
 	var gotPost bool
 

--- a/internal/cmd/admin/users/refund_balance_test.go
+++ b/internal/cmd/admin/users/refund_balance_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/antiwork/gumroad-cli/internal/adminconfig"
 	"github.com/antiwork/gumroad-cli/internal/testutil"
 )
 
@@ -281,6 +282,33 @@ func TestRefundBalanceDryRunPreviewsOnly(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("dry-run output missing %q: %q", want, out)
 		}
+	}
+}
+
+func TestRefundBalanceDryRunRequiresStoredMutationAuthWithEnvToken(t *testing.T) {
+	called := false
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+	if err := adminconfig.Delete(); err != nil {
+		t.Fatalf("delete admin config: %v", err)
+	}
+	t.Setenv(adminconfig.EnvAccessToken, "env-admin-token")
+
+	cmd := testutil.Command(newRefundBalanceCmd(), testutil.DryRun(true), testutil.NoInput(true))
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--expected-email", "seller@example.com"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected stored-token policy error")
+	}
+	if !strings.Contains(err.Error(), "mutating admin commands require stored admin auth") ||
+		!strings.Contains(err.Error(), "--non-interactive") ||
+		!strings.Contains(err.Error(), adminconfig.EnvAccessToken) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Fatal("request should not be sent")
 	}
 }
 

--- a/internal/cmd/admin/users/refund_balance_test.go
+++ b/internal/cmd/admin/users/refund_balance_test.go
@@ -1,0 +1,286 @@
+package users
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestRefundBalanceRequiresUserID(t *testing.T) {
+	cmd := newRefundBalanceCmd()
+	cmd.SetArgs([]string{"--expected-email", "seller@example.com"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "missing required flag: --user-id") {
+		t.Fatalf("expected missing user ID error, got %v", err)
+	}
+}
+
+func TestRefundBalanceRequiresExpectedEmail(t *testing.T) {
+	cmd := newRefundBalanceCmd()
+	cmd.SetArgs([]string{"--user-id", "2245593582708"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "missing required flag: --expected-email") {
+		t.Fatalf("expected missing expected email error, got %v", err)
+	}
+}
+
+func TestRefundBalanceRequiresConfirmationAfterPreview(t *testing.T) {
+	var gotPost bool
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			gotPost = true
+			t.Error("must not POST without confirmation")
+		}
+		testutil.JSON(t, w, map[string]any{
+			"user_id":            "2245593582708",
+			"count":              1,
+			"total":              1334,
+			"total_amount_cents": 1334,
+			"currency":           "usd",
+		})
+	})
+
+	cmd := testutil.Command(newRefundBalanceCmd(), testutil.NoInput(true))
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--expected-email", "seller@example.com"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--yes") {
+		t.Fatalf("expected --yes error, got %v", err)
+	}
+	if gotPost {
+		t.Fatal("unexpected POST")
+	}
+}
+
+func TestRefundBalanceSendsPreviewedCountAndTotal(t *testing.T) {
+	var requests []string
+	var gotPreviewQuery, gotPostQuery, gotAuth string
+	var body refundBalanceRequest
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Method+" "+r.URL.Path)
+		gotAuth = r.Header.Get("Authorization")
+
+		switch r.Method + " " + r.URL.Path {
+		case "GET /internal/admin/users/unpaid_balance":
+			gotPreviewQuery = r.URL.RawQuery
+			testutil.JSON(t, w, map[string]any{
+				"user_id":            "2245593582708",
+				"count":              2,
+				"total":              4200,
+				"total_amount_cents": 4200,
+				"currency":           "usd",
+			})
+		case "POST /internal/admin/users/refund_balance":
+			gotPostQuery = r.URL.RawQuery
+			raw, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read body: %v", err)
+			}
+			if err := json.Unmarshal(raw, &body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			testutil.JSON(t, w, map[string]any{
+				"user_id":            "2245593582708",
+				"status":             "queued",
+				"message":            "Refund balance queued",
+				"count":              2,
+				"total":              4200,
+				"total_amount_cents": 4200,
+				"currency":           "usd",
+			})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	})
+
+	cmd := testutil.Command(newRefundBalanceCmd(), testutil.Yes(true), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--expected-email", "seller@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if strings.Join(requests, ",") != "GET /internal/admin/users/unpaid_balance,POST /internal/admin/users/refund_balance" {
+		t.Fatalf("unexpected request sequence: %v", requests)
+	}
+	if gotPreviewQuery != "user_id=2245593582708" {
+		t.Fatalf("unexpected preview query: %q", gotPreviewQuery)
+	}
+	if gotPostQuery != "" {
+		t.Fatalf("body fields must not appear in query string, got %q", gotPostQuery)
+	}
+	if gotAuth != "Bearer admin-token" {
+		t.Fatalf("got auth %q, want Bearer admin-token", gotAuth)
+	}
+	if body.UserID != "2245593582708" || body.ExpectedEmail != "seller@example.com" || body.ExpectedPurchaseCount != 2 || body.ExpectedTotalAmountCents != 4200 {
+		t.Fatalf("unexpected request body: %#v", body)
+	}
+	for _, want := range []string{
+		"Refund balance queued",
+		"User ID: 2245593582708",
+		"Status: queued",
+		"Purchases: 2",
+		"Amount: 4200 USD cents",
+		"Currency: usd",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestRefundBalanceDryRunPreviewsOnly(t *testing.T) {
+	var gotPost bool
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			gotPost = true
+			t.Error("dry-run must not POST to refund_balance")
+		}
+		if r.Method != http.MethodGet || r.URL.Path != "/internal/admin/users/unpaid_balance" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		testutil.JSON(t, w, map[string]any{
+			"user_id":            "2245593582708",
+			"count":              3,
+			"total":              9900,
+			"total_amount_cents": 9900,
+			"currency":           "usd",
+		})
+	})
+
+	cmd := testutil.Command(newRefundBalanceCmd(), testutil.DryRun(true), testutil.NoInput(true), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--expected-email", "seller@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotPost {
+		t.Fatal("unexpected POST")
+	}
+	for _, want := range []string{
+		"Refund balance preview",
+		"User ID: 2245593582708",
+		"Purchases: 3",
+		"Amount: 9900 USD cents",
+		"POST",
+		"/internal/admin/users/refund_balance",
+		"expected_email: seller@example.com",
+		"expected_purchase_count: 3",
+		"expected_total_amount_cents: 9900",
+		"user_id: 2245593582708",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("dry-run output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestRefundBalanceJSONPreservesPostResponse(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.URL.Path {
+		case "GET /internal/admin/users/unpaid_balance":
+			testutil.JSON(t, w, map[string]any{
+				"user_id":            "2245593582708",
+				"count":              1,
+				"total":              1334,
+				"total_amount_cents": 1334,
+				"currency":           "usd",
+			})
+		case "POST /internal/admin/users/refund_balance":
+			testutil.JSON(t, w, map[string]any{
+				"user_id":            "2245593582708",
+				"status":             "queued",
+				"message":            "Refund balance queued",
+				"count":              1,
+				"total":              1334,
+				"total_amount_cents": 1334,
+				"currency":           "usd",
+			})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	})
+
+	cmd := testutil.Command(newRefundBalanceCmd(), testutil.Yes(true), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--expected-email", "seller@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp refundBalanceResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if !resp.Success || resp.UserID != "2245593582708" || resp.Status != "queued" || resp.Count != 1 || resp.TotalAmountCents != 1334 {
+		t.Fatalf("unexpected JSON payload: %s", out)
+	}
+}
+
+func TestRefundBalancePlainOutput(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.URL.Path {
+		case "GET /internal/admin/users/unpaid_balance":
+			testutil.JSON(t, w, map[string]any{
+				"user_id":            "2245593582708",
+				"count":              1,
+				"total":              1334,
+				"total_amount_cents": 1334,
+				"currency":           "usd",
+			})
+		case "POST /internal/admin/users/refund_balance":
+			testutil.JSON(t, w, map[string]any{
+				"user_id":            "2245593582708",
+				"status":             "queued",
+				"message":            "Refund balance queued",
+				"count":              1,
+				"total":              1334,
+				"total_amount_cents": 1334,
+				"currency":           "usd",
+			})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	})
+
+	cmd := testutil.Command(newRefundBalanceCmd(), testutil.Yes(true), testutil.PlainOutput())
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--expected-email", "seller@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	want := "true\tRefund balance queued\t2245593582708\tqueued\t1\t1334\tusd"
+	if strings.TrimSpace(out) != want {
+		t.Fatalf("unexpected plain output: %q", out)
+	}
+}
+
+func TestRefundBalanceServerErrorSurfacesMessage(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.URL.Path {
+		case "GET /internal/admin/users/unpaid_balance":
+			testutil.JSON(t, w, map[string]any{
+				"user_id":            "2245593582708",
+				"count":              1,
+				"total":              1334,
+				"total_amount_cents": 1334,
+				"currency":           "usd",
+			})
+		case "POST /internal/admin/users/refund_balance":
+			w.WriteHeader(http.StatusConflict)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"success": false,
+				"message": "Expected unpaid balance does not match current unpaid balance",
+			})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	})
+
+	cmd := testutil.Command(newRefundBalanceCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--expected-email", "seller@example.com"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "Expected unpaid balance does not match current unpaid balance") {
+		t.Fatalf("expected server message in error, got %v", err)
+	}
+}

--- a/internal/cmd/admin/users/refund_balance_test.go
+++ b/internal/cmd/admin/users/refund_balance_test.go
@@ -134,6 +134,43 @@ func TestRefundBalanceSendsPreviewedCountAndTotal(t *testing.T) {
 	}
 }
 
+func TestRefundBalanceSkipsZeroBalanceWithoutConfirmationOrPost(t *testing.T) {
+	var requests []string
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Method+" "+r.URL.Path)
+		if r.Method == http.MethodPost {
+			t.Error("must not POST when preview has no unpaid purchases")
+		}
+		testutil.JSON(t, w, map[string]any{
+			"user_id":            "2245593582708",
+			"count":              0,
+			"total":              0,
+			"total_amount_cents": 0,
+			"currency":           "usd",
+		})
+	})
+
+	cmd := testutil.Command(newRefundBalanceCmd(), testutil.NoInput(true), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--expected-email", "seller@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if strings.Join(requests, ",") != "GET /internal/admin/users/unpaid_balance" {
+		t.Fatalf("unexpected request sequence: %v", requests)
+	}
+	for _, want := range []string{
+		"No unpaid purchases to refund",
+		"User ID: 2245593582708",
+		"Status: skipped",
+		"Purchases: 0",
+		"Amount: 0 USD cents",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q: %q", want, out)
+		}
+	}
+}
+
 func TestRefundBalanceDryRunPreviewsOnly(t *testing.T) {
 	var gotPost bool
 

--- a/internal/cmd/admin/users/users.go
+++ b/internal/cmd/admin/users/users.go
@@ -26,6 +26,7 @@ func NewUsersCmd() *cobra.Command {
   gumroad admin users unwatch --user-id 2245593582708
   gumroad admin users suspend --user-id 2245593582708 --note "Chargeback risk confirmed"
   gumroad admin users suspend-for-tos-violation --user-id 2245593582708 --note "DMCA takedown notice confirmed"
+  gumroad admin users refund-balance --user-id 2245593582708 --expected-email user@example.com --dry-run
   gumroad admin users reset-password --user-id 2245593582708
   gumroad admin users update-email --user-id 2245593582708 --new-email new@example.com
   gumroad admin users two-factor disable --user-id 2245593582708`,
@@ -45,6 +46,7 @@ func NewUsersCmd() *cobra.Command {
 	cmd.AddCommand(newUnwatchCmd())
 	cmd.AddCommand(newSuspendCmd())
 	cmd.AddCommand(newSuspendForTOSViolationCmd())
+	cmd.AddCommand(newRefundBalanceCmd())
 	cmd.AddCommand(newResetPasswordCmd())
 	cmd.AddCommand(newUpdateEmailCmd())
 	cmd.AddCommand(newTwoFactorCmd())

--- a/internal/cmd/admin/users/users_test.go
+++ b/internal/cmd/admin/users/users_test.go
@@ -191,6 +191,7 @@ func TestNewUsersCmdWiresSubcommands(t *testing.T) {
 		"unwatch",
 		"suspend",
 		"suspend-for-tos-violation",
+		"refund-balance",
 		"reset-password",
 		"update-email",
 		"two-factor",

--- a/skills/embed_test.go
+++ b/skills/embed_test.go
@@ -126,6 +126,8 @@ func TestSkillMarkdown_ContainsAdminRolloutCommands(t *testing.T) {
 		"`admin products flag-for-tos-violation` → `.status`, `.message`, `.user_id`, `.product_id`",
 		"gumroad admin payouts scheduled create --user-id",
 		"`admin payouts scheduled create` → `.message`, `.user_id`, `.scheduled_payout`",
+		"gumroad admin users refund-balance --user-id",
+		"`admin users refund-balance` → `.status`, `.message`, `.user_id`, `.count`, `.total_amount_cents`, `.currency`",
 		"gumroad admin purchases view <purchase-id> --with-clusters",
 		"gumroad admin purchases search --email",
 		"gumroad admin purchases lookup --stripe-fingerprint",

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -74,6 +74,7 @@ Responses are wrapped in `{"success": true, ...}` with resource-specific keys:
 - `admin users mark-compliant`, `admin users suspend`, `admin users suspend-for-tos-violation` → `.status`, `.message`, `.user_id`
 - `admin products flag-for-tos-violation` → `.status`, `.message`, `.user_id`, `.product_id`
 - `admin payouts scheduled create` → `.message`, `.user_id`, `.scheduled_payout`
+- `admin users refund-balance` → `.status`, `.message`, `.user_id`, `.count`, `.total_amount_cents`, `.currency`
 - `admin purchases view` → `.purchase`
 - `admin purchases search` → `.purchases[]`, `.has_more`, `.limit`
 - `admin purchases lookup` → `.purchases[]`
@@ -151,6 +152,10 @@ gumroad admin users suspend-for-tos-violation --user-id 2245593582708 --expected
 gumroad admin products flag-for-tos-violation <product-id> --user-id 2245593582708 --expected-email seller@example.com --yes --json --non-interactive --no-input
 gumroad admin payouts scheduled create --user-id 2245593582708 --expected-email seller@example.com --processor stripe --payout-date 2026-06-15 --note "Appeal window closes before payout." --yes --json --non-interactive --no-input
 gumroad admin payouts scheduled list --status pending --user-id 2245593582708 --json --non-interactive --no-input
+
+# Refund-balance dry-run still calls the preview GET, but skips the guarded POST.
+gumroad admin users refund-balance --user-id 2245593582708 --expected-email seller@example.com --dry-run --json --non-interactive --no-input
+gumroad admin users refund-balance --user-id 2245593582708 --expected-email seller@example.com --yes --json --non-interactive --no-input
 
 # Inspect purchase and product fraud context
 gumroad admin purchases view <purchase-id> --with-clusters --json --non-interactive --no-input


### PR DESCRIPTION
Ref antiwork/gumroad/issues/5153

## What

Adds `gumroad admin users refund-balance` for suspended users. The command previews unpaid balance first, requires `--expected-email`, then queues refund balance only if the previewed count and total still match.

It also supports `--dry-run` for previewing the guarded POST without queueing refunds, and updates the admin docs and embedded skill guidance to match the new flow.

## Why

This closes the gap between the internal admin API and the CLI for the post-suspension refund workflow. The stale-preview guard reduces the risk of refunding the wrong balance after state changes, and the required email check adds a basic account-safety guard.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Queues buyer refunds from Gumroad-held unpaid balance; mistakes or stale preview mismatches are financially impactful despite count/total/email guards.
> 
> **Overview**
> Adds **`gumroad admin users refund-balance`** for post-suspension workflows: it **GETs** unpaid balance, then **POSTs** to queue refunds only when the previewed purchase count and total cents still match (plus required **`--expected-email`**).
> 
> **`--dry-run`** still hits the preview endpoint but prints the guarded POST instead of queueing refunds; zero balance skips confirmation and POST with a **skipped** result. **`admincmd`** now exposes mutation token/actor banner helpers so this two-step flow can show the admin actor before preview. README, embedded skill, and tests document and lock in the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 955ecb198d2a4dddb8448a41162780e56d24121a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->