### PR TITLE
Add update notices for the CLI

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -37,6 +37,7 @@ var (
 	exitProcess    = os.Exit
 	getOSArgs      = func() []string { return os.Args }
 	notifyUpdate   = updatecheck.Notify
+	refreshUpdate  = updatecheck.Refresh
 )
 
 func NewRootCmd() *cobra.Command {
@@ -76,6 +77,9 @@ func NewRootCmd() *cobra.Command {
 			}
 			if err := cmdutil.RequireNonNegativeDurationFlag(cmd, "page-delay", opts.PageDelay); err != nil {
 				return err
+			}
+			if updatecheck.IsRefreshCommand(cmd.CommandPath()) {
+				return nil
 			}
 			skill.AutoRefresh(Version)
 			notifyUpdate(opts, cmd.CommandPath())
@@ -124,9 +128,20 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(webhooks.NewWebhooksCmd())
 	cmd.AddCommand(completion.NewCompletionCmd())
 	cmd.AddCommand(skill.NewSkillCmd())
+	cmd.AddCommand(newUpdateCheckRefreshCmd())
 	cmdutil.PropagateExamples(cmd)
 
 	return cmd
+}
+
+func newUpdateCheckRefreshCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:    updatecheck.RefreshCommandName,
+		Hidden: true,
+		Run: func(c *cobra.Command, args []string) {
+			refreshUpdate(c.Context())
+		},
+	}
 }
 
 func commandContext(cmd *cobra.Command) context.Context {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -27,6 +27,7 @@ import (
 	"github.com/antiwork/gumroad-cli/internal/cmd/webhooks"
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/updatecheck"
 	"github.com/spf13/cobra"
 )
 
@@ -35,6 +36,7 @@ var (
 	newRootCommand = NewRootCmd
 	exitProcess    = os.Exit
 	getOSArgs      = func() []string { return os.Args }
+	notifyUpdate   = updatecheck.Notify
 )
 
 func NewRootCmd() *cobra.Command {
@@ -76,6 +78,7 @@ func NewRootCmd() *cobra.Command {
 				return err
 			}
 			skill.AutoRefresh(Version)
+			notifyUpdate(opts, cmd.CommandPath())
 			return nil
 		},
 		Version: Version,

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/config"
 	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/updatecheck"
 	"github.com/antiwork/gumroad-cli/internal/upload"
 	"github.com/spf13/cobra"
 )
@@ -66,6 +67,13 @@ func replaceNotifyUpdate(t *testing.T, fn func(cmdutil.Options, string)) {
 	previous := notifyUpdate
 	notifyUpdate = fn
 	t.Cleanup(func() { notifyUpdate = previous })
+}
+
+func replaceRefreshUpdate(t *testing.T, fn func(context.Context)) {
+	t.Helper()
+	previous := refreshUpdate
+	refreshUpdate = fn
+	t.Cleanup(func() { refreshUpdate = previous })
 }
 
 func replaceExitProcess(t *testing.T, exitFn func(int)) {
@@ -260,6 +268,34 @@ func TestRootCmd_UpdateNoticeUsesStderrWithJSONOutput(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "warning: gumroad v1.1.0 is available") {
 		t.Fatalf("expected warning on stderr, got %q", stderr.String())
+	}
+}
+
+func TestRootCmd_UpdateCheckRefreshSkipsNotifier(t *testing.T) {
+	replaceNotifyUpdate(t, func(cmdutil.Options, string) {
+		t.Fatal("update notifier should not run for background refresh command")
+	})
+
+	calledRefresh := false
+	replaceRefreshUpdate(t, func(context.Context) {
+		calledRefresh = true
+	})
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{updatecheck.RefreshCommandName})
+
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !calledRefresh {
+		t.Fatal("expected refresh command to run")
+	}
+	if stdout.Len() != 0 || stderr.Len() != 0 {
+		t.Fatalf("expected silent refresh, got stdout=%q stderr=%q", stdout.String(), stderr.String())
 	}
 }
 

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -61,6 +61,13 @@ func replaceGetOSArgs(t *testing.T, args []string) {
 	t.Cleanup(func() { getOSArgs = previous })
 }
 
+func replaceNotifyUpdate(t *testing.T, fn func(cmdutil.Options, string)) {
+	t.Helper()
+	previous := notifyUpdate
+	notifyUpdate = fn
+	t.Cleanup(func() { notifyUpdate = previous })
+}
+
 func replaceExitProcess(t *testing.T, exitFn func(int)) {
 	t.Helper()
 
@@ -210,6 +217,49 @@ func TestRootCmd_VersionFlag(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "gumroad version ") {
 		t.Fatalf("expected version output, got %q", out.String())
+	}
+}
+
+func TestRootCmd_UpdateNoticeUsesStderrWithJSONOutput(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	called := false
+	replaceNotifyUpdate(t, func(opts cmdutil.Options, commandPath string) {
+		called = true
+		if commandPath != "gumroad noop" {
+			t.Fatalf("got command path %q, want gumroad noop", commandPath)
+		}
+		if !opts.JSONOutput {
+			t.Fatal("expected JSON output flag in update notifier options")
+		}
+		fmt.Fprintln(opts.Err(), "warning: gumroad v1.1.0 is available; you have v1.0.0. Update: brew upgrade antiwork/cli/gumroad")
+	})
+
+	cmd := NewRootCmd()
+	cmd.AddCommand(&cobra.Command{
+		Use: "noop",
+		RunE: func(c *cobra.Command, args []string) error {
+			_, err := fmt.Fprintln(c.OutOrStdout(), `{"ok":true}`)
+			return err
+		},
+	})
+	cmd.SetArgs([]string{"noop", "--json"})
+
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Fatal("expected update notifier to be called")
+	}
+	if got := stdout.String(); got != "{\"ok\":true}\n" {
+		t.Fatalf("stdout should stay machine-readable, got %q", got)
+	}
+	if !strings.Contains(stderr.String(), "warning: gumroad v1.1.0 is available") {
+		t.Fatalf("expected warning on stderr, got %q", stderr.String())
 	}
 }
 

--- a/internal/updatecheck/updatecheck.go
+++ b/internal/updatecheck/updatecheck.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -31,7 +33,10 @@ var (
 	userHomeDir   = os.UserHomeDir
 	httpClient    = http.DefaultClient
 	latestVersion = fetchLatestVersion
+	startRefresh  = startRefreshProcess
 )
+
+const RefreshCommandName = "__update-check-refresh"
 
 type cacheState struct {
 	LatestVersion     string    `json:"latest_version,omitempty"`
@@ -70,10 +75,10 @@ func Notify(opts cmdutil.Options, commandPath string) {
 	t := now()
 	if shouldRefresh(state, t) {
 		state.CheckedAt = t
-		if latest, err := checkLatest(opts.Context); err == nil && latest != "" {
-			state.LatestVersion = latest
+		if err := saveCache(path, state); err != nil {
+			return
 		}
-		_ = saveCache(path, state)
+		defer startRefresh()
 	}
 
 	latest, ok := parseVersion(state.LatestVersion)
@@ -81,10 +86,32 @@ func Notify(opts cmdutil.Options, commandPath string) {
 		return
 	}
 
-	fmt.Fprintf(opts.Err(), "warning: gumroad %s is available; you have %s. Update: %s\n", state.LatestVersion, opts.Version, updateCommand())
 	state.LastNoticeVersion = state.LatestVersion
 	state.LastNoticeAt = t
-	_ = saveCache(path, state)
+	if err := saveCache(path, state); err != nil {
+		return
+	}
+	fmt.Fprintf(opts.Err(), "warning: gumroad %s is available; you have %s. Update: %s\n", state.LatestVersion, opts.Version, updateCommand())
+}
+
+// Refresh updates the cache for the hidden background refresh command. It is
+// intentionally silent; update checks must never affect the foreground command.
+func Refresh(ctx context.Context) {
+	path, state, ok := loadCache()
+	if !ok {
+		return
+	}
+	_ = refreshCacheOnce(ctx, path, state, now())
+}
+
+func IsRefreshCommand(commandPath string) bool {
+	fields := strings.Fields(commandPath)
+	for _, field := range fields {
+		if field == RefreshCommandName {
+			return true
+		}
+	}
+	return false
 }
 
 func eligible(opts cmdutil.Options, commandPath string) bool {
@@ -95,7 +122,7 @@ func eligible(opts cmdutil.Options, commandPath string) bool {
 	if version == "" || version == "dev" || version == "test" {
 		return false
 	}
-	return !isCompletionCommand(commandPath)
+	return !isCompletionCommand(commandPath) && !IsRefreshCommand(commandPath)
 }
 
 func isCompletionCommand(commandPath string) bool {
@@ -114,15 +141,26 @@ func loadCache() (string, cacheState, bool) {
 		return "", cacheState{}, false
 	}
 	path := filepath.Join(dir, cacheFileName)
-	data, err := os.ReadFile(path)
+	state, ok, err := readCacheFile(path)
 	if err != nil {
 		return path, cacheState{}, os.IsNotExist(err)
 	}
-	var state cacheState
-	if err := json.Unmarshal(data, &state); err != nil {
+	if !ok {
 		return path, cacheState{}, true
 	}
 	return path, state, true
+}
+
+func readCacheFile(path string) (cacheState, bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return cacheState{}, false, err
+	}
+	var state cacheState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return cacheState{}, false, nil
+	}
+	return state, true, nil
 }
 
 func saveCache(path string, state cacheState) error {
@@ -137,6 +175,39 @@ func saveCache(path string, state cacheState) error {
 		return err
 	}
 	return os.WriteFile(path, data, 0600)
+}
+
+func startRefreshProcess() {
+	path, err := executable()
+	if err != nil {
+		return
+	}
+	cmd := exec.Command(path, RefreshCommandName) //nolint:gosec // path is the current executable, not user input
+	cmd.Stdin = nil
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	if err := cmd.Start(); err != nil {
+		return
+	}
+	_ = cmd.Process.Release()
+}
+
+func refreshCacheOnce(parent context.Context, path string, state cacheState, checkedAt time.Time) error {
+	state.CheckedAt = checkedAt
+	latest, hasLatest := "", false
+	if fetched, err := checkLatest(parent); err == nil && fetched != "" {
+		latest = fetched
+		hasLatest = true
+		state.LatestVersion = fetched
+	}
+	if current, ok, err := readCacheFile(path); err == nil && ok {
+		current.CheckedAt = state.CheckedAt
+		if hasLatest {
+			current.LatestVersion = latest
+		}
+		state = current
+	}
+	return saveCache(path, state)
 }
 
 func shouldRefresh(state cacheState, t time.Time) bool {

--- a/internal/updatecheck/updatecheck.go
+++ b/internal/updatecheck/updatecheck.go
@@ -1,0 +1,278 @@
+package updatecheck
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/config"
+)
+
+const (
+	latestReleaseURL = "https://api.github.com/repos/antiwork/gumroad-cli/releases/latest"
+	cacheFileName    = "update-check.json"
+	checkInterval    = 24 * time.Hour
+	noticeInterval   = 24 * time.Hour
+	requestTimeout   = 750 * time.Millisecond
+)
+
+var (
+	now           = time.Now
+	configDir     = config.Dir
+	executable    = os.Executable
+	evalSymlinks  = filepath.EvalSymlinks
+	userHomeDir   = os.UserHomeDir
+	httpClient    = http.DefaultClient
+	latestVersion = fetchLatestVersion
+)
+
+type cacheState struct {
+	LatestVersion     string    `json:"latest_version,omitempty"`
+	CheckedAt         time.Time `json:"checked_at,omitempty"`
+	LastNoticeVersion string    `json:"last_notice_version,omitempty"`
+	LastNoticeAt      time.Time `json:"last_notice_at,omitempty"`
+}
+
+type releaseResponse struct {
+	TagName string `json:"tag_name"`
+}
+
+type semver struct {
+	Major int
+	Minor int
+	Patch int
+}
+
+// Notify prints a low-noise update notice to stderr when a newer release exists.
+// It never returns an error; update checks should not affect the requested command.
+func Notify(opts cmdutil.Options, commandPath string) {
+	if !eligible(opts, commandPath) {
+		return
+	}
+
+	current, ok := parseVersion(opts.Version)
+	if !ok {
+		return
+	}
+
+	path, state, ok := loadCache()
+	if !ok {
+		return
+	}
+
+	t := now()
+	if shouldRefresh(state, t) {
+		state.CheckedAt = t
+		if latest, err := checkLatest(opts.Context); err == nil && latest != "" {
+			state.LatestVersion = latest
+		}
+		_ = saveCache(path, state)
+	}
+
+	latest, ok := parseVersion(state.LatestVersion)
+	if !ok || compareVersions(latest, current) <= 0 || !shouldShowNotice(state, t) {
+		return
+	}
+
+	fmt.Fprintf(opts.Err(), "warning: gumroad %s is available; you have %s. Update: %s\n", state.LatestVersion, opts.Version, updateCommand())
+	state.LastNoticeVersion = state.LatestVersion
+	state.LastNoticeAt = t
+	_ = saveCache(path, state)
+}
+
+func eligible(opts cmdutil.Options, commandPath string) bool {
+	if opts.Quiet {
+		return false
+	}
+	version := strings.TrimSpace(opts.Version)
+	if version == "" || version == "dev" || version == "test" {
+		return false
+	}
+	return !isCompletionCommand(commandPath)
+}
+
+func isCompletionCommand(commandPath string) bool {
+	fields := strings.Fields(commandPath)
+	for _, field := range fields {
+		if field == "completion" || field == "__complete" || field == "__completeNoDesc" {
+			return true
+		}
+	}
+	return false
+}
+
+func loadCache() (string, cacheState, bool) {
+	dir, err := configDir()
+	if err != nil {
+		return "", cacheState{}, false
+	}
+	path := filepath.Join(dir, cacheFileName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return path, cacheState{}, os.IsNotExist(err)
+	}
+	var state cacheState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return path, cacheState{}, true
+	}
+	return path, state, true
+}
+
+func saveCache(path string, state cacheState) error {
+	if path == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0600)
+}
+
+func shouldRefresh(state cacheState, t time.Time) bool {
+	return state.CheckedAt.IsZero() || t.Sub(state.CheckedAt) >= checkInterval
+}
+
+func shouldShowNotice(state cacheState, t time.Time) bool {
+	return state.LastNoticeVersion != state.LatestVersion ||
+		state.LastNoticeAt.IsZero() ||
+		t.Sub(state.LastNoticeAt) >= noticeInterval
+}
+
+func checkLatest(parent context.Context) (string, error) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parent, requestTimeout)
+	defer cancel()
+	return latestVersion(ctx)
+}
+
+func fetchLatestVersion(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, latestReleaseURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "gumroad-cli")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("latest release returned %s", resp.Status)
+	}
+
+	var release releaseResponse
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(release.TagName), nil
+}
+
+func parseVersion(version string) (semver, bool) {
+	version = strings.TrimSpace(version)
+	version = strings.TrimPrefix(version, "v")
+	if i := strings.IndexAny(version, "-+"); i >= 0 {
+		version = version[:i]
+	}
+	parts := strings.Split(version, ".")
+	if len(parts) != 3 {
+		return semver{}, false
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return semver{}, false
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return semver{}, false
+	}
+	patch, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return semver{}, false
+	}
+	return semver{Major: major, Minor: minor, Patch: patch}, true
+}
+
+func compareVersions(a, b semver) int {
+	switch {
+	case a.Major != b.Major:
+		return a.Major - b.Major
+	case a.Minor != b.Minor:
+		return a.Minor - b.Minor
+	default:
+		return a.Patch - b.Patch
+	}
+}
+
+func updateCommand() string {
+	switch detectInstallMethod() {
+	case "homebrew":
+		return "brew upgrade antiwork/cli/gumroad"
+	case "go":
+		return "go install github.com/antiwork/gumroad-cli/cmd/gumroad@latest"
+	case "source":
+		return "git pull && make install"
+	default:
+		return "curl -fsSL https://gumroad.com/install-cli.sh | bash"
+	}
+}
+
+func detectInstallMethod() string {
+	path, err := executable()
+	if err != nil {
+		return ""
+	}
+	paths := []string{filepath.Clean(path)}
+	if resolved, err := evalSymlinks(path); err == nil && resolved != "" {
+		paths = append(paths, filepath.Clean(resolved))
+	}
+	for _, p := range paths {
+		normalized := filepath.ToSlash(p)
+		if strings.Contains(normalized, "/Cellar/gumroad/") || strings.Contains(normalized, "/Cellar/gumroad-cli/") {
+			return "homebrew"
+		}
+		if isGoInstallPath(p) {
+			return "go"
+		}
+		if isSourceInstallPath(p) {
+			return "source"
+		}
+	}
+	return ""
+}
+
+func isGoInstallPath(path string) bool {
+	if gobin := strings.TrimSpace(os.Getenv("GOBIN")); gobin != "" && samePath(filepath.Dir(path), gobin) {
+		return true
+	}
+	if gopath := strings.TrimSpace(os.Getenv("GOPATH")); gopath != "" && samePath(filepath.Dir(path), filepath.Join(gopath, "bin")) {
+		return true
+	}
+	home, err := userHomeDir()
+	if err != nil {
+		return false
+	}
+	return samePath(filepath.Dir(path), filepath.Join(home, "go", "bin"))
+}
+
+func isSourceInstallPath(path string) bool {
+	return strings.Contains(filepath.ToSlash(path), "/gumroad-cli/")
+}
+
+func samePath(a, b string) bool {
+	return filepath.Clean(a) == filepath.Clean(b)
+}

--- a/internal/updatecheck/updatecheck_test.go
+++ b/internal/updatecheck/updatecheck_test.go
@@ -1,0 +1,339 @@
+package updatecheck
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+)
+
+func testOptions(stderr *bytes.Buffer) cmdutil.Options {
+	opts := cmdutil.DefaultOptions()
+	opts.Version = "v1.0.0"
+	opts.Stderr = stderr
+	return opts
+}
+
+func replaceConfigDir(t *testing.T, dir string) {
+	t.Helper()
+	previous := configDir
+	configDir = func() (string, error) { return dir, nil }
+	t.Cleanup(func() { configDir = previous })
+}
+
+func replaceNow(t *testing.T, t0 time.Time) {
+	t.Helper()
+	previous := now
+	now = func() time.Time { return t0 }
+	t.Cleanup(func() { now = previous })
+}
+
+func replaceLatestVersion(t *testing.T, fn func(context.Context) (string, error)) {
+	t.Helper()
+	previous := latestVersion
+	latestVersion = fn
+	t.Cleanup(func() { latestVersion = previous })
+}
+
+func replaceExecutable(t *testing.T, path string, resolved string) {
+	t.Helper()
+	previousExecutable := executable
+	previousEvalSymlinks := evalSymlinks
+	executable = func() (string, error) { return path, nil }
+	evalSymlinks = func(string) (string, error) { return resolved, nil }
+	t.Cleanup(func() {
+		executable = previousExecutable
+		evalSymlinks = previousEvalSymlinks
+	})
+}
+
+func replaceHomeDir(t *testing.T, path string) {
+	t.Helper()
+	previous := userHomeDir
+	userHomeDir = func() (string, error) { return path, nil }
+	t.Cleanup(func() { userHomeDir = previous })
+}
+
+func readCache(t *testing.T, dir string) cacheState {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, cacheFileName))
+	if err != nil {
+		t.Fatalf("read cache: %v", err)
+	}
+	var state cacheState
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatalf("parse cache: %v", err)
+	}
+	return state
+}
+
+func writeCache(t *testing.T, dir string, state cacheState) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatalf("mkdir cache dir: %v", err)
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("marshal cache: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, cacheFileName), data, 0600); err != nil {
+		t.Fatalf("write cache: %v", err)
+	}
+}
+
+func TestNotifyPrintsWarningAndCachesNotice(t *testing.T) {
+	dir := t.TempDir()
+	replaceConfigDir(t, dir)
+	t0 := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
+	replaceNow(t, t0)
+	replaceLatestVersion(t, func(context.Context) (string, error) {
+		return "v1.1.0", nil
+	})
+
+	var stderr bytes.Buffer
+	Notify(testOptions(&stderr), "gumroad products list")
+
+	got := stderr.String()
+	if !strings.Contains(got, "warning: gumroad v1.1.0 is available; you have v1.0.0.") {
+		t.Fatalf("expected update warning, got %q", got)
+	}
+	if !strings.Contains(got, "Update:") {
+		t.Fatalf("expected update command, got %q", got)
+	}
+
+	state := readCache(t, dir)
+	if state.LatestVersion != "v1.1.0" || state.LastNoticeVersion != "v1.1.0" {
+		t.Fatalf("unexpected cache state: %+v", state)
+	}
+	if !state.CheckedAt.Equal(t0) || !state.LastNoticeAt.Equal(t0) {
+		t.Fatalf("unexpected cache timestamps: %+v", state)
+	}
+}
+
+func TestNotifyDoesNotRepeatSameVersionImmediately(t *testing.T) {
+	dir := t.TempDir()
+	replaceConfigDir(t, dir)
+	t0 := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
+	replaceNow(t, t0)
+	writeCache(t, dir, cacheState{
+		LatestVersion:     "v1.1.0",
+		CheckedAt:         t0,
+		LastNoticeVersion: "v1.1.0",
+		LastNoticeAt:      t0,
+	})
+	replaceLatestVersion(t, func(context.Context) (string, error) {
+		t.Fatal("fresh cache should not fetch")
+		return "", nil
+	})
+
+	var stderr bytes.Buffer
+	Notify(testOptions(&stderr), "gumroad products list")
+
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no repeated warning, got %q", stderr.String())
+	}
+}
+
+func TestNotifyRepeatsSameVersionAfterNoticeInterval(t *testing.T) {
+	dir := t.TempDir()
+	replaceConfigDir(t, dir)
+	t0 := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
+	replaceNow(t, t0.Add(noticeInterval))
+	writeCache(t, dir, cacheState{
+		LatestVersion:     "v1.1.0",
+		CheckedAt:         t0.Add(noticeInterval),
+		LastNoticeVersion: "v1.1.0",
+		LastNoticeAt:      t0,
+	})
+
+	var stderr bytes.Buffer
+	Notify(testOptions(&stderr), "gumroad products list")
+
+	if !strings.Contains(stderr.String(), "v1.1.0 is available") {
+		t.Fatalf("expected repeated warning after interval, got %q", stderr.String())
+	}
+}
+
+func TestNotifyUsesFreshCachedLatestWithoutNetwork(t *testing.T) {
+	dir := t.TempDir()
+	replaceConfigDir(t, dir)
+	t0 := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
+	replaceNow(t, t0)
+	writeCache(t, dir, cacheState{
+		LatestVersion: "v1.1.0",
+		CheckedAt:     t0,
+	})
+	replaceLatestVersion(t, func(context.Context) (string, error) {
+		t.Fatal("fresh cache should not fetch")
+		return "", nil
+	})
+
+	var stderr bytes.Buffer
+	Notify(testOptions(&stderr), "gumroad sales list")
+
+	if !strings.Contains(stderr.String(), "v1.1.0 is available") {
+		t.Fatalf("expected cached warning, got %q", stderr.String())
+	}
+}
+
+func TestNotifySuppressesQuietCompletionAndDevBuilds(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		opts        cmdutil.Options
+		commandPath string
+	}{
+		{name: "quiet", opts: func() cmdutil.Options {
+			opts := cmdutil.DefaultOptions()
+			opts.Version = "v1.0.0"
+			opts.Quiet = true
+			return opts
+		}(), commandPath: "gumroad products list"},
+		{name: "completion", opts: func() cmdutil.Options {
+			opts := cmdutil.DefaultOptions()
+			opts.Version = "v1.0.0"
+			return opts
+		}(), commandPath: "gumroad completion bash"},
+		{name: "cobra complete", opts: func() cmdutil.Options {
+			opts := cmdutil.DefaultOptions()
+			opts.Version = "v1.0.0"
+			return opts
+		}(), commandPath: "gumroad __complete products list"},
+		{name: "cobra complete no desc", opts: func() cmdutil.Options {
+			opts := cmdutil.DefaultOptions()
+			opts.Version = "v1.0.0"
+			return opts
+		}(), commandPath: "gumroad __completeNoDesc products list"},
+		{name: "dev", opts: func() cmdutil.Options {
+			opts := cmdutil.DefaultOptions()
+			opts.Version = "dev"
+			return opts
+		}(), commandPath: "gumroad products list"},
+		{name: "test", opts: func() cmdutil.Options {
+			opts := cmdutil.DefaultOptions()
+			opts.Version = "test"
+			return opts
+		}(), commandPath: "gumroad products list"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			replaceLatestVersion(t, func(context.Context) (string, error) {
+				t.Fatal("suppressed update check should not fetch")
+				return "", nil
+			})
+
+			var stderr bytes.Buffer
+			tc.opts.Stderr = &stderr
+			Notify(tc.opts, tc.commandPath)
+
+			if stderr.Len() != 0 {
+				t.Fatalf("expected no output, got %q", stderr.String())
+			}
+		})
+	}
+}
+
+func TestNotifyRefreshFailureIsSilent(t *testing.T) {
+	dir := t.TempDir()
+	replaceConfigDir(t, dir)
+	t0 := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
+	replaceNow(t, t0)
+	replaceLatestVersion(t, func(context.Context) (string, error) {
+		return "", errors.New("offline")
+	})
+
+	var stderr bytes.Buffer
+	Notify(testOptions(&stderr), "gumroad products list")
+
+	if stderr.Len() != 0 {
+		t.Fatalf("expected silent failure, got %q", stderr.String())
+	}
+	state := readCache(t, dir)
+	if !state.CheckedAt.Equal(t0) {
+		t.Fatalf("expected failed check to be cached, got %+v", state)
+	}
+}
+
+func TestNotifyIgnoresOlderOrMalformedVersions(t *testing.T) {
+	for _, latest := range []string{"v0.9.0", "not-semver"} {
+		t.Run(latest, func(t *testing.T) {
+			dir := t.TempDir()
+			replaceConfigDir(t, dir)
+			replaceLatestVersion(t, func(context.Context) (string, error) {
+				return latest, nil
+			})
+
+			var stderr bytes.Buffer
+			Notify(testOptions(&stderr), "gumroad products list")
+
+			if stderr.Len() != 0 {
+				t.Fatalf("expected no warning, got %q", stderr.String())
+			}
+		})
+	}
+}
+
+func TestUpdateCommandDetectsInstallMethod(t *testing.T) {
+	tmp := t.TempDir()
+	replaceHomeDir(t, filepath.Join(tmp, "home"))
+
+	tests := []struct {
+		name     string
+		path     string
+		resolved string
+		env      map[string]string
+		want     string
+	}{
+		{
+			name:     "homebrew",
+			path:     "/opt/homebrew/bin/gumroad",
+			resolved: "/opt/homebrew/Cellar/gumroad/1.1.0/bin/gumroad",
+			want:     "brew upgrade antiwork/cli/gumroad",
+		},
+		{
+			name:     "go gobin",
+			path:     filepath.Join(tmp, "gobin", "gumroad"),
+			resolved: filepath.Join(tmp, "gobin", "gumroad"),
+			env:      map[string]string{"GOBIN": filepath.Join(tmp, "gobin")},
+			want:     "go install github.com/antiwork/gumroad-cli/cmd/gumroad@latest",
+		},
+		{
+			name:     "go default",
+			path:     filepath.Join(tmp, "home", "go", "bin", "gumroad"),
+			resolved: filepath.Join(tmp, "home", "go", "bin", "gumroad"),
+			want:     "go install github.com/antiwork/gumroad-cli/cmd/gumroad@latest",
+		},
+		{
+			name:     "source checkout",
+			path:     filepath.Join(tmp, "gumroad-cli", "gumroad"),
+			resolved: filepath.Join(tmp, "gumroad-cli", "gumroad"),
+			want:     "git pull && make install",
+		},
+		{
+			name:     "unknown",
+			path:     filepath.Join(tmp, ".local", "bin", "gumroad"),
+			resolved: filepath.Join(tmp, ".local", "bin", "gumroad"),
+			want:     "curl -fsSL https://gumroad.com/install-cli.sh | bash",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("GOBIN", "")
+			t.Setenv("GOPATH", "")
+			for key, value := range tt.env {
+				t.Setenv(key, value)
+			}
+			replaceExecutable(t, tt.path, tt.resolved)
+
+			if got := updateCommand(); got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/updatecheck/updatecheck_test.go
+++ b/internal/updatecheck/updatecheck_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -40,6 +41,13 @@ func replaceLatestVersion(t *testing.T, fn func(context.Context) (string, error)
 	previous := latestVersion
 	latestVersion = fn
 	t.Cleanup(func() { latestVersion = previous })
+}
+
+func replaceStartRefresh(t *testing.T, fn func()) {
+	t.Helper()
+	previous := startRefresh
+	startRefresh = fn
+	t.Cleanup(func() { startRefresh = previous })
 }
 
 func replaceExecutable(t *testing.T, path string, resolved string) {
@@ -93,8 +101,12 @@ func TestNotifyPrintsWarningAndCachesNotice(t *testing.T) {
 	replaceConfigDir(t, dir)
 	t0 := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
 	replaceNow(t, t0)
-	replaceLatestVersion(t, func(context.Context) (string, error) {
-		return "v1.1.0", nil
+	writeCache(t, dir, cacheState{
+		LatestVersion: "v1.1.0",
+		CheckedAt:     t0,
+	})
+	replaceStartRefresh(t, func() {
+		t.Fatal("fresh cache should not refresh")
 	})
 
 	var stderr bytes.Buffer
@@ -128,9 +140,8 @@ func TestNotifyDoesNotRepeatSameVersionImmediately(t *testing.T) {
 		LastNoticeVersion: "v1.1.0",
 		LastNoticeAt:      t0,
 	})
-	replaceLatestVersion(t, func(context.Context) (string, error) {
-		t.Fatal("fresh cache should not fetch")
-		return "", nil
+	replaceStartRefresh(t, func() {
+		t.Fatal("fresh cache should not refresh")
 	})
 
 	var stderr bytes.Buffer
@@ -152,6 +163,9 @@ func TestNotifyRepeatsSameVersionAfterNoticeInterval(t *testing.T) {
 		LastNoticeVersion: "v1.1.0",
 		LastNoticeAt:      t0,
 	})
+	replaceStartRefresh(t, func() {
+		t.Fatal("fresh cache should not refresh")
+	})
 
 	var stderr bytes.Buffer
 	Notify(testOptions(&stderr), "gumroad products list")
@@ -170,9 +184,8 @@ func TestNotifyUsesFreshCachedLatestWithoutNetwork(t *testing.T) {
 		LatestVersion: "v1.1.0",
 		CheckedAt:     t0,
 	})
-	replaceLatestVersion(t, func(context.Context) (string, error) {
-		t.Fatal("fresh cache should not fetch")
-		return "", nil
+	replaceStartRefresh(t, func() {
+		t.Fatal("fresh cache should not refresh")
 	})
 
 	var stderr bytes.Buffer
@@ -180,6 +193,32 @@ func TestNotifyUsesFreshCachedLatestWithoutNetwork(t *testing.T) {
 
 	if !strings.Contains(stderr.String(), "v1.1.0 is available") {
 		t.Fatalf("expected cached warning, got %q", stderr.String())
+	}
+}
+
+func TestNotifyStartsRefreshWithoutBlockingForStaleCache(t *testing.T) {
+	dir := t.TempDir()
+	replaceConfigDir(t, dir)
+	t0 := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
+	replaceNow(t, t0)
+
+	called := false
+	replaceStartRefresh(t, func() {
+		called = true
+	})
+
+	var stderr bytes.Buffer
+	Notify(testOptions(&stderr), "gumroad products list")
+
+	if !called {
+		t.Fatal("expected stale cache to start refresh")
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no first-run warning from live refresh, got %q", stderr.String())
+	}
+	state := readCache(t, dir)
+	if !state.CheckedAt.Equal(t0) {
+		t.Fatalf("expected checked_at throttle marker before refresh, got %+v", state)
 	}
 }
 
@@ -210,6 +249,11 @@ func TestNotifySuppressesQuietCompletionAndDevBuilds(t *testing.T) {
 			opts.Version = "v1.0.0"
 			return opts
 		}(), commandPath: "gumroad __completeNoDesc products list"},
+		{name: "background refresh", opts: func() cmdutil.Options {
+			opts := cmdutil.DefaultOptions()
+			opts.Version = "v1.0.0"
+			return opts
+		}(), commandPath: "gumroad __update-check-refresh"},
 		{name: "dev", opts: func() cmdutil.Options {
 			opts := cmdutil.DefaultOptions()
 			opts.Version = "dev"
@@ -243,19 +287,24 @@ func TestNotifyRefreshFailureIsSilent(t *testing.T) {
 	replaceConfigDir(t, dir)
 	t0 := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
 	replaceNow(t, t0)
+	writeCache(t, dir, cacheState{
+		LatestVersion: "v1.1.0",
+		CheckedAt:     t0.Add(-checkInterval),
+	})
 	replaceLatestVersion(t, func(context.Context) (string, error) {
 		return "", errors.New("offline")
 	})
 
-	var stderr bytes.Buffer
-	Notify(testOptions(&stderr), "gumroad products list")
-
-	if stderr.Len() != 0 {
-		t.Fatalf("expected silent failure, got %q", stderr.String())
+	if err := refreshCacheOnce(context.Background(), filepath.Join(dir, cacheFileName), cacheState{}, t0); err != nil {
+		t.Fatalf("refresh cache: %v", err)
 	}
+
 	state := readCache(t, dir)
 	if !state.CheckedAt.Equal(t0) {
 		t.Fatalf("expected failed check to be cached, got %+v", state)
+	}
+	if state.LatestVersion != "v1.1.0" {
+		t.Fatalf("expected failed check to preserve latest version, got %+v", state)
 	}
 }
 
@@ -264,8 +313,14 @@ func TestNotifyIgnoresOlderOrMalformedVersions(t *testing.T) {
 		t.Run(latest, func(t *testing.T) {
 			dir := t.TempDir()
 			replaceConfigDir(t, dir)
-			replaceLatestVersion(t, func(context.Context) (string, error) {
-				return latest, nil
+			t0 := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
+			replaceNow(t, t0)
+			writeCache(t, dir, cacheState{
+				LatestVersion: latest,
+				CheckedAt:     t0,
+			})
+			replaceStartRefresh(t, func() {
+				t.Fatal("fresh cache should not refresh")
 			})
 
 			var stderr bytes.Buffer
@@ -275,6 +330,62 @@ func TestNotifyIgnoresOlderOrMalformedVersions(t *testing.T) {
 				t.Fatalf("expected no warning, got %q", stderr.String())
 			}
 		})
+	}
+}
+
+func TestNotifySkipsWarningWhenNoticeCannotBePersisted(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod-based write failure is Unix-specific")
+	}
+	dir := t.TempDir()
+	replaceConfigDir(t, dir)
+	t0 := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
+	replaceNow(t, t0)
+	writeCache(t, dir, cacheState{
+		LatestVersion: "v1.1.0",
+		CheckedAt:     t0,
+	})
+	path := filepath.Join(dir, cacheFileName)
+	if err := os.Chmod(path, 0400); err != nil {
+		t.Fatalf("chmod cache file: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0600) })
+	replaceStartRefresh(t, func() {
+		t.Fatal("fresh cache should not refresh")
+	})
+
+	var stderr bytes.Buffer
+	Notify(testOptions(&stderr), "gumroad products list")
+
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no warning when notice marker cannot persist, got %q", stderr.String())
+	}
+}
+
+func TestRefreshCacheOncePreservesNoticeFields(t *testing.T) {
+	dir := t.TempDir()
+	t0 := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
+	noticeAt := t0.Add(-time.Hour)
+	writeCache(t, dir, cacheState{
+		LatestVersion:     "v1.1.0",
+		CheckedAt:         t0.Add(-checkInterval),
+		LastNoticeVersion: "v1.1.0",
+		LastNoticeAt:      noticeAt,
+	})
+	replaceLatestVersion(t, func(context.Context) (string, error) {
+		return "v1.2.0", nil
+	})
+
+	if err := refreshCacheOnce(context.Background(), filepath.Join(dir, cacheFileName), cacheState{}, t0); err != nil {
+		t.Fatalf("refresh cache: %v", err)
+	}
+
+	state := readCache(t, dir)
+	if state.LatestVersion != "v1.2.0" || !state.CheckedAt.Equal(t0) {
+		t.Fatalf("expected refreshed latest version, got %+v", state)
+	}
+	if state.LastNoticeVersion != "v1.1.0" || !state.LastNoticeAt.Equal(noticeAt) {
+		t.Fatalf("expected notice fields to be preserved, got %+v", state)
 	}
 }
 


### PR DESCRIPTION
## What

Adds a quiet update notice that runs when someone starts the CLI and a newer release is available. The notice goes to stderr so JSON, plain, and piped stdout output stay stable, and it tells the user or agent which install-specific command to run.

The check is cached, rate-limited, silent on failures, and skipped for quiet mode, dev/test builds, and generated shell completion requests.

## Why

Agents and users will not reliably remember to run a separate update check. A startup notice makes stale CLI versions visible at the point of use without letting the CLI mutate itself or bypass Homebrew, Go, or source installs.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional GitHub check and self-spawned refresh; failures are silent and do not alter command exit behavior.
> 
> **Overview**
> Adds a **startup update notice** that compares the running CLI version to the latest GitHub release and prints a one-line **stderr warning** (with an install-specific upgrade hint) when a newer semver is known, so **stdout stays clean** for `--json` and piping.
> 
> The check is **cached and throttled** in config (`update-check.json`), can **spawn a hidden background refresh** (`__update-check-refresh`) instead of blocking on the network, and is **skipped** for quiet mode, dev/test builds, shell completion, and the refresh command itself. Root wiring and tests cover stderr-vs-stdout behavior and the silent refresh path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41021aad997ba762e771f1fa783417751c0f5c31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->