### PR TITLE
Add refund-policy CLI for account-level settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ export GUMROAD_ACCESS_TOKEN=your-token
 # View your account
 gumroad user
 
+# View or set your account refund policy
+gumroad refund-policy view
+gumroad refund-policy set --period 30 --fine-print "Refund requests are reviewed within 2 business days."
+
 # List products, then inspect one
 gumroad products list
 gumroad products view abc123
@@ -70,6 +74,21 @@ When a browser isn't available, the CLI prints the authorize URL and you paste t
 Run `gumroad --help` and `gumroad <command> --help` for subcommands, usage details, and examples.
 
 Admin commands use a separate internal token. Run `gumroad auth login` and check the admin box to store one locally, or use `GUMROAD_ADMIN_TOKEN` with `--non-interactive` in CI and agent runs. For local testing, set `GUMROAD_ADMIN_API_BASE_URL`.
+
+## Refund policy
+
+```sh
+# Read the store-wide refund policy shown to buyers
+gumroad refund-policy view
+
+# Set the refund period and fine print
+gumroad refund-policy set --period 30 --fine-print "Refund requests are reviewed within 2 business days."
+
+# Clear fine print and allow no refunds
+gumroad refund-policy set --period none --fine-print ""
+```
+
+Refund policy is account-level, not per-product. Allowed periods are `none`, `7`, `14`, `30`, and `183`; `--fine-print` is optional and capped by the API at 3000 characters.
 
 ## Product categories
 

--- a/cmd/gen-man/main_test.go
+++ b/cmd/gen-man/main_test.go
@@ -28,6 +28,14 @@ func TestRunRemovesStaleManPagesAndGeneratesCurrentTree(t *testing.T) {
 	if _, err := os.Stat(productSKUsPath); err != nil {
 		t.Fatalf("expected nested sku man page, got err=%v", err)
 	}
+	refundPolicyPath := filepath.Join(outputDir, "gumroad-refund-policy.1")
+	if _, err := os.Stat(refundPolicyPath); err != nil {
+		t.Fatalf("expected refund policy man page, got err=%v", err)
+	}
+	refundPolicySetPath := filepath.Join(outputDir, "gumroad-refund-policy-set.1")
+	if _, err := os.Stat(refundPolicySetPath); err != nil {
+		t.Fatalf("expected refund policy set man page, got err=%v", err)
+	}
 
 	productPageData, err := os.ReadFile(filepath.Join(outputDir, "gumroad-products.1"))
 	if err != nil {

--- a/cmd/gen-man/main_test.go
+++ b/cmd/gen-man/main_test.go
@@ -32,6 +32,10 @@ func TestRunRemovesStaleManPagesAndGeneratesCurrentTree(t *testing.T) {
 	if _, err := os.Stat(refundPolicyPath); err != nil {
 		t.Fatalf("expected refund policy man page, got err=%v", err)
 	}
+	refundPolicyViewPath := filepath.Join(outputDir, "gumroad-refund-policy-view.1")
+	if _, err := os.Stat(refundPolicyViewPath); err != nil {
+		t.Fatalf("expected refund policy view man page, got err=%v", err)
+	}
 	refundPolicySetPath := filepath.Join(outputDir, "gumroad-refund-policy-set.1")
 	if _, err := os.Stat(refundPolicySetPath); err != nil {
 		t.Fatalf("expected refund policy set man page, got err=%v", err)

--- a/internal/cmd/refundpolicy/refundpolicy.go
+++ b/internal/cmd/refundpolicy/refundpolicy.go
@@ -1,0 +1,168 @@
+package refundpolicy
+
+import (
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+const refundPolicyPath = "/refund_policy"
+
+var allowedRefundPeriods = []string{"none", "7", "14", "30", "183"}
+
+type refundPolicy struct {
+	RefundPeriod string  `json:"refund_period"`
+	Title        string  `json:"title"`
+	FinePrint    *string `json:"fine_print"`
+	InEffect     bool    `json:"in_effect"`
+}
+
+type refundPolicyResponse struct {
+	RefundPolicy refundPolicy `json:"refund_policy"`
+}
+
+func NewRefundPolicyCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "refund-policy",
+		Short: "View and update the account refund policy",
+		Long: "View and update the account-level refund policy shown to buyers.\n\n" +
+			"Refund policy is store-wide. Allowed refund periods are none, 7, 14, 30, and 183 days.",
+		Example: `  gumroad refund-policy view
+  gumroad refund-policy view --json --jq '.refund_policy.refund_period'
+  gumroad refund-policy set --period 30 --fine-print "Refund requests are reviewed within 2 business days."
+  gumroad refund-policy set --period none --fine-print ""`,
+	}
+
+	cmd.AddCommand(newViewCmd())
+	cmd.AddCommand(newSetCmd())
+
+	return cmd
+}
+
+func newViewCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "view",
+		Short: "Show the account refund policy",
+		Args:  cmdutil.ExactArgs(0),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			return cmdutil.RunRequestDecoded[refundPolicyResponse](opts,
+				"Fetching refund policy...", http.MethodGet, refundPolicyPath, url.Values{},
+				func(resp refundPolicyResponse) error {
+					return renderRefundPolicy(opts, resp, "")
+				})
+		},
+	}
+}
+
+func newSetCmd() *cobra.Command {
+	var period, finePrint string
+
+	cmd := &cobra.Command{
+		Use:   "set --period <none|7|14|30|183>",
+		Short: "Update the account refund policy",
+		Args:  cmdutil.ExactArgs(0),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			if period == "" {
+				return cmdutil.MissingFlagError(c, "--period")
+			}
+			if err := validateRefundPeriod(c, period); err != nil {
+				return err
+			}
+
+			params := url.Values{}
+			params.Set("refund_period", period)
+			if c.Flags().Changed("fine-print") {
+				params.Set("fine_print", finePrint)
+			}
+
+			return cmdutil.RunRequestDecoded[refundPolicyResponse](opts,
+				"Updating refund policy...", http.MethodPut, refundPolicyPath, params,
+				func(resp refundPolicyResponse) error {
+					return renderRefundPolicy(opts, resp, "Updated refund policy.")
+				})
+		},
+	}
+
+	cmd.Flags().StringVar(&period, "period", "", "Refund period: none, 7, 14, 30, or 183 (required)")
+	cmd.Flags().StringVar(&finePrint, "fine-print", "", "Optional fine print; pass an empty value to clear it")
+	_ = cmd.RegisterFlagCompletionFunc("period", refundPeriodCompletion)
+
+	return cmd
+}
+
+func validateRefundPeriod(cmd *cobra.Command, period string) error {
+	for _, allowed := range allowedRefundPeriods {
+		if period == allowed {
+			return nil
+		}
+	}
+	return cmdutil.UsageErrorf(cmd, "--period must be one of: %s", strings.Join(allowedRefundPeriods, ", "))
+}
+
+func refundPeriodCompletion(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return allowedRefundPeriods, cobra.ShellCompDirectiveNoFileComp
+}
+
+func renderRefundPolicy(opts cmdutil.Options, resp refundPolicyResponse, header string) error {
+	policy := resp.RefundPolicy
+
+	if opts.PlainOutput {
+		return output.PrintPlain(opts.Out(), [][]string{{
+			policy.RefundPeriod,
+			policy.Title,
+			finePrintValue(policy.FinePrint),
+			strconv.FormatBool(policy.InEffect),
+		}})
+	}
+
+	if header != "" {
+		if opts.Quiet {
+			return nil
+		}
+		if err := output.Writeln(opts.Out(), opts.Style().Green(header)); err != nil {
+			return err
+		}
+	}
+
+	if err := output.Writeln(opts.Out(), opts.Style().Bold("Refund policy")); err != nil {
+		return err
+	}
+	if err := output.Writef(opts.Out(), "Period: %s\n", policy.RefundPeriod); err != nil {
+		return err
+	}
+	if err := output.Writef(opts.Out(), "Title: %s\n", policy.Title); err != nil {
+		return err
+	}
+	if err := output.Writef(opts.Out(), "Fine print: %s\n", displayFinePrint(policy.FinePrint)); err != nil {
+		return err
+	}
+	return output.Writef(opts.Out(), "In effect: %s\n", yesNo(policy.InEffect))
+}
+
+func finePrintValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func displayFinePrint(value *string) string {
+	if value == nil || *value == "" {
+		return "(none)"
+	}
+	return *value
+}
+
+func yesNo(value bool) string {
+	if value {
+		return "yes"
+	}
+	return "no"
+}

--- a/internal/cmd/refundpolicy/refundpolicy_test.go
+++ b/internal/cmd/refundpolicy/refundpolicy_test.go
@@ -52,6 +52,38 @@ func TestView_RendersRefundPolicy(t *testing.T) {
 	}
 }
 
+func TestNewRefundPolicyCmd_RegistersSubcommands(t *testing.T) {
+	cmd := NewRefundPolicyCmd()
+
+	for _, args := range [][]string{{"view"}, {"set", "--period", "30"}} {
+		found, _, err := cmd.Find(args)
+		if err != nil {
+			t.Fatalf("Find(%v) failed: %v", args, err)
+		}
+		if found == nil {
+			t.Fatalf("Find(%v) returned nil command", args)
+		}
+	}
+}
+
+func TestView_NilFinePrintAndInactivePolicy(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, refundPolicyPayload("none", "No refunds allowed", nil, false))
+	})
+
+	cmd := newViewCmd()
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	for _, want := range []string{
+		"Fine print: (none)",
+		"In effect: no",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q: %q", want, out)
+		}
+	}
+}
+
 func TestView_JSON(t *testing.T) {
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
 		testutil.JSON(t, w, refundPolicyPayload("none", "No refunds allowed", nil, false))
@@ -152,6 +184,20 @@ func TestSet_OmitsFinePrintWhenFlagNotProvided(t *testing.T) {
 
 	if hasFinePrint {
 		t.Fatal("fine_print must be omitted when --fine-print is not provided")
+	}
+}
+
+func TestSet_QuietSuppressesHumanOutput(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, refundPolicyPayload("7", "7-day money back guarantee", nil, true))
+	})
+
+	cmd := testutil.Command(newSetCmd())
+	cmd.SetArgs([]string{"--period", "7"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if out != "" {
+		t.Fatalf("quiet set command should not print human output, got %q", out)
 	}
 }
 

--- a/internal/cmd/refundpolicy/refundpolicy_test.go
+++ b/internal/cmd/refundpolicy/refundpolicy_test.go
@@ -1,0 +1,257 @@
+package refundpolicy
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+	"github.com/spf13/cobra"
+)
+
+func refundPolicyPayload(period, title string, finePrint any, inEffect bool) map[string]any {
+	return map[string]any{
+		"refund_policy": map[string]any{
+			"refund_period": period,
+			"title":         title,
+			"fine_print":    finePrint,
+			"in_effect":     inEffect,
+		},
+	}
+}
+
+func TestView_RendersRefundPolicy(t *testing.T) {
+	var gotMethod, gotPath string
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		testutil.JSON(t, w, refundPolicyPayload(
+			"30",
+			"30-day money back guarantee",
+			"Refund requests are reviewed within 2 business days.",
+			true,
+		))
+	})
+
+	cmd := newViewCmd()
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != http.MethodGet || gotPath != refundPolicyPath {
+		t.Fatalf("got %s %s, want GET %s", gotMethod, gotPath, refundPolicyPath)
+	}
+	for _, want := range []string{
+		"Period: 30",
+		"Title: 30-day money back guarantee",
+		"Fine print: Refund requests are reviewed within 2 business days.",
+		"In effect: yes",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestView_JSON(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, refundPolicyPayload("none", "No refunds allowed", nil, false))
+	})
+
+	cmd := testutil.Command(newViewCmd(), testutil.JSONOutput())
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp struct {
+		RefundPolicy struct {
+			RefundPeriod string `json:"refund_period"`
+			InEffect     bool   `json:"in_effect"`
+		} `json:"refund_policy"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if resp.RefundPolicy.RefundPeriod != "none" || resp.RefundPolicy.InEffect {
+		t.Fatalf("unexpected JSON response: %+v", resp.RefundPolicy)
+	}
+}
+
+func TestView_JQ(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, refundPolicyPayload("14", "14-day money back guarantee", nil, true))
+	})
+
+	cmd := testutil.Command(newViewCmd(), testutil.JQ(".refund_policy.refund_period"))
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if strings.TrimSpace(out) != `"14"` {
+		t.Fatalf("got %q, want %q", strings.TrimSpace(out), `"14"`)
+	}
+}
+
+func TestView_Plain(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, refundPolicyPayload("7", "7-day money back guarantee", "Short terms.", true))
+	})
+
+	cmd := testutil.Command(newViewCmd(), testutil.PlainOutput())
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if strings.TrimSpace(out) != "7\t7-day money back guarantee\tShort terms.\ttrue" {
+		t.Fatalf("unexpected plain output: %q", out)
+	}
+}
+
+func TestSet_SendsRefundPolicyParams(t *testing.T) {
+	var gotMethod, gotPath, gotPeriod, gotFinePrint string
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm failed: %v", err)
+		}
+		gotPeriod = r.PostForm.Get("refund_period")
+		gotFinePrint = r.PostForm.Get("fine_print")
+		testutil.JSON(t, w, refundPolicyPayload(
+			"30",
+			"30-day money back guarantee",
+			"Refund requests are reviewed within 2 business days.",
+			true,
+		))
+	})
+
+	cmd := newSetCmd()
+	cmd.SetArgs([]string{"--period", "30", "--fine-print", "Refund requests are reviewed within 2 business days."})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != http.MethodPut || gotPath != refundPolicyPath {
+		t.Fatalf("got %s %s, want PUT %s", gotMethod, gotPath, refundPolicyPath)
+	}
+	if gotPeriod != "30" {
+		t.Fatalf("refund_period = %q, want 30", gotPeriod)
+	}
+	if gotFinePrint != "Refund requests are reviewed within 2 business days." {
+		t.Fatalf("fine_print = %q", gotFinePrint)
+	}
+	if !strings.Contains(out, "Updated refund policy.") || !strings.Contains(out, "Period: 30") {
+		t.Fatalf("output missing updated policy: %q", out)
+	}
+}
+
+func TestSet_OmitsFinePrintWhenFlagNotProvided(t *testing.T) {
+	var hasFinePrint bool
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm failed: %v", err)
+		}
+		_, hasFinePrint = r.PostForm["fine_print"]
+		testutil.JSON(t, w, refundPolicyPayload("7", "7-day money back guarantee", nil, true))
+	})
+
+	cmd := testutil.Command(newSetCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--period", "7"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if hasFinePrint {
+		t.Fatal("fine_print must be omitted when --fine-print is not provided")
+	}
+}
+
+func TestSet_EmptyFinePrintClearsPolicy(t *testing.T) {
+	var gotValues []string
+	var hasFinePrint bool
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm failed: %v", err)
+		}
+		gotValues, hasFinePrint = r.PostForm["fine_print"]
+		testutil.JSON(t, w, refundPolicyPayload("none", "No refunds allowed", nil, true))
+	})
+
+	cmd := newSetCmd()
+	cmd.SetArgs([]string{"--period", "none", "--fine-print", ""})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !hasFinePrint {
+		t.Fatal("fine_print must be sent when --fine-print is provided")
+	}
+	if len(gotValues) != 1 || gotValues[0] != "" {
+		t.Fatalf("fine_print values = %#v, want one empty string", gotValues)
+	}
+}
+
+func TestSet_InvalidPeriodErrorsLocally(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("invalid period must not reach API")
+	})
+
+	cmd := newSetCmd()
+	cmd.SetArgs([]string{"--period", "0"})
+	err := cmd.Execute()
+
+	if err == nil {
+		t.Fatal("expected invalid period error")
+	}
+	if !strings.Contains(err.Error(), "--period must be one of: none, 7, 14, 30, 183") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSet_PeriodRequired(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("missing period must not reach API")
+	})
+
+	cmd := newSetCmd()
+	err := cmd.Execute()
+
+	if err == nil || !strings.Contains(err.Error(), "missing required flag: --period") {
+		t.Fatalf("expected missing period error, got: %v", err)
+	}
+}
+
+func TestSet_DryRunDoesNotReachAPI(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("dry-run must not reach API")
+	})
+
+	cmd := testutil.Command(newSetCmd(), testutil.DryRun(true), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--period", "183", "--fine-print", "Longer refund window."})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	for _, want := range []string{
+		"Dry run: PUT /refund_policy",
+		"refund_period: 183",
+		"fine_print: Longer refund window.",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("dry-run output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestSet_NotInEffectRejectionSurfaces(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.RawJSON(t, w, `{"success":false,"message":"The account-level refund policy is not in effect for this seller."}`)
+	})
+
+	cmd := newSetCmd()
+	cmd.SetArgs([]string{"--period", "7", "--fine-print", "Updated fine print"})
+	err := cmd.Execute()
+
+	if err == nil {
+		t.Fatal("expected API error")
+	}
+	if !strings.Contains(err.Error(), "The account-level refund policy is not in effect for this seller.") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRefundPeriodCompletion(t *testing.T) {
+	values, directive := refundPeriodCompletion(nil, nil, "")
+
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Fatalf("directive = %v, want NoFileComp", directive)
+	}
+	if strings.Join(values, ",") != "none,7,14,30,183" {
+		t.Fatalf("values = %#v", values)
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -18,6 +18,7 @@ import (
 	"github.com/antiwork/gumroad-cli/internal/cmd/offercodes"
 	"github.com/antiwork/gumroad-cli/internal/cmd/payouts"
 	"github.com/antiwork/gumroad-cli/internal/cmd/products"
+	"github.com/antiwork/gumroad-cli/internal/cmd/refundpolicy"
 	"github.com/antiwork/gumroad-cli/internal/cmd/sales"
 	"github.com/antiwork/gumroad-cli/internal/cmd/skill"
 	"github.com/antiwork/gumroad-cli/internal/cmd/subscribers"
@@ -106,6 +107,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(admin.NewAdminCmd())
 	cmd.AddCommand(auth.NewAuthCmd())
 	cmd.AddCommand(user.NewUserCmd())
+	cmd.AddCommand(refundpolicy.NewRefundPolicyCmd())
 	cmd.AddCommand(products.NewProductsCmd())
 	cmd.AddCommand(sales.NewSalesCmd())
 	cmd.AddCommand(payouts.NewPayoutsCmd())

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -187,6 +187,17 @@ func TestRootCmd_HelpIncludesPageDelayFlag(t *testing.T) {
 	}
 }
 
+func TestRootCmd_IncludesRefundPolicyCommand(t *testing.T) {
+	cmd := NewRootCmd()
+	found, _, err := cmd.Find([]string{"refund-policy", "view"})
+	if err != nil {
+		t.Fatalf("find refund-policy view: %v", err)
+	}
+	if found == nil || found.CommandPath() != "gumroad refund-policy view" {
+		t.Fatalf("expected gumroad refund-policy view, got %v", found)
+	}
+}
+
 func TestRootCmd_VersionFlag(t *testing.T) {
 	cmd := NewRootCmd()
 	cmd.SetArgs([]string{"--version"})

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -4,13 +4,14 @@ description: >
   Use the `gumroad` CLI to look up and manage Gumroad data from the terminal.
   Trigger when the user asks about Gumroad products, files, file uploads,
   attachments, sales, subscribers, licenses, payouts, offer codes, webhooks,
+  refund policies,
   or any Gumroad data lookup.
   Also trigger on "check my Gumroad", "look up a sale", "verify a license",
   "list my products", "how much have I made", "who bought", "recent sales",
   "refund a sale", "create a product", "upload a file", "attach a file to a product",
   "add a cover image", "set a product thumbnail", "upload product media",
   "attach a file to a variant", "finish a failed upload", "abort an upload", "manage webhooks",
-  "check my earnings", "see my revenue", "who subscribed", "manage my store",
+  "set refund policy", "check my refund policy", "check my earnings", "see my revenue", "who subscribed", "manage my store",
   "discount code", "coupon", "shipping status", "payout schedule", or any
   request to query or act on Gumroad data — even if the user doesn't say
   "Gumroad" explicitly but is clearly referring to their creator store or
@@ -44,6 +45,7 @@ Always follow these rules:
 Responses are wrapped in `{"success": true, ...}` with resource-specific keys:
 
 - `user` → `.user`
+- `refund-policy view/set` → `.refund_policy`
 - `products list` → `.products[]`
 - `products view` → `.product`
 - `sales list` → `.sales[]`
@@ -118,6 +120,20 @@ gumroad auth logout --yes --no-input
 ```sh
 gumroad user --json --no-input
 gumroad user --json --jq '.user.email' --no-input
+```
+
+### refund-policy — Store-wide refund policy
+
+```sh
+# View the current account-level refund policy
+gumroad refund-policy view --json --no-input
+gumroad refund-policy view --json --jq '.refund_policy.in_effect' --no-input
+
+# Set the refund period. Allowed values: none, 7, 14, 30, 183.
+gumroad refund-policy set --period 30 --fine-print "Refund requests are reviewed within 2 business days." --json --no-input
+
+# Clear fine print. This is account-level, not per-product.
+gumroad refund-policy set --period none --fine-print "" --json --no-input
 ```
 
 ### admin — Internal admin API


### PR DESCRIPTION
Ref antiwork/gumroad/issues/5330

## What
- Adds a dedicated `gumroad refund-policy` command with `view` and `set` subcommands for the store-wide refund policy.
- `view` shows the current refund period, title, fine print, and whether the policy is in effect.
- `set` updates the refund period and optional fine print, validates allowed periods locally, and respects dry-run output.
- Updates the README, agent skill guidance, and generated-manpage coverage to match the new command surface.

## Why
- Refund policy is account-level, so it belongs beside `user`, not under `products`.
- This gives sellers a direct CLI path to read and update the setting without going through the browser, while keeping the CLI aligned with the backend contract.

---

This PR was implemented with AI assistance using gpt-5.5 xhigh.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New seller-facing API surface with local validation and broad tests; `set` mutates account policy but follows existing cmdutil patterns and is not auth or payment code.
> 
> **Overview**
> Adds a top-level **`gumroad refund-policy`** command (next to **`user`**) for **store-wide** buyer refund settings, with **`view`** (GET `/refund_policy`) and **`set`** (PUT with required **`--period`**, optional **`--fine-print`** only when the flag is passed).
> 
> **`set`** validates periods locally (`none`, `7`, `14`, `30`, `183`), supports shell completion, and reuses shared CLI output modes (human, JSON/jq, plain, quiet, dry-run). Docs and agent skill examples are updated; man-page generation tests expect **`gumroad-refund-policy`** pages for the parent and subcommands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49ee3447818444951c2fa2a665b973d1b67723e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->