### PR TITLE
products update: add --custom-html flag for landing pages

### DIFF
--- a/internal/cmd/products/update.go
+++ b/internal/cmd/products/update.go
@@ -2,6 +2,7 @@ package products
 
 import (
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 
@@ -25,6 +26,7 @@ func newUpdateCmd() *cobra.Command {
 	var replaceFiles bool
 	var coverImage, thumbnail string
 	var previewImages []string
+	var customHTML string
 
 	cmd := &cobra.Command{
 		Use:   "update <product_id>",
@@ -36,6 +38,8 @@ func newUpdateCmd() *cobra.Command {
   gumroad products update <id> --cover-image ./cover.jpg
   gumroad products update <id> --preview-image ./gallery-1.jpg --preview-image ./gallery-2.jpg
   gumroad products update <id> --file ./pack.zip
+  gumroad products update <id> --custom-html ./landing.html
+  gumroad products update <id> --custom-html ''
   gumroad products update <id> --replace-files --keep-file file_123 --file ./new-pack.zip`,
 		Args: cmdutil.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
@@ -50,6 +54,7 @@ func newUpdateCmd() *cobra.Command {
 				"file", "file-name", "file-description",
 				"keep-file", "remove-file", "replace-files",
 				"cover-image", "preview-image", "thumbnail",
+				"custom-html",
 			); err != nil {
 				return err
 			}
@@ -120,6 +125,17 @@ func newUpdateCmd() *cobra.Command {
 			}
 			if flags.Changed("taxonomy-id") {
 				params.Set("taxonomy_id", taxonomyID)
+			}
+			if flags.Changed("custom-html") {
+				if customHTML == "" {
+					params.Set("custom_html", "")
+				} else {
+					html, err := os.ReadFile(customHTML)
+					if err != nil {
+						return cmdutil.UsageErrorf(c, "--custom-html: cannot read %s: %v", customHTML, err)
+					}
+					params.Set("custom_html", string(html))
+				}
 			}
 			for _, t := range tags {
 				params.Add("tags[]", t)
@@ -280,6 +296,7 @@ func newUpdateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&coverImage, "cover-image", "", "Local JPEG, PNG, or GIF cover image to upload")
 	cmd.Flags().StringArrayVar(&previewImages, "preview-image", nil, "Additional local JPEG, PNG, or GIF preview image to upload as a product cover (repeatable)")
 	cmd.Flags().StringVar(&thumbnail, "thumbnail", "", "Local JPEG, PNG, or GIF thumbnail image to upload")
+	cmd.Flags().StringVar(&customHTML, "custom-html", "", "Path to an HTML file for the product's custom landing page (empty string clears it)")
 
 	return cmd
 }
@@ -289,7 +306,7 @@ func productUpdateFieldFlagsChanged(cmd *cobra.Command) bool {
 		"name", "price", "currency", "description",
 		"custom-permalink", "custom-summary", "custom-receipt",
 		"pay-what-you-want", "suggested-price", "max-purchase-count",
-		"category", "taxonomy-id", "tag",
+		"category", "taxonomy-id", "tag", "custom-html",
 	} {
 		if cmd.Flags().Changed(flag) {
 			return true

--- a/internal/cmd/products/update_custom_html_test.go
+++ b/internal/cmd/products/update_custom_html_test.go
@@ -1,0 +1,83 @@
+package products
+
+import (
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestUpdate_CustomHTMLFromFile(t *testing.T) {
+	dir := t.TempDir()
+	htmlPath := filepath.Join(dir, "landing.html")
+	body := "<section><h1>Buy now</h1></section>"
+	if err := os.WriteFile(htmlPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	var gotMethod, gotPath string
+	var gotForm url.Values
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		_ = r.ParseForm()
+		gotForm = r.PostForm
+		testutil.JSON(t, w, map[string]any{})
+	})
+
+	cmd := testutil.Command(newUpdateCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"prod1", "--custom-html", htmlPath})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != "PUT" {
+		t.Errorf("got method %q, want PUT", gotMethod)
+	}
+	if gotPath != "/products/prod1" {
+		t.Errorf("got path %q, want /products/prod1", gotPath)
+	}
+	if got := gotForm.Get("custom_html"); got != body {
+		t.Errorf("got custom_html=%q, want %q", got, body)
+	}
+	if !strings.Contains(out, "updated") {
+		t.Errorf("expected updated message, got: %q", out)
+	}
+}
+
+func TestUpdate_CustomHTMLEmptyClears(t *testing.T) {
+	var gotForm url.Values
+	var hasField bool
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotForm = r.PostForm
+		_, hasField = r.PostForm["custom_html"]
+		testutil.JSON(t, w, map[string]any{})
+	})
+
+	cmd := testutil.Command(newUpdateCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"prod1", "--custom-html", ""})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !hasField {
+		t.Errorf("custom_html should be sent (empty) to clear, but was absent")
+	}
+	if got := gotForm.Get("custom_html"); got != "" {
+		t.Errorf("got custom_html=%q, want empty string", got)
+	}
+}
+
+func TestUpdate_CustomHTMLMissingFileErrors(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API on a bad --custom-html path")
+	})
+
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{"prod1", "--custom-html", filepath.Join(t.TempDir(), "does-not-exist.html")})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--custom-html") {
+		t.Errorf("expected --custom-html read error, got: %v", err)
+	}
+}

--- a/internal/cmd/products/update_custom_html_test.go
+++ b/internal/cmd/products/update_custom_html_test.go
@@ -74,7 +74,7 @@ func TestUpdate_CustomHTMLMissingFileErrors(t *testing.T) {
 		t.Error("should not reach API on a bad --custom-html path")
 	})
 
-	cmd := newUpdateCmd()
+	cmd := testutil.Command(newUpdateCmd(), testutil.Quiet(false))
 	cmd.SetArgs([]string{"prod1", "--custom-html", filepath.Join(t.TempDir(), "does-not-exist.html")})
 	err := cmd.Execute()
 	if err == nil || !strings.Contains(err.Error(), "--custom-html") {

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -10,6 +10,7 @@ description: >
   "list my products", "how much have I made", "who bought", "recent sales",
   "refund a sale", "create a product", "upload a file", "attach a file to a product",
   "add a cover image", "set a product thumbnail", "upload product media",
+  "publish a product landing page", "publish custom HTML", "clear custom HTML",
   "attach a file to a variant", "finish a failed upload", "abort an upload", "manage webhooks",
   "set refund policy", "check my refund policy", "check my earnings", "see my revenue", "who subscribed", "manage my store",
   "discount code", "coupon", "shipping status", "payout schedule", or any
@@ -37,6 +38,8 @@ Always follow these rules:
 - Prices are in whole currency units (e.g. `--price 10.00` for $10), not cents. The CLI converts internally. Use `--currency eur` to change currency.
 - Products are created as drafts — use `gumroad products publish <id>` to make them live.
 - Product cover and thumbnail uploads support JPEG, PNG, and GIF. WebP is not supported by the API and the CLI rejects it before upload.
+- Product custom HTML landing pages are published with `gumroad products update <id> --custom-html ./landing.html`. Use `--custom-html ''` to clear the page. `--dry-run` only previews the CLI request body; it does not call the backend sanitizer. Inspect `.result.sanitization_report` in the publish response for server-side changes.
+- Custom HTML pages can use `data-gumroad-field="name"`, `data-gumroad-field="price"`, `data-gumroad-field="description"`, and `data-gumroad-action="buy"`. To preselect checkout state, add `data-gumroad-option="<variant name>"`, `data-gumroad-quantity="<integer>"`, `data-gumroad-price="<decimal>"`, or `data-gumroad-recurrence="monthly|quarterly|biannually|yearly|every_two_years"`. Production validates these values and falls back to product defaults when invalid. Prefer anchors for buy CTAs so production can add a checkout href; non-anchor buy elements also post to checkout.
 - If a command fails with a seller auth error, tell the user to run `gumroad auth login` interactively — agents cannot do this step.
 - For admin commands in agents/CI, pass `--non-interactive` and set `GUMROAD_ADMIN_TOKEN`; interactive shells can store an admin token with `gumroad auth login`.
 
@@ -65,6 +68,7 @@ Responses are wrapped in `{"success": true, ...}` with resource-specific keys:
 - `products covers add --url` → `.result.covers[]`, `.result.main_cover_id`
 - `products thumbnail set --image` → `.result.thumbnail`, plus `.result.media[]`
 - `products thumbnail set --url` → `.result.thumbnail`
+- `products update --custom-html` → `.result.product.custom_html`, `.result.product.landing_url`, `.result.previous_custom_html`, `.result.sanitization_report`
 - `webhooks list` → `.resource_subscriptions[]`
 - `admin users info` → `.user`
 - `admin users affiliates` → `.affiliates[]`
@@ -216,6 +220,9 @@ gumroad products update <id> --file ./pack.zip --json --no-input
 gumroad products update <id> --cover-image ./cover.jpg --json --no-input
 gumroad products update <id> --preview-image ./gallery-1.jpg --preview-image ./gallery-2.jpg --json --no-input
 gumroad products update <id> --thumbnail ./thumb.jpg --json --no-input
+gumroad products update <id> --custom-html ./landing.html --json --no-input
+gumroad products update <id> --custom-html '' --json --no-input
+gumroad products view <id> --json --jq '.product.landing_url' --no-input
 gumroad products update <id> --replace-files --keep-file file_123 --file ./new-pack.zip --yes --json --no-input
 gumroad products update <id> --remove-file file_456 --yes --json --no-input
 
@@ -239,11 +246,23 @@ gumroad products delete <id> --yes --json --no-input
 gumroad products skus <id> --json --no-input
 ```
 
+In custom HTML, use Gumroad data attributes for live product values and checkout:
+
+```html
+<h1 data-gumroad-field="name">Product name</h1>
+<span data-gumroad-field="price">$0</span>
+<p data-gumroad-field="description">Product description</p>
+<a data-gumroad-action="buy">Buy now</a>
+<a data-gumroad-action="buy" data-gumroad-option="Pro" data-gumroad-recurrence="yearly">Buy Pro - $99/year</a>
+<button data-gumroad-action="buy" data-gumroad-quantity="2">Buy 2 seats</button>
+<button data-gumroad-action="buy" data-gumroad-price="19.99">Pay $19.99</button>
+```
+
 **Categories:** `products categories [--search <term>]` returns label, path, and numeric ID. Prefer `--category <path>` for product create/update. `--taxonomy-id` remains supported when you already have the numeric ID, but it cannot be combined with `--category`.
 
 **Create flags:** `--name` (required), `--price`, `--type` (digital|course|ebook|membership|bundle|coffee|call|commission), `--currency`, `--pay-what-you-want`, `--suggested-price`, `--description`, `--custom-summary`, `--custom-permalink`, `--custom-receipt`, `--max-purchase-count`, `--category`, `--taxonomy-id`, `--tag` (repeatable), `--file` (repeatable), `--file-name` (repeatable, aligned to `--file`), `--file-description` (repeatable, aligned to `--file`), `--cover-image`, `--preview-image` (repeatable), `--thumbnail`.
 
-**Update flags:** `--name`, `--price`, `--currency`, `--description`, `--custom-summary`, `--custom-permalink`, `--custom-receipt`, `--max-purchase-count`, `--category`, `--taxonomy-id`, `--tag` (repeatable), `--file` (repeatable), `--file-name`, `--file-description`, `--remove-file` (repeatable), `--replace-files`, `--keep-file` (repeatable with `--replace-files`), `--cover-image`, `--preview-image` (repeatable), `--thumbnail`. Updates preserve existing files by default unless `--replace-files` is set.
+**Update flags:** `--name`, `--price`, `--currency`, `--description`, `--custom-summary`, `--custom-permalink`, `--custom-receipt`, `--max-purchase-count`, `--category`, `--taxonomy-id`, `--tag` (repeatable), `--custom-html`, `--file` (repeatable), `--file-name`, `--file-description`, `--remove-file` (repeatable), `--replace-files`, `--keep-file` (repeatable with `--replace-files`), `--cover-image`, `--preview-image` (repeatable), `--thumbnail`. Updates preserve existing files by default unless `--replace-files` is set.
 
 Use `products update --file` for shared product Content. For products with per-variant Content, use `variants update ... --file` for the specific variant you want to change.
 


### PR DESCRIPTION
Closes #120

## What

Adds `--custom-html` to `gumroad products update`:

```bash
gumroad products update <id> --custom-html ./landing.html   # publish
gumroad products update <id> --custom-html ''               # clear
```

It reads the file at the given path and sends the contents as the `custom_html` param on `PUT /api/v2/products/:permalink`; an empty string sends an empty value, which the backend treats as a reset. A nonexistent path fails with a usage error before any network call.

This is the last remaining surface from antiwork/gumroad#5063 — the backend + web UI shipped in antiwork/gumroad#5309.

## Why

The custom-HTML landing page feature is agent-native: the seller's agent builds the HTML and publishes it via the API. The CLI is the natural deploy target for that workflow (and for scripting), so `products update` should be able to push and clear the page like any other product attribute.

`custom-html` is wired into the existing field-flag set (`productUpdateFieldFlagsChanged` + the `RequireAnyFlagChanged` allowlist) so it routes through the same form-data PUT path the other scalar product fields use — no new request path, no interaction with the file-upload/S3 flow.

## Self-review

- Reading happens only when a non-empty path is given; `--custom-html ''` deliberately sends an empty `custom_html` (the documented reset), so the test asserts the field is present-but-empty rather than absent.
- Error path uses `cmdutil.UsageErrorf` to match the other flag-validation failures in this command, and returns before `config.Token()` so a bad path never hits the API.
- No size pre-check on the client: the backend enforces the 500 KB cap and per-token rate limits, and surfaces those as normal API errors — duplicating the limit client-side would just drift from the server.

## Test Results

New `internal/cmd/products/update_custom_html_test.go` covers publish-from-file, empty-clears, and missing-file error. Local run:

```
$ go test ./internal/cmd/products/ -run TestUpdate_CustomHTML -v
--- PASS: TestUpdate_CustomHTMLFromFile
--- PASS: TestUpdate_CustomHTMLEmptyClears
--- PASS: TestUpdate_CustomHTMLMissingFileErrors
PASS

$ go test ./...        # full suite green
$ go test ./internal/cmd/products/ -cover   # coverage: 85.6% (≥85% gate)
$ go vet ./internal/cmd/products/            # clean
$ gofmt -l ...                               # clean
```

> **Note:** I can't attach the required terminal recording (automated authoring environment). Requesting a maintainer add the before/after video, or let me know if a different artifact is acceptable.

---

This PR was implemented with AI assistance using Claude Opus 4.7. Prompt: implement antiwork/gumroad-cli#120 — add a `--custom-html` flag to `gumroad products update` that reads an HTML file and publishes it as the product's `custom_html` (empty string clears), with tests, following the repo's no-FactoryBot/field-flag conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad-cli/pr/121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782927639&installation_id=134400930&pr_number=121&repository=antiwork%2Fgumroad-cli&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad-cli%2Fpull%2F121&signature=e46139a2d20de446cb73e08cd0e8c03d0b3ac1919771df7250349d1539f67a1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive CLI flag on an existing update path; validation is local file read only, with server-side size/sanitization limits unchanged.
> 
> **Overview**
> Adds **`--custom-html`** to **`gumroad products update`**: a file path is read and sent as **`custom_html`** on the usual form **`PUT`**; **`--custom-html ''`** sends an empty value to clear the landing page. Bad paths fail with a usage error before any API call. The flag is included in the same “at least one field changed” and scalar-field routing as other product attributes (not the file/S3 path).
> 
> Tests cover publish-from-file, clear-via-empty-string, and missing-file errors. The **gumroad** skill doc is updated with publish/clear examples, response fields (e.g. **`sanitization_report`**), and **`data-gumroad-*`** HTML hooks for agents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 570dffec0782956d56273008aa8b1e277a1c72f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->