### PR TITLE
Surface product share link after publish and add products url command

### DIFF
--- a/internal/cmd/products/products.go
+++ b/internal/cmd/products/products.go
@@ -30,6 +30,7 @@ func NewProductsCmd() *cobra.Command {
   gumroad products content get <product_id> > content.json
   gumroad products content set <product_id> content.json --dry-run
   gumroad products view <id>
+  gumroad products url <id>
   gumroad products publish <id>
   gumroad products unpublish <id>
   gumroad products delete <id>
@@ -41,6 +42,7 @@ func NewProductsCmd() *cobra.Command {
 	cmd.AddCommand(newCategoriesCmd())
 	cmd.AddCommand(newListCmd())
 	cmd.AddCommand(newViewCmd())
+	cmd.AddCommand(newURLCmd())
 	cmd.AddCommand(newDeleteCmd())
 	cmd.AddCommand(newPublishCmd())
 	cmd.AddCommand(newUnpublishCmd())

--- a/internal/cmd/products/products_test.go
+++ b/internal/cmd/products/products_test.go
@@ -1220,6 +1220,87 @@ func TestPublish_Output(t *testing.T) {
 	}
 }
 
+func TestPublish_PrintsShortURL(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"success": true,
+			"product": map[string]any{
+				"id":        "p1",
+				"short_url": "https://seller.gumroad.com/l/p1",
+			},
+		})
+	})
+
+	cmd := testutil.Command(newPublishCmd(), testutil.Quiet(false))
+	out := testutil.CaptureStdout(func() { _ = cmd.RunE(cmd, []string{"p1"}) })
+	if !strings.Contains(out, " published.") {
+		t.Errorf("expected published message, got: %q", out)
+	}
+	if !strings.Contains(out, "URL: https://seller.gumroad.com/l/p1") {
+		t.Errorf("expected short_url in publish output, got: %q", out)
+	}
+}
+
+func TestPublish_PlainIncludesShortURL(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"success": true,
+			"product": map[string]any{"id": "p1", "short_url": "https://seller.gumroad.com/l/p1"},
+		})
+	})
+
+	cmd := testutil.Command(newPublishCmd(), testutil.PlainOutput())
+	out := testutil.CaptureStdout(func() { _ = cmd.RunE(cmd, []string{"p1"}) })
+	if strings.TrimSpace(out) != "true\tProduct p1 published.\thttps://seller.gumroad.com/l/p1" {
+		t.Errorf("expected short_url as third plain column, got: %q", out)
+	}
+}
+
+func TestPublish_JSONExposesShortURLAtProductPath(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"success": true,
+			"product": map[string]any{
+				"id":        "p1",
+				"short_url": "https://seller.gumroad.com/l/p1",
+			},
+		})
+	})
+
+	cmd := testutil.Command(newPublishCmd(), testutil.JSONOutput())
+	out := testutil.CaptureStdout(func() { _ = cmd.RunE(cmd, []string{"p1"}) })
+	var resp struct {
+		Success bool `json:"success"`
+		Product struct {
+			ShortURL string `json:"short_url"`
+		} `json:"product"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+	if !resp.Success {
+		t.Errorf("expected raw API response with success, got: %q", out)
+	}
+	if resp.Product.ShortURL != "https://seller.gumroad.com/l/p1" {
+		t.Errorf("expected short_url at .product.short_url (parity with products view), got: %q", out)
+	}
+}
+
+func TestPublish_QuietSuppressesURL(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"success": true,
+			"product": map[string]any{"id": "p1", "short_url": "https://seller.gumroad.com/l/p1"},
+		})
+	})
+
+	cmd := testutil.Command(newPublishCmd(), testutil.Quiet(true))
+	out := testutil.CaptureStdout(func() { _ = cmd.RunE(cmd, []string{"p1"}) })
+	if strings.TrimSpace(out) != "" {
+		t.Errorf("expected no output in quiet mode, got: %q", out)
+	}
+}
+
 func TestUnpublish_Output(t *testing.T) {
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
 		testutil.JSON(t, w, map[string]any{})
@@ -1379,7 +1460,7 @@ func TestNewProductsCmd(t *testing.T) {
 	for _, c := range cmd.Commands() {
 		subs[c.Use] = true
 	}
-	for _, name := range []string{"create", "update <product_id>", "list", "view <id>", "delete <id>", "publish <id>", "unpublish <id>", "page", "content", "covers", "thumbnail", "skus <id>"} {
+	for _, name := range []string{"create", "update <product_id>", "list", "view <id>", "url <id>", "delete <id>", "publish <id>", "unpublish <id>", "page", "content", "covers", "thumbnail", "skus <id>"} {
 		if !subs[name] {
 			t.Errorf("missing subcommand %q", name)
 		}

--- a/internal/cmd/products/publish.go
+++ b/internal/cmd/products/publish.go
@@ -1,9 +1,12 @@
 package products
 
 import (
+	"net/http"
 	"net/url"
 
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/pageutil"
 	"github.com/spf13/cobra"
 )
 
@@ -14,7 +17,27 @@ func newPublishCmd() *cobra.Command {
 		Args:  cmdutil.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
-			return cmdutil.RunRequestWithSuccess(opts, "Publishing product...", "PUT", cmdutil.JoinPath("products", args[0], "enable"), url.Values{}, args[0], "Product "+args[0]+" published.")
+			message := "Product " + args[0] + " published."
+			return cmdutil.RunRequestDecoded[pageutil.ShowResponse](
+				opts,
+				"Publishing product...",
+				http.MethodPut,
+				cmdutil.JoinPath("products", args[0], "enable"),
+				url.Values{},
+				func(resp pageutil.ShowResponse) error {
+					shareURL := pageutil.ShareURL(resp.Product)
+					if opts.PlainOutput {
+						return output.PrintPlain(opts.Out(), [][]string{{"true", message, shareURL}})
+					}
+					if err := cmdutil.PrintSuccess(opts, message); err != nil {
+						return err
+					}
+					if shareURL != "" && !opts.Quiet {
+						return output.Writef(opts.Out(), "URL: %s\n", shareURL)
+					}
+					return nil
+				},
+			)
 		},
 	}
 }

--- a/internal/cmd/products/url.go
+++ b/internal/cmd/products/url.go
@@ -1,0 +1,41 @@
+package products
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/pageutil"
+	"github.com/spf13/cobra"
+)
+
+func newURLCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "url <id>",
+		Short:   "Print a product's share link",
+		Args:    cmdutil.ExactArgs(1),
+		Example: `  gumroad products url <id>`,
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			return cmdutil.RunRequestDecoded[pageutil.ShowResponse](
+				opts,
+				"Fetching product URL...",
+				http.MethodGet,
+				cmdutil.JoinPath("products", args[0]),
+				url.Values{},
+				func(resp pageutil.ShowResponse) error {
+					shareURL := pageutil.ShareURL(resp.Product)
+					if shareURL == "" {
+						return fmt.Errorf("product %s has no share link yet; run `gumroad products view %s` to confirm it exists", args[0], args[0])
+					}
+					if opts.PlainOutput {
+						return output.PrintPlain(opts.Out(), [][]string{{shareURL}})
+					}
+					return output.Writeln(opts.Out(), shareURL)
+				},
+			)
+		},
+	}
+}

--- a/internal/cmd/products/url_test.go
+++ b/internal/cmd/products/url_test.go
@@ -1,0 +1,93 @@
+package products
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestURL_PrintsShortURL(t *testing.T) {
+	var gotMethod, gotPath string
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		testutil.JSON(t, w, map[string]any{
+			"product": map[string]any{
+				"id":        "prod1",
+				"short_url": "https://seller.gumroad.com/l/prod1",
+			},
+		})
+	})
+
+	cmd := testutil.Command(newURLCmd())
+	cmd.SetArgs([]string{"prod1"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != http.MethodGet {
+		t.Errorf("got method %q, want GET", gotMethod)
+	}
+	if gotPath != "/products/prod1" {
+		t.Errorf("got path %q, want /products/prod1", gotPath)
+	}
+	if strings.TrimSpace(out) != "https://seller.gumroad.com/l/prod1" {
+		t.Fatalf("got output %q", out)
+	}
+}
+
+func TestURL_PlainPrintsShortURL(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"product": map[string]any{
+				"id":        "prod1",
+				"short_url": "https://seller.gumroad.com/l/prod1",
+			},
+		})
+	})
+
+	cmd := testutil.Command(newURLCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{"prod1"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if strings.TrimSpace(out) != "https://seller.gumroad.com/l/prod1" {
+		t.Fatalf("got plain output %q", out)
+	}
+}
+
+func TestURL_FallsBackToLandingURL(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"product": map[string]any{
+				"id":          "prod1",
+				"landing_url": "https://seller.gumroad.com/l/prod1",
+			},
+		})
+	})
+
+	cmd := testutil.Command(newURLCmd())
+	cmd.SetArgs([]string{"prod1"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if strings.TrimSpace(out) != "https://seller.gumroad.com/l/prod1" {
+		t.Fatalf("got output %q", out)
+	}
+}
+
+func TestURL_MissingShareLinkErrors(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"product": map[string]any{"id": "prod1"},
+		})
+	})
+
+	cmd := testutil.Command(newURLCmd())
+	cmd.SetArgs([]string{"prod1"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when product response lacks a share link")
+	}
+	if !strings.Contains(err.Error(), "share link") {
+		t.Fatalf("got error %q, want it to mention share link", err.Error())
+	}
+}

--- a/internal/pageutil/api.go
+++ b/internal/pageutil/api.go
@@ -65,6 +65,18 @@ func LandingURL(product PageProduct) string {
 	return product.PermalinkURL
 }
 
+// ShareURL returns the product's public share link, preferring the canonical
+// short_url and falling back to landing_url then permalink_url.
+func ShareURL(product PageProduct) string {
+	if product.ShortURL != "" {
+		return product.ShortURL
+	}
+	if product.LandingURL != "" {
+		return product.LandingURL
+	}
+	return product.PermalinkURL
+}
+
 func HTMLParams(html string) url.Values {
 	return url.Values{"custom_html": []string{html}}
 }

--- a/internal/pageutil/api_test.go
+++ b/internal/pageutil/api_test.go
@@ -8,6 +8,25 @@ import (
 	"github.com/antiwork/gumroad-cli/internal/api"
 )
 
+func TestShareURLPrecedence(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		product PageProduct
+		want    string
+	}{
+		{"prefers short_url", PageProduct{ShortURL: "https://s/l/a", LandingURL: "https://s/l/b", PermalinkURL: "https://s/l/c"}, "https://s/l/a"},
+		{"falls back to landing_url", PageProduct{LandingURL: "https://s/l/b", PermalinkURL: "https://s/l/c"}, "https://s/l/b"},
+		{"falls back to permalink_url", PageProduct{PermalinkURL: "https://s/l/c"}, "https://s/l/c"},
+		{"empty when none present", PageProduct{}, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ShareURL(tc.product); got != tc.want {
+				t.Fatalf("ShareURL = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestTranslateRateLimitErrorPreservesAPIError(t *testing.T) {
 	err := TranslateRateLimitError(&api.APIError{
 		StatusCode: http.StatusTooManyRequests,


### PR DESCRIPTION
Closes #136

## What

- `products publish <id>` now surfaces the live product share link instead of only confirming success.
  - **Human:** prints a `URL: <short_url>` line under the success message.
  - **`--json`:** passes the API response through, so `gumroad products publish <id> --json --jq '.product.short_url'` works — mirroring the existing `products view` path.
  - **`--plain`:** appends the share link as a third column.
- New `gumroad products url <id>` command: fetches the product and echoes its share link in one line.

## Why

"I published it — what's the link to share?" is the immediate next step after publishing. Previously the creator had to re-run `gumroad products view <id> --json --jq '.product.short_url'` to dig it out. `short_url` is already returned by the API, so this is purely surfacing existing data at the moment it's needed plus a convenience shortcut.

The `enable`/`disable` endpoints already return the full product object (verified against prod — `success: true` with `product.short_url` and `product.landing_url`), so `publish` switches from the bare `RunRequestWithSuccess` mutation envelope to `RunRequestDecoded[pageutil.ShowResponse]`. This is the same pattern already used by `products page publish`. The `url` command falls back to `landing_url` when `short_url` is absent and errors clearly when neither is present.

## Breaking change

`publish --json` now returns the raw API response `{success, product}` instead of the previous mutation envelope `{success, message, id, result}`. Scripts reading `.id` / `.message` / `.result.*` from `publish --json` must move to `.product.*` (e.g. `.product.short_url`), which matches `products view`. The only internal reference to the command is an example line in `skills/gumroad/SKILL.md`, which doesn't parse any envelope field.

<img width="675" height="168" alt="image" src="https://github.com/user-attachments/assets/7615555f-18a7-4761-9f32-d954dd790fc0" />

---

AI disclosure: written by Claude Opus 4.8 (via Claude Code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad-cli/pr/137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783519478&installation_id=134400930&pr_number=137&repository=antiwork%2Fgumroad-cli&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad-cli%2Fpull%2F137&signature=1f9c20a0a8d3dba7ecd2c7d73649b5bfa50d3038e37c55d71c78bbec497ab526"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> `publish --json` output shape changes for automation; behavior is otherwise additive CLI output with shared URL resolution logic covered by tests.
> 
> **Overview**
> Adds **`gumroad products url <id>`** to fetch a product and print its public share link (via new **`pageutil.ShareURL`**, preferring `short_url`, then `landing_url`, then `permalink_url`).
> 
> **`products publish`** now decodes the enable response as **`ShowResponse`** instead of the mutation envelope from **`RunRequestWithSuccess`**, and surfaces the link in human (`URL: …`), **`--plain`** (third column), and **`--json`** (raw `{success, product}` like **`products view`**). Quiet mode still suppresses the URL line.
> 
> **Breaking:** scripts using **`publish --json`** must read **`.product.*`** instead of **`.id` / `.message` / `.result.*`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f8f0c2a98784a8395d8fbacd68488221b4d72bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->




