### PR TITLE
docs: document product build file updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,34 @@ gumroad products update <product_id> --file ./pack.zip
 
 `gumroad files upload` prints the canonical `file_url`; product create/update commands accept repeatable `--file` flags. Run command help for metadata, removal, replacement, and per-variant Content options.
 
+### Roll a new build
+
+For software, plugin, and asset creators, you can push a new downloadable build without opening the web editor:
+
+```sh
+# Add the latest build while preserving existing downloads
+gumroad products update <product_id> --file ./dist/plugin-v1.2.3.zip --file-name "Plugin v1.2.3.zip"
+```
+
+To replace the downloadable file set, inspect the current files first, then keep or remove the existing IDs explicitly:
+
+```sh
+# See the product payload, including existing file IDs
+gumroad products view <product_id> --json --jq '.product.files[]? | {id, name}'
+
+# Swap to a new build, preserving one existing file such as docs or examples
+gumroad products update <product_id> \
+  --replace-files \
+  --keep-file file_existing_docs \
+  --file ./dist/plugin-v1.2.3.zip \
+  --file-name "Plugin v1.2.3.zip"
+
+# Remove one obsolete file without touching the rest
+gumroad products update <product_id> --remove-file file_old_build
+```
+
+Use `--dry-run` before a scripted release, and add `--yes` when `--replace-files` or `--remove-file` would otherwise ask for confirmation in non-interactive runs.
+
 ## Product media
 
 ```sh

--- a/skills/embed_test.go
+++ b/skills/embed_test.go
@@ -109,6 +109,28 @@ func TestSkillMarkdown_ContainsProductMediaAndBulkGuidance(t *testing.T) {
 	}
 }
 
+func TestSkillMarkdown_ContainsBuildRollFileReplacementGuidance(t *testing.T) {
+	data, err := SkillMarkdown()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	content := string(data)
+	for _, example := range []string{
+		"### Rolling a new build or replacing download files",
+		"gumroad products update <id> --file ./dist/build.zip --file-name \"Build.zip\" --dry-run --json --no-input",
+		"gumroad products view <id> --json --jq '.product.files[]? | {id, name}' --no-input",
+		"gumroad products update <id> --remove-file file_old_build --yes --json --no-input",
+		"Preserve existing files by default",
+		"Use `--replace-files` only when the user",
+		"swap with repeated `--keep-file` flags",
+	} {
+		if !strings.Contains(content, example) {
+			t.Errorf("expected skill to mention build roll or file replacement guidance %q", example)
+		}
+	}
+}
+
 func TestSkillMarkdown_ContainsAdminRolloutCommands(t *testing.T) {
 	data, err := SkillMarkdown()
 	if err != nil {

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -295,6 +295,45 @@ Use `products update --file` for shared product Content. For products with per-v
 
 Use `--cover-image` for the primary cover, repeat `--preview-image` for additional gallery/preview images, and `--thumbnail` for the card/library thumbnail. These media flags run the required two-step API flow: direct upload first, then attach by signed blob ID. For an existing product, `products thumbnail set --url` asks Gumroad to download and attach a public HTTP(S) image directly.
 
+### Rolling a new build or replacing download files
+
+When a creator asks to publish a new software/plugin build, update attached
+download files, replace an existing ZIP, or push a new version to an existing
+product, do not send them to the web editor first. The CLI supports this path.
+
+Default to a dry run, then execute after confirmation:
+
+```sh
+# Add a new downloadable build while preserving current attachments.
+gumroad products update <id> --file ./dist/build.zip --file-name "Build.zip" --dry-run --json --no-input
+gumroad products update <id> --file ./dist/build.zip --file-name "Build.zip" --json --no-input
+
+# Inspect existing file IDs before replacing or removing downloads.
+gumroad products view <id> --json --jq '.product.files[]? | {id, name}' --no-input
+
+# Replace the file set, preserving selected files by ID.
+gumroad products update <id> \
+  --replace-files \
+  --keep-file file_existing_docs \
+  --file ./dist/build.zip \
+  --file-name "Build.zip" \
+  --dry-run --json --no-input
+gumroad products update <id> \
+  --replace-files \
+  --keep-file file_existing_docs \
+  --file ./dist/build.zip \
+  --file-name "Build.zip" \
+  --yes --json --no-input
+
+# Remove an obsolete build file by ID.
+gumroad products update <id> --remove-file file_old_build --dry-run --json --no-input
+gumroad products update <id> --remove-file file_old_build --yes --json --no-input
+```
+
+Preserve existing files by default. Use `--replace-files` only when the user
+explicitly wants a file-set swap, and keep any file IDs that should survive the
+swap with repeated `--keep-file` flags.
+
 ### files — Upload and recover file attachments
 
 ```sh


### PR DESCRIPTION
## What

- Adds a `Roll a new build` recipe to the README file-attachments section.
- Adds an agent-skill recipe for updating an existing product's downloadable files from the CLI.
- Shows the safe paths for append, inspect, replace-with-keep, and remove-file workflows.

## Why

Issue #129 describes a discoverability gap: the CLI can already attach and replace product download files, but creators and AI agents may conclude incorrectly that updating downloadable builds requires the web editor. This PR documents the existing path instead of adding a new command, so the first fix is small and matches current behavior.

The examples preserve existing files by default, require explicit file IDs for replacement/removal, and call out `--dry-run` plus `--yes` for non-interactive destructive file updates.

## Before/After

Before: the README and agent skill included generic `products update --file` examples, but not a build-roll workflow for existing downloadable products.

After: creators and agents have a direct recipe for adding a build, inspecting current file IDs, swapping a file set with `--replace-files --keep-file`, and removing an obsolete build.

Video: https://github.com/ai-hustle-bro/gumroad-cli/releases/download/pr-134-walkthrough-20260606/pr134-terminal-recording.mp4

Raw terminal recording: https://github.com/ai-hustle-bro/gumroad-cli/releases/download/pr-134-walkthrough-20260606/pr134-terminal.typescript

This is a script(1) terminal recording rendered to MP4. It shows the existing products update file flags, the new README/SKILL.md recipe anchors, and the local Go test run.

## Test Results

- `git diff --check` passed.
- Installed a local Go 1.26.4 toolchain from the official `go.dev/dl` Windows archive to satisfy the repo's Go 1.25+ requirement.
- First `go test ./...` run on Windows failed only in `internal/output` because `TestPager_CustomPager` sets `PAGER=cat` and this workspace did not have a `cat` executable on PATH.
- Re-ran with the local Go toolchain and Git for Windows `usr/bin` on PATH; `go test ./...` passed.
- Claude Code CLI docs review returned `READY`; follow-up review returned `READY` after the `script(1)` terminal recording was created and secret-scanned.

---

AI disclosure: This PR was prepared with GPT-5 Codex. Prompts used: inspect issue #129 and the repository docs, add the minimal README and agent-skill documentation for the existing build-file update workflow, verify the examples against source behavior, create and review a terminal walkthrough artifact, and ask Claude Code CLI to review the diff and readiness blockers.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad-cli/pr/134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783295418&installation_id=134400930&pr_number=134&repository=antiwork%2Fgumroad-cli&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad-cli%2Fpull%2F134&signature=565fb06b70e74a99f84279435b763150bb86aacd8cb5decb964218bb8d33462c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and skill embed tests only; no runtime or API behavior changes.
> 
> **Overview**
> Documents how creators and agents can **roll new product builds** and manage download files via the CLI—without implying the web editor is required.
> 
> The **README** gains a **Roll a new build** subsection under file attachments: append a build with `products update --file`, inspect file IDs with `products view --json --jq`, swap the file set with `--replace-files` and `--keep-file`, remove obsolete files with `--remove-file`, and use `--dry-run` / `--yes` for scripted or non-interactive runs.
> 
> The **agent skill** (`SKILL.md`) adds a matching **Rolling a new build or replacing download files** section with the same workflows (dry-run first, preserve-by-default, explicit replace/remove by ID). A new **`embed_test`** asserts those skill strings stay present in embedded markdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de5f9de7863eef8b2a513b8f23f7a62fa6f59569. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->