### PR TITLE
Add URL support for product thumbnails

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ gumroad products create --name "Art Pack" --price 10.00 --cover-image ./cover.jp
 
 # Add preview/gallery images to an existing product
 gumroad products update <product_id> --preview-image ./gallery-1.jpg --preview-image ./gallery-2.jpg
+
+# Set a thumbnail from a public image URL
+gumroad products thumbnail set <product_id> --url https://example.com/thumb.png
 ```
 
 Product media upload supports JPEG, PNG, and GIF. Use `gumroad products covers --help` and `gumroad products thumbnail --help` for full-control resource commands.

--- a/internal/cmd/products/product_media_test.go
+++ b/internal/cmd/products/product_media_test.go
@@ -767,7 +767,7 @@ func TestThumbnailSet_WithImageUploadsAndAttaches(t *testing.T) {
 	path := writeMediaFixture(t, "thumb.png", pngFixtureContents())
 	cmd := testutil.Command(newThumbnailSetCmd(), testutil.JSONOutput())
 	cmd.SetArgs([]string{"prod1", "--image", path})
-	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
 	sequence, forms, _, signedIDs, _, _ := srv.snapshot()
 	if !reflect.DeepEqual(sequence, []string{"POST /direct_uploads", "POST /products/prod1/thumbnail"}) {
@@ -778,6 +778,106 @@ func TestThumbnailSet_WithImageUploadsAndAttaches(t *testing.T) {
 	}
 	if !reflect.DeepEqual(signedIDs, []string{"signed-1"}) {
 		t.Fatalf("attached signed IDs = %#v", signedIDs)
+	}
+	var payload struct {
+		Result struct {
+			Thumbnail struct {
+				GUID string `json:"guid"`
+			} `json:"thumbnail"`
+			Media []productMediaAttachmentResult `json:"media"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("parse JSON output: %v\n%s", err, out)
+	}
+	if payload.Result.Thumbnail.GUID != "thumb-1" {
+		t.Fatalf("expected thumbnail response fields, got %+v", payload.Result.Thumbnail)
+	}
+	if len(payload.Result.Media) != 1 || payload.Result.Media[0].Kind != "thumbnail" {
+		t.Fatalf("expected media metadata, got %+v", payload.Result.Media)
+	}
+}
+
+func TestThumbnailSet_WithURLSendsURL(t *testing.T) {
+	var gotForm urlValues
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/products/prod1/thumbnail" {
+			t.Fatalf("got %s %s, want POST /products/prod1/thumbnail", r.Method, r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		gotForm = urlValues(r.PostForm)
+		testutil.JSON(t, w, map[string]any{
+			"success":   true,
+			"thumbnail": map[string]any{"guid": "thumb-url", "url": "https://cdn.example/thumb.png"},
+		})
+	})
+
+	cmd := testutil.Command(newThumbnailSetCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"prod1", "--url", "https://example.com/assets/thumb.png"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotForm.Get("url") != "https://example.com/assets/thumb.png" {
+		t.Fatalf("url = %q", gotForm.Get("url"))
+	}
+	if gotForm.Get("signed_blob_id") != "" {
+		t.Fatalf("signed_blob_id = %q, want empty", gotForm.Get("signed_blob_id"))
+	}
+
+	var payload struct {
+		Result struct {
+			Thumbnail struct {
+				GUID string `json:"guid"`
+				URL  string `json:"url"`
+			} `json:"thumbnail"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("parse JSON output: %v\n%s", err, out)
+	}
+	if payload.Result.Thumbnail.GUID != "thumb-url" || payload.Result.Thumbnail.URL != "https://cdn.example/thumb.png" {
+		t.Fatalf("unexpected thumbnail JSON: %+v", payload.Result.Thumbnail)
+	}
+}
+
+func TestThumbnailSet_WithMissingOrConflictingMediaFlagsReturnsUsageError(t *testing.T) {
+	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
+		t.Fatal("invalid flags must not reach the API")
+	})
+
+	for _, tc := range []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "missing input",
+			args:    []string{"prod1"},
+			wantErr: "provide --image or --url",
+		},
+		{
+			name:    "image and url",
+			args:    []string{"prod1", "--image", "thumb.png", "--url", "https://example.com/thumb.png"},
+			wantErr: "--image and --url cannot be used together",
+		},
+		{
+			name:    "non-http url",
+			args:    []string{"prod1", "--url", "ftp://example.com/thumb.png"},
+			wantErr: "--url must use http or https",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := testutil.Command(newThumbnailSetCmd())
+			cmd.SetArgs(tc.args)
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatal("expected usage error")
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected %q in error, got %v", tc.wantErr, err)
+			}
+		})
 	}
 }
 

--- a/internal/cmd/products/thumbnail.go
+++ b/internal/cmd/products/thumbnail.go
@@ -1,9 +1,8 @@
 package products
 
 import (
-	"encoding/json"
-	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
@@ -16,6 +15,7 @@ func newThumbnailCmd() *cobra.Command {
 		Use:   "thumbnail",
 		Short: "Manage a product thumbnail",
 		Example: `  gumroad products thumbnail set <product_id> --image ./thumb.jpg
+  gumroad products thumbnail set <product_id> --url https://example.com/thumb.png
   gumroad products thumbnail remove <product_id>`,
 	}
 
@@ -25,7 +25,7 @@ func newThumbnailCmd() *cobra.Command {
 }
 
 func newThumbnailSetCmd() *cobra.Command {
-	var imagePath string
+	var imagePath, thumbnailURL string
 
 	cmd := &cobra.Command{
 		Use:   "set <product_id>",
@@ -33,13 +33,28 @@ func newThumbnailSetCmd() *cobra.Command {
 		Args:  cmdutil.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
-			if !c.Flags().Changed("image") {
-				return cmdutil.MissingFlagError(c, "--image")
+			flags := c.Flags()
+			if !flags.Changed("image") && !flags.Changed("url") {
+				return cmdutil.UsageErrorf(c, "provide --image or --url")
 			}
-			if strings.TrimSpace(imagePath) == "" {
+			if flags.Changed("image") && flags.Changed("url") {
+				return cmdutil.UsageErrorf(c, "--image and --url cannot be used together")
+			}
+			if flags.Changed("image") && strings.TrimSpace(imagePath) == "" {
 				return cmdutil.UsageErrorf(c, "--image cannot be empty")
 			}
 			productID := args[0]
+			path := productMediaAttachPath(productID, productMediaThumbnail)
+
+			if flags.Changed("url") {
+				if err := cmdutil.RequireHTTPURLFlag(c, "url", thumbnailURL); err != nil {
+					return err
+				}
+				params := url.Values{}
+				params.Set("url", thumbnailURL)
+				return cmdutil.RunRequestWithSuccess(opts, "Setting thumbnail...", http.MethodPost, path, params, productID, "Thumbnail set for product "+productID+".")
+			}
+
 			media, err := describeProductMedia([]requestedProductMedia{{Kind: productMediaThumbnail, Path: imagePath}})
 			if err != nil {
 				return err
@@ -57,14 +72,15 @@ func newThumbnailSetCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			data, err := json.Marshal(map[string]any{"media": results})
+			data, err := productMediaSingleAttachResult(results)
 			if err != nil {
-				return fmt.Errorf("could not encode response: %w", err)
+				return err
 			}
 			return cmdutil.PrintMutationSuccess(opts, data, productID, "Thumbnail set for product "+productID+".")
 		},
 	}
 	cmd.Flags().StringVar(&imagePath, "image", "", "Local JPEG, PNG, or GIF image to upload as the thumbnail")
+	cmd.Flags().StringVar(&thumbnailURL, "url", "", "Remote http(s) image URL to set as the thumbnail")
 	return cmd
 }
 

--- a/skills/embed_test.go
+++ b/skills/embed_test.go
@@ -93,9 +93,11 @@ func TestSkillMarkdown_ContainsProductMediaAndBulkGuidance(t *testing.T) {
 		"gumroad products update <id> --preview-image ./gallery-1.jpg --preview-image ./gallery-2.jpg --json --no-input",
 		"gumroad products covers add <id> --image ./cover.jpg --json --no-input",
 		"gumroad products thumbnail set <id> --image ./thumb.jpg --json --no-input",
+		"gumroad products thumbnail set <id> --url https://example.com/thumb.png --json --no-input",
 		"WebP is not supported by the API",
 		"`products update` with media flags → mutation envelope with `.result.media[]`",
 		"`products covers add --url` → `.result.covers[]`, `.result.main_cover_id`",
+		"`products thumbnail set --url` → `.result.thumbnail`",
 		"Check existing products and permalinks first",
 		"Continue past per-product errors",
 	} {

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -61,7 +61,8 @@ Responses are wrapped in `{"success": true, ...}` with resource-specific keys:
 - `products update` with media flags → mutation envelope with `.result.media[]`
 - `products covers add --image` → `.result.covers[]`, `.result.main_cover_id`, plus `.result.media[]`
 - `products covers add --url` → `.result.covers[]`, `.result.main_cover_id`
-- `products thumbnail set` → `.result.media[].response`
+- `products thumbnail set --image` → `.result.thumbnail`, plus `.result.media[]`
+- `products thumbnail set --url` → `.result.thumbnail`
 - `webhooks list` → `.resource_subscriptions[]`
 - `admin users info` → `.user`
 - `admin users affiliates` → `.affiliates[]`
@@ -203,6 +204,7 @@ gumroad products covers add <id> --url https://www.youtube.com/watch?v=qKebcV1jv
 gumroad products covers reorder <id> <cover_id> <cover_id> --json --no-input
 gumroad products covers remove <id> <cover_id> --yes --json --no-input
 gumroad products thumbnail set <id> --image ./thumb.jpg --json --no-input
+gumroad products thumbnail set <id> --url https://example.com/thumb.png --json --no-input
 gumroad products thumbnail remove <id> --yes --json --no-input
 
 # Publish / unpublish
@@ -222,7 +224,7 @@ gumroad products skus <id> --json --no-input
 
 Use `products update --file` for shared product Content. For products with per-variant Content, use `variants update ... --file` for the specific variant you want to change.
 
-Use `--cover-image` for the primary cover, repeat `--preview-image` for additional gallery/preview images, and `--thumbnail` for the card/library thumbnail. These media flags run the required two-step API flow: direct upload first, then attach by signed blob ID.
+Use `--cover-image` for the primary cover, repeat `--preview-image` for additional gallery/preview images, and `--thumbnail` for the card/library thumbnail. These media flags run the required two-step API flow: direct upload first, then attach by signed blob ID. For an existing product, `products thumbnail set --url` asks Gumroad to download and attach a public HTTP(S) image directly.
 
 ### files — Upload and recover file attachments
 


### PR DESCRIPTION
Ref antiwork/gumroad/issues/5328

## What

`products thumbnail set` now accepts either a local image or a public HTTP(S) URL. URL input is validated locally and sent to the existing thumbnail endpoint as `url`; uploaded images keep the direct upload flow and now expose the server thumbnail response alongside media metadata. README and skill examples cover both paths.

## Why

The Gumroad API now supports server-side thumbnail downloads. Mirroring `products covers add --url` lets CLI users set thumbnails without handling a local file upload while keeping storage, validation, and CDN delivery on the server.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CLI product-media change with validation and tests; no auth or core infrastructure changes.
> 
> **Overview**
> **`products thumbnail set`** now accepts either **`--image`** (existing direct-upload flow) or **`--url`** for a public HTTP(S) image, matching the pattern used for **`products covers add --url`**. The command requires one of the two inputs, rejects using both, and validates remote URLs before calling the thumbnail endpoint with a **`url`** form field (no direct upload).
> 
> For **local image** uploads, JSON success output now surfaces the API **`thumbnail`** object (e.g. **`guid`**) alongside **`media[]`**, via shared **`productMediaSingleAttachResult`** handling instead of only returning media metadata.
> 
> **README**, the **agent skill**, and **tests** document the new flag, expected **`.result.thumbnail`** shape for URL vs image paths, and client-side validation (missing input, conflicting flags, non-HTTP(S) URLs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d0214a1452ae4b617522bcd2727fc6afd683ee9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->