### PR TITLE
Add product category browsing and path input

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,19 @@ Run `gumroad --help` and `gumroad <command> --help` for subcommands, usage detai
 
 Admin commands use a separate internal token. Run `gumroad auth login` and check the admin box to store one locally, or use `GUMROAD_ADMIN_TOKEN` with `--non-interactive` in CI and agent runs. For local testing, set `GUMROAD_ADMIN_API_BASE_URL`.
 
+## Product categories
+
+```sh
+# Find the category path to use on create/update
+gumroad products categories --search figma
+
+# Set a product category by path
+gumroad products create --name "Figma Kit" --category design/ui-and-web/figma
+gumroad products update <product_id> --category design/ui-and-web/figma
+```
+
+Use the `path` from `gumroad products categories` with `--category`. The older numeric `--taxonomy-id` flag still works when you already have an API taxonomy ID, but it cannot be combined with `--category`.
+
 ## File attachments
 
 ```sh

--- a/internal/cmd/products/categories.go
+++ b/internal/cmd/products/categories.go
@@ -1,0 +1,127 @@
+package products
+
+import (
+	"encoding/json"
+	"io"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/config"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+type productCategoryListItem struct {
+	ID       api.JSONInt  `json:"id"`
+	Name     string       `json:"name"`
+	Label    string       `json:"label"`
+	Path     string       `json:"path"`
+	ParentID *api.JSONInt `json:"parent_id"`
+}
+
+type productCategoriesResponse struct {
+	Success    bool                      `json:"success"`
+	Categories []productCategoryListItem `json:"categories"`
+}
+
+func newCategoriesCmd() *cobra.Command {
+	var search string
+
+	cmd := &cobra.Command{
+		Use:   "categories",
+		Short: "List product categories",
+		Long:  "List product categories. Use the PATH value with products create or products update --category.",
+		Args:  cmdutil.ExactArgs(0),
+		Example: `  gumroad products categories
+  gumroad products categories --search figma
+  gumroad products categories --json --jq '.categories[] | {label, path}'`,
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			return runProductCategoriesList(opts, search)
+		},
+	}
+
+	cmd.Flags().StringVar(&search, "search", "", "Filter by label or path")
+
+	return cmd
+}
+
+func runProductCategoriesList(opts cmdutil.Options, search string) error {
+	token, err := config.Token()
+	if err != nil {
+		return err
+	}
+
+	data, err := cmdutil.RunWithTokenData(opts, token, "Fetching product categories...",
+		func(client *api.Client) (json.RawMessage, error) {
+			return client.Get("/categories", url.Values{})
+		})
+	if err != nil {
+		return err
+	}
+
+	resp, err := cmdutil.DecodeJSON[productCategoriesResponse](data)
+	if err != nil {
+		return err
+	}
+	resp.Categories = filterProductCategories(resp.Categories, search)
+
+	if opts.UsesJSONOutput() {
+		data, err := json.Marshal(resp)
+		if err != nil {
+			return err
+		}
+		return output.PrintJSON(opts.Out(), data, opts.JQExpr)
+	}
+
+	return renderProductCategoriesList(opts, resp.Categories, search)
+}
+
+func filterProductCategories(categories []productCategoryListItem, search string) []productCategoryListItem {
+	query := strings.ToLower(strings.TrimSpace(search))
+	if query == "" {
+		return categories
+	}
+
+	filtered := make([]productCategoryListItem, 0, len(categories))
+	for _, category := range categories {
+		if strings.Contains(strings.ToLower(category.Label), query) ||
+			strings.Contains(strings.ToLower(category.Path), query) {
+			filtered = append(filtered, category)
+		}
+	}
+	return filtered
+}
+
+func renderProductCategoriesList(opts cmdutil.Options, categories []productCategoryListItem, search string) error {
+	if len(categories) == 0 {
+		if strings.TrimSpace(search) != "" {
+			return cmdutil.PrintInfo(opts, "No product categories found matching "+strconv.Quote(search)+".")
+		}
+		return cmdutil.PrintInfo(opts, "No product categories found.")
+	}
+
+	if opts.PlainOutput {
+		rows := make([][]string, 0, len(categories))
+		for _, category := range categories {
+			rows = append(rows, []string{category.Label, category.Path, categoryIDString(category)})
+		}
+		return output.PrintPlain(opts.Out(), rows)
+	}
+
+	style := opts.Style()
+	tbl := output.NewStyledTable(style, "LABEL", "PATH", "ID")
+	for _, category := range categories {
+		tbl.AddRow(category.Label, category.Path, categoryIDString(category))
+	}
+	return output.WithPager(opts.Out(), opts.Err(), func(w io.Writer) error {
+		return tbl.Render(w)
+	})
+}
+
+func categoryIDString(category productCategoryListItem) string {
+	return strconv.Itoa(int(category.ID))
+}

--- a/internal/cmd/products/categories_test.go
+++ b/internal/cmd/products/categories_test.go
@@ -15,6 +15,7 @@ func productCategoriesHandler(t *testing.T) http.HandlerFunc {
 			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
 		}
 		testutil.JSON(t, w, map[string]any{
+			"success": true,
 			"categories": []map[string]any{
 				{"id": 10, "name": "design", "label": "Design", "path": "design", "parent_id": nil},
 				{"id": 11, "name": "ui-and-web", "label": "UI & Web", "path": "design/ui-and-web", "parent_id": 10},
@@ -51,6 +52,9 @@ func TestCategories_JSON(t *testing.T) {
 	var resp productCategoriesResponse
 	if err := json.Unmarshal([]byte(out), &resp); err != nil {
 		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+	if !resp.Success {
+		t.Fatalf("success = false, want true")
 	}
 	if len(resp.Categories) != 4 {
 		t.Fatalf("got %d categories, want 4", len(resp.Categories))

--- a/internal/cmd/products/categories_test.go
+++ b/internal/cmd/products/categories_test.go
@@ -1,0 +1,106 @@
+package products
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func productCategoriesHandler(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" || r.URL.Path != "/categories" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		testutil.JSON(t, w, map[string]any{
+			"categories": []map[string]any{
+				{"id": 10, "name": "design", "label": "Design", "path": "design", "parent_id": nil},
+				{"id": 11, "name": "ui-and-web", "label": "UI & Web", "path": "design/ui-and-web", "parent_id": 10},
+				{"id": 12, "name": "figma", "label": "Figma", "path": "design/ui-and-web/figma", "parent_id": 11},
+				{"id": 20, "name": "business-and-money", "label": "Business & Money", "path": "business-and-money", "parent_id": nil},
+			},
+		})
+	}
+}
+
+func TestCategories_Table(t *testing.T) {
+	testutil.Setup(t, productCategoriesHandler(t))
+
+	cmd := newCategoriesCmd()
+	out := testutil.CaptureStdout(func() {
+		testutil.MustExecute(t, cmd)
+	})
+
+	for _, want := range []string{"LABEL", "PATH", "ID", "Figma", "design/ui-and-web/figma", "12"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in output: %q", want, out)
+		}
+	}
+}
+
+func TestCategories_JSON(t *testing.T) {
+	testutil.Setup(t, productCategoriesHandler(t))
+
+	cmd := testutil.Command(newCategoriesCmd(), testutil.JSONOutput())
+	out := testutil.CaptureStdout(func() {
+		testutil.MustExecute(t, cmd)
+	})
+
+	var resp productCategoriesResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+	if len(resp.Categories) != 4 {
+		t.Fatalf("got %d categories, want 4", len(resp.Categories))
+	}
+	if resp.Categories[2].Path != "design/ui-and-web/figma" {
+		t.Fatalf("unexpected category order or path: %+v", resp.Categories)
+	}
+}
+
+func TestCategories_SearchFiltersByLabelOrPath(t *testing.T) {
+	testutil.Setup(t, productCategoriesHandler(t))
+
+	cmd := testutil.Command(newCategoriesCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--search", "ui-and-web"})
+	out := testutil.CaptureStdout(func() {
+		testutil.MustExecute(t, cmd)
+	})
+
+	var resp productCategoriesResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+	if len(resp.Categories) != 2 {
+		t.Fatalf("got %d categories, want 2: %+v", len(resp.Categories), resp.Categories)
+	}
+	for _, category := range resp.Categories {
+		if !strings.Contains(category.Path, "ui-and-web") {
+			t.Fatalf("search returned non-matching category: %+v", category)
+		}
+	}
+
+	cmd = newCategoriesCmd()
+	cmd.SetArgs([]string{"--search", "business"})
+	out = testutil.CaptureStdout(func() {
+		testutil.MustExecute(t, cmd)
+	})
+	if strings.Contains(out, "Figma") || !strings.Contains(out, "Business & Money") {
+		t.Fatalf("label search did not filter table output: %q", out)
+	}
+}
+
+func TestCategories_JQ(t *testing.T) {
+	testutil.Setup(t, productCategoriesHandler(t))
+
+	cmd := testutil.Command(newCategoriesCmd(), testutil.JQ(".categories[] | select(.label == \"Figma\") | .path"))
+	out := testutil.CaptureStdout(func() {
+		testutil.MustExecute(t, cmd)
+	})
+
+	if strings.TrimSpace(out) != `"design/ui-and-web/figma"` {
+		t.Fatalf("unexpected jq output: %q", out)
+	}
+}

--- a/internal/cmd/products/category_flags.go
+++ b/internal/cmd/products/category_flags.go
@@ -1,0 +1,14 @@
+package products
+
+import (
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+func validateProductCategoryFlags(cmd *cobra.Command) error {
+	flags := cmd.Flags()
+	if flags.Changed("category") && flags.Changed("taxonomy-id") {
+		return cmdutil.UsageErrorf(cmd, "specify either --category or --taxonomy-id, not both")
+	}
+	return nil
+}

--- a/internal/cmd/products/create.go
+++ b/internal/cmd/products/create.go
@@ -79,7 +79,7 @@ type dryRunCreatePayload struct {
 
 func newCreateCmd() *cobra.Command {
 	var name, nativeType, currency, description, customPermalink string
-	var customSummary, customReceipt, subscriptionDuration, taxonomyID string
+	var customSummary, customReceipt, subscriptionDuration, category, taxonomyID string
 	var price, suggestedPrice string
 	var maxPurchaseCount int
 	var payWhatYouWant bool
@@ -94,6 +94,7 @@ func newCreateCmd() *cobra.Command {
 		Example: `  gumroad products create --name "Art Pack" --price 10.00
   gumroad products create --name "Art Pack" --file ./pack.zip --file-name "Art Pack.zip"
   gumroad products create --name "Art Pack" --cover-image ./cover.jpg --thumbnail ./thumb.jpg
+  gumroad products create --name "Figma Kit" --category design/ui-and-web/figma
   gumroad products create --name "Newsletter" --type membership --subscription-duration monthly
   gumroad products create --name "E-Book" --type ebook --price 5 --tag art --tag digital`,
 		Args: cmdutil.ExactArgs(0),
@@ -119,6 +120,9 @@ func newCreateCmd() *cobra.Command {
 			}
 
 			if err := cmdutil.RequireNonNegativeIntFlag(c, "max-purchase-count", maxPurchaseCount); err != nil {
+				return err
+			}
+			if err := validateProductCategoryFlags(c); err != nil {
 				return err
 			}
 
@@ -172,6 +176,9 @@ func newCreateCmd() *cobra.Command {
 			}
 			if flags.Changed("max-purchase-count") {
 				params.Set("max_purchase_count", strconv.Itoa(maxPurchaseCount))
+			}
+			if flags.Changed("category") {
+				params.Set("category", category)
 			}
 			if flags.Changed("taxonomy-id") {
 				params.Set("taxonomy_id", taxonomyID)
@@ -279,7 +286,8 @@ func newCreateCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&payWhatYouWant, "pay-what-you-want", false, "Enable pay-what-you-want pricing")
 	cmd.Flags().StringVar(&suggestedPrice, "suggested-price", "", "Suggested price for pay-what-you-want (e.g. 5, 5.00)")
 	cmd.Flags().IntVar(&maxPurchaseCount, "max-purchase-count", 0, "Maximum number of purchases (inventory limit)")
-	cmd.Flags().StringVar(&taxonomyID, "taxonomy-id", "", "Taxonomy/category ID")
+	cmd.Flags().StringVar(&category, "category", "", "Product category path (for example: design/ui-and-web/figma)")
+	cmd.Flags().StringVar(&taxonomyID, "taxonomy-id", "", "Numeric taxonomy/category ID")
 	cmd.Flags().StringVar(&subscriptionDuration, "subscription-duration", "", "Subscription duration (membership only: monthly, quarterly, biannually, yearly, every_two_years)")
 	cmd.Flags().StringArrayVar(&tags, "tag", nil, "Tag (repeatable)")
 	cmd.Flags().StringArrayVar(&files, "file", nil, "Attach a local file to the new product (repeatable)")

--- a/internal/cmd/products/products.go
+++ b/internal/cmd/products/products.go
@@ -16,7 +16,10 @@ func NewProductsCmd() *cobra.Command {
   gumroad products create --name "Art Pack" --price 10.00
   gumroad products create --name "Art Pack" --file ./pack.zip --file-name "Art Pack.zip"
   gumroad products create --name "Art Pack" --cover-image ./cover.jpg --thumbnail ./thumb.jpg
+  gumroad products categories --search figma
+  gumroad products create --name "Figma Kit" --category design/ui-and-web/figma
   gumroad products update <product_id> --name "New Name"
+  gumroad products update <product_id> --category design/ui-and-web/figma
   gumroad products update <product_id> --preview-image ./gallery.jpg
   gumroad products covers add <product_id> --image ./cover.jpg
   gumroad products thumbnail set <product_id> --image ./thumb.jpg
@@ -31,6 +34,7 @@ func NewProductsCmd() *cobra.Command {
 
 	cmd.AddCommand(newCreateCmd())
 	cmd.AddCommand(newUpdateCmd())
+	cmd.AddCommand(newCategoriesCmd())
 	cmd.AddCommand(newListCmd())
 	cmd.AddCommand(newViewCmd())
 	cmd.AddCommand(newDeleteCmd())

--- a/internal/cmd/products/products_test.go
+++ b/internal/cmd/products/products_test.go
@@ -604,6 +604,47 @@ func TestCreate_AllOptionalFlags(t *testing.T) {
 	}
 }
 
+func TestCreate_CategorySendsCategoryParam(t *testing.T) {
+	var gotForm url.Values
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotForm = r.PostForm
+		testutil.JSON(t, w, map[string]any{
+			"product": map[string]any{
+				"id": "p1", "name": "Figma Kit", "formatted_price": "$0",
+			},
+		})
+	})
+
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--name", "Figma Kit", "--category", "design/ui-and-web/figma"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if got := gotForm.Get("category"); got != "design/ui-and-web/figma" {
+		t.Fatalf("category = %q, want design/ui-and-web/figma", got)
+	}
+	if got := gotForm.Get("taxonomy_id"); got != "" {
+		t.Fatalf("taxonomy_id should not be sent with --category, got %q", got)
+	}
+}
+
+func TestCreate_CategoryAndTaxonomyIDError(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API")
+	})
+
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{
+		"--name", "Figma Kit",
+		"--category", "design/ui-and-web/figma",
+		"--taxonomy-id", "12",
+	})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "specify either --category or --taxonomy-id") {
+		t.Fatalf("expected mutually exclusive category error, got: %v", err)
+	}
+}
+
 func TestCreate_MissingName(t *testing.T) {
 	cmd := newCreateCmd()
 	cmd.SetArgs([]string{"--price", "1.00"})
@@ -918,6 +959,43 @@ func TestUpdate_MultipleFlags(t *testing.T) {
 		if got := gotForm.Get(param); got != want {
 			t.Errorf("param %s: got %q, want %q", param, got, want)
 		}
+	}
+}
+
+func TestUpdate_CategorySendsCategoryParam(t *testing.T) {
+	var gotForm url.Values
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotForm = r.PostForm
+		testutil.JSON(t, w, map[string]any{})
+	})
+
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{"prod1", "--category", "design/ui-and-web/figma"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if got := gotForm.Get("category"); got != "design/ui-and-web/figma" {
+		t.Fatalf("category = %q, want design/ui-and-web/figma", got)
+	}
+	if got := gotForm.Get("taxonomy_id"); got != "" {
+		t.Fatalf("taxonomy_id should not be sent with --category, got %q", got)
+	}
+}
+
+func TestUpdate_CategoryAndTaxonomyIDError(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API")
+	})
+
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{
+		"prod1",
+		"--category", "design/ui-and-web/figma",
+		"--taxonomy-id", "12",
+	})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "specify either --category or --taxonomy-id") {
+		t.Fatalf("expected mutually exclusive category error, got: %v", err)
 	}
 }
 

--- a/internal/cmd/products/update.go
+++ b/internal/cmd/products/update.go
@@ -12,7 +12,7 @@ import (
 
 func newUpdateCmd() *cobra.Command {
 	var name, currency, description, customPermalink string
-	var customSummary, customReceipt, taxonomyID string
+	var customSummary, customReceipt, category, taxonomyID string
 	var price, suggestedPrice string
 	var maxPurchaseCount int
 	var payWhatYouWant bool
@@ -31,6 +31,7 @@ func newUpdateCmd() *cobra.Command {
 		Short: "Update a product",
 		Example: `  gumroad products update <id> --name "New Name"
   gumroad products update <id> --price 15.00 --currency eur
+  gumroad products update <id> --category design/ui-and-web/figma
   gumroad products update <id> --tag art --tag digital
   gumroad products update <id> --cover-image ./cover.jpg
   gumroad products update <id> --preview-image ./gallery-1.jpg --preview-image ./gallery-2.jpg
@@ -45,7 +46,7 @@ func newUpdateCmd() *cobra.Command {
 				"name", "price", "currency", "description",
 				"custom-permalink", "custom-summary", "custom-receipt",
 				"pay-what-you-want", "suggested-price", "max-purchase-count",
-				"taxonomy-id", "tag",
+				"category", "taxonomy-id", "tag",
 				"file", "file-name", "file-description",
 				"keep-file", "remove-file", "replace-files",
 				"cover-image", "preview-image", "thumbnail",
@@ -57,6 +58,9 @@ func newUpdateCmd() *cobra.Command {
 				return cmdutil.UsageErrorf(c, "--name cannot be empty")
 			}
 			if err := cmdutil.RequireNonNegativeIntFlag(c, "max-purchase-count", maxPurchaseCount); err != nil {
+				return err
+			}
+			if err := validateProductCategoryFlags(c); err != nil {
 				return err
 			}
 			requestedUploads, err := collectRequestedProductUploads(c, files, fileNames, fileDescriptions)
@@ -110,6 +114,9 @@ func newUpdateCmd() *cobra.Command {
 			}
 			if flags.Changed("max-purchase-count") {
 				params.Set("max_purchase_count", strconv.Itoa(maxPurchaseCount))
+			}
+			if flags.Changed("category") {
+				params.Set("category", category)
 			}
 			if flags.Changed("taxonomy-id") {
 				params.Set("taxonomy_id", taxonomyID)
@@ -261,7 +268,8 @@ func newUpdateCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&payWhatYouWant, "pay-what-you-want", false, "Enable pay-what-you-want pricing")
 	cmd.Flags().StringVar(&suggestedPrice, "suggested-price", "", "New suggested price for pay-what-you-want (e.g. 5, 5.00)")
 	cmd.Flags().IntVar(&maxPurchaseCount, "max-purchase-count", 0, "New maximum number of purchases")
-	cmd.Flags().StringVar(&taxonomyID, "taxonomy-id", "", "New taxonomy/category ID")
+	cmd.Flags().StringVar(&category, "category", "", "New product category path (for example: design/ui-and-web/figma)")
+	cmd.Flags().StringVar(&taxonomyID, "taxonomy-id", "", "New numeric taxonomy/category ID")
 	cmd.Flags().StringArrayVar(&tags, "tag", nil, "Tag (repeatable, replaces all existing tags)")
 	cmd.Flags().StringArrayVar(&files, "file", nil, "Attach a new local file (repeatable)")
 	cmd.Flags().StringArrayVar(&fileNames, "file-name", nil, "Display name for the matching --file (repeatable)")
@@ -281,7 +289,7 @@ func productUpdateFieldFlagsChanged(cmd *cobra.Command) bool {
 		"name", "price", "currency", "description",
 		"custom-permalink", "custom-summary", "custom-receipt",
 		"pay-what-you-want", "suggested-price", "max-purchase-count",
-		"taxonomy-id", "tag",
+		"category", "taxonomy-id", "tag",
 	} {
 		if cmd.Flags().Changed(flag) {
 			return true

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -181,8 +181,12 @@ gumroad products list --json --no-input
 # View a product
 gumroad products view <id> --json --no-input
 
+# Find product categories
+gumroad products categories --search figma --json --no-input
+
 # Create a product (created as draft)
 gumroad products create --name "Art Pack" --price 10.00 --json --no-input
+gumroad products create --name "Figma Kit" --category design/ui-and-web/figma --json --no-input
 gumroad products create --name "Art Pack" --price 10.00 --file ./pack.zip --file-name "Art Pack.zip" --json --no-input
 gumroad products create --name "Art Pack" --price 10.00 --cover-image ./cover.jpg --thumbnail ./thumb.jpg --json --no-input
 gumroad products create --name "Newsletter" --type membership --subscription-duration monthly --json --no-input
@@ -191,6 +195,7 @@ gumroad products create --name "E-Book" --type ebook --price 5 --tag art --tag d
 # Update a product
 gumroad products update <id> --name "New Name" --json --no-input
 gumroad products update <id> --price 15.00 --currency eur --json --no-input
+gumroad products update <id> --category design/ui-and-web/figma --json --no-input
 gumroad products update <id> --file ./pack.zip --json --no-input
 gumroad products update <id> --cover-image ./cover.jpg --json --no-input
 gumroad products update <id> --preview-image ./gallery-1.jpg --preview-image ./gallery-2.jpg --json --no-input
@@ -218,9 +223,11 @@ gumroad products delete <id> --yes --json --no-input
 gumroad products skus <id> --json --no-input
 ```
 
-**Create flags:** `--name` (required), `--price`, `--type` (digital|course|ebook|membership|bundle|coffee|call|commission), `--currency`, `--pay-what-you-want`, `--suggested-price`, `--description`, `--custom-summary`, `--custom-permalink`, `--custom-receipt`, `--max-purchase-count`, `--taxonomy-id`, `--tag` (repeatable), `--file` (repeatable), `--file-name` (repeatable, aligned to `--file`), `--file-description` (repeatable, aligned to `--file`), `--cover-image`, `--preview-image` (repeatable), `--thumbnail`.
+**Categories:** `products categories [--search <term>]` returns label, path, and numeric ID. Prefer `--category <path>` for product create/update. `--taxonomy-id` remains supported when you already have the numeric ID, but it cannot be combined with `--category`.
 
-**Update flags:** `--name`, `--price`, `--currency`, `--description`, `--custom-summary`, `--custom-permalink`, `--custom-receipt`, `--max-purchase-count`, `--taxonomy-id`, `--tag` (repeatable), `--file` (repeatable), `--file-name`, `--file-description`, `--remove-file` (repeatable), `--replace-files`, `--keep-file` (repeatable with `--replace-files`), `--cover-image`, `--preview-image` (repeatable), `--thumbnail`. Updates preserve existing files by default unless `--replace-files` is set.
+**Create flags:** `--name` (required), `--price`, `--type` (digital|course|ebook|membership|bundle|coffee|call|commission), `--currency`, `--pay-what-you-want`, `--suggested-price`, `--description`, `--custom-summary`, `--custom-permalink`, `--custom-receipt`, `--max-purchase-count`, `--category`, `--taxonomy-id`, `--tag` (repeatable), `--file` (repeatable), `--file-name` (repeatable, aligned to `--file`), `--file-description` (repeatable, aligned to `--file`), `--cover-image`, `--preview-image` (repeatable), `--thumbnail`.
+
+**Update flags:** `--name`, `--price`, `--currency`, `--description`, `--custom-summary`, `--custom-permalink`, `--custom-receipt`, `--max-purchase-count`, `--category`, `--taxonomy-id`, `--tag` (repeatable), `--file` (repeatable), `--file-name`, `--file-description`, `--remove-file` (repeatable), `--replace-files`, `--keep-file` (repeatable with `--replace-files`), `--cover-image`, `--preview-image` (repeatable), `--thumbnail`. Updates preserve existing files by default unless `--replace-files` is set.
 
 Use `products update --file` for shared product Content. For products with per-variant Content, use `variants update ... --file` for the specific variant you want to change.
 


### PR DESCRIPTION
Ref antiwork/gumroad/issues/5329

## What

Adds CLI support for product categories: users can list available category paths with `gumroad products categories`, filter them with `--search`, and use `--category <path>` when creating or updating products.

The existing `--taxonomy-id` flag remains supported, but `--category` and `--taxonomy-id` are mutually exclusive.

## Why

Category paths are easier to discover and use than numeric taxonomy IDs. This follows the new API contract where the server owns category path resolution, keeping the CLI simple and avoiding duplicated taxonomy logic.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only product metadata and a read-only categories endpoint; validation prevents conflicting flags, with broad test coverage.
> 
> **Overview**
> Adds **`gumroad products categories`** to list taxonomy entries from `GET /categories`, with optional **`--search`** filtering on label or path and the usual table, plain, JSON, and jq output modes.
> 
> **`products create`** and **`products update`** gain **`--category <path>`**, which sends a `category` form field to the API. **`--taxonomy-id`** is unchanged but documented as numeric-only; **`validateProductCategoryFlags`** rejects using both flags together.
> 
> README and the agent skill document the discovery → create/update workflow (e.g. `categories --search figma`, then `--category design/ui-and-web/figma`). Tests cover the list command, API param mapping, and mutual exclusion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08b9224a32227dd24a573473794b211835d57f95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->