### PR TITLE
Add product page commands for custom HTML

### DIFF
--- a/internal/cmd/products/page.go
+++ b/internal/cmd/products/page.go
@@ -1,0 +1,42 @@
+package products
+
+import (
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/pageutil"
+	"github.com/spf13/cobra"
+)
+
+func newPageCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "page",
+		Short: "Manage a product landing page",
+		Example: `  gumroad products page preview <product_id> ./landing.html
+  gumroad products page publish <product_id> ./landing.html
+  gumroad products page publish <product_id> - < landing.html
+  gumroad products page clear <product_id> --yes
+  gumroad products page url <product_id>`,
+	}
+
+	cmd.AddCommand(newPagePreviewCmd())
+	cmd.AddCommand(newPagePublishCmd())
+	cmd.AddCommand(newPageClearCmd())
+	cmd.AddCommand(newPageURLCmd())
+	return cmd
+}
+
+func productPageHTMLArgs(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return cmdutil.UsageErrorf(cmd, "missing required argument: <product_id>")
+	}
+	if len(args) > 2 {
+		return cmdutil.UsageErrorf(cmd, "unexpected argument: %s", args[2])
+	}
+	return nil
+}
+
+func productPageHTMLPath(args []string) string {
+	if len(args) > 1 {
+		return args[1]
+	}
+	return pageutil.DefaultHTMLPath
+}

--- a/internal/cmd/products/page_clear.go
+++ b/internal/cmd/products/page_clear.go
@@ -1,0 +1,48 @@
+package products
+
+import (
+	"net/http"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/pageutil"
+	"github.com/spf13/cobra"
+)
+
+func newPageClearCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "clear <product_id>",
+		Short: "Clear a product landing page",
+		Args:  cmdutil.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			productID := args[0]
+			ok, err := cmdutil.ConfirmAction(opts, "Clear landing page for product "+productID+"?")
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return cmdutil.PrintCancelledAction(opts, "clear landing page for product "+productID, productID)
+			}
+
+			target := pageutil.ProductTarget(productID)
+			err = cmdutil.RunRequestDecoded[pageutil.UpdateResponse](
+				opts,
+				"Clearing page...",
+				http.MethodPut,
+				target.Path,
+				pageutil.ClearParams(),
+				func(resp pageutil.UpdateResponse) error {
+					return pageutil.RenderSanitizationResult(opts, pageutil.RenderResult{
+						Action:       "Cleared page",
+						BeforeHTML:   pageutil.PreviousHTML(resp),
+						AfterHTML:    resp.Product.CustomHTML,
+						LandingURL:   pageutil.LandingURL(resp.Product),
+						Report:       resp.SanitizationReport,
+						ClearMessage: "Page cleared.",
+					})
+				},
+			)
+			return pageutil.TranslateRateLimitError(err, pageutil.PublishRateLimitMessage)
+		},
+	}
+}

--- a/internal/cmd/products/page_clear.go
+++ b/internal/cmd/products/page_clear.go
@@ -42,7 +42,7 @@ func newPageClearCmd() *cobra.Command {
 					})
 				},
 			)
-			return pageutil.TranslateRateLimitError(err, pageutil.PublishRateLimitMessage)
+			return pageutil.TranslateRateLimitError(err, pageutil.ClearRateLimitMessage)
 		},
 	}
 }

--- a/internal/cmd/products/page_clear_test.go
+++ b/internal/cmd/products/page_clear_test.go
@@ -69,3 +69,23 @@ func TestPageClearNoInputRequiresYesBeforeAPI(t *testing.T) {
 		t.Fatalf("expected confirmation error, got %v", err)
 	}
 }
+
+func TestPageClearRateLimitMessage(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		testutil.RawJSON(t, w, `{"success":false,"message":"Rate limited"}`)
+	})
+
+	cmd := testutil.Command(newPageClearCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"prod1"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected rate limit error")
+	}
+	if !strings.Contains(err.Error(), "Wait a moment before trying again") {
+		t.Fatalf("expected clear-specific rate limit message, got %v", err)
+	}
+	if strings.Contains(err.Error(), "page preview") {
+		t.Fatalf("clear rate limit message should not mention preview, got %v", err)
+	}
+}

--- a/internal/cmd/products/page_clear_test.go
+++ b/internal/cmd/products/page_clear_test.go
@@ -1,0 +1,71 @@
+package products
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestPageClearConfirmsAndSendsEmptyCustomHTML(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotForm url.Values
+	var hasCustomHTML bool
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		_ = r.ParseForm()
+		gotForm = r.PostForm
+		_, hasCustomHTML = r.PostForm["custom_html"]
+		previous := "<h1>Old</h1>"
+		testutil.JSON(t, w, map[string]any{
+			"product": map[string]any{
+				"id":          "prod1",
+				"custom_html": "",
+				"landing_url": "https://seller.gumroad.com/l/prod1",
+			},
+			"previous_custom_html": previous,
+			"sanitization_report": map[string]any{
+				"removed_tags":       []any{},
+				"removed_attributes": []any{},
+				"total_removed":      0,
+				"truncated":          false,
+			},
+		})
+	})
+
+	cmd := testutil.Command(newPageClearCmd(), testutil.Yes(true), testutil.Quiet(false), testutil.NoColor(true))
+	cmd.SetArgs([]string{"prod1"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != http.MethodPut {
+		t.Errorf("got method %q, want PUT", gotMethod)
+	}
+	if gotPath != "/products/prod1" {
+		t.Errorf("got path %q, want /products/prod1", gotPath)
+	}
+	if !hasCustomHTML {
+		t.Fatalf("custom_html should be sent to clear")
+	}
+	if got := gotForm.Get("custom_html"); got != "" {
+		t.Fatalf("got custom_html=%q, want empty", got)
+	}
+	if !strings.Contains(out, "Page cleared.") {
+		t.Fatalf("output missing clear message: %q", out)
+	}
+}
+
+func TestPageClearNoInputRequiresYesBeforeAPI(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("clear without confirmation should not call API")
+	})
+
+	cmd := testutil.Command(newPageClearCmd(), testutil.NoInput(true), testutil.Quiet(false), testutil.NoColor(true))
+	cmd.SetArgs([]string{"prod1"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "Use --yes to skip confirmation") {
+		t.Fatalf("expected confirmation error, got %v", err)
+	}
+}

--- a/internal/cmd/products/page_preview.go
+++ b/internal/cmd/products/page_preview.go
@@ -1,0 +1,43 @@
+package products
+
+import (
+	"net/http"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/pageutil"
+	"github.com/spf13/cobra"
+)
+
+func newPagePreviewCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "preview <product_id> [path]",
+		Short: "Preview server sanitization for a product landing page",
+		Args:  productPageHTMLArgs,
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			input, err := pageutil.ReadHTML(opts.In(), productPageHTMLPath(args))
+			if err != nil {
+				return cmdutil.UsageErrorf(c, "%s", err)
+			}
+
+			target := pageutil.ProductTarget(args[0])
+			err = cmdutil.RunRequestDecoded[pageutil.PreviewResponse](
+				opts,
+				"Previewing page...",
+				http.MethodPost,
+				target.PreviewPath,
+				pageutil.HTMLParams(input.HTML),
+				func(resp pageutil.PreviewResponse) error {
+					return pageutil.RenderSanitizationResult(opts, pageutil.RenderResult{
+						Action:     "Previewed page",
+						Source:     input.Source,
+						BeforeHTML: input.HTML,
+						AfterHTML:  resp.CustomHTML,
+						Report:     resp.SanitizationReport,
+					})
+				},
+			)
+			return pageutil.TranslateRateLimitError(err, pageutil.PreviewRateLimitMessage)
+		},
+	}
+}

--- a/internal/cmd/products/page_preview_test.go
+++ b/internal/cmd/products/page_preview_test.go
@@ -1,0 +1,108 @@
+package products
+
+import (
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestPagePreviewPostsHTMLToPreviewEndpoint(t *testing.T) {
+	htmlPath := writePageHTML(t, "<script src=\"https://evil.test/x.js\"></script><h1>Buy</h1>")
+
+	var gotMethod, gotPath string
+	var gotForm url.Values
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		_ = r.ParseForm()
+		gotForm = r.PostForm
+		testutil.JSON(t, w, map[string]any{
+			"custom_html": "<h1>Buy</h1>",
+			"sanitization_report": map[string]any{
+				"removed_tags": []map[string]any{{
+					"tag":    "\x1b[31mscript\x1b[0m",
+					"attrs":  map[string]string{"src": "https://evil.test/x.js"},
+					"reason": "script src host not allowed",
+				}},
+				"removed_attributes": []any{},
+				"total_removed":      1,
+				"truncated":          false,
+			},
+		})
+	})
+
+	cmd := testutil.Command(newPagePreviewCmd(), testutil.Quiet(false), testutil.NoColor(true))
+	cmd.SetArgs([]string{"prod1", htmlPath})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("got method %q, want POST", gotMethod)
+	}
+	if gotPath != "/products/prod1/preview_custom_html" {
+		t.Errorf("got path %q, want /products/prod1/preview_custom_html", gotPath)
+	}
+	if got := gotForm.Get("custom_html"); got != "<script src=\"https://evil.test/x.js\"></script><h1>Buy</h1>" {
+		t.Errorf("got custom_html=%q", got)
+	}
+	if !strings.Contains(out, "Previewed page") || !strings.Contains(out, "Sanitization removed 1 item") {
+		t.Fatalf("output missing preview summary: %q", out)
+	}
+	if !strings.Contains(out, "script src host not allowed") {
+		t.Fatalf("output missing report reason: %q", out)
+	}
+	if strings.Contains(out, "\x1b") {
+		t.Fatalf("output should strip report ANSI controls: %q", out)
+	}
+}
+
+func TestPagePreviewDryRunDoesNotCallAPI(t *testing.T) {
+	htmlPath := writePageHTML(t, "<h1>Buy</h1>")
+
+	var calls atomic.Int32
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		t.Errorf("preview --dry-run should not call API")
+	})
+
+	cmd := testutil.Command(newPagePreviewCmd(), testutil.DryRun(true), testutil.Quiet(false), testutil.NoColor(true))
+	cmd.SetArgs([]string{"prod1", htmlPath})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if calls.Load() != 0 {
+		t.Fatalf("API was called %d times", calls.Load())
+	}
+	if !strings.Contains(out, "Dry run: POST /products/prod1/preview_custom_html") {
+		t.Fatalf("dry-run output missing preview request: %q", out)
+	}
+}
+
+func TestPagePreviewSuccessFalseReturnsMessage(t *testing.T) {
+	htmlPath := writePageHTML(t, "<h1>Buy</h1>")
+
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.RawJSON(t, w, `{"success":false,"message":"Custom html is too long (maximum is 500000 characters)"}`)
+	})
+
+	cmd := testutil.Command(newPagePreviewCmd())
+	cmd.SetArgs([]string{"prod1", htmlPath})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "Custom html is too long") {
+		t.Fatalf("expected validation message, got %v", err)
+	}
+}
+
+func writePageHTML(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "landing.html")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}

--- a/internal/cmd/products/page_publish.go
+++ b/internal/cmd/products/page_publish.go
@@ -1,0 +1,44 @@
+package products
+
+import (
+	"net/http"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/pageutil"
+	"github.com/spf13/cobra"
+)
+
+func newPagePublishCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "publish <product_id> [path]",
+		Short: "Publish custom HTML for a product landing page",
+		Args:  productPageHTMLArgs,
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			input, err := pageutil.ReadHTML(opts.In(), productPageHTMLPath(args))
+			if err != nil {
+				return cmdutil.UsageErrorf(c, "%s", err)
+			}
+
+			target := pageutil.ProductTarget(args[0])
+			err = cmdutil.RunRequestDecoded[pageutil.UpdateResponse](
+				opts,
+				"Publishing page...",
+				http.MethodPut,
+				target.Path,
+				pageutil.HTMLParams(input.HTML),
+				func(resp pageutil.UpdateResponse) error {
+					return pageutil.RenderSanitizationResult(opts, pageutil.RenderResult{
+						Action:     "Published page",
+						Source:     input.Source,
+						BeforeHTML: input.HTML,
+						AfterHTML:  resp.Product.CustomHTML,
+						LandingURL: pageutil.LandingURL(resp.Product),
+						Report:     resp.SanitizationReport,
+					})
+				},
+			)
+			return pageutil.TranslateRateLimitError(err, pageutil.PublishRateLimitMessage)
+		},
+	}
+}

--- a/internal/cmd/products/page_publish_test.go
+++ b/internal/cmd/products/page_publish_test.go
@@ -1,0 +1,129 @@
+package products
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestPagePublishPutsHTMLAndPrintsLandingURL(t *testing.T) {
+	htmlPath := writePageHTML(t, "<h1>Buy</h1>")
+
+	var gotMethod, gotPath string
+	var gotForm url.Values
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		_ = r.ParseForm()
+		gotForm = r.PostForm
+		testutil.JSON(t, w, map[string]any{
+			"product": map[string]any{
+				"id":          "prod1",
+				"custom_html": "<h1>Buy</h1>",
+				"landing_url": "https://seller.gumroad.com/l/prod1",
+			},
+			"previous_custom_html": nil,
+			"sanitization_report": map[string]any{
+				"removed_tags":       []any{},
+				"removed_attributes": []any{},
+				"total_removed":      0,
+				"truncated":          false,
+			},
+		})
+	})
+
+	cmd := testutil.Command(newPagePublishCmd(), testutil.Quiet(false), testutil.NoColor(true))
+	cmd.SetArgs([]string{"prod1", htmlPath})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != http.MethodPut {
+		t.Errorf("got method %q, want PUT", gotMethod)
+	}
+	if gotPath != "/products/prod1" {
+		t.Errorf("got path %q, want /products/prod1", gotPath)
+	}
+	if got := gotForm.Get("custom_html"); got != "<h1>Buy</h1>" {
+		t.Errorf("got custom_html=%q", got)
+	}
+	if !strings.Contains(out, "Published page") || !strings.Contains(out, "Live at https://seller.gumroad.com/l/prod1") {
+		t.Fatalf("output missing publish summary: %q", out)
+	}
+}
+
+func TestPagePublishJSONPrintsRawResponse(t *testing.T) {
+	htmlPath := writePageHTML(t, "<h1>Buy</h1>")
+
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"product": map[string]any{
+				"id":          "prod1",
+				"custom_html": "<h1>Buy</h1>",
+				"landing_url": "https://seller.gumroad.com/l/prod1",
+			},
+			"previous_custom_html": nil,
+			"sanitization_report": map[string]any{
+				"removed_tags":       []any{},
+				"removed_attributes": []any{},
+				"total_removed":      0,
+				"truncated":          false,
+			},
+		})
+	})
+
+	cmd := testutil.Command(newPagePublishCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"prod1", htmlPath})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+	if _, ok := resp["result"]; ok {
+		t.Fatalf("page publish JSON should be raw API response, got mutation wrapper: %s", out)
+	}
+	if product, ok := resp["product"].(map[string]any); !ok || product["landing_url"] != "https://seller.gumroad.com/l/prod1" {
+		t.Fatalf("JSON output missing product landing_url: %s", out)
+	}
+}
+
+func TestPagePublishDryRunDoesNotCallAPI(t *testing.T) {
+	htmlPath := writePageHTML(t, "<h1>Buy</h1>")
+
+	var calls atomic.Int32
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		t.Errorf("publish --dry-run should not call API")
+	})
+
+	cmd := testutil.Command(newPagePublishCmd(), testutil.DryRun(true), testutil.Quiet(false), testutil.NoColor(true))
+	cmd.SetArgs([]string{"prod1", htmlPath})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if calls.Load() != 0 {
+		t.Fatalf("API was called %d times", calls.Load())
+	}
+	if !strings.Contains(out, "Dry run: PUT /products/prod1") {
+		t.Fatalf("dry-run output missing publish request: %q", out)
+	}
+}
+
+func TestPagePublishRateLimitMessage(t *testing.T) {
+	htmlPath := writePageHTML(t, "<h1>Buy</h1>")
+
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		testutil.RawJSON(t, w, `{"success":false,"message":"Rate limited"}`)
+	})
+
+	cmd := testutil.Command(newPagePublishCmd())
+	cmd.SetArgs([]string{"prod1", htmlPath})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "30 PUTs/min") {
+		t.Fatalf("expected page-specific rate limit message, got %v", err)
+	}
+}

--- a/internal/cmd/products/page_url.go
+++ b/internal/cmd/products/page_url.go
@@ -1,0 +1,41 @@
+package products
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/pageutil"
+	"github.com/spf13/cobra"
+)
+
+func newPageURLCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "url <product_id>",
+		Short: "Print a product landing page URL",
+		Args:  cmdutil.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			target := pageutil.ProductTarget(args[0])
+			return cmdutil.RunRequestDecoded[pageutil.ShowResponse](
+				opts,
+				"Fetching page URL...",
+				http.MethodGet,
+				target.Path,
+				url.Values{},
+				func(resp pageutil.ShowResponse) error {
+					landingURL := pageutil.LandingURL(resp.Product)
+					if landingURL == "" {
+						return fmt.Errorf("product response did not include landing_url")
+					}
+					if opts.PlainOutput {
+						return output.PrintPlain(opts.Out(), [][]string{{landingURL}})
+					}
+					return output.Writeln(opts.Out(), landingURL)
+				},
+			)
+		},
+	}
+}

--- a/internal/cmd/products/page_url_test.go
+++ b/internal/cmd/products/page_url_test.go
@@ -1,0 +1,67 @@
+package products
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestPageURLPrintsLandingURL(t *testing.T) {
+	var gotMethod, gotPath string
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		testutil.JSON(t, w, map[string]any{
+			"product": map[string]any{
+				"id":          "prod1",
+				"landing_url": "https://seller.gumroad.com/l/prod1",
+			},
+		})
+	})
+
+	cmd := testutil.Command(newPageURLCmd())
+	cmd.SetArgs([]string{"prod1"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != http.MethodGet {
+		t.Errorf("got method %q, want GET", gotMethod)
+	}
+	if gotPath != "/products/prod1" {
+		t.Errorf("got path %q, want /products/prod1", gotPath)
+	}
+	if strings.TrimSpace(out) != "https://seller.gumroad.com/l/prod1" {
+		t.Fatalf("got output %q", out)
+	}
+}
+
+func TestPageURLPlainPrintsLandingURL(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"product": map[string]any{
+				"id":          "prod1",
+				"landing_url": "https://seller.gumroad.com/l/prod1",
+			},
+		})
+	})
+
+	cmd := testutil.Command(newPageURLCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{"prod1"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if strings.TrimSpace(out) != "https://seller.gumroad.com/l/prod1" {
+		t.Fatalf("got plain output %q", out)
+	}
+}
+
+func TestProductsCommandIncludesPageNamespace(t *testing.T) {
+	cmd := NewProductsCmd()
+	found, _, err := cmd.Find([]string{"page", "preview"})
+	if err != nil {
+		t.Fatalf("Find returned error: %v", err)
+	}
+	if found == nil || found.Name() != "preview" {
+		t.Fatalf("expected products page preview command, got %#v", found)
+	}
+}

--- a/internal/cmd/products/products.go
+++ b/internal/cmd/products/products.go
@@ -21,6 +21,8 @@ func NewProductsCmd() *cobra.Command {
   gumroad products update <product_id> --name "New Name"
   gumroad products update <product_id> --category design/ui-and-web/figma
   gumroad products update <product_id> --preview-image ./gallery.jpg
+  gumroad products page preview <product_id> ./landing.html
+  gumroad products page publish <product_id> ./landing.html
   gumroad products covers add <product_id> --image ./cover.jpg
   gumroad products thumbnail set <product_id> --image ./thumb.jpg
   gumroad products update <product_id> --file ./pack.zip
@@ -40,6 +42,7 @@ func NewProductsCmd() *cobra.Command {
 	cmd.AddCommand(newDeleteCmd())
 	cmd.AddCommand(newPublishCmd())
 	cmd.AddCommand(newUnpublishCmd())
+	cmd.AddCommand(newPageCmd())
 	cmd.AddCommand(newCoversCmd())
 	cmd.AddCommand(newThumbnailCmd())
 	cmd.AddCommand(skus.NewProductSKUsCmd())

--- a/internal/pageutil/api.go
+++ b/internal/pageutil/api.go
@@ -12,11 +12,10 @@ import (
 const (
 	PublishRateLimitMessage = "Hit Gumroad's rate limit (30 PUTs/min). Use `gumroad products page preview` to iterate without burning your publish budget."
 	PreviewRateLimitMessage = "Hit Gumroad's rate limit (60 previews/min). Wait a moment before previewing again."
+	ClearRateLimitMessage   = "Hit Gumroad's rate limit (30 PUTs/min). Wait a moment before trying again."
 )
 
 type Target struct {
-	Resource    string
-	ID          string
 	Path        string
 	PreviewPath string
 }
@@ -24,8 +23,6 @@ type Target struct {
 func ProductTarget(id string) Target {
 	path := cmdutil.JoinPath("products", id)
 	return Target{
-		Resource:    "products",
-		ID:          id,
 		Path:        path,
 		PreviewPath: cmdutil.JoinPath("products", id, "preview_custom_html"),
 	}

--- a/internal/pageutil/api.go
+++ b/internal/pageutil/api.go
@@ -1,0 +1,100 @@
+package pageutil
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+)
+
+const (
+	PublishRateLimitMessage = "Hit Gumroad's rate limit (30 PUTs/min). Use `gumroad products page preview` to iterate without burning your publish budget."
+	PreviewRateLimitMessage = "Hit Gumroad's rate limit (60 previews/min). Wait a moment before previewing again."
+)
+
+type Target struct {
+	Resource    string
+	ID          string
+	Path        string
+	PreviewPath string
+}
+
+func ProductTarget(id string) Target {
+	path := cmdutil.JoinPath("products", id)
+	return Target{
+		Resource:    "products",
+		ID:          id,
+		Path:        path,
+		PreviewPath: cmdutil.JoinPath("products", id, "preview_custom_html"),
+	}
+}
+
+type PageProduct struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	CustomHTML   string `json:"custom_html"`
+	LandingURL   string `json:"landing_url"`
+	ShortURL     string `json:"short_url"`
+	PermalinkURL string `json:"permalink_url"`
+}
+
+type UpdateResponse struct {
+	Success            bool               `json:"success"`
+	Product            PageProduct        `json:"product"`
+	PreviousCustomHTML *string            `json:"previous_custom_html"`
+	SanitizationReport SanitizationReport `json:"sanitization_report"`
+}
+
+type PreviewResponse struct {
+	Success            bool               `json:"success"`
+	CustomHTML         string             `json:"custom_html"`
+	SanitizationReport SanitizationReport `json:"sanitization_report"`
+}
+
+type ShowResponse struct {
+	Success bool        `json:"success"`
+	Product PageProduct `json:"product"`
+}
+
+func LandingURL(product PageProduct) string {
+	if product.LandingURL != "" {
+		return product.LandingURL
+	}
+	if product.ShortURL != "" {
+		return product.ShortURL
+	}
+	return product.PermalinkURL
+}
+
+func HTMLParams(html string) url.Values {
+	return url.Values{"custom_html": []string{html}}
+}
+
+func ClearParams() url.Values {
+	return url.Values{"custom_html": []string{""}}
+}
+
+func PreviousHTML(resp UpdateResponse) string {
+	if resp.PreviousCustomHTML == nil {
+		return ""
+	}
+	return *resp.PreviousCustomHTML
+}
+
+func TranslateRateLimitError(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+
+	var apiErr *api.APIError
+	if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusTooManyRequests {
+		return &api.APIError{
+			StatusCode: apiErr.StatusCode,
+			Message:    message,
+			Hint:       apiErr.Hint,
+		}
+	}
+	return err
+}

--- a/internal/pageutil/api_test.go
+++ b/internal/pageutil/api_test.go
@@ -1,0 +1,31 @@
+package pageutil
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/api"
+)
+
+func TestTranslateRateLimitErrorPreservesAPIError(t *testing.T) {
+	err := TranslateRateLimitError(&api.APIError{
+		StatusCode: http.StatusTooManyRequests,
+		Message:    "Rate limited.",
+		Hint:       "Wait a moment and retry.",
+	}, PublishRateLimitMessage)
+
+	var apiErr *api.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("translated error should preserve *api.APIError, got %T", err)
+	}
+	if apiErr.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("got status %d, want 429", apiErr.StatusCode)
+	}
+	if apiErr.Message != PublishRateLimitMessage {
+		t.Fatalf("got message %q, want %q", apiErr.Message, PublishRateLimitMessage)
+	}
+	if apiErr.Hint != "Wait a moment and retry." {
+		t.Fatalf("got hint %q", apiErr.Hint)
+	}
+}

--- a/internal/pageutil/io.go
+++ b/internal/pageutil/io.go
@@ -1,0 +1,88 @@
+package pageutil
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+const DefaultHTMLPath = "./landing.html"
+
+type HTMLInput struct {
+	Source string
+	HTML   string
+}
+
+func ReadHTML(r io.Reader, path string) (HTMLInput, error) {
+	if path == "" {
+		path = DefaultHTMLPath
+	}
+
+	if path == "-" {
+		data, err := io.ReadAll(r)
+		if err != nil {
+			return HTMLInput{}, fmt.Errorf("cannot read stdin: %w", err)
+		}
+		return HTMLInput{Source: "stdin", HTML: string(data)}, nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return HTMLInput{}, fmt.Errorf("cannot read %s: %w", path, err)
+	}
+	return HTMLInput{Source: path, HTML: string(data)}, nil
+}
+
+func StripTerminalControls(value string) string {
+	var b strings.Builder
+	b.Grow(len(value))
+
+	for i := 0; i < len(value); {
+		r, size := utf8.DecodeRuneInString(value[i:])
+
+		if r == '\x1b' {
+			i += skipEscapeSequence(value[i:])
+			continue
+		}
+		if r < 0x20 || r == 0x7f || unicode.IsControl(r) {
+			i += size
+			continue
+		}
+
+		b.WriteRune(r)
+		i += size
+	}
+
+	return b.String()
+}
+
+func skipEscapeSequence(value string) int {
+	if len(value) < 2 {
+		return 1
+	}
+
+	switch value[1] {
+	case '[':
+		for i := 2; i < len(value); i++ {
+			if value[i] >= 0x40 && value[i] <= 0x7e {
+				return i + 1
+			}
+		}
+		return len(value)
+	case ']':
+		for i := 2; i < len(value); i++ {
+			if value[i] == '\a' {
+				return i + 1
+			}
+			if value[i] == '\x1b' && i+1 < len(value) && value[i+1] == '\\' {
+				return i + 2
+			}
+		}
+		return len(value)
+	default:
+		return 2
+	}
+}

--- a/internal/pageutil/io_test.go
+++ b/internal/pageutil/io_test.go
@@ -1,0 +1,49 @@
+package pageutil
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadHTMLDefaultPath(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	body := "<section>Buy</section>"
+	if err := os.WriteFile(filepath.Join(dir, "landing.html"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	input, err := ReadHTML(bytes.NewBuffer(nil), "")
+	if err != nil {
+		t.Fatalf("ReadHTML returned error: %v", err)
+	}
+	if input.Source != DefaultHTMLPath {
+		t.Errorf("got source %q, want %q", input.Source, DefaultHTMLPath)
+	}
+	if input.HTML != body {
+		t.Errorf("got HTML %q, want %q", input.HTML, body)
+	}
+}
+
+func TestReadHTMLStdin(t *testing.T) {
+	input, err := ReadHTML(bytes.NewBufferString("<h1>stdin</h1>"), "-")
+	if err != nil {
+		t.Fatalf("ReadHTML returned error: %v", err)
+	}
+	if input.Source != "stdin" {
+		t.Errorf("got source %q, want stdin", input.Source)
+	}
+	if input.HTML != "<h1>stdin</h1>" {
+		t.Errorf("got HTML %q", input.HTML)
+	}
+}
+
+func TestStripTerminalControls(t *testing.T) {
+	got := StripTerminalControls("\x1b[31m<script>\x1b[0m\nbad\x00\x1b]0;title\a")
+	if got != "<script>bad" {
+		t.Errorf("got %q, want %q", got, "<script>bad")
+	}
+}

--- a/internal/pageutil/report.go
+++ b/internal/pageutil/report.go
@@ -1,0 +1,224 @@
+package pageutil
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+)
+
+type SanitizationReport struct {
+	RemovedTags       []RemovedTag       `json:"removed_tags"`
+	RemovedAttributes []RemovedAttribute `json:"removed_attributes"`
+	TotalRemoved      int                `json:"total_removed"`
+	Truncated         bool               `json:"truncated"`
+}
+
+type RemovedTag struct {
+	Tag    string            `json:"tag"`
+	Attrs  map[string]string `json:"attrs"`
+	Reason string            `json:"reason"`
+}
+
+type RemovedAttribute struct {
+	Tag       string `json:"tag"`
+	Attribute string `json:"attribute"`
+	Value     string `json:"value"`
+	Reason    string `json:"reason"`
+}
+
+type RenderResult struct {
+	Action       string
+	Source       string
+	BeforeHTML   string
+	AfterHTML    string
+	LandingURL   string
+	Report       SanitizationReport
+	ClearMessage string
+}
+
+func RenderSanitizationResult(opts cmdutil.Options, result RenderResult) error {
+	if opts.PlainOutput {
+		return renderPlainReport(opts, result)
+	}
+	if opts.Quiet {
+		return nil
+	}
+
+	style := opts.Style()
+	title := result.Action
+	if result.Source != "" {
+		title += " " + result.Source
+	}
+	if err := output.Writeln(opts.Out(), style.Bold(title)); err != nil {
+		return err
+	}
+
+	before := utf8.RuneCountInString(result.BeforeHTML)
+	after := utf8.RuneCountInString(result.AfterHTML)
+	if err := output.Writef(opts.Out(), "HTML: %d -> %d chars (%s)\n", before, after, deltaLabel(after-before)); err != nil {
+		return err
+	}
+
+	if err := renderHumanReport(opts, result.Report); err != nil {
+		return err
+	}
+	if result.LandingURL != "" {
+		if err := output.Writef(opts.Out(), "Live at %s\n", result.LandingURL); err != nil {
+			return err
+		}
+	}
+	if result.ClearMessage != "" {
+		if err := output.Writeln(opts.Out(), result.ClearMessage); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func renderPlainReport(opts cmdutil.Options, result RenderResult) error {
+	before := utf8.RuneCountInString(result.BeforeHTML)
+	after := utf8.RuneCountInString(result.AfterHTML)
+	rows := [][]string{{
+		"summary",
+		result.Action,
+		result.Source,
+		strconv.Itoa(before),
+		strconv.Itoa(after),
+		strconv.Itoa(after - before),
+		strconv.Itoa(result.Report.TotalRemoved),
+		strconv.FormatBool(result.Report.Truncated),
+	}}
+
+	for _, removed := range result.Report.RemovedTags {
+		rows = append(rows, []string{
+			"removed_tag",
+			cleanReportValue(removed.Tag),
+			formatAttrs(removed.Attrs),
+			cleanReportValue(removed.Reason),
+		})
+	}
+	for _, removed := range result.Report.RemovedAttributes {
+		rows = append(rows, []string{
+			"removed_attribute",
+			cleanReportValue(removed.Tag),
+			cleanReportValue(removed.Attribute),
+			cleanReportValue(removed.Value),
+			cleanReportValue(removed.Reason),
+		})
+	}
+	if result.LandingURL != "" {
+		rows = append(rows, []string{"landing_url", result.LandingURL})
+	}
+	if result.ClearMessage != "" {
+		rows = append(rows, []string{"message", result.ClearMessage})
+	}
+
+	return output.PrintPlain(opts.Out(), rows)
+}
+
+func renderHumanReport(opts cmdutil.Options, report SanitizationReport) error {
+	if report.TotalRemoved == 0 {
+		return output.Writeln(opts.Out(), "No sanitization changes.")
+	}
+
+	suffix := ""
+	if report.Truncated {
+		suffix = " (showing first 100)"
+	}
+	if err := output.Writef(opts.Out(), "Sanitization removed %d item%s%s.\n", report.TotalRemoved, plural(report.TotalRemoved), suffix); err != nil {
+		return err
+	}
+
+	if len(report.RemovedTags) > 0 {
+		tbl := output.NewStyledTable(opts.Style(), "TAG", "ATTRS", "REASON")
+		for _, removed := range report.RemovedTags {
+			tbl.AddRow(
+				truncateReportValue(cleanReportValue(removed.Tag)),
+				truncateReportValue(formatAttrs(removed.Attrs)),
+				truncateReportValue(cleanReportValue(removed.Reason)),
+			)
+		}
+		if err := tbl.Render(opts.Out()); err != nil {
+			return err
+		}
+	}
+
+	if len(report.RemovedAttributes) > 0 {
+		tbl := output.NewStyledTable(opts.Style(), "TAG", "ATTRIBUTE", "VALUE", "REASON")
+		for _, removed := range report.RemovedAttributes {
+			tbl.AddRow(
+				truncateReportValue(cleanReportValue(removed.Tag)),
+				truncateReportValue(cleanReportValue(removed.Attribute)),
+				truncateReportValue(cleanReportValue(removed.Value)),
+				truncateReportValue(cleanReportValue(removed.Reason)),
+			)
+		}
+		if err := tbl.Render(opts.Out()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func deltaLabel(delta int) string {
+	switch {
+	case delta > 0:
+		return fmt.Sprintf("+%d", delta)
+	case delta < 0:
+		return strconv.Itoa(delta)
+	default:
+		return "no change"
+	}
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}
+
+func formatAttrs(attrs map[string]string) string {
+	if len(attrs) == 0 {
+		return ""
+	}
+
+	cleaned := make(map[string]string, len(attrs))
+	for k, v := range attrs {
+		cleaned[cleanReportValue(k)] = cleanReportValue(v)
+	}
+	data, err := json.Marshal(cleaned)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+func cleanReportValue(value string) string {
+	return strings.TrimSpace(StripTerminalControls(value))
+}
+
+func truncateReportValue(value string) string {
+	const maxRunes = 120
+	if utf8.RuneCountInString(value) <= maxRunes {
+		return value
+	}
+
+	var b strings.Builder
+	count := 0
+	for _, r := range value {
+		if count >= maxRunes-3 {
+			break
+		}
+		b.WriteRune(r)
+		count++
+	}
+	b.WriteString("...")
+	return b.String()
+}

--- a/internal/pageutil/report_test.go
+++ b/internal/pageutil/report_test.go
@@ -1,0 +1,83 @@
+package pageutil
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+)
+
+func TestRenderSanitizationResultStripsReportControls(t *testing.T) {
+	var out bytes.Buffer
+	opts := cmdutil.DefaultOptions()
+	opts.Stdout = &out
+	opts.NoColor = true
+
+	err := RenderSanitizationResult(opts, RenderResult{
+		Action:     "Previewed page",
+		Source:     "landing.html",
+		BeforeHTML: "<a>Buy</a>",
+		AfterHTML:  "<a>Buy</a>",
+		Report: SanitizationReport{
+			RemovedAttributes: []RemovedAttribute{{
+				Tag:       "a",
+				Attribute: "href",
+				Value:     "\x1b[31mjavascript:alert(1)\x1b[0m\n",
+				Reason:    "javascript: URL blocked\x00",
+			}},
+			TotalRemoved: 1,
+		},
+	})
+	if err != nil {
+		t.Fatalf("RenderSanitizationResult returned error: %v", err)
+	}
+
+	got := out.String()
+	if strings.Contains(got, "\x1b") || strings.Contains(got, "\x00") {
+		t.Fatalf("expected terminal controls to be stripped, got %q", got)
+	}
+	if !strings.Contains(got, "javascript:alert(1)") || !strings.Contains(got, "javascript: URL blocked") {
+		t.Fatalf("expected sanitized report values, got %q", got)
+	}
+}
+
+func TestRenderSanitizationResultPlainRows(t *testing.T) {
+	var out bytes.Buffer
+	opts := cmdutil.DefaultOptions()
+	opts.Stdout = &out
+	opts.PlainOutput = true
+
+	err := RenderSanitizationResult(opts, RenderResult{
+		Action:     "Published page",
+		Source:     "landing.html",
+		BeforeHTML: "<script></script>",
+		AfterHTML:  "",
+		LandingURL: "https://seller.gumroad.com/l/prod",
+		Report: SanitizationReport{
+			RemovedTags: []RemovedTag{{
+				Tag:    "script",
+				Attrs:  map[string]string{"src": "\x1b[31mhttps://evil.test/x.js\x1b[0m"},
+				Reason: "script src host not allowed",
+			}},
+			TotalRemoved: 1,
+		},
+	})
+	if err != nil {
+		t.Fatalf("RenderSanitizationResult returned error: %v", err)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "summary\tPublished page\tlanding.html") {
+		t.Fatalf("plain output missing summary row: %q", got)
+	}
+	if !strings.Contains(got, "removed_tag\tscript") {
+		t.Fatalf("plain output missing removed tag row: %q", got)
+	}
+	if !strings.Contains(got, "landing_url\thttps://seller.gumroad.com/l/prod") {
+		t.Fatalf("plain output missing landing URL row: %q", got)
+	}
+	if strings.Contains(got, "\x1b") {
+		t.Fatalf("expected terminal controls to be stripped, got %q", got)
+	}
+}

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -38,7 +38,7 @@ Always follow these rules:
 - Prices are in whole currency units (e.g. `--price 10.00` for $10), not cents. The CLI converts internally. Use `--currency eur` to change currency.
 - Products are created as drafts — use `gumroad products publish <id>` to make them live.
 - Product cover and thumbnail uploads support JPEG, PNG, and GIF. WebP is not supported by the API and the CLI rejects it before upload.
-- Product custom HTML landing pages are published with `gumroad products update <id> --custom-html ./landing.html`. Use `--custom-html ''` to clear the page. `--dry-run` only previews the CLI request body; it does not call the backend sanitizer. Inspect `.result.sanitization_report` in the publish response for server-side changes.
+- Product custom HTML landing pages use `gumroad products page preview <id> ./landing.html` to run the backend sanitizer without writing, `gumroad products page publish <id> ./landing.html` to store the page, `gumroad products page clear <id> --yes` to remove it, and `gumroad products page url <id>` to print the live URL. `--dry-run` only previews the CLI request body; it does not call the backend sanitizer. Inspect `.sanitization_report` in `preview` and `publish` JSON output for server-side changes.
 - Custom HTML pages can use `data-gumroad-field="name"`, `data-gumroad-field="price"`, `data-gumroad-field="description"`, and `data-gumroad-action="buy"`. To preselect checkout state, add `data-gumroad-option="<variant name>"`, `data-gumroad-quantity="<integer>"`, `data-gumroad-price="<decimal>"`, or `data-gumroad-recurrence="monthly|quarterly|biannually|yearly|every_two_years"`. Production validates these values and falls back to product defaults when invalid. Prefer anchors for buy CTAs so production can add a checkout href; non-anchor buy elements also post to checkout.
 - If a command fails with a seller auth error, tell the user to run `gumroad auth login` interactively — agents cannot do this step.
 - For admin commands in agents/CI, pass `--non-interactive` and set `GUMROAD_ADMIN_TOKEN`; interactive shells can store an admin token with `gumroad auth login`.
@@ -68,7 +68,9 @@ Responses are wrapped in `{"success": true, ...}` with resource-specific keys:
 - `products covers add --url` → `.result.covers[]`, `.result.main_cover_id`
 - `products thumbnail set --image` → `.result.thumbnail`, plus `.result.media[]`
 - `products thumbnail set --url` → `.result.thumbnail`
-- `products update --custom-html` → `.result.product.custom_html`, `.result.product.landing_url`, `.result.previous_custom_html`, `.result.sanitization_report`
+- `products page preview` → `.custom_html`, `.sanitization_report`
+- `products page publish` / `products page clear` → `.product.custom_html`, `.product.landing_url`, `.previous_custom_html`, `.sanitization_report`
+- `products update --custom-html` → mutation envelope with `.result.product.custom_html`, `.result.product.landing_url`, `.result.previous_custom_html`, `.result.sanitization_report`
 - `webhooks list` → `.resource_subscriptions[]`
 - `admin users info` → `.user`
 - `admin users affiliates` → `.affiliates[]`
@@ -220,9 +222,12 @@ gumroad products update <id> --file ./pack.zip --json --no-input
 gumroad products update <id> --cover-image ./cover.jpg --json --no-input
 gumroad products update <id> --preview-image ./gallery-1.jpg --preview-image ./gallery-2.jpg --json --no-input
 gumroad products update <id> --thumbnail ./thumb.jpg --json --no-input
-gumroad products update <id> --custom-html ./landing.html --json --no-input
-gumroad products update <id> --custom-html '' --json --no-input
-gumroad products view <id> --json --jq '.product.landing_url' --no-input
+gumroad products page preview <id> ./landing.html --json --no-input
+gumroad products page publish <id> ./landing.html --json --no-input
+gumroad products page publish <id> - --json --no-input < landing.html
+gumroad products page clear <id> --yes --json --no-input
+gumroad products page url <id> --no-input
+gumroad products page url <id> --json --jq '.product.landing_url' --no-input
 gumroad products update <id> --replace-files --keep-file file_123 --file ./new-pack.zip --yes --json --no-input
 gumroad products update <id> --remove-file file_456 --yes --json --no-input
 
@@ -262,7 +267,7 @@ In custom HTML, use Gumroad data attributes for live product values and checkout
 
 **Create flags:** `--name` (required), `--price`, `--type` (digital|course|ebook|membership|bundle|coffee|call|commission), `--currency`, `--pay-what-you-want`, `--suggested-price`, `--description`, `--custom-summary`, `--custom-permalink`, `--custom-receipt`, `--max-purchase-count`, `--category`, `--taxonomy-id`, `--tag` (repeatable), `--file` (repeatable), `--file-name` (repeatable, aligned to `--file`), `--file-description` (repeatable, aligned to `--file`), `--cover-image`, `--preview-image` (repeatable), `--thumbnail`.
 
-**Update flags:** `--name`, `--price`, `--currency`, `--description`, `--custom-summary`, `--custom-permalink`, `--custom-receipt`, `--max-purchase-count`, `--category`, `--taxonomy-id`, `--tag` (repeatable), `--custom-html`, `--file` (repeatable), `--file-name`, `--file-description`, `--remove-file` (repeatable), `--replace-files`, `--keep-file` (repeatable with `--replace-files`), `--cover-image`, `--preview-image` (repeatable), `--thumbnail`. Updates preserve existing files by default unless `--replace-files` is set.
+**Update flags:** `--name`, `--price`, `--currency`, `--description`, `--custom-summary`, `--custom-permalink`, `--custom-receipt`, `--max-purchase-count`, `--category`, `--taxonomy-id`, `--tag` (repeatable), `--custom-html`, `--file` (repeatable), `--file-name`, `--file-description`, `--remove-file` (repeatable), `--replace-files`, `--keep-file` (repeatable with `--replace-files`), `--cover-image`, `--preview-image` (repeatable), `--thumbnail`. Updates preserve existing files by default unless `--replace-files` is set. Prefer `products page preview/publish/clear/url` for custom HTML page workflows; `products update --custom-html` remains supported as a low-level product update flag.
 
 Use `products update --file` for shared product Content. For products with per-variant Content, use `variants update ... --file` for the specific variant you want to change.
 


### PR DESCRIPTION
Ref antiwork/gumroad#5364

## What

Adds a `products page` namespace for custom HTML workflows, with explicit preview, publish, clear, and URL commands. The new flow uses the backend sanitizer directly and keeps dry-run behavior local.

## Why

This makes the page workflow easier to discover and aligns the CLI with the shipped product-page contract instead of overloading `products update`. It also keeps the shipped Gumroad skill in sync so agents use the supported commands.

---

This PR was implemented with AI assistance using gpt-5.5 xhigh.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mutates live product `custom_html` via publish/clear and adds a large new surface area, but behavior is covered by tests and confirmation on clear.
> 
> **Overview**
> Adds a **`gumroad products page`** command group for custom HTML landing pages, with **`preview`**, **`publish`**, **`clear`**, and **`url`** subcommands wired into `products` and documented in the Gumroad skill.
> 
> **`preview`** POSTs HTML to the backend sanitizer without saving; **`publish`** and **`clear`** PUT `custom_html` (clear requires confirmation/`--yes`); **`url`** GETs the product and prints the live landing URL. HTML is read from a path (default `./landing.html`), **`-`** for stdin, with shared **`pageutil`** helpers for API types, rate-limit messaging, sanitization report rendering (human/plain, terminal-control stripping), and tests.
> 
> Agents are steered toward these commands instead of overloading **`products update --custom-html`**, which remains as a low-level option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a64ff23dd3fac5b504d04b0be3dc9776c6930f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->