### PR TITLE
Add explicit token auth helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,13 @@ gumroad sales refund abc123 --amount 5.00 --dry-run
 ```sh
 gumroad auth login          # Browser-based OAuth (default)
 gumroad auth login --web    # Force browser OAuth, no fallback
+gumroad auth login --with-token < token.txt
 gumroad auth status         # Check seller auth and stored admin auth
+gumroad auth token          # Print the active seller token
 gumroad auth logout         # Revoke/delete stored tokens
 ```
 
-When a browser isn't available, the CLI prints the authorize URL and you paste the redirect URL back. For CI and agents, set `GUMROAD_ACCESS_TOKEN`; it takes precedence over stored seller config and needs no interactive login.
+When a browser isn't available, the CLI prints the authorize URL and you paste the redirect URL back. For CI and agents with an existing token, set `GUMROAD_ACCESS_TOKEN` or pipe the token into `gumroad auth login --with-token`; `GUMROAD_ACCESS_TOKEN` takes precedence over stored seller config and needs no interactive login. The CLI cannot yet create a fresh creator token headlessly.
 
 ## Commands
 
@@ -147,7 +149,7 @@ Paginated commands (`sales list`, `payouts list`, `subscribers list`) accept `--
 
 ## AI agents
 
-`gumroad` is built to work with AI agents. The `--json`, `--jq`, `--no-input`, and `--non-interactive` flags make it easy to query Gumroad data programmatically, and `GUMROAD_ACCESS_TOKEN` gives agents a no-persistence seller auth path.
+`gumroad` is built to work with AI agents. The `--json`, `--jq`, `--no-input`, and `--non-interactive` flags make it easy to query Gumroad data programmatically, and `GUMROAD_ACCESS_TOKEN` gives agents a no-persistence seller auth path when a token already exists.
 
 An [agent skill](skills/gumroad/SKILL.md) is included. Run `gumroad skill` to install or refresh it.
 

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 )
 
-const HintRunAuthLogin = "Run: gumroad auth login — or set GUMROAD_ACCESS_TOKEN"
+const HintRunAuthLogin = "Run: gumroad auth login. For CI/agents with an existing token, set GUMROAD_ACCESS_TOKEN or run: gumroad auth login --with-token < token.txt"
 
 var (
 	ErrNotAuthenticated = errors.New("not authenticated")

--- a/internal/cmd/auth/auth.go
+++ b/internal/cmd/auth/auth.go
@@ -8,13 +8,15 @@ func NewAuthCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "auth",
 		Short: "Manage authentication",
-		Example: `  gumroad auth login
-  gumroad auth status
-  gumroad auth logout`,
+		Example: "  gumroad auth login\n" +
+			"  gumroad auth status\n" +
+			"  gumroad auth token\n" +
+			"  gumroad auth logout",
 	}
 
 	cmd.AddCommand(newLoginCmd())
 	cmd.AddCommand(newStatusCmd())
+	cmd.AddCommand(newTokenCmd())
 	cmd.AddCommand(newLogoutCmd())
 
 	return cmd

--- a/internal/cmd/auth/auth_test.go
+++ b/internal/cmd/auth/auth_test.go
@@ -494,6 +494,67 @@ func TestLogin_DryRunSkipsVerificationAndSave(t *testing.T) {
 	}
 }
 
+func TestLogin_WithTokenFlagReadsTokenFromStdin(t *testing.T) {
+	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer stdin-token" {
+			w.WriteHeader(401)
+			testutil.JSON(t, w, map[string]any{"success": false})
+			return
+		}
+		testutil.JSON(t, w, map[string]any{
+			"success": true,
+			"user":    map[string]any{"name": "Token User", "email": "token@example.com"},
+		})
+	})
+	cfgDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+
+	cmd := testutil.Command(newLoginCmd(), testutil.Stdin(strings.NewReader("stdin-token\n")))
+	if err := cmd.Flags().Set("with-token", "true"); err != nil {
+		t.Fatalf("set --with-token: %v", err)
+	}
+	if err := cmd.RunE(cmd, []string{}); err != nil {
+		t.Fatalf("RunE failed: %v", err)
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load config failed: %v", err)
+	}
+	if cfg.AccessToken != "stdin-token" {
+		t.Fatalf("got token %q, want stdin-token", cfg.AccessToken)
+	}
+}
+
+func TestLogin_WithTokenFlagRejectsTerminalStdin(t *testing.T) {
+	withTerminal(t, true)
+	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("login --with-token without piped stdin should not reach API")
+	})
+
+	cmd := testutil.Command(newLoginCmd())
+	if err := cmd.Flags().Set("with-token", "true"); err != nil {
+		t.Fatalf("set --with-token: %v", err)
+	}
+	err := cmd.RunE(cmd, []string{})
+	if err == nil || !strings.Contains(err.Error(), "--with-token reads a token from stdin") {
+		t.Fatalf("expected stdin guidance error, got: %v", err)
+	}
+}
+
+func TestLogin_WebAndWithTokenFlagsConflict(t *testing.T) {
+	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("conflicting login flags should not reach API")
+	})
+
+	cmd := testutil.Command(newLoginCmd(), testutil.Stdin(strings.NewReader("stdin-token\n")))
+	cmd.SetArgs([]string{"--web", "--with-token"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "if any flags in the group [web with-token] are set none of the others can be") {
+		t.Fatalf("expected flag conflict error, got: %v", err)
+	}
+}
+
 // --- Status ---
 
 func TestStatus_NotLoggedIn(t *testing.T) {
@@ -1274,6 +1335,70 @@ func TestAdminActorNameFallbacks(t *testing.T) {
 	}
 }
 
+// --- Token ---
+
+func TestToken_PrintsStoredToken(t *testing.T) {
+	t.Setenv(config.EnvAccessToken, "")
+	withConfig(t, "stored-token")
+
+	var out bytes.Buffer
+	cmd := testutil.Command(newTokenCmd(), testutil.Stdout(&out))
+	if err := cmd.RunE(cmd, []string{}); err != nil {
+		t.Fatalf("RunE failed: %v", err)
+	}
+	if strings.TrimSpace(out.String()) != "stored-token" {
+		t.Fatalf("got output %q, want stored-token", out.String())
+	}
+}
+
+func TestToken_PrefersEnvToken(t *testing.T) {
+	withConfig(t, "stored-token")
+	t.Setenv(config.EnvAccessToken, "env-token")
+
+	var out bytes.Buffer
+	cmd := testutil.Command(newTokenCmd(), testutil.Stdout(&out))
+	if err := cmd.RunE(cmd, []string{}); err != nil {
+		t.Fatalf("RunE failed: %v", err)
+	}
+	if strings.TrimSpace(out.String()) != "env-token" {
+		t.Fatalf("got output %q, want env-token", out.String())
+	}
+}
+
+func TestToken_JSONOutputIncludesSource(t *testing.T) {
+	t.Setenv(config.EnvAccessToken, "")
+	withConfig(t, "stored-token")
+
+	var out bytes.Buffer
+	cmd := testutil.Command(newTokenCmd(), testutil.JSONOutput(), testutil.Stdout(&out))
+	if err := cmd.RunE(cmd, []string{}); err != nil {
+		t.Fatalf("RunE failed: %v", err)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(out.Bytes(), &resp); err != nil {
+		t.Fatalf("token JSON output is invalid: %v\n%s", err, out.String())
+	}
+	if resp["token"] != "stored-token" || resp["source"] != string(config.TokenSourceConfig) {
+		t.Fatalf("unexpected token JSON: %#v", resp)
+	}
+}
+
+func TestToken_NotLoggedInShowsExistingTokenOptions(t *testing.T) {
+	t.Setenv(config.EnvAccessToken, "")
+	cfgDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+
+	cmd := testutil.Command(newTokenCmd())
+	err := cmd.RunE(cmd, []string{})
+	if err == nil {
+		t.Fatal("expected not authenticated error")
+	}
+	if !strings.Contains(err.Error(), "gumroad auth login") || !strings.Contains(err.Error(), "gumroad auth login --with-token") || !strings.Contains(err.Error(), config.EnvAccessToken) {
+		t.Fatalf("expected auth recovery guidance, got: %v", err)
+	}
+}
+
 // --- Logout ---
 
 func TestLogout_WithYes(t *testing.T) {
@@ -2041,7 +2166,7 @@ func TestNewAuthCmd(t *testing.T) {
 	for _, c := range cmd.Commands() {
 		subs[c.Use] = true
 	}
-	for _, name := range []string{"login", "status", "logout"} {
+	for _, name := range []string{"login", "status", "token", "logout"} {
 		if !subs[name] {
 			t.Errorf("missing subcommand %q", name)
 		}

--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -36,30 +36,30 @@ var isTerminalFunc = defaultIsTerminal
 
 func newLoginCmd() *cobra.Command {
 	var webFlag bool
+	var withTokenFlag bool
 
 	cmd := &cobra.Command{
 		Use:   "login",
 		Short: "Log in to Gumroad",
 		Args:  cmdutil.ExactArgs(0),
-		Long: `Log in to Gumroad via browser-based OAuth or a manual API token.
-
-By default, opens your browser for OAuth authorization.
-When stdin is piped (e.g. echo $TOKEN | gumroad auth login), reads a seller token directly.`,
-		Example: `  # Browser-based OAuth login (default)
-  gumroad auth login
-
-  # Explicit browser OAuth
-  gumroad auth login --web
-
-  # Pipe token from stdin (CI/scripts)
-  echo "your-token" | gumroad auth login`,
+		Long: "Log in to Gumroad via browser-based OAuth or a manual API token.\n\n" +
+			"By default, opens your browser for OAuth authorization.\n" +
+			"Use --with-token to read an existing seller token from stdin.\n" +
+			"Piped stdin without --with-token is still accepted for compatibility.",
+		Example: "  # Browser-based OAuth login (default)\n" +
+			"  gumroad auth login\n\n" +
+			"  # Explicit browser OAuth\n" +
+			"  gumroad auth login --web\n\n" +
+			"  # Store an existing token from stdin (CI/scripts)\n" +
+			"  gumroad auth login --with-token < token.txt\n" +
+			"  printf '%s\\n' \"$GUMROAD_ACCESS_TOKEN\" | gumroad auth login --with-token",
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
 			if opts.DryRun {
 				return cmdutil.PrintDryRunAction(opts, "store API token")
 			}
 
-			creds, err := resolveLoginCredentials(opts, webFlag)
+			creds, err := resolveLoginCredentials(opts, webFlag, withTokenFlag)
 			if err != nil {
 				return err
 			}
@@ -72,16 +72,28 @@ When stdin is piped (e.g. echo $TOKEN | gumroad auth login), reads a seller toke
 	}
 
 	cmd.Flags().BoolVar(&webFlag, "web", false, "Force browser-based OAuth login")
+	cmd.Flags().BoolVar(&withTokenFlag, "with-token", false, "Read an existing seller token from stdin")
+	cmd.MarkFlagsMutuallyExclusive("web", "with-token")
 
 	return cmd
 }
 
-func resolveLoginCredentials(opts cmdutil.Options, webFlag bool) (loginCredentials, error) {
+func resolveLoginCredentials(opts cmdutil.Options, webFlag, withTokenFlag bool) (loginCredentials, error) {
+	if withTokenFlag {
+		return stdinTokenCredentials(opts)
+	}
 	if !isTerminalFunc(opts.In()) {
-		token, err := prompt.TokenInput(opts.In(), opts.Err(), opts.NoInput)
-		return loginCredentials{SellerToken: token}, err
+		return stdinTokenCredentials(opts)
 	}
 	return oauthLogin(opts, webFlag)
+}
+
+func stdinTokenCredentials(opts cmdutil.Options) (loginCredentials, error) {
+	if isTerminalFunc(opts.In()) {
+		return loginCredentials{}, fmt.Errorf("--with-token reads a token from stdin. Run: gumroad auth login --with-token < token.txt")
+	}
+	token, err := prompt.TokenInput(opts.In(), opts.Err(), opts.NoInput)
+	return loginCredentials{SellerToken: token}, err
 }
 
 func defaultIsTerminal(r interface{}) bool {

--- a/internal/cmd/auth/status.go
+++ b/internal/cmd/auth/status.go
@@ -76,7 +76,7 @@ func newStatusCmd() *cobra.Command {
 				if opts.PlainOutput {
 					return printStatusPlain(opts, status)
 				}
-				if err := output.Writeln(opts.Out(), "Not logged in. Run "+style.Bold("gumroad auth login")+" or set "+style.Bold(config.EnvAccessToken)+" to authenticate."); err != nil {
+				if err := output.Writeln(opts.Out(), "Not logged in. Run "+style.Bold("gumroad auth login")+", set "+style.Bold(config.EnvAccessToken)+", or pipe an existing token into "+style.Bold("gumroad auth login --with-token")+"."); err != nil {
 					return err
 				}
 				if status.Admin != nil {

--- a/internal/cmd/auth/token.go
+++ b/internal/cmd/auth/token.go
@@ -1,0 +1,41 @@
+package auth
+
+import (
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/config"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+type tokenOutput struct {
+	Token  string             `json:"token"`
+	Source config.TokenSource `json:"source,omitempty"`
+}
+
+func newTokenCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "token",
+		Short: "Print the active seller auth token",
+		Args:  cmdutil.ExactArgs(0),
+		Example: `  gumroad auth token
+  gumroad auth token --json --jq '.token'`,
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			info, err := config.ResolveToken()
+			if err != nil {
+				return err
+			}
+
+			if opts.UsesJSONOutput() {
+				return printAuthJSON(opts, tokenOutput{
+					Token:  info.Value,
+					Source: info.Source,
+				})
+			}
+			if opts.PlainOutput {
+				return output.PrintPlain(opts.Out(), [][]string{{info.Value}})
+			}
+			return output.Writeln(opts.Out(), info.Value)
+		},
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -197,7 +197,7 @@ func ResolveToken() (TokenInfo, error) {
 		return TokenInfo{}, err
 	}
 	if cfg.AccessToken == "" {
-		return TokenInfo{}, fmt.Errorf("%w. Run `gumroad auth login` first or set `%s`", ErrNotAuthenticated, EnvAccessToken)
+		return TokenInfo{}, fmt.Errorf("%w. Run `gumroad auth login`, set `%s`, or pipe an existing token into `gumroad auth login --with-token`", ErrNotAuthenticated, EnvAccessToken)
 	}
 	return TokenInfo{Value: cfg.AccessToken, Source: TokenSourceConfig}, nil
 }

--- a/internal/prompt/input.go
+++ b/internal/prompt/input.go
@@ -62,5 +62,5 @@ func SecretInput(promptLabel, noun string, in io.Reader, out io.Writer, noInput 
 }
 
 func TokenInput(in io.Reader, out io.Writer, noInput bool) (string, error) {
-	return SecretInput("your Gumroad API token", "token", in, out, noInput, "Pipe your token via stdin: echo $TOKEN | gumroad auth login")
+	return SecretInput("your Gumroad API token", "token", in, out, noInput, "Pipe your token via stdin: gumroad auth login --with-token < token.txt")
 }

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -40,7 +40,7 @@ Always follow these rules:
 - Product cover and thumbnail uploads support JPEG, PNG, and GIF. WebP is not supported by the API and the CLI rejects it before upload.
 - Product custom HTML landing pages use `gumroad products page preview <id> ./landing.html` to run the backend sanitizer without writing, `gumroad products page publish <id> ./landing.html` to store the page, `gumroad products page clear <id> --yes` to remove it, and `gumroad products page url <id>` to print the live URL. `--dry-run` only previews the CLI request body; it does not call the backend sanitizer. Inspect `.sanitization_report` in `preview` and `publish` JSON output for server-side changes.
 - Custom HTML pages can use `data-gumroad-field="name"`, `data-gumroad-field="price"`, `data-gumroad-field="description"`, and `data-gumroad-action="buy"`. To preselect checkout state, add `data-gumroad-option="<variant name>"`, `data-gumroad-quantity="<integer>"`, `data-gumroad-price="<decimal>"`, or `data-gumroad-recurrence="monthly|quarterly|biannually|yearly|every_two_years"`. Production validates these values and falls back to product defaults when invalid. Prefer anchors for buy CTAs so production can add a checkout href; non-anchor buy elements also post to checkout.
-- If a command fails with a seller auth error, tell the user to run `gumroad auth login` interactively — agents cannot do this step.
+- If a command fails with a seller auth error, run `gumroad auth status --json --no-input` first. Agents can use an existing seller token via `GUMROAD_ACCESS_TOKEN` or `gumroad auth login --with-token`; creating a fresh creator token still requires a human browser/session until device auth exists.
 - For admin commands in agents/CI, pass `--non-interactive` and set `GUMROAD_ADMIN_TOKEN`; interactive shells can store an admin token with `gumroad auth login`.
 
 ## Response shapes
@@ -115,9 +115,16 @@ When creating or updating many products:
 
 ```sh
 # Check auth (do this first if unsure)
-gumroad auth status --no-input
+gumroad auth status --json --no-input
 
-# Login requires interactive input — tell the user to run it themselves
+# Use an existing seller token without a browser
+gumroad auth login --with-token --json --no-input < token.txt
+printf '%s\n' "$GUMROAD_ACCESS_TOKEN" | gumroad auth login --with-token --json --no-input
+
+# Print the active resolved seller token for another tool
+gumroad auth token --no-input
+
+# Browser login still requires a human/session
 # gumroad auth login
 
 # Logout


### PR DESCRIPTION
Ref #123

## What

Adds the Phase 0 auth improvements for agents and CI: an explicit `auth login --with-token` path for existing tokens, `auth token` for scripting, clearer unauthenticated guidance, and updated README/agent-skill instructions.

## Why

This does not solve fresh headless token creation yet; that still needs server-side device authorization. It makes the current token-based path explicit and usable while we build the real device-code flow.

---

This PR was implemented with AI assistance using gpt‑5.5 xhigh.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes seller authentication entry points and adds a command that prints secrets; behavior is additive but mishandling tokens or scripts could leak credentials.
> 
> **Overview**
> Adds **explicit seller-token paths for CI and agents** without changing browser OAuth for new credentials.
> 
> **`gumroad auth login --with-token`** reads an existing token from stdin (mutually exclusive with `--web`), verifies it, and stores it locally; piped stdin without the flag still works. **`gumroad auth token`** prints the resolved seller token (`GUMROAD_ACCESS_TOKEN` wins over stored config), with JSON/plain output including source where applicable.
> 
> Unauthenticated errors and docs (**README**, agent **SKILL**) now point to `GUMROAD_ACCESS_TOKEN`, `--with-token`, and `auth token`; messaging clarifies that **headless creation of a new creator token is still not supported**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8ac38ba801c29c46a55c52058aa9554934a234a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->