### PR TITLE
Add admin user credits commands

### DIFF
--- a/internal/cmd/admin/users/credits.go
+++ b/internal/cmd/admin/users/credits.go
@@ -1,6 +1,7 @@
 package users
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -74,16 +75,16 @@ func newCreditsAddCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "add",
 		Short: "Issue a goodwill account credit",
-		Long: `Issue a positive goodwill account credit to a user.
+		Long: fmt.Sprintf(`Issue a positive goodwill account credit to a user.
 
 This moves money into the user's balance and sends the backend credit
 notification. Each successful call creates a new credit. If the request fails
 after being sent, run "gumroad admin users credits list" for the user before
 retrying to avoid issuing a duplicate credit.
 
-Credits are capped at $1,000 per call unless --allow-large-amount is passed.
+Credits are capped at %s per call unless --allow-large-amount is passed.
 Negative credits and clawbacks are intentionally not supported by this CLI
-command.`,
+command.`, creditCapLabel()),
 		Example: `  gumroad admin users credits add --user-id 2245593582708 --amount-cents 1000 --reason "Goodwill for checkout bug" --dry-run
   gumroad admin users credits add --user-id 2245593582708 --expected-email seller@example.com --amount-cents 1000 --reason "Goodwill for checkout bug" --yes
   gumroad admin users credits add --user-id 2245593582708 --amount-cents 150000 --reason "Approved large goodwill credit" --allow-large-amount --yes`,
@@ -110,6 +111,18 @@ command.`,
 			}
 			path := "users/add_credit"
 
+			var client *adminapi.Client
+			if !opts.DryRun {
+				info, err := admincmd.ResolveMutationToken(opts)
+				if err != nil {
+					return err
+				}
+				if err := admincmd.WriteActorBanner(opts, info); err != nil {
+					return err
+				}
+				client = admincmd.NewAPIClient(opts, info.Value)
+			}
+
 			ok, err := cmdutil.ConfirmAction(opts, fmt.Sprintf(
 				"Issue %s credit to user_id %s? This adds funds to the user's balance.",
 				formatCreditAmount(amountCents),
@@ -126,7 +139,7 @@ command.`,
 				return cmdutil.PrintDryRunRequest(opts, http.MethodPost, adminapi.AdminPath(path), addCreditDryRunParams(req))
 			}
 
-			data, err := admincmd.FetchPostJSON(opts, "Issuing credit...", path, req)
+			data, err := postAddCredit(opts, client, path, req)
 			if err != nil {
 				return wrapCreditError(target.UserID, err)
 			}
@@ -145,7 +158,7 @@ command.`,
 	addUserMutationFlags(cmd, &targetFlags)
 	cmd.Flags().IntVar(&amountCents, "amount-cents", 0, "Credit amount in cents (required, positive)")
 	cmd.Flags().StringVar(&reason, "reason", "", "Reason shown in the creator notification and audit comment (required)")
-	cmd.Flags().BoolVar(&allowLarge, "allow-large-amount", false, "Allow credits over the $1,000 per-call cap")
+	cmd.Flags().BoolVar(&allowLarge, "allow-large-amount", false, "Allow credits over the "+creditCapLabel()+" per-call cap")
 
 	return cmd
 }
@@ -197,9 +210,18 @@ func validateCreditAmount(cmd *cobra.Command, amountCents int, allowLarge bool) 
 		return cmdutil.UsageErrorf(cmd, "--amount-cents must be greater than 0")
 	}
 	if amountCents > creditMaxCents && !allowLarge {
-		return cmdutil.UsageErrorf(cmd, "--amount-cents exceeds the $1,000 per-call cap; pass --allow-large-amount to override")
+		return cmdutil.UsageErrorf(cmd, "--amount-cents exceeds the %s per-call cap; pass --allow-large-amount to override", creditCapLabel())
 	}
 	return nil
+}
+
+func postAddCredit(opts cmdutil.Options, client *adminapi.Client, path string, req addCreditRequest) (json.RawMessage, error) {
+	if cmdutil.ShouldShowSpinner(opts) {
+		sp := output.NewSpinnerTo("Issuing credit...", opts.Err())
+		sp.Start()
+		defer sp.Stop()
+	}
+	return client.PostJSON(path, req)
 }
 
 func validateCreditReason(cmd *cobra.Command, reason string) (string, error) {
@@ -350,6 +372,48 @@ func formatCreditAmount(cents int) string {
 		return fmt.Sprintf("-$%s (%d cents)", strings.TrimPrefix(amount, "-"), cents)
 	}
 	return fmt.Sprintf("$%s (%d cents)", amount, cents)
+}
+
+func creditCapLabel() string {
+	return "$" + formatCreditMoneyLabel(creditMaxCents)
+}
+
+func formatCreditMoneyLabel(cents int) string {
+	amount := cmdutil.FormatMoney(cents, "")
+	negative := strings.HasPrefix(amount, "-")
+	if negative {
+		amount = strings.TrimPrefix(amount, "-")
+	}
+
+	whole, frac, hasFrac := strings.Cut(amount, ".")
+	whole = addThousandsSeparators(whole)
+
+	label := whole
+	if hasFrac && frac != "00" {
+		label += "." + frac
+	}
+	if negative {
+		return "-" + label
+	}
+	return label
+}
+
+func addThousandsSeparators(value string) string {
+	if len(value) <= 3 {
+		return value
+	}
+
+	var b strings.Builder
+	prefix := len(value) % 3
+	if prefix == 0 {
+		prefix = 3
+	}
+	b.WriteString(value[:prefix])
+	for i := prefix; i < len(value); i += 3 {
+		b.WriteByte(',')
+		b.WriteString(value[i : i+3])
+	}
+	return b.String()
 }
 
 func wrapCreditError(userID string, err error) error {

--- a/internal/cmd/admin/users/credits.go
+++ b/internal/cmd/admin/users/credits.go
@@ -1,0 +1,367 @@
+package users
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/antiwork/gumroad-cli/internal/adminapi"
+	"github.com/antiwork/gumroad-cli/internal/admincmd"
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil/cursor"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+const creditMaxCents = 100_000
+
+type creditPayload struct {
+	ID              string `json:"id"`
+	AmountCents     int    `json:"amount_cents"`
+	Reason          string `json:"reason"`
+	CreditingUserID string `json:"crediting_user_id"`
+	CreatedAt       string `json:"created_at"`
+}
+
+type addCreditRequest struct {
+	UserID        string `json:"user_id"`
+	AmountCents   int    `json:"amount_cents"`
+	Reason        string `json:"reason"`
+	ExpectedEmail string `json:"expected_email,omitempty"`
+}
+
+type addCreditResponse struct {
+	Success bool          `json:"success"`
+	UserID  string        `json:"user_id"`
+	Credit  creditPayload `json:"credit"`
+}
+
+type creditsResponse struct {
+	UserID     string            `json:"user_id"`
+	Credits    []creditPayload   `json:"credits"`
+	Pagination cursor.Pagination `json:"pagination"`
+}
+
+func newCreditsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "credits",
+		Short: "List and issue user credits",
+		Example: `  gumroad admin users credits list --user-id 2245593582708
+  gumroad admin users credits list --email seller@example.com --cursor cur-next
+  gumroad admin users credits add --user-id 2245593582708 --amount-cents 1000 --reason "Goodwill for checkout bug" --dry-run
+  gumroad admin users credits add --user-id 2245593582708 --expected-email seller@example.com --amount-cents 1000 --reason "Goodwill for checkout bug" --yes`,
+	}
+
+	cmd.AddCommand(newCreditsListCmd())
+	cmd.AddCommand(newCreditsAddCmd())
+
+	return cmd
+}
+
+func newCreditsAddCmd() *cobra.Command {
+	var (
+		targetFlags userMutationFlags
+		amountCents int
+		reason      string
+		allowLarge  bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "add",
+		Short: "Issue a goodwill account credit",
+		Long: `Issue a positive goodwill account credit to a user.
+
+This moves money into the user's balance and sends the backend credit
+notification. Each successful call creates a new credit. If the request fails
+after being sent, run "gumroad admin users credits list" for the user before
+retrying to avoid issuing a duplicate credit.
+
+Credits are capped at $1,000 per call unless --allow-large-amount is passed.
+Negative credits and clawbacks are intentionally not supported by this CLI
+command.`,
+		Example: `  gumroad admin users credits add --user-id 2245593582708 --amount-cents 1000 --reason "Goodwill for checkout bug" --dry-run
+  gumroad admin users credits add --user-id 2245593582708 --expected-email seller@example.com --amount-cents 1000 --reason "Goodwill for checkout bug" --yes
+  gumroad admin users credits add --user-id 2245593582708 --amount-cents 150000 --reason "Approved large goodwill credit" --allow-large-amount --yes`,
+		Args: cmdutil.ExactArgs(0),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			target, err := resolveUserMutationTarget(c, targetFlags)
+			if err != nil {
+				return err
+			}
+			if err := validateCreditAmount(c, amountCents, allowLarge); err != nil {
+				return err
+			}
+			trimmedReason, err := validateCreditReason(c, reason)
+			if err != nil {
+				return err
+			}
+
+			req := addCreditRequest{
+				UserID:        target.UserID,
+				AmountCents:   amountCents,
+				Reason:        trimmedReason,
+				ExpectedEmail: target.ExpectedEmail,
+			}
+			path := "users/add_credit"
+
+			ok, err := cmdutil.ConfirmAction(opts, fmt.Sprintf(
+				"Issue %s credit to user_id %s? This adds funds to the user's balance.",
+				formatCreditAmount(amountCents),
+				target.UserID,
+			))
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return cmdutil.PrintCancelledAction(opts, "issue credit for user_id "+target.UserID, target.UserID)
+			}
+
+			if opts.DryRun {
+				return cmdutil.PrintDryRunRequest(opts, http.MethodPost, adminapi.AdminPath(path), addCreditDryRunParams(req))
+			}
+
+			data, err := admincmd.FetchPostJSON(opts, "Issuing credit...", path, req)
+			if err != nil {
+				return wrapCreditError(target.UserID, err)
+			}
+			if opts.UsesJSONOutput() {
+				return cmdutil.PrintJSONResponse(opts, data)
+			}
+
+			decoded, err := cmdutil.DecodeJSON[addCreditResponse](data)
+			if err != nil {
+				return err
+			}
+			return renderAddCredit(opts, fallback(decoded.UserID, target.UserID), decoded)
+		},
+	}
+
+	addUserMutationFlags(cmd, &targetFlags)
+	cmd.Flags().IntVar(&amountCents, "amount-cents", 0, "Credit amount in cents (required, positive)")
+	cmd.Flags().StringVar(&reason, "reason", "", "Reason shown in the creator notification and audit comment (required)")
+	cmd.Flags().BoolVar(&allowLarge, "allow-large-amount", false, "Allow credits over the $1,000 per-call cap")
+
+	return cmd
+}
+
+func newCreditsListCmd() *cobra.Command {
+	var (
+		lookup userLookupFlags
+		page   cursor.Flags
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List credits for a user",
+		Long:  `List a user's account credits, newest first.`,
+		Example: `  gumroad admin users credits list --user-id 2245593582708
+  gumroad admin users credits list --email seller@example.com --limit 50
+  gumroad admin users credits list --user-id 2245593582708 --cursor cur-next`,
+		Args: cmdutil.ExactArgs(0),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			target, err := resolveUserLookupTarget(c, lookup)
+			if err != nil {
+				return err
+			}
+			if err := cmdutil.RequirePositiveIntFlag(c, "limit", page.Limit); err != nil {
+				return err
+			}
+
+			params := target.Values()
+			cursor.Apply(params, page)
+
+			return admincmd.RunGetDecoded[creditsResponse](opts, "Fetching user credits...", "/users/credits", params, func(resp creditsResponse) error {
+				return renderCreditsList(opts, target.Identifier(), resp)
+			})
+		},
+	}
+
+	addUserLookupFlags(cmd, &lookup)
+	cursor.AddFlags(cmd, &page)
+
+	return cmd
+}
+
+func validateCreditAmount(cmd *cobra.Command, amountCents int, allowLarge bool) error {
+	if !cmd.Flags().Changed("amount-cents") {
+		return cmdutil.MissingFlagError(cmd, "--amount-cents")
+	}
+	if amountCents <= 0 {
+		return cmdutil.UsageErrorf(cmd, "--amount-cents must be greater than 0")
+	}
+	if amountCents > creditMaxCents && !allowLarge {
+		return cmdutil.UsageErrorf(cmd, "--amount-cents exceeds the $1,000 per-call cap; pass --allow-large-amount to override")
+	}
+	return nil
+}
+
+func validateCreditReason(cmd *cobra.Command, reason string) (string, error) {
+	if !cmd.Flags().Changed("reason") {
+		return "", cmdutil.MissingFlagError(cmd, "--reason")
+	}
+	trimmed := strings.TrimSpace(reason)
+	if trimmed == "" {
+		return "", cmdutil.UsageErrorf(cmd, "--reason cannot be empty")
+	}
+	return trimmed, nil
+}
+
+func addCreditDryRunParams(req addCreditRequest) url.Values {
+	params := url.Values{}
+	params.Set("user_id", req.UserID)
+	params.Set("amount_cents", strconv.Itoa(req.AmountCents))
+	params.Set("reason", req.Reason)
+	if req.ExpectedEmail != "" {
+		params.Set("expected_email", req.ExpectedEmail)
+	}
+	return params
+}
+
+func renderAddCredit(opts cmdutil.Options, userID string, resp addCreditResponse) error {
+	if opts.PlainOutput {
+		return output.PrintPlain(opts.Out(), [][]string{{
+			strconv.FormatBool(resp.Success),
+			userID,
+			resp.Credit.ID,
+			strconv.Itoa(resp.Credit.AmountCents),
+			resp.Credit.Reason,
+			resp.Credit.CreditingUserID,
+			resp.Credit.CreatedAt,
+		}})
+	}
+
+	if opts.Quiet {
+		return nil
+	}
+
+	headline := "Credit issued"
+	if err := output.Writeln(opts.Out(), opts.Style().Green(headline)); err != nil {
+		return err
+	}
+	if err := cmdutil.WriteIdentifierLine(opts.Out(), "User ID", headline, userID); err != nil {
+		return err
+	}
+	return writeCreditDetails(opts.Out(), resp.Credit)
+}
+
+func renderCreditsList(opts cmdutil.Options, identifier string, resp creditsResponse) error {
+	if opts.PlainOutput {
+		return writeCreditsPlain(opts.Out(), resp.Credits)
+	}
+
+	if opts.Quiet {
+		return nil
+	}
+
+	style := opts.Style()
+	return output.WithPager(opts.Out(), opts.Err(), func(w io.Writer) error {
+		if len(resp.Credits) == 0 {
+			if err := output.Writef(w, "No credits found for %s.\n", identifier); err != nil {
+				return err
+			}
+			return cursor.WriteMoreFooter(w, resp.Pagination)
+		}
+
+		if err := output.Writeln(w, style.Bold(fmt.Sprintf("%d credit(s) for %s", len(resp.Credits), identifier))); err != nil {
+			return err
+		}
+		if resp.UserID != "" && resp.UserID != identifier {
+			if err := output.Writef(w, "User ID: %s\n", resp.UserID); err != nil {
+				return err
+			}
+		}
+		if err := output.Writeln(w, ""); err != nil {
+			return err
+		}
+		if err := writeCreditsTable(w, style, resp.Credits); err != nil {
+			return err
+		}
+		return cursor.WriteMoreFooter(w, resp.Pagination)
+	})
+}
+
+func writeCreditDetails(w io.Writer, credit creditPayload) error {
+	if credit.ID != "" {
+		if err := output.Writef(w, "Credit ID: %s\n", credit.ID); err != nil {
+			return err
+		}
+	}
+	if err := output.Writef(w, "Amount: %s\n", formatCreditAmount(credit.AmountCents)); err != nil {
+		return err
+	}
+	if credit.Reason != "" {
+		if err := output.Writef(w, "Reason: %s\n", credit.Reason); err != nil {
+			return err
+		}
+	}
+	if credit.CreditingUserID != "" {
+		if err := output.Writef(w, "Crediting user: %s\n", credit.CreditingUserID); err != nil {
+			return err
+		}
+	}
+	if credit.CreatedAt != "" {
+		return output.Writef(w, "Created: %s\n", credit.CreatedAt)
+	}
+	return nil
+}
+
+func writeCreditsPlain(w io.Writer, credits []creditPayload) error {
+	rows := make([][]string, 0, len(credits))
+	for _, credit := range credits {
+		rows = append(rows, creditRow(credit))
+	}
+	return output.PrintPlain(w, rows)
+}
+
+func writeCreditsTable(w io.Writer, style output.Styler, credits []creditPayload) error {
+	tbl := output.NewStyledTable(style, "ID", "AMOUNT", "REASON", "CREDITED BY", "CREATED")
+	for _, credit := range credits {
+		tbl.AddRow(
+			credit.ID,
+			formatCreditAmount(credit.AmountCents),
+			credit.Reason,
+			credit.CreditingUserID,
+			credit.CreatedAt,
+		)
+	}
+	return tbl.Render(w)
+}
+
+func creditRow(credit creditPayload) []string {
+	return []string{
+		credit.ID,
+		strconv.Itoa(credit.AmountCents),
+		credit.Reason,
+		credit.CreditingUserID,
+		credit.CreatedAt,
+	}
+}
+
+func formatCreditAmount(cents int) string {
+	amount := cmdutil.FormatMoney(cents, "")
+	if strings.HasPrefix(amount, "-") {
+		return fmt.Sprintf("-$%s (%d cents)", strings.TrimPrefix(amount, "-"), cents)
+	}
+	return fmt.Sprintf("$%s (%d cents)", amount, cents)
+}
+
+func wrapCreditError(userID string, err error) error {
+	verify := fmt.Sprintf("Verify status with 'gumroad admin users credits list --user-id %s' before retrying to avoid duplicate credits", userID)
+
+	var apiErr *api.APIError
+	if errors.As(err, &apiErr) {
+		return &api.APIError{
+			StatusCode: apiErr.StatusCode,
+			Message:    fmt.Sprintf("credit request failed: %s. %s", apiErr.Message, verify),
+			Hint:       apiErr.Hint,
+		}
+	}
+	return fmt.Errorf("credit request failed: %w. %s", err, verify)
+}

--- a/internal/cmd/admin/users/credits_test.go
+++ b/internal/cmd/admin/users/credits_test.go
@@ -1,6 +1,7 @@
 package users
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -94,13 +95,14 @@ func TestCreditsAddRejectsLargeAmountWithoutOverride(t *testing.T) {
 }
 
 func TestCreditsAddRequiresConfirmationBeforePost(t *testing.T) {
+	var stderr bytes.Buffer
 	var gotPost bool
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
 		gotPost = true
 		t.Error("must not POST without confirmation")
 	})
 
-	cmd := testutil.Command(newCreditsAddCmd(), testutil.NoInput(true))
+	cmd := testutil.Command(newCreditsAddCmd(), testutil.NoInput(true), testutil.Stderr(&stderr))
 	cmd.SetArgs([]string{"--user-id", "2245593582708", "--amount-cents", "1000", "--reason", "Goodwill"})
 
 	err := cmd.Execute()
@@ -109,6 +111,9 @@ func TestCreditsAddRequiresConfirmationBeforePost(t *testing.T) {
 	}
 	if gotPost {
 		t.Fatal("unexpected POST")
+	}
+	if !strings.Contains(stderr.String(), "Admin actor: Test Admin (admin@example.com)") {
+		t.Fatalf("expected actor banner before confirmation failure, got stderr %q", stderr.String())
 	}
 }
 

--- a/internal/cmd/admin/users/credits_test.go
+++ b/internal/cmd/admin/users/credits_test.go
@@ -1,0 +1,496 @@
+package users
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/adminconfig"
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestCreditsCommandWiresAddAndListSubcommands(t *testing.T) {
+	cmd := newCreditsCmd()
+	got := map[string]bool{}
+	for _, sub := range cmd.Commands() {
+		got[sub.Use] = true
+	}
+
+	for _, name := range []string{"add", "list"} {
+		if !got[name] {
+			t.Fatalf("missing credits subcommand %q in %v", name, got)
+		}
+	}
+	if got["credit"] {
+		t.Fatal("credits command must not expose confusing singular credit subcommand")
+	}
+}
+
+func TestCreditsAddRequiresUserID(t *testing.T) {
+	cmd := newCreditsAddCmd()
+	cmd.SetArgs([]string{"--amount-cents", "1000", "--reason", "Goodwill"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "missing required flag: --user-id") {
+		t.Fatalf("expected missing user ID error, got %v", err)
+	}
+}
+
+func TestCreditsAddRequiresAmountCents(t *testing.T) {
+	cmd := newCreditsAddCmd()
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--reason", "Goodwill"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "missing required flag: --amount-cents") {
+		t.Fatalf("expected missing amount error, got %v", err)
+	}
+}
+
+func TestCreditsAddRequiresReason(t *testing.T) {
+	cmd := newCreditsAddCmd()
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--amount-cents", "1000"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "missing required flag: --reason") {
+		t.Fatalf("expected missing reason error, got %v", err)
+	}
+}
+
+func TestCreditsAddRejectsBlankReason(t *testing.T) {
+	cmd := newCreditsAddCmd()
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--amount-cents", "1000", "--reason", "   "})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--reason cannot be empty") {
+		t.Fatalf("expected blank reason error, got %v", err)
+	}
+}
+
+func TestCreditsAddRejectsNonPositiveAmounts(t *testing.T) {
+	for _, amount := range []string{"0", "-1"} {
+		t.Run(amount, func(t *testing.T) {
+			cmd := newCreditsAddCmd()
+			cmd.SetArgs([]string{"--user-id", "2245593582708", "--amount-cents=" + amount, "--reason", "Goodwill"})
+
+			err := cmd.Execute()
+			if err == nil || !strings.Contains(err.Error(), "--amount-cents must be greater than 0") {
+				t.Fatalf("expected positive amount error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestCreditsAddRejectsLargeAmountWithoutOverride(t *testing.T) {
+	cmd := newCreditsAddCmd()
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--amount-cents", "100001", "--reason", "Goodwill"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "$1,000 per-call cap") || !strings.Contains(err.Error(), "--allow-large-amount") {
+		t.Fatalf("expected cap error, got %v", err)
+	}
+}
+
+func TestCreditsAddRequiresConfirmationBeforePost(t *testing.T) {
+	var gotPost bool
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPost = true
+		t.Error("must not POST without confirmation")
+	})
+
+	cmd := testutil.Command(newCreditsAddCmd(), testutil.NoInput(true))
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--amount-cents", "1000", "--reason", "Goodwill"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--yes") {
+		t.Fatalf("expected --yes error, got %v", err)
+	}
+	if gotPost {
+		t.Fatal("unexpected POST")
+	}
+}
+
+func TestCreditsAddPostsJSONBodyAndRendersCredit(t *testing.T) {
+	var gotMethod, gotPath, gotAuth, gotQuery string
+	var body addCreditRequest
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotQuery = r.URL.RawQuery
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if err := json.Unmarshal(raw, &body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		testutil.JSON(t, w, map[string]any{
+			"user_id": "2245593582708",
+			"credit":  creditFixture(),
+		})
+	})
+
+	cmd := testutil.Command(newCreditsAddCmd(), testutil.Yes(true), testutil.Quiet(false))
+	cmd.SetArgs([]string{
+		"--user-id", "2245593582708",
+		"--expected-email", "seller@example.com",
+		"--amount-cents", "1000",
+		"--reason", "  Goodwill for checkout bug  ",
+	})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != "POST" || gotPath != "/internal/admin/users/add_credit" {
+		t.Fatalf("got %s %s, want POST /internal/admin/users/add_credit", gotMethod, gotPath)
+	}
+	if gotAuth != "Bearer admin-token" {
+		t.Fatalf("got auth %q, want Bearer admin-token", gotAuth)
+	}
+	if gotQuery != "" {
+		t.Fatalf("body fields must not appear in query string, got %q", gotQuery)
+	}
+	if body.UserID != "2245593582708" || body.ExpectedEmail != "seller@example.com" || body.AmountCents != 1000 || body.Reason != "Goodwill for checkout bug" {
+		t.Fatalf("unexpected request body: %#v", body)
+	}
+	for _, want := range []string{
+		"Credit issued",
+		"User ID: 2245593582708",
+		"Credit ID: credit_123",
+		"Amount: $10.00 (1000 cents)",
+		"Reason: Goodwill for checkout bug",
+		"Crediting user: admin_123",
+		"Created: 2026-06-03T19:00:00Z",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestCreditsAddAllowsLargeAmountWithOverride(t *testing.T) {
+	var body addCreditRequest
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		testutil.JSON(t, w, map[string]any{
+			"user_id": "2245593582708",
+			"credit": map[string]any{
+				"id":                "credit_large",
+				"amount_cents":      150000,
+				"reason":            "Approved large goodwill credit",
+				"crediting_user_id": "admin_123",
+				"created_at":        "2026-06-03T19:00:00Z",
+			},
+		})
+	})
+
+	cmd := testutil.Command(newCreditsAddCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{
+		"--user-id", "2245593582708",
+		"--amount-cents", "150000",
+		"--reason", "Approved large goodwill credit",
+		"--allow-large-amount",
+	})
+	testutil.MustExecute(t, cmd)
+
+	if body.AmountCents != 150000 {
+		t.Fatalf("got amount_cents %d, want 150000", body.AmountCents)
+	}
+}
+
+func TestCreditsAddDryRunDoesNotPost(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("dry-run must not POST")
+	})
+
+	cmd := testutil.Command(newCreditsAddCmd(), testutil.DryRun(true), testutil.NoInput(true))
+	cmd.SetArgs([]string{
+		"--user-id", "2245593582708",
+		"--expected-email", "seller@example.com",
+		"--amount-cents", "1000",
+		"--reason", "Goodwill for checkout bug",
+	})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	for _, want := range []string{
+		"POST",
+		"/internal/admin/users/add_credit",
+		"amount_cents: 1000",
+		"expected_email: seller@example.com",
+		"reason: Goodwill for checkout bug",
+		"user_id: 2245593582708",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("dry-run output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestCreditsAddJSONPreservesResponse(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"user_id": "2245593582708",
+			"credit":  creditFixture(),
+		})
+	})
+
+	cmd := testutil.Command(newCreditsAddCmd(), testutil.Yes(true), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--amount-cents", "1000", "--reason", "Goodwill"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp addCreditResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if !resp.Success || resp.UserID != "2245593582708" || resp.Credit.ID != "credit_123" {
+		t.Fatalf("unexpected JSON payload: %s", out)
+	}
+}
+
+func TestCreditsAddPlainOutput(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"user_id": "2245593582708",
+			"credit":  creditFixture(),
+		})
+	})
+
+	cmd := testutil.Command(newCreditsAddCmd(), testutil.Yes(true), testutil.PlainOutput())
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--amount-cents", "1000", "--reason", "Goodwill"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	want := "true\t2245593582708\tcredit_123\t1000\tGoodwill for checkout bug\tadmin_123\t2026-06-03T19:00:00Z"
+	if strings.TrimSpace(out) != want {
+		t.Fatalf("unexpected plain output:\ngot  %q\nwant %q", strings.TrimSpace(out), want)
+	}
+}
+
+func TestCreditsAddConflictSurfacesServerMessageAndRetryHint(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"success": false,
+			"message": "expected_email does not match the user's current email",
+		})
+	})
+
+	cmd := testutil.Command(newCreditsAddCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{
+		"--user-id", "2245593582708",
+		"--expected-email", "old@example.com",
+		"--amount-cents", "1000",
+		"--reason", "Goodwill",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected conflict error")
+	}
+	for _, want := range []string{
+		"expected_email does not match the user's current email",
+		"gumroad admin users credits list --user-id 2245593582708",
+		"avoid duplicate credits",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error missing %q: %v", want, err)
+		}
+	}
+}
+
+func TestCreditsAddNonInteractiveUsesEnvAdminToken(t *testing.T) {
+	var gotAuth string
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		testutil.JSON(t, w, map[string]any{
+			"user_id": "2245593582708",
+			"credit":  creditFixture(),
+		})
+	})
+	if err := adminconfig.Delete(); err != nil {
+		t.Fatalf("delete admin config: %v", err)
+	}
+	t.Setenv(adminconfig.EnvAccessToken, "env-admin-token")
+
+	cmd := testutil.Command(newCreditsAddCmd(), testutil.Yes(true), testutil.NonInteractive(true))
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--amount-cents", "1000", "--reason", "Goodwill"})
+	testutil.MustExecute(t, cmd)
+
+	if gotAuth != "Bearer env-admin-token" {
+		t.Fatalf("got auth %q, want Bearer env-admin-token", gotAuth)
+	}
+}
+
+func TestCreditsListUsesInternalAdminEndpoint(t *testing.T) {
+	var gotMethod, gotPath, gotAuth string
+	var gotQuery url.Values
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotQuery = r.URL.Query()
+		testutil.JSON(t, w, map[string]any{
+			"user_id": "2245593582708",
+			"credits": []map[string]any{
+				creditFixture(),
+				{
+					"id":                "credit_zero",
+					"amount_cents":      0,
+					"reason":            nil,
+					"crediting_user_id": nil,
+					"created_at":        "2026-06-02T19:00:00Z",
+				},
+			},
+			"pagination": map[string]any{"next": "cur-next", "limit": 50},
+		})
+	})
+
+	cmd := testutil.Command(newCreditsListCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--email", "seller@example.com", "--limit", "50", "--cursor", "cur-1"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != "GET" || gotPath != "/internal/admin/users/credits" {
+		t.Fatalf("got %s %s, want GET /internal/admin/users/credits", gotMethod, gotPath)
+	}
+	if gotAuth != "Bearer admin-token" {
+		t.Fatalf("got auth %q, want Bearer admin-token", gotAuth)
+	}
+	for key, want := range map[string]string{
+		"email":  "seller@example.com",
+		"limit":  "50",
+		"cursor": "cur-1",
+	} {
+		if got := gotQuery.Get(key); got != want {
+			t.Fatalf("query %s = %q, want %q; full query %s", key, got, want, gotQuery.Encode())
+		}
+	}
+	for _, want := range []string{
+		"2 credit(s) for seller@example.com",
+		"User ID: 2245593582708",
+		"credit_123",
+		"$10.00 (1000 cents)",
+		"Goodwill for checkout bug",
+		"admin_123",
+		"credit_zero",
+		"$0.00 (0 cents)",
+		"More results: --cursor cur-next",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestCreditsListPlainOutput(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"credits": []map[string]any{
+				creditFixture(),
+				{
+					"id":                "credit_456",
+					"amount_cents":      -500,
+					"reason":            "Historical clawback",
+					"crediting_user_id": nil,
+					"created_at":        "2026-06-02T19:00:00Z",
+				},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newCreditsListCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{"--user-id", "2245593582708"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	want := strings.Join([]string{
+		"credit_123\t1000\tGoodwill for checkout bug\tadmin_123\t2026-06-03T19:00:00Z",
+		"credit_456\t-500\tHistorical clawback\t\t2026-06-02T19:00:00Z",
+	}, "\n")
+	if strings.TrimSpace(out) != want {
+		t.Fatalf("unexpected plain output:\ngot  %q\nwant %q", strings.TrimSpace(out), want)
+	}
+}
+
+func TestCreditsListJSONPreservesResponse(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"user_id":    "2245593582708",
+			"credits":    []map[string]any{creditFixture()},
+			"pagination": map[string]any{"next": "cur-next", "limit": 20},
+		})
+	})
+
+	cmd := testutil.Command(newCreditsListCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--user-id", "2245593582708"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp struct {
+		Success    bool             `json:"success"`
+		UserID     string           `json:"user_id"`
+		Credits    []map[string]any `json:"credits"`
+		Pagination map[string]any   `json:"pagination"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if !resp.Success || resp.UserID != "2245593582708" || len(resp.Credits) != 1 || resp.Credits[0]["id"] != "credit_123" || resp.Pagination["next"] != "cur-next" {
+		t.Fatalf("unexpected JSON payload: %s", out)
+	}
+}
+
+func TestCreditsListEmptyResultShowsFooter(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"user_id":    "2245593582708",
+			"credits":    []any{},
+			"pagination": map[string]any{"next": "cur-next", "limit": 20},
+		})
+	})
+
+	cmd := testutil.Command(newCreditsListCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--user-id", "2245593582708"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	for _, want := range []string{
+		"No credits found for 2245593582708.",
+		"More results: --cursor cur-next",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestCreditsListRequiresEmailOrUserID(t *testing.T) {
+	cmd := newCreditsListCmd()
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "supply --email or --user-id") {
+		t.Fatalf("expected missing identifier error, got %v", err)
+	}
+}
+
+func TestCreditsListRejectsInvalidLimit(t *testing.T) {
+	cmd := newCreditsListCmd()
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--limit", "0"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--limit must be greater than 0") {
+		t.Fatalf("expected limit validation error, got %v", err)
+	}
+}
+
+func creditFixture() map[string]any {
+	return map[string]any{
+		"id":                "credit_123",
+		"amount_cents":      1000,
+		"reason":            "Goodwill for checkout bug",
+		"crediting_user_id": "admin_123",
+		"created_at":        "2026-06-03T19:00:00Z",
+	}
+}

--- a/internal/cmd/admin/users/users.go
+++ b/internal/cmd/admin/users/users.go
@@ -16,6 +16,8 @@ func NewUsersCmd() *cobra.Command {
   gumroad admin users comments list --user-id 2245593582708
   gumroad admin users comments add --user-id 2245593582708 --content "VAT exempt confirmed"
   gumroad admin users compliance --user-id 2245593582708
+  gumroad admin users credits list --user-id 2245593582708
+  gumroad admin users credits add --user-id 2245593582708 --amount-cents 1000 --reason "Goodwill for checkout bug" --dry-run
   gumroad admin users radar --user-id 2245593582708
   gumroad admin users purchases --user-id 2245593582708 --status successful
   gumroad admin users related --email user@example.com --signal ip --signal payment_address
@@ -36,6 +38,7 @@ func NewUsersCmd() *cobra.Command {
 	cmd.AddCommand(newAffiliatesCmd())
 	cmd.AddCommand(usercomments.NewCommentsCmd())
 	cmd.AddCommand(newComplianceCmd())
+	cmd.AddCommand(newCreditsCmd())
 	cmd.AddCommand(newRadarCmd())
 	cmd.AddCommand(newPurchasesCmd())
 	cmd.AddCommand(newRelatedCmd())

--- a/internal/cmd/admin/users/users_test.go
+++ b/internal/cmd/admin/users/users_test.go
@@ -181,6 +181,7 @@ func TestNewUsersCmdWiresSubcommands(t *testing.T) {
 		"affiliates",
 		"comments",
 		"compliance",
+		"credits",
 		"radar",
 		"purchases",
 		"related",

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -78,6 +78,8 @@ Responses are wrapped in `{"success": true, ...}` with resource-specific keys:
 - `admin users comments list` → `.comments[]`
 - `admin users comments add` → `.comment`
 - `admin users compliance` → `.compliance_info`, `.info_requests[]`
+- `admin users credits add` → `.user_id`, `.credit.id`, `.credit.amount_cents`, `.credit.reason`, `.credit.crediting_user_id`, `.credit.created_at`
+- `admin users credits list` → `.credits[]`, `.pagination.next`
 - `admin users radar` → `.radar_stats`, `.recent_efws[]`
 - `admin users purchases` → `.purchases[]`
 - `admin users related` → `.related_users[]`, `.truncated`, `.per_signal_limit`
@@ -92,7 +94,7 @@ Responses are wrapped in `{"success": true, ...}` with resource-specific keys:
 
 Admin pagination models differ by command:
 
-- Cursor-paginated: `admin users affiliates`, `admin users comments list`, `admin users radar`, `admin users purchases`, and `admin purchases lookup` return `.pagination.next` as a cursor string. Pass it back with `--cursor`.
+- Cursor-paginated: `admin users affiliates`, `admin users comments list`, `admin users credits list`, `admin users radar`, `admin users purchases`, and `admin purchases lookup` return `.pagination.next` as a cursor string. Pass it back with `--cursor`.
 - Page-paginated: `admin products list` returns `.pagination.next` as an integer page number. Pass it back with `--page`; use `--per-page` for page size.
 - Capped, not continuable: `admin users related` returns at most 50 related users per signal. Always inspect `.truncated`; when any signal is `true`, the result hit the cap and there is no cursor/page to fetch the rest.
 - Capped, not continuable: `admin purchases search` returns `.has_more` when the server capped results. `--limit` is server-capped at 25 and there is no continuation token.
@@ -159,6 +161,12 @@ gumroad admin users affiliates --email seller@example.com --direction received -
 # Read and add admin comments
 gumroad admin users comments list --user-id 2245593582708 --type note --limit 50 --json --non-interactive --no-input
 gumroad admin users comments add --user-id 2245593582708 --content "VAT exempt confirmed" --yes --json --non-interactive --no-input
+
+# Account credits. credits add is a high-stakes write: dry-run first, then issue with explicit --yes.
+# Amounts are cents, positive only, capped at $1,000 unless --allow-large-amount is explicitly passed.
+gumroad admin users credits list --user-id 2245593582708 --limit 50 --json --non-interactive --no-input
+gumroad admin users credits add --user-id 2245593582708 --expected-email seller@example.com --amount-cents 1000 --reason "Goodwill for checkout bug" --dry-run --json --non-interactive --no-input
+gumroad admin users credits add --user-id 2245593582708 --expected-email seller@example.com --amount-cents 1000 --reason "Goodwill for checkout bug" --yes --json --non-interactive --no-input
 
 # Inspect compliance, Radar risk, and buyer history
 gumroad admin users compliance --user-id 2245593582708 --json --non-interactive --no-input


### PR DESCRIPTION
Closes #122

## What

- Add grouped `admin users credits` commands for listing and issuing credits.
- Enforce positive-only amounts, a $1,000 per-call cap, and an explicit override for larger credits.
- Update the embedded Gumroad skill so agent-facing docs match the new response shapes and usage.

## Why

- The new surface is clearer than a singular `credit` command and keeps the write and list flows under one obvious group.
- The guardrails stay client-side so clawbacks remain out of scope and the CLI stays aligned with the intended human workflow.

---

This PR was implemented with AI assistance using gpt-5.5 xhigh.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> `credits add` moves real money into user balances via the admin API; mistakes or retries without listing first could duplicate credits despite CLI guardrails.
> 
> **Overview**
> Adds **`admin users credits`** with **`list`** (cursor-paginated GET) and **`add`** (POST goodwill credits), wired into `admin users` and documented in the Gumroad skill.
> 
> **`credits add`** follows existing admin mutation patterns: `--user-id` / `--expected-email`, admin token + actor banner, confirmation (`--yes`), and `--dry-run`. Client-side rules require positive **`--amount-cents`**, a non-empty **`--reason`**, a **$1,000** default cap (override via **`--allow-large-amount`**), and no negative/clawback issuance. Failed adds append guidance to **`credits list`** before retrying to reduce duplicate credits.
> 
> **`credits list`** resolves users by email or user id and renders table/plain/JSON output. Broad tests cover validation, HTTP shapes, and output modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c32c1b9269bc16de33e2b86f9304ab3f6d861b33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->