### PR TITLE
Add device authorization login flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ make install PREFIX="$HOME/.local"
 ## Quick start
 
 ```sh
-# Authenticate (opens browser for OAuth)
+# Authenticate with device approval
 gumroad auth login
 
 # Or use an environment variable for CI / agents
@@ -58,24 +58,24 @@ gumroad sales refund abc123 --amount 5.00 --dry-run
 
 ## Authentication
 
-`gumroad auth login` opens your browser for OAuth authorization. After you approve, the CLI stores the seller token locally.
+`gumroad auth login` starts OAuth device authorization. It prints a Gumroad approval URL, waits while you approve in the browser, then stores the seller token locally.
 
 ```sh
-gumroad auth login          # Browser-based OAuth (default)
-gumroad auth login --web    # Force browser OAuth, no fallback
+gumroad auth login          # Device authorization (default)
+gumroad auth login --web    # Local browser OAuth
 gumroad auth login --with-token < token.txt
 gumroad auth status         # Check seller auth and stored admin auth
 gumroad auth token          # Print the active seller token
 gumroad auth logout         # Revoke/delete stored tokens
 ```
 
-When a browser isn't available, the CLI prints the authorize URL and you paste the redirect URL back. For CI and agents with an existing token, set `GUMROAD_ACCESS_TOKEN` or pipe the token into `gumroad auth login --with-token`; `GUMROAD_ACCESS_TOKEN` takes precedence over stored seller config and needs no interactive login. The CLI cannot yet create a fresh creator token headlessly.
+For CI and agents with an existing token, set `GUMROAD_ACCESS_TOKEN` or pipe the token into `gumroad auth login --with-token`; `GUMROAD_ACCESS_TOKEN` takes precedence over stored seller config and needs no interactive login. Use `--web` only when you specifically want the local browser PKCE flow.
 
 ## Commands
 
 Run `gumroad --help` and `gumroad <command> --help` for subcommands, usage details, and examples.
 
-Admin commands use a separate internal token. Run `gumroad auth login` and check the admin box to store one locally, or use `GUMROAD_ADMIN_TOKEN` with `--non-interactive` in CI and agent runs. For local testing, set `GUMROAD_ADMIN_API_BASE_URL`.
+Admin commands use a separate internal token. Run `gumroad auth login --web` and check the admin box to store one locally, or use `GUMROAD_ADMIN_TOKEN` with `--non-interactive` in CI and agent runs. For local testing, set `GUMROAD_ADMIN_API_BASE_URL`.
 
 ## Refund policy
 
@@ -149,7 +149,7 @@ Paginated commands (`sales list`, `payouts list`, `subscribers list`) accept `--
 
 ## AI agents
 
-`gumroad` is built to work with AI agents. The `--json`, `--jq`, `--no-input`, and `--non-interactive` flags make it easy to query Gumroad data programmatically, and `GUMROAD_ACCESS_TOKEN` gives agents a no-persistence seller auth path when a token already exists.
+`gumroad` is built to work with AI agents. The `--json`, `--jq`, `--no-input`, and `--non-interactive` flags make it easy to query Gumroad data programmatically. Agents can start fresh seller auth with `gumroad auth login` and hand the printed approval URL to a human, or use `GUMROAD_ACCESS_TOKEN` for a no-persistence auth path when a token already exists.
 
 An [agent skill](skills/gumroad/SKILL.md) is included. Run `gumroad skill` to install or refresh it.
 

--- a/internal/cmd/auth/auth_test.go
+++ b/internal/cmd/auth/auth_test.go
@@ -1939,6 +1939,33 @@ func TestLogin_OAuth_BrowserFlow(t *testing.T) {
 	}
 }
 
+func TestLogin_OAuth_WebFlagIgnoresPipedStdin(t *testing.T) {
+	withTerminal(t, false)
+	withMockBrowser(t)
+	setupOAuthTokenServer(t)
+	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer oauth-access-token-from-server" {
+			t.Fatalf("got Authorization=%q, want OAuth token", got)
+		}
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"success": true,
+			"user":    map[string]any{"name": "OAuth User", "email": "oauth@test.com"},
+		}); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
+	})
+	cfgDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+
+	cmd := testutil.Command(newLoginCmd(), testutil.Stdin(strings.NewReader("piped-token\n")))
+	if err := cmd.Flags().Set("web", "true"); err != nil {
+		t.Fatalf("set --web flag: %v", err)
+	}
+	if err := cmd.RunE(cmd, []string{}); err != nil {
+		t.Fatalf("RunE: %v", err)
+	}
+}
+
 func TestLogin_OAuth_BrowserFlowSavesAdminTokenFromSameApproval(t *testing.T) {
 	withTerminal(t, true)
 	withMockBrowser(t)

--- a/internal/cmd/auth/auth_test.go
+++ b/internal/cmd/auth/auth_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -10,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -20,24 +20,6 @@ import (
 	"github.com/antiwork/gumroad-cli/internal/oauth"
 	"github.com/antiwork/gumroad-cli/internal/testutil"
 )
-
-// syncBuffer is a thread-safe bytes.Buffer for concurrent test read/write.
-type syncBuffer struct {
-	mu  sync.Mutex
-	buf bytes.Buffer
-}
-
-func (b *syncBuffer) Write(p []byte) (int, error) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return b.buf.Write(p)
-}
-
-func (b *syncBuffer) String() string {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return b.buf.String()
-}
 
 func setupAuth(t *testing.T, handler http.HandlerFunc) {
 	t.Helper()
@@ -160,6 +142,9 @@ func TestLogin_EmptyToken(t *testing.T) {
 	cfgDir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", cfgDir)
 	cmd := testutil.Command(newLoginCmd(), testutil.Stdin(strings.NewReader("  \n")))
+	if err := cmd.Flags().Set("with-token", "true"); err != nil {
+		t.Fatalf("set --with-token flag: %v", err)
+	}
 
 	err := cmd.RunE(cmd, []string{})
 	if err == nil || !strings.Contains(err.Error(), "token cannot be empty") {
@@ -1845,6 +1830,72 @@ func setupOAuthTokenServerWithResponse(t *testing.T, tokenResponse oauth.TokenRe
 	t.Cleanup(func() { oauth.DefaultFlowConfigFunc = oldCfg })
 }
 
+func setupOAuthDeviceServer(t *testing.T) {
+	t.Helper()
+	setupOAuthDeviceServerWithResponse(t, oauth.TokenResponse{
+		AccessToken: "device-access-token-from-server",
+		TokenType:   "bearer",
+		Scope:       "edit_products view_sales",
+	})
+}
+
+func setupOAuthDeviceServerWithResponse(t *testing.T, tokenResponse oauth.TokenResponse) {
+	t.Helper()
+
+	oauthSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("ParseForm failed: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/oauth/device/code":
+			if r.PostForm.Get("client_id") == "" {
+				t.Error("device code request missing client_id")
+			}
+			if r.PostForm.Get("admin_scope") != "optional" {
+				t.Errorf("admin_scope=%q, want optional", r.PostForm.Get("admin_scope"))
+			}
+			if err := json.NewEncoder(w).Encode(oauth.DeviceCodeResponse{
+				DeviceCode:              "test-device-code",
+				UserCode:                "GRD-TEST-1234",
+				VerificationURI:         "http://" + r.Host + "/oauth/device",
+				VerificationURIComplete: "http://" + r.Host + "/oauth/device?user_code=GRD-TEST-1234",
+				ExpiresIn:               600,
+				Interval:                1,
+			}); err != nil {
+				t.Errorf("encode device response: %v", err)
+			}
+		case "/oauth/token":
+			if r.PostForm.Get("grant_type") != oauth.DeviceGrantType {
+				t.Errorf("grant_type=%q, want %s", r.PostForm.Get("grant_type"), oauth.DeviceGrantType)
+			}
+			if r.PostForm.Get("device_code") != "test-device-code" {
+				t.Errorf("device_code=%q, want test-device-code", r.PostForm.Get("device_code"))
+			}
+			if err := json.NewEncoder(w).Encode(tokenResponse); err != nil {
+				t.Errorf("encode token response: %v", err)
+			}
+		default:
+			t.Errorf("unexpected OAuth path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(oauthSrv.Close)
+
+	oldCfg := oauth.DefaultFlowConfigFunc
+	oauth.DefaultFlowConfigFunc = func() oauth.FlowConfig {
+		cfg := oldCfg()
+		cfg.DeviceCodeURL = oauthSrv.URL + "/oauth/device/code"
+		cfg.TokenURL = oauthSrv.URL + "/oauth/token"
+		cfg.Sleep = func(context.Context, time.Duration) error {
+			return nil
+		}
+		return cfg
+	}
+	t.Cleanup(func() { oauth.DefaultFlowConfigFunc = oldCfg })
+}
+
 func TestLogin_OAuth_BrowserFlow(t *testing.T) {
 	withTerminal(t, true)
 	withMockBrowser(t)
@@ -1869,6 +1920,9 @@ func TestLogin_OAuth_BrowserFlow(t *testing.T) {
 
 	var out bytes.Buffer
 	cmd := testutil.Command(newLoginCmd(), testutil.Quiet(false), testutil.Stdout(&out))
+	if err := cmd.Flags().Set("web", "true"); err != nil {
+		t.Fatalf("set --web flag: %v", err)
+	}
 	if err := cmd.RunE(cmd, []string{}); err != nil {
 		t.Fatalf("RunE: %v", err)
 	}
@@ -1918,6 +1972,9 @@ func TestLogin_OAuth_BrowserFlowSavesAdminTokenFromSameApproval(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", cfgDir)
 
 	cmd := testutil.Command(newLoginCmd())
+	if err := cmd.Flags().Set("web", "true"); err != nil {
+		t.Fatalf("set --web flag: %v", err)
+	}
 	if err := cmd.RunE(cmd, []string{}); err != nil {
 		t.Fatalf("RunE: %v", err)
 	}
@@ -1945,14 +2002,20 @@ func TestLogin_OAuth_BrowserFlowSavesAdminTokenFromSameApproval(t *testing.T) {
 	}
 }
 
-func TestLogin_OAuth_BrowserFails_FallsBackToHeadless(t *testing.T) {
+func TestLogin_OAuth_DefaultDeviceFlow(t *testing.T) {
 	withTerminal(t, true)
-	withMockBrowserFail(t)
-	setupOAuthTokenServer(t)
+	setupOAuthDeviceServer(t)
 	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer device-access-token-from-server" {
+			w.WriteHeader(401)
+			if err := json.NewEncoder(w).Encode(map[string]any{"success": false}); err != nil {
+				t.Errorf("encode response: %v", err)
+			}
+			return
+		}
 		if err := json.NewEncoder(w).Encode(map[string]any{
 			"success": true,
-			"user":    map[string]any{"name": "Headless User", "email": "h@test.com"},
+			"user":    map[string]any{"name": "Device User", "email": "device@test.com"},
 		}); err != nil {
 			t.Errorf("encode response: %v", err)
 		}
@@ -1961,48 +2024,81 @@ func TestLogin_OAuth_BrowserFails_FallsBackToHeadless(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", cfgDir)
 
 	var out bytes.Buffer
+	var errOut bytes.Buffer
 
-	// Use a mutex-protected buffer for stderr to avoid data races
-	// between the command goroutine writing and the test goroutine reading.
-	errOut := &syncBuffer{}
-
-	pr, pw, _ := os.Pipe()
-	cmd := testutil.Command(newLoginCmd(), testutil.Quiet(false), testutil.Stdout(&out), testutil.Stderr(errOut), testutil.Stdin(pr))
-
-	done := make(chan error, 1)
-	go func() {
-		done <- cmd.RunE(cmd, []string{})
-	}()
-
-	// Poll stderr until the headless prompt appears.
-	var state string
-	for i := 0; i < 200; i++ {
-		time.Sleep(10 * time.Millisecond)
-		content := errOut.String()
-		if strings.Contains(content, "Paste the full URL") {
-			for _, line := range strings.Split(content, "\n") {
-				line = strings.TrimSpace(line)
-				if strings.HasPrefix(line, "http") {
-					u, _ := url.Parse(line)
-					state = u.Query().Get("state")
-					break
-				}
-			}
-			break
+	cmd := testutil.Command(newLoginCmd(), testutil.Quiet(false), testutil.Stdout(&out), testutil.Stderr(&errOut))
+	if err := cmd.RunE(cmd, []string{}); err != nil {
+		t.Fatalf("RunE: %v", err)
+	}
+	if !strings.Contains(out.String(), "Device User") {
+		t.Fatalf("expected device user in output: %q", out.String())
+	}
+	for _, want := range []string{"Open this URL to authorize Gumroad CLI", "user_code=GRD-TEST-1234", "Waiting for approval"} {
+		if !strings.Contains(errOut.String(), want) {
+			t.Fatalf("device flow stderr missing %q:\n%s", want, errOut.String())
 		}
 	}
+	if strings.Contains(errOut.String(), "Paste the full URL") {
+		t.Fatalf("device flow should not ask for redirect URL paste:\n%s", errOut.String())
+	}
+}
 
-	if state == "" {
-		pw.Close()
-		<-done
-		t.Fatalf("could not extract state from headless prompt. stderr: %q", errOut.String())
+func TestLogin_OAuth_DefaultDeviceFlowSavesAdminTokenFromSameApproval(t *testing.T) {
+	withTerminal(t, true)
+	setupOAuthDeviceServerWithResponse(t, oauth.TokenResponse{
+		AccessToken: "device-access-token-from-server",
+		TokenType:   "bearer",
+		Scope:       "edit_products view_sales",
+		AdminToken: &oauth.AdminTokenResponse{
+			Token:           "admin-token-from-device-oauth",
+			TokenExternalID: "adm_device_123",
+			Actor:           oauth.AdminActor{Name: "Device Admin", Email: "device-admin@example.com"},
+			ExpiresAt:       "2026-06-01T00:00:00Z",
+		},
+	})
+	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer device-access-token-from-server" {
+			w.WriteHeader(401)
+			if err := json.NewEncoder(w).Encode(map[string]any{"success": false}); err != nil {
+				t.Errorf("encode response: %v", err)
+			}
+			return
+		}
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"success": true,
+			"user":    map[string]any{"name": "Device User", "email": "device@test.com"},
+		}); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
+	})
+	cfgDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+
+	cmd := testutil.Command(newLoginCmd())
+	if err := cmd.RunE(cmd, []string{}); err != nil {
+		t.Fatalf("RunE: %v", err)
 	}
 
-	fmt.Fprintf(pw, "http://127.0.0.1/callback?code=headless-code&state=%s\n", state)
-	pw.Close()
+	publicData, err := os.ReadFile(filepath.Join(cfgDir, "gumroad", "config.json"))
+	if err != nil {
+		t.Fatalf("public config not saved: %v", err)
+	}
+	if !strings.Contains(string(publicData), "device-access-token-from-server") {
+		t.Fatalf("public config should contain device OAuth token, got %s", publicData)
+	}
 
-	if err := <-done; err != nil {
-		t.Fatalf("RunE: %v", err)
+	adminPath, err := adminconfig.Path()
+	if err != nil {
+		t.Fatalf("adminconfig.Path: %v", err)
+	}
+	adminData, err := os.ReadFile(adminPath)
+	if err != nil {
+		t.Fatalf("admin config not saved: %v", err)
+	}
+	for _, want := range []string{"admin-token-from-device-oauth", "adm_device_123", "device-admin@example.com", "2026-06-01T00:00:00Z"} {
+		if !strings.Contains(string(adminData), want) {
+			t.Fatalf("admin config missing %q: %s", want, adminData)
+		}
 	}
 }
 
@@ -2028,8 +2124,7 @@ func TestLogin_OAuth_WebFlag_NoFallback(t *testing.T) {
 
 func TestLogin_OAuth_VerifyAndSave_401(t *testing.T) {
 	withTerminal(t, true)
-	withMockBrowser(t)
-	setupOAuthTokenServer(t)
+	setupOAuthDeviceServer(t)
 	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(401)
 		if err := json.NewEncoder(w).Encode(map[string]any{"success": false, "message": "Unauthorized"}); err != nil {
@@ -2048,8 +2143,7 @@ func TestLogin_OAuth_VerifyAndSave_401(t *testing.T) {
 
 func TestLogin_OAuth_JSONOutput(t *testing.T) {
 	withTerminal(t, true)
-	withMockBrowser(t)
-	setupOAuthTokenServer(t)
+	setupOAuthDeviceServer(t)
 	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewEncoder(w).Encode(map[string]any{
 			"success": true,
@@ -2077,8 +2171,7 @@ func TestLogin_OAuth_JSONOutput(t *testing.T) {
 
 func TestLogin_OAuth_PlainOutput(t *testing.T) {
 	withTerminal(t, true)
-	withMockBrowser(t)
-	setupOAuthTokenServer(t)
+	setupOAuthDeviceServer(t)
 	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewEncoder(w).Encode(map[string]any{
 			"success": true,
@@ -2102,8 +2195,7 @@ func TestLogin_OAuth_PlainOutput(t *testing.T) {
 
 func TestLogin_OAuth_QuietOutput(t *testing.T) {
 	withTerminal(t, true)
-	withMockBrowser(t)
-	setupOAuthTokenServer(t)
+	setupOAuthDeviceServer(t)
 	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewEncoder(w).Encode(map[string]any{
 			"success": true,
@@ -2122,6 +2214,33 @@ func TestLogin_OAuth_QuietOutput(t *testing.T) {
 	}
 	if out.String() != "" {
 		t.Errorf("quiet mode should produce no output, got: %q", out.String())
+	}
+}
+
+func TestLogin_NonTTYEmptyStdinUsesDeviceFlow(t *testing.T) {
+	withTerminal(t, false)
+	setupOAuthDeviceServer(t)
+	setupAuth(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer device-access-token-from-server" {
+			w.WriteHeader(401)
+			if err := json.NewEncoder(w).Encode(map[string]any{"success": false}); err != nil {
+				t.Errorf("encode response: %v", err)
+			}
+			return
+		}
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"success": true,
+			"user":    map[string]any{"name": "Device User", "email": "device@test.com"},
+		}); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
+	})
+	cfgDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+
+	cmd := testutil.Command(newLoginCmd(), testutil.Stdin(strings.NewReader("")))
+	if err := cmd.RunE(cmd, []string{}); err != nil {
+		t.Fatalf("RunE: %v", err)
 	}
 }
 

--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -81,7 +81,7 @@ func resolveLoginCredentials(opts cmdutil.Options, webFlag, withTokenFlag bool) 
 	if withTokenFlag {
 		return stdinTokenCredentials(opts)
 	}
-	if !isTerminalFunc(opts.In()) {
+	if !isTerminalFunc(opts.In()) && !webFlag {
 		creds, ok, err := stdinTokenCredentialsIfProvided(opts)
 		if err != nil || ok {
 			return creds, err

--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -1,11 +1,9 @@
 package auth
 
 import (
-	"bufio"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/url"
 	"os"
 	"strings"
@@ -42,13 +40,14 @@ func newLoginCmd() *cobra.Command {
 		Use:   "login",
 		Short: "Log in to Gumroad",
 		Args:  cmdutil.ExactArgs(0),
-		Long: "Log in to Gumroad via browser-based OAuth or a manual API token.\n\n" +
-			"By default, opens your browser for OAuth authorization.\n" +
+		Long: "Log in to Gumroad via OAuth device authorization or a manual API token.\n\n" +
+			"By default, starts device authorization and waits for approval.\n" +
+			"Use --web to force the local browser OAuth flow.\n" +
 			"Use --with-token to read an existing seller token from stdin.\n" +
 			"Piped stdin without --with-token is still accepted for compatibility.",
-		Example: "  # Browser-based OAuth login (default)\n" +
+		Example: "  # Device authorization login (default)\n" +
 			"  gumroad auth login\n\n" +
-			"  # Explicit browser OAuth\n" +
+			"  # Local browser OAuth\n" +
 			"  gumroad auth login --web\n\n" +
 			"  # Store an existing token from stdin (CI/scripts)\n" +
 			"  gumroad auth login --with-token < token.txt\n" +
@@ -56,7 +55,7 @@ func newLoginCmd() *cobra.Command {
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
 			if opts.DryRun {
-				return cmdutil.PrintDryRunAction(opts, "store API token")
+				return cmdutil.PrintDryRunAction(opts, "authenticate and store API token")
 			}
 
 			creds, err := resolveLoginCredentials(opts, webFlag, withTokenFlag)
@@ -83,7 +82,10 @@ func resolveLoginCredentials(opts cmdutil.Options, webFlag, withTokenFlag bool) 
 		return stdinTokenCredentials(opts)
 	}
 	if !isTerminalFunc(opts.In()) {
-		return stdinTokenCredentials(opts)
+		creds, ok, err := stdinTokenCredentialsIfProvided(opts)
+		if err != nil || ok {
+			return creds, err
+		}
 	}
 	return oauthLogin(opts, webFlag)
 }
@@ -96,6 +98,17 @@ func stdinTokenCredentials(opts cmdutil.Options) (loginCredentials, error) {
 	return loginCredentials{SellerToken: token}, err
 }
 
+func stdinTokenCredentialsIfProvided(opts cmdutil.Options) (loginCredentials, bool, error) {
+	token, err := prompt.TokenInput(opts.In(), opts.Err(), opts.NoInput)
+	if err != nil {
+		return loginCredentials{}, false, err
+	}
+	if token == "" {
+		return loginCredentials{}, false, nil
+	}
+	return loginCredentials{SellerToken: token}, true, nil
+}
+
 func defaultIsTerminal(r interface{}) bool {
 	if f, ok := r.(*os.File); ok {
 		return term.IsTerminal(int(f.Fd()))
@@ -106,22 +119,17 @@ func defaultIsTerminal(r interface{}) bool {
 func oauthLogin(opts cmdutil.Options, webFlag bool) (loginCredentials, error) {
 	cfg := oauth.DefaultFlowConfig()
 
-	result, browserErr := tryBrowserFlow(opts, cfg)
-	if browserErr == nil {
+	if webFlag {
+		result, err := tryBrowserFlow(opts, cfg)
+		if err != nil {
+			return loginCredentials{}, fmt.Errorf("browser login failed: %w", err)
+		}
 		return loginCredentialsFromOAuthResult(opts, result)
 	}
 
-	if webFlag {
-		return loginCredentials{}, fmt.Errorf("browser login failed: %w", browserErr)
-	}
-
-	// Fall back to headless flow.
-	fmt.Fprintln(opts.Err(), "Could not open browser. Falling back to manual flow.")
-	fmt.Fprintln(opts.Err())
-
-	result, err := oauth.HeadlessFlowResult(opts.Context, cfg, opts.Err(), stdinReader(opts.In()))
+	result, err := oauth.DeviceFlowResult(opts.Context, cfg, opts.Err())
 	if err != nil {
-		return loginCredentials{}, err
+		return loginCredentials{}, fmt.Errorf("device login failed: %w. Use `gumroad auth login --web` for browser OAuth", err)
 	}
 	return loginCredentialsFromOAuthResult(opts, result)
 }
@@ -141,19 +149,6 @@ func tryBrowserFlow(opts cmdutil.Options, cfg oauth.FlowConfig) (oauth.FlowResul
 		fmt.Fprintln(opts.Err(), "Waiting for authorization in browser...")
 		return nil
 	})
-}
-
-func stdinReader(in io.Reader) func() (string, error) {
-	return func() (string, error) {
-		scanner := bufio.NewScanner(in)
-		if !scanner.Scan() {
-			if err := scanner.Err(); err != nil {
-				return "", err
-			}
-			return "", fmt.Errorf("no input received")
-		}
-		return scanner.Text(), nil
-	}
 }
 
 func loginCredentialsFromOAuthResult(opts cmdutil.Options, result oauth.FlowResult) (loginCredentials, error) {

--- a/internal/oauth/flow.go
+++ b/internal/oauth/flow.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"html"
 	"io"
@@ -49,10 +50,12 @@ type FlowConfig struct {
 	ClientID      string
 	AuthorizeURL  string
 	TokenURL      string
+	DeviceCodeURL string
 	Scopes        string
 	OptionalAdmin bool
 	Timeout       time.Duration
 	HTTPClient    *http.Client // optional; defaults to http.DefaultClient
+	Sleep         func(context.Context, time.Duration) error
 }
 
 // DefaultFlowConfigFunc returns a FlowConfig using the built-in constants.
@@ -69,10 +72,26 @@ func defaultFlowConfig() FlowConfig {
 		ClientID:      ClientID,
 		AuthorizeURL:  AuthorizeURL,
 		TokenURL:      TokenURL,
+		DeviceCodeURL: DeviceCodeURL,
 		Scopes:        Scopes,
 		OptionalAdmin: true,
 		Timeout:       DefaultTimeout,
 	}
+}
+
+type DeviceCodeResponse struct {
+	DeviceCode              string `json:"device_code"`
+	UserCode                string `json:"user_code"`
+	VerificationURI         string `json:"verification_uri"`
+	VerificationURIComplete string `json:"verification_uri_complete"`
+	ExpiresIn               int    `json:"expires_in"`
+	Interval                int    `json:"interval"`
+}
+
+type oauthErrorResponse struct {
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+	Interval         int    `json:"interval"`
 }
 
 type callbackPayload struct {
@@ -258,6 +277,194 @@ func HeadlessFlowResult(ctx context.Context, cfg FlowConfig, out io.Writer, read
 	return exchangeCodeResult(ctx, cfg, payload, redirectURI, verifier)
 }
 
+func DeviceFlowResult(ctx context.Context, cfg FlowConfig, out io.Writer) (FlowResult, error) {
+	if cfg.HTTPClient == nil {
+		cfg.HTTPClient = http.DefaultClient
+	}
+	if cfg.Sleep == nil {
+		cfg.Sleep = sleepContext
+	}
+
+	deviceCode, err := requestDeviceCode(ctx, cfg)
+	if err != nil {
+		return FlowResult{}, err
+	}
+	if deviceCode.DeviceCode == "" {
+		return FlowResult{}, fmt.Errorf("device code response did not contain a device code")
+	}
+	if deviceCode.ExpiresIn <= 0 {
+		return FlowResult{}, fmt.Errorf("device code response did not contain a valid expiration")
+	}
+
+	writeDeviceInstructions(out, deviceCode)
+	return pollDeviceToken(ctx, cfg, deviceCode)
+}
+
+func requestDeviceCode(ctx context.Context, cfg FlowConfig) (DeviceCodeResponse, error) {
+	data := url.Values{
+		"client_id": {cfg.ClientID},
+		"scope":     {cfg.Scopes},
+	}
+	if cfg.OptionalAdmin {
+		data.Set("admin_scope", "optional")
+	}
+
+	requestCtx, cancel := requestContext(ctx, cfg)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(requestCtx, "POST", cfg.DeviceCodeURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return DeviceCodeResponse{}, fmt.Errorf("could not build device authorization request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := cfg.HTTPClient.Do(req)
+	if err != nil {
+		return DeviceCodeResponse{}, fmt.Errorf("device authorization failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return DeviceCodeResponse{}, fmt.Errorf("could not read device authorization response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return DeviceCodeResponse{}, oauthHTTPError("device authorization failed", resp.StatusCode, body)
+	}
+
+	var deviceCode DeviceCodeResponse
+	if err := json.Unmarshal(body, &deviceCode); err != nil {
+		return DeviceCodeResponse{}, fmt.Errorf("could not parse device authorization response: %w", err)
+	}
+	return deviceCode, nil
+}
+
+func writeDeviceInstructions(out io.Writer, deviceCode DeviceCodeResponse) {
+	if out == nil {
+		return
+	}
+
+	verificationURL := strings.TrimSpace(deviceCode.VerificationURIComplete)
+	if verificationURL == "" {
+		verificationURL = strings.TrimSpace(deviceCode.VerificationURI)
+	}
+
+	fmt.Fprintf(out, "Open this URL to authorize Gumroad CLI:\n  %s\n\n", verificationURL)
+	if strings.TrimSpace(deviceCode.UserCode) != "" {
+		fmt.Fprintf(out, "Code: %s\n\n", deviceCode.UserCode)
+	}
+	fmt.Fprintln(out, "Waiting for approval...")
+}
+
+func pollDeviceToken(ctx context.Context, cfg FlowConfig, deviceCode DeviceCodeResponse) (FlowResult, error) {
+	interval := time.Duration(deviceCode.Interval) * time.Second
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+	expiresAt := time.Now().Add(time.Duration(deviceCode.ExpiresIn) * time.Second)
+
+	for {
+		remaining := time.Until(expiresAt)
+		if remaining <= 0 {
+			return FlowResult{}, fmt.Errorf("authorization expired")
+		}
+		wait := interval
+		if wait > remaining {
+			wait = remaining
+		}
+		if err := cfg.Sleep(ctx, wait); err != nil {
+			return FlowResult{}, fmt.Errorf("authorization cancelled")
+		}
+
+		result, nextInterval, err := pollDeviceTokenOnce(ctx, cfg, deviceCode.DeviceCode, interval)
+		if err == nil {
+			return result, nil
+		}
+		var oauthErr *oauthDevicePollError
+		if !errors.As(err, &oauthErr) {
+			return FlowResult{}, err
+		}
+		switch oauthErr.Code {
+		case "authorization_pending":
+			continue
+		case "slow_down":
+			interval = nextInterval
+			continue
+		case "access_denied":
+			return FlowResult{}, fmt.Errorf("authorization denied: access was denied")
+		case "expired_token":
+			return FlowResult{}, fmt.Errorf("authorization expired")
+		default:
+			return FlowResult{}, oauthErr
+		}
+	}
+}
+
+type oauthDevicePollError struct {
+	Code        string
+	Description string
+}
+
+func (e *oauthDevicePollError) Error() string {
+	if e.Description == "" || e.Description == e.Code {
+		return e.Code
+	}
+	return e.Code + ": " + e.Description
+}
+
+func pollDeviceTokenOnce(ctx context.Context, cfg FlowConfig, deviceCode string, currentInterval time.Duration) (FlowResult, time.Duration, error) {
+	data := url.Values{
+		"grant_type":  {DeviceGrantType},
+		"client_id":   {cfg.ClientID},
+		"device_code": {deviceCode},
+	}
+
+	requestCtx, cancel := requestContext(ctx, cfg)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(requestCtx, "POST", cfg.TokenURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return FlowResult{}, currentInterval, fmt.Errorf("could not build token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := cfg.HTTPClient.Do(req)
+	if err != nil {
+		return FlowResult{}, currentInterval, fmt.Errorf("token exchange failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return FlowResult{}, currentInterval, fmt.Errorf("could not read token response: %w", err)
+	}
+
+	if resp.StatusCode == http.StatusOK {
+		result, err := tokenResponseResult(body, "", "")
+		return result, currentInterval, err
+	}
+
+	oauthErr := parseOAuthError(body)
+	if oauthErr.Error == "slow_down" {
+		if oauthErr.Interval > 0 {
+			return FlowResult{}, time.Duration(oauthErr.Interval) * time.Second, &oauthDevicePollError{Code: oauthErr.Error, Description: oauthErr.ErrorDescription}
+		}
+		return FlowResult{}, currentInterval + 5*time.Second, &oauthDevicePollError{Code: oauthErr.Error, Description: oauthErr.ErrorDescription}
+	}
+	if oauthErr.Error != "" {
+		return FlowResult{}, currentInterval, &oauthDevicePollError{Code: oauthErr.Error, Description: oauthErr.ErrorDescription}
+	}
+	return FlowResult{}, currentInterval, fmt.Errorf("token exchange failed (HTTP %d)", resp.StatusCode)
+}
+
+func requestContext(ctx context.Context, cfg FlowConfig) (context.Context, context.CancelFunc) {
+	if cfg.Timeout <= 0 {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, cfg.Timeout)
+}
+
 func generateState() (string, error) {
 	buf := make([]byte, 16)
 	if _, err := rand.Read(buf); err != nil {
@@ -378,9 +585,13 @@ func exchangeCodeResult(ctx context.Context, cfg FlowConfig, payload callbackPay
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return FlowResult{}, fmt.Errorf("token exchange failed (HTTP %d)", resp.StatusCode)
+		return FlowResult{}, oauthHTTPError("token exchange failed", resp.StatusCode, body)
 	}
 
+	return tokenResponseResult(body, payload.AdminCode, verifier)
+}
+
+func tokenResponseResult(body []byte, adminCode, verifier string) (FlowResult, error) {
 	var tokenResp TokenResponse
 	if err := json.Unmarshal(body, &tokenResp); err != nil {
 		return FlowResult{}, fmt.Errorf("could not parse token response: %w", err)
@@ -397,9 +608,39 @@ func exchangeCodeResult(ctx context.Context, cfg FlowConfig, payload callbackPay
 	return FlowResult{
 		AccessToken:            tokenResp.AccessToken,
 		AdminToken:             adminToken,
-		AdminAuthorizationCode: payload.AdminCode,
+		AdminAuthorizationCode: adminCode,
 		CodeVerifier:           verifier,
 	}, nil
+}
+
+func oauthHTTPError(prefix string, statusCode int, body []byte) error {
+	oauthErr := parseOAuthError(body)
+	if oauthErr.Error == "" {
+		return fmt.Errorf("%s (HTTP %d)", prefix, statusCode)
+	}
+	desc := oauthErr.ErrorDescription
+	if desc == "" || desc == oauthErr.Error {
+		return fmt.Errorf("%s: %s (HTTP %d)", prefix, oauthErr.Error, statusCode)
+	}
+	return fmt.Errorf("%s: %s: %s (HTTP %d)", prefix, oauthErr.Error, desc, statusCode)
+}
+
+func parseOAuthError(body []byte) oauthErrorResponse {
+	var oauthErr oauthErrorResponse
+	_ = json.Unmarshal(body, &oauthErr)
+	return oauthErr
+}
+
+func sleepContext(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func htmlPage(title, message string, isError bool) string {

--- a/internal/oauth/flow.go
+++ b/internal/oauth/flow.go
@@ -374,7 +374,7 @@ func pollDeviceToken(ctx context.Context, cfg FlowConfig, deviceCode DeviceCodeR
 			wait = remaining
 		}
 		if err := cfg.Sleep(ctx, wait); err != nil {
-			return FlowResult{}, fmt.Errorf("authorization cancelled")
+			return FlowResult{}, fmt.Errorf("authorization cancelled: %w", err)
 		}
 
 		result, nextInterval, err := pollDeviceTokenOnce(ctx, cfg, deviceCode.DeviceCode, interval)

--- a/internal/oauth/flow_test.go
+++ b/internal/oauth/flow_test.go
@@ -3,6 +3,7 @@ package oauth
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -553,6 +554,40 @@ func TestDeviceFlow_SlowDownUsesServerInterval(t *testing.T) {
 	}
 	if len(sleeps) != 2 || sleeps[0] != time.Second || sleeps[1] != 7*time.Second {
 		t.Fatalf("got sleeps %v, want [1s 7s]", sleeps)
+	}
+}
+
+func TestDeviceFlow_SleepErrorPreservesContextCause(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/oauth/device/code":
+			mustEncode(t, w, DeviceCodeResponse{
+				DeviceCode:      "device-code-123",
+				UserCode:        "GRD-ABCD-1234",
+				VerificationURI: "https://gumroad.com/oauth/device",
+				ExpiresIn:       600,
+				Interval:        1,
+			})
+		case "/oauth/token":
+			t.Fatal("token endpoint should not be reached when sleep is cancelled")
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	cfg := deviceFlowConfig(srv)
+	cfg.Sleep = func(context.Context, time.Duration) error {
+		return context.Canceled
+	}
+
+	_, err := DeviceFlowResult(context.Background(), cfg, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "authorization cancelled") {
+		t.Fatalf("expected authorization cancelled error, got: %v", err)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled in error chain, got: %v", err)
 	}
 }
 

--- a/internal/oauth/flow_test.go
+++ b/internal/oauth/flow_test.go
@@ -256,7 +256,7 @@ func TestBrowserFlow_TokenExchangeFailure(t *testing.T) {
 		resp.Body.Close()
 		return nil
 	})
-	if err == nil || !strings.Contains(err.Error(), "token exchange failed (HTTP 400)") {
+	if err == nil || !strings.Contains(err.Error(), "token exchange failed: invalid_grant (HTTP 400)") {
 		t.Fatalf("expected token exchange error, got: %v", err)
 	}
 }
@@ -427,6 +427,176 @@ func TestHeadlessFlow_NoCode(t *testing.T) {
 	}
 }
 
+func deviceFlowConfig(srv *httptest.Server) FlowConfig {
+	return FlowConfig{
+		ClientID:      "test-client-id",
+		DeviceCodeURL: srv.URL + "/oauth/device/code",
+		TokenURL:      srv.URL + "/oauth/token",
+		Scopes:        "view_profile edit_products",
+		OptionalAdmin: true,
+		HTTPClient:    srv.Client(),
+		Sleep: func(context.Context, time.Duration) error {
+			return nil
+		},
+	}
+}
+
+func TestDeviceFlow_PollsUntilApproved(t *testing.T) {
+	var deviceRequest url.Values
+	var tokenRequests []url.Values
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/oauth/device/code":
+			deviceRequest = r.PostForm
+			mustEncode(t, w, DeviceCodeResponse{
+				DeviceCode:              "device-code-123",
+				UserCode:                "GRD-ABCD-1234",
+				VerificationURI:         "https://gumroad.com/oauth/device",
+				VerificationURIComplete: "https://gumroad.com/oauth/device?user_code=GRD-ABCD-1234",
+				ExpiresIn:               600,
+				Interval:                1,
+			})
+		case "/oauth/token":
+			tokenRequests = append(tokenRequests, r.PostForm)
+			if len(tokenRequests) == 1 {
+				w.WriteHeader(http.StatusBadRequest)
+				mustEncode(t, w, oauthErrorResponse{Error: "authorization_pending", ErrorDescription: "Authorization is pending"})
+				return
+			}
+			mustEncode(t, w, TokenResponse{AccessToken: "device-access-token", TokenType: "Bearer", Scope: "view_profile"})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	var output strings.Builder
+	result, err := DeviceFlowResult(context.Background(), deviceFlowConfig(srv), &output)
+	if err != nil {
+		t.Fatalf("DeviceFlowResult: %v", err)
+	}
+	if result.AccessToken != "device-access-token" {
+		t.Fatalf("got access token %q, want device-access-token", result.AccessToken)
+	}
+	if deviceRequest.Get("client_id") != "test-client-id" ||
+		deviceRequest.Get("scope") != "view_profile edit_products" ||
+		deviceRequest.Get("admin_scope") != "optional" {
+		t.Fatalf("unexpected device request: %v", deviceRequest)
+	}
+	if len(tokenRequests) != 2 {
+		t.Fatalf("got %d token requests, want 2", len(tokenRequests))
+	}
+	if tokenRequests[0].Get("grant_type") != DeviceGrantType || tokenRequests[0].Get("device_code") != "device-code-123" {
+		t.Fatalf("unexpected token request: %v", tokenRequests[0])
+	}
+	for _, want := range []string{
+		"Open this URL to authorize Gumroad CLI:",
+		"https://gumroad.com/oauth/device?user_code=GRD-ABCD-1234",
+		"Code: GRD-ABCD-1234",
+		"Waiting for approval...",
+	} {
+		if !strings.Contains(output.String(), want) {
+			t.Fatalf("device flow output missing %q:\n%s", want, output.String())
+		}
+	}
+	if strings.Contains(output.String(), "Paste the full URL") {
+		t.Fatalf("device flow should not ask for redirect URL paste:\n%s", output.String())
+	}
+}
+
+func TestDeviceFlow_SlowDownUsesServerInterval(t *testing.T) {
+	var sleeps []time.Duration
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/oauth/device/code":
+			mustEncode(t, w, DeviceCodeResponse{
+				DeviceCode:      "device-code-123",
+				UserCode:        "GRD-ABCD-1234",
+				VerificationURI: "https://gumroad.com/oauth/device",
+				ExpiresIn:       600,
+				Interval:        1,
+			})
+		case "/oauth/token":
+			if len(sleeps) == 1 {
+				w.WriteHeader(http.StatusBadRequest)
+				mustEncode(t, w, oauthErrorResponse{Error: "slow_down", ErrorDescription: "Polling too quickly", Interval: 7})
+				return
+			}
+			mustEncode(t, w, TokenResponse{AccessToken: "device-access-token", TokenType: "Bearer"})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	cfg := deviceFlowConfig(srv)
+	cfg.Sleep = func(_ context.Context, d time.Duration) error {
+		sleeps = append(sleeps, d)
+		return nil
+	}
+
+	_, err := DeviceFlowResult(context.Background(), cfg, io.Discard)
+	if err != nil {
+		t.Fatalf("DeviceFlowResult: %v", err)
+	}
+	if len(sleeps) != 2 || sleeps[0] != time.Second || sleeps[1] != 7*time.Second {
+		t.Fatalf("got sleeps %v, want [1s 7s]", sleeps)
+	}
+}
+
+func TestDeviceFlow_AccessDenied(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/oauth/device/code":
+			mustEncode(t, w, DeviceCodeResponse{
+				DeviceCode:      "device-code-123",
+				UserCode:        "GRD-ABCD-1234",
+				VerificationURI: "https://gumroad.com/oauth/device",
+				ExpiresIn:       600,
+				Interval:        1,
+			})
+		case "/oauth/token":
+			w.WriteHeader(http.StatusBadRequest)
+			mustEncode(t, w, oauthErrorResponse{Error: "access_denied", ErrorDescription: "Access was denied"})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	_, err := DeviceFlowResult(context.Background(), deviceFlowConfig(srv), io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "authorization denied") {
+		t.Fatalf("expected authorization denied, got: %v", err)
+	}
+}
+
+func TestDeviceFlow_DeviceCodeRequestError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		mustEncode(t, w, oauthErrorResponse{Error: "unauthorized_client", ErrorDescription: "Client is not allowed to use device authorization"})
+	}))
+	defer srv.Close()
+
+	_, err := DeviceFlowResult(context.Background(), deviceFlowConfig(srv), io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "unauthorized_client") {
+		t.Fatalf("expected unauthorized_client error, got: %v", err)
+	}
+}
+
 func TestBrowserFlow_NoCode(t *testing.T) {
 	tokenSrv := httptest.NewServer(tokenHandler(t, false))
 	defer tokenSrv.Close()
@@ -500,6 +670,9 @@ func TestDefaultFlowConfig(t *testing.T) {
 	}
 	if cfg.TokenURL != TokenURL {
 		t.Errorf("TokenURL = %q, want %q", cfg.TokenURL, TokenURL)
+	}
+	if cfg.DeviceCodeURL != DeviceCodeURL {
+		t.Errorf("DeviceCodeURL = %q, want %q", cfg.DeviceCodeURL, DeviceCodeURL)
 	}
 	if cfg.Scopes != Scopes {
 		t.Errorf("Scopes = %q, want %q", cfg.Scopes, Scopes)

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -7,10 +7,13 @@ const (
 	// This is a public client (confidential: false) — the client ID is not secret.
 	ClientID = "oljO5HmcOWvCZ5wbitpXPXk3u0LjAb5GdAEBBU5hwKA"
 
-	AuthorizeURL = "https://app.gumroad.com/oauth/authorize"
-	TokenURL     = "https://app.gumroad.com/oauth/token" //nolint:gosec // G101: not a credential
+	AuthorizeURL  = "https://app.gumroad.com/oauth/authorize"
+	TokenURL      = "https://app.gumroad.com/oauth/token" //nolint:gosec // G101: not a credential
+	DeviceCodeURL = "https://app.gumroad.com/oauth/device/code"
 
 	Scopes = "edit_products view_sales mark_sales_as_shipped edit_sales view_payouts view_profile account"
+
+	DeviceGrantType = "urn:ietf:params:oauth:grant-type:device_code"
 
 	DefaultTimeout = 2 * time.Minute
 )

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -40,8 +40,8 @@ Always follow these rules:
 - Product cover and thumbnail uploads support JPEG, PNG, and GIF. WebP is not supported by the API and the CLI rejects it before upload.
 - Product custom HTML landing pages use `gumroad products page preview <id> ./landing.html` to run the backend sanitizer without writing, `gumroad products page publish <id> ./landing.html` to store the page, `gumroad products page clear <id> --yes` to remove it, and `gumroad products page url <id>` to print the live URL. `--dry-run` only previews the CLI request body; it does not call the backend sanitizer. Inspect `.sanitization_report` in `preview` and `publish` JSON output for server-side changes.
 - Custom HTML pages can use `data-gumroad-field="name"`, `data-gumroad-field="price"`, `data-gumroad-field="description"`, and `data-gumroad-action="buy"`. To preselect checkout state, add `data-gumroad-option="<variant name>"`, `data-gumroad-quantity="<integer>"`, `data-gumroad-price="<decimal>"`, or `data-gumroad-recurrence="monthly|quarterly|biannually|yearly|every_two_years"`. Production validates these values and falls back to product defaults when invalid. Prefer anchors for buy CTAs so production can add a checkout href; non-anchor buy elements also post to checkout.
-- If a command fails with a seller auth error, run `gumroad auth status --json --no-input` first. Agents can use an existing seller token via `GUMROAD_ACCESS_TOKEN` or `gumroad auth login --with-token`; creating a fresh creator token still requires a human browser/session until device auth exists.
-- For admin commands in agents/CI, pass `--non-interactive` and set `GUMROAD_ADMIN_TOKEN`; interactive shells can store an admin token with `gumroad auth login`.
+- If a command fails with a seller auth error, run `gumroad auth status --json --no-input` first. Agents can start seller auth with `gumroad auth login --no-input` and hand the printed approval URL to a human, or use an existing seller token via `GUMROAD_ACCESS_TOKEN` or `gumroad auth login --with-token`.
+- For admin commands in agents/CI, pass `--non-interactive` and set `GUMROAD_ADMIN_TOKEN`; interactive shells can store an admin token with `gumroad auth login --web`.
 
 ## Response shapes
 
@@ -117,15 +117,18 @@ When creating or updating many products:
 # Check auth (do this first if unsure)
 gumroad auth status --json --no-input
 
-# Use an existing seller token without a browser
+# Start device authorization and wait for human approval
+gumroad auth login --no-input
+
+# Use an existing seller token without browser approval
 gumroad auth login --with-token --json --no-input < token.txt
 printf '%s\n' "$GUMROAD_ACCESS_TOKEN" | gumroad auth login --with-token --json --no-input
 
 # Print the active resolved seller token for another tool
 gumroad auth token --no-input
 
-# Browser login still requires a human/session
-# gumroad auth login
+# Force the local browser OAuth flow
+gumroad auth login --web
 
 # Logout
 gumroad auth logout --yes --no-input


### PR DESCRIPTION
Ref #123

## What

- Adds a device-based login flow that prints a Gumroad authorization link and waits for approval.
- Lets the CLI complete authentication after the browser approval step and stores the resulting token for later commands.
- Keeps the old browser-based login path available for cases that need it.

## Why

- Makes login work in a cleaner, more direct flow for CLI users.
- Removes the copy-paste step from the authorization handoff so the browser can open the exact approval link.
- Preserves the existing web flow as a fallback instead of forcing one path.

### E2E test pointing to production

<img width="1328" height="388" alt="CleanShot 2026-06-05 at 18 28 13@2x" src="https://github.com/user-attachments/assets/aa77effa-6a1e-4689-a31c-211fe058c8d5" />
<img width="2922" height="1652" alt="CleanShot 2026-06-05 at 18 29 03@2x" src="https://github.com/user-attachments/assets/33e6d1ae-0694-45aa-8ce4-f0b35da7d582" />
<img width="2920" height="1650" alt="CleanShot 2026-06-05 at 18 29 18@2x" src="https://github.com/user-attachments/assets/81e3f495-58d6-4558-a170-b3fd00a5efa4" />
<img width="1356" height="364" alt="CleanShot 2026-06-05 at 18 29 32@2x" src="https://github.com/user-attachments/assets/7ad83f5c-e59e-41f8-b2f1-84c527267c92" />


---

This PR was implemented with AI assistance using gpt‑5.5 xhigh.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the primary authentication path and login behavior for non-TTY/agents; token storage and admin handling are unchanged but users must approve via the new device flow unless they use `--web` or `--with-token`.
> 
> **Overview**
> **`gumroad auth login` now defaults to OAuth device authorization** instead of opening a local browser. The CLI requests a device code, prints an approval URL (and user code), polls until approval, then verifies and stores the seller token—and optional admin token from the same approval—like before.
> 
> **`--web` is now explicit** for the local PKCE browser flow; browser failures no longer fall back to the old “paste the redirect URL” headless path. Non-TTY stdin with no token starts device auth (so agents can surface a URL to a human); piped tokens still work, and `--with-token` is required for empty stdin validation.
> 
> The OAuth layer adds **`DeviceFlowResult`** (device code request, polling with `authorization_pending` / `slow_down`, richer OAuth error messages) plus **`DeviceCodeURL`** / device grant constants. README and the agent skill document the new default, `--web` for admin login, and agent-friendly `gumroad auth login --no-input`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1af4ca5048fb795248c6d1e6a4a5b6a65fd7009. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->