### PR TITLE
Add sales buyers command for deduplicated buyer export

### DIFF
--- a/internal/cmd/sales/buyers.go
+++ b/internal/cmd/sales/buyers.go
@@ -41,6 +41,10 @@ type buyersResponse struct {
 	Buyers  []buyer `json:"buyers"`
 }
 
+func (b buyer) fields() []string {
+	return []string{b.Email, b.Name, strconv.Itoa(b.PurchaseCount), b.LastPurchaseDate}
+}
+
 func newBuyersCmd() *cobra.Command {
 	var products []string
 	var before, after string
@@ -194,7 +198,7 @@ func (i *buyerIndex) add(sale buyersSaleItem) {
 	}
 
 	name := strings.TrimSpace(sale.FullName)
-	if name != "" && sale.CreatedAt >= aggregate.nameDate {
+	if name != "" && (aggregate.name == "" || sale.CreatedAt > aggregate.nameDate) {
 		aggregate.name = name
 		aggregate.nameDate = sale.CreatedAt
 	}
@@ -227,11 +231,11 @@ func renderBuyers(opts cmdutil.Options, buyers []buyer, csvOutput bool) error {
 	if csvOutput {
 		return writeBuyersCSV(opts.Out(), buyers)
 	}
-	if len(buyers) == 0 {
-		return cmdutil.PrintInfo(opts, "No buyers found.")
-	}
 	if opts.PlainOutput {
 		return writeBuyersPlain(opts.Out(), buyers)
+	}
+	if len(buyers) == 0 {
+		return cmdutil.PrintInfo(opts, "No buyers found.")
 	}
 
 	style := opts.Style()
@@ -256,7 +260,7 @@ func writeBuyersCSV(w io.Writer, buyers []buyer) error {
 		return err
 	}
 	for _, b := range buyers {
-		if err := cw.Write([]string{b.Email, b.Name, strconv.Itoa(b.PurchaseCount), b.LastPurchaseDate}); err != nil {
+		if err := cw.Write(b.fields()); err != nil {
 			return err
 		}
 	}
@@ -267,7 +271,7 @@ func writeBuyersCSV(w io.Writer, buyers []buyer) error {
 func writeBuyersPlain(w io.Writer, buyers []buyer) error {
 	var rows [][]string
 	for _, b := range buyers {
-		rows = append(rows, []string{b.Email, b.Name, strconv.Itoa(b.PurchaseCount), b.LastPurchaseDate})
+		rows = append(rows, b.fields())
 	}
 	return output.PrintPlain(w, rows)
 }
@@ -275,7 +279,7 @@ func writeBuyersPlain(w io.Writer, buyers []buyer) error {
 func writeBuyersTable(w io.Writer, style output.Styler, buyers []buyer) error {
 	tbl := output.NewStyledTable(style, "EMAIL", "NAME", "PURCHASES", "LAST PURCHASE")
 	for _, b := range buyers {
-		tbl.AddRow(b.Email, b.Name, strconv.Itoa(b.PurchaseCount), b.LastPurchaseDate)
+		tbl.AddRow(b.fields()...)
 	}
 	return tbl.Render(w)
 }

--- a/internal/cmd/sales/buyers.go
+++ b/internal/cmd/sales/buyers.go
@@ -1,0 +1,281 @@
+package sales
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/config"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+type buyersSaleItem struct {
+	Email     string `json:"email"`
+	FullName  string `json:"full_name"`
+	CreatedAt string `json:"created_at"`
+}
+
+type buyersSalesPage struct {
+	Success     bool             `json:"success"`
+	Sales       []buyersSaleItem `json:"sales"`
+	NextPageKey string           `json:"next_page_key,omitempty"`
+}
+
+type buyer struct {
+	Email            string `json:"email"`
+	Name             string `json:"name"`
+	PurchaseCount    int    `json:"purchase_count"`
+	LastPurchaseDate string `json:"last_purchase_date"`
+}
+
+type buyersResponse struct {
+	Success bool    `json:"success"`
+	Buyers  []buyer `json:"buyers"`
+}
+
+func newBuyersCmd() *cobra.Command {
+	var products []string
+	var before, after string
+	var csvOutput bool
+
+	cmd := &cobra.Command{
+		Use:   "buyers",
+		Short: "List deduplicated buyers for a product",
+		Args:  cmdutil.ExactArgs(0),
+		Long: `List the unique buyers who purchased one or more products.
+
+Buyers are deduplicated by email and aggregated across every page, so a buyer
+who purchased more than once appears a single time with a purchase count and
+their most recent purchase date. Pass --product more than once to union buyers
+across a relaunched listing's old and new IDs and dedupe them in one shot.`,
+		Example: `  gumroad sales buyers --product <id>
+  gumroad sales buyers --product <old-id> --product <new-id>
+  gumroad sales buyers --product <id> --after 2024-01-01 --csv
+  gumroad sales buyers --product <id> --json --jq '.buyers[].email'`,
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			if err := validateSalesCSVOutput(c, opts, csvOutput); err != nil {
+				return err
+			}
+			if err := cmdutil.RequireDateFlag(c, "before", before); err != nil {
+				return err
+			}
+			if err := cmdutil.RequireDateFlag(c, "after", after); err != nil {
+				return err
+			}
+
+			return runBuyers(opts, dedupeProducts(products), before, after, csvOutput)
+		},
+	}
+
+	cmd.Flags().StringArrayVar(&products, "product", nil, "Filter by product ID (repeatable)")
+	cmd.Flags().StringVar(&before, "before", "", "Filter sales before date (YYYY-MM-DD)")
+	cmd.Flags().StringVar(&after, "after", "", "Filter sales after date (YYYY-MM-DD)")
+	cmd.Flags().BoolVar(&csvOutput, "csv", false, "Output as CSV")
+
+	return cmd
+}
+
+func dedupeProducts(products []string) []string {
+	seen := make(map[string]struct{}, len(products))
+	var unique []string
+	for _, product := range products {
+		if product == "" {
+			continue
+		}
+		if _, ok := seen[product]; ok {
+			continue
+		}
+		seen[product] = struct{}{}
+		unique = append(unique, product)
+	}
+	return unique
+}
+
+func runBuyers(opts cmdutil.Options, products []string, before, after string, csvOutput bool) error {
+	token, err := config.Token()
+	if err != nil {
+		return err
+	}
+
+	sp := output.NewSpinnerTo("Fetching buyers...", opts.Err())
+	if cmdutil.ShouldShowSpinner(opts) {
+		sp.Start()
+	}
+	defer sp.Stop()
+
+	client := cmdutil.NewAPIClient(opts, token)
+	index := newBuyerIndex()
+
+	queries := buyerQueries(products, before, after)
+	for _, params := range queries {
+		if err := walkBuyerPages(opts, client, params, index.add); err != nil {
+			return err
+		}
+	}
+
+	sp.Stop()
+	return renderBuyers(opts, index.sorted(), csvOutput)
+}
+
+func buyerQueries(products []string, before, after string) []url.Values {
+	base := url.Values{}
+	if before != "" {
+		base.Set("before", before)
+	}
+	if after != "" {
+		base.Set("after", after)
+	}
+
+	if len(products) == 0 {
+		return []url.Values{base}
+	}
+
+	queries := make([]url.Values, 0, len(products))
+	for _, product := range products {
+		params := cmdutil.CloneValues(base)
+		params.Set("product_id", product)
+		queries = append(queries, params)
+	}
+	return queries
+}
+
+func walkBuyerPages(opts cmdutil.Options, client *api.Client, params url.Values, visit func(buyersSaleItem)) error {
+	return cmdutil.WalkPagesWithDelay[buyersSalesPage](opts.Context, opts.PageDelay, client, "/sales", params, func(page buyersSalesPage) string {
+		return page.NextPageKey
+	}, func(page buyersSalesPage) (bool, error) {
+		for _, sale := range page.Sales {
+			visit(sale)
+		}
+		return false, nil
+	})
+}
+
+type buyerIndex struct {
+	byEmail map[string]*buyerAggregate
+}
+
+type buyerAggregate struct {
+	email            string
+	name             string
+	nameDate         string
+	count            int
+	lastPurchaseDate string
+}
+
+func newBuyerIndex() *buyerIndex {
+	return &buyerIndex{byEmail: make(map[string]*buyerAggregate)}
+}
+
+func (i *buyerIndex) add(sale buyersSaleItem) {
+	email := strings.TrimSpace(sale.Email)
+	if email == "" {
+		return
+	}
+
+	key := strings.ToLower(email)
+	aggregate, ok := i.byEmail[key]
+	if !ok {
+		aggregate = &buyerAggregate{email: email}
+		i.byEmail[key] = aggregate
+	}
+
+	aggregate.count++
+	if sale.CreatedAt > aggregate.lastPurchaseDate {
+		aggregate.lastPurchaseDate = sale.CreatedAt
+	}
+
+	name := strings.TrimSpace(sale.FullName)
+	if name != "" && sale.CreatedAt >= aggregate.nameDate {
+		aggregate.name = name
+		aggregate.nameDate = sale.CreatedAt
+	}
+}
+
+func (i *buyerIndex) sorted() []buyer {
+	buyers := make([]buyer, 0, len(i.byEmail))
+	for _, aggregate := range i.byEmail {
+		buyers = append(buyers, buyer{
+			Email:            aggregate.email,
+			Name:             aggregate.name,
+			PurchaseCount:    aggregate.count,
+			LastPurchaseDate: aggregate.lastPurchaseDate,
+		})
+	}
+
+	sort.Slice(buyers, func(a, b int) bool {
+		if buyers[a].LastPurchaseDate != buyers[b].LastPurchaseDate {
+			return buyers[a].LastPurchaseDate > buyers[b].LastPurchaseDate
+		}
+		return buyers[a].Email < buyers[b].Email
+	})
+	return buyers
+}
+
+func renderBuyers(opts cmdutil.Options, buyers []buyer, csvOutput bool) error {
+	if opts.UsesJSONOutput() {
+		return printBuyersJSON(opts, buyers)
+	}
+	if csvOutput {
+		return writeBuyersCSV(opts.Out(), buyers)
+	}
+	if len(buyers) == 0 {
+		return cmdutil.PrintInfo(opts, "No buyers found.")
+	}
+	if opts.PlainOutput {
+		return writeBuyersPlain(opts.Out(), buyers)
+	}
+
+	style := opts.Style()
+	return output.WithPager(opts.Out(), opts.Err(), func(w io.Writer) error {
+		return writeBuyersTable(w, style, buyers)
+	})
+}
+
+func printBuyersJSON(opts cmdutil.Options, buyers []buyer) error {
+	data, err := json.Marshal(buyersResponse{Success: true, Buyers: buyers})
+	if err != nil {
+		return fmt.Errorf("could not encode JSON output: %w", err)
+	}
+	return output.PrintJSON(opts.Out(), data, opts.JQExpr)
+}
+
+var buyersCSVHeader = []string{"email", "name", "purchase_count", "last_purchase_date"}
+
+func writeBuyersCSV(w io.Writer, buyers []buyer) error {
+	cw := csv.NewWriter(w)
+	if err := cw.Write(buyersCSVHeader); err != nil {
+		return err
+	}
+	for _, b := range buyers {
+		if err := cw.Write([]string{b.Email, b.Name, strconv.Itoa(b.PurchaseCount), b.LastPurchaseDate}); err != nil {
+			return err
+		}
+	}
+	cw.Flush()
+	return cw.Error()
+}
+
+func writeBuyersPlain(w io.Writer, buyers []buyer) error {
+	var rows [][]string
+	for _, b := range buyers {
+		rows = append(rows, []string{b.Email, b.Name, strconv.Itoa(b.PurchaseCount), b.LastPurchaseDate})
+	}
+	return output.PrintPlain(w, rows)
+}
+
+func writeBuyersTable(w io.Writer, style output.Styler, buyers []buyer) error {
+	tbl := output.NewStyledTable(style, "EMAIL", "NAME", "PURCHASES", "LAST PURCHASE")
+	for _, b := range buyers {
+		tbl.AddRow(b.Email, b.Name, strconv.Itoa(b.PurchaseCount), b.LastPurchaseDate)
+	}
+	return tbl.Render(w)
+}

--- a/internal/cmd/sales/buyers_test.go
+++ b/internal/cmd/sales/buyers_test.go
@@ -196,6 +196,45 @@ func TestBuyers_DedupesEmailCaseInsensitively(t *testing.T) {
 	}
 }
 
+func TestBuyers_SameDateNameTieKeepsFirstSeenAcrossProducts(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Query().Get("product_id") {
+		case "p1":
+			testutil.JSON(t, w, map[string]any{
+				"sales": []map[string]any{
+					{"email": "tie@example.com", "full_name": "First Seen", "created_at": "2024-06-01"},
+				},
+			})
+		case "p2":
+			testutil.JSON(t, w, map[string]any{
+				"sales": []map[string]any{
+					{"email": "tie@example.com", "full_name": "Second Seen", "created_at": "2024-06-01"},
+				},
+			})
+		default:
+			t.Fatalf("unexpected product_id %q", r.URL.Query().Get("product_id"))
+		}
+	})
+
+	cmd := testutil.Command(newBuyersCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--product", "p1", "--product", "p2"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp buyersResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if len(resp.Buyers) != 1 {
+		t.Fatalf("expected 1 buyer, got %+v", resp.Buyers)
+	}
+	if resp.Buyers[0].Name != "First Seen" {
+		t.Fatalf("got name %q, want First Seen (same-date tie must keep first-seen deterministically)", resp.Buyers[0].Name)
+	}
+	if resp.Buyers[0].PurchaseCount != 2 {
+		t.Fatalf("got count %d, want 2", resp.Buyers[0].PurchaseCount)
+	}
+}
+
 func TestBuyers_KeepsLatestNonEmptyName(t *testing.T) {
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
 		testutil.JSON(t, w, map[string]any{
@@ -397,6 +436,42 @@ func TestBuyers_Empty(t *testing.T) {
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 	if !strings.Contains(out, "No buyers found.") {
 		t.Fatalf("expected empty message, got %q", out)
+	}
+}
+
+func TestBuyers_EmptyPlainIsSilent(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{"sales": []any{}})
+	})
+
+	cmd := testutil.Command(newBuyersCmd(), testutil.PlainOutput(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--product", "p1"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if strings.TrimSpace(out) != "" {
+		t.Fatalf("expected empty --plain output for pipe-friendliness, got %q", out)
+	}
+}
+
+func TestBuyers_CapturesNameWhenCreatedAtMissing(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"sales": []map[string]any{
+				{"email": "a@example.com", "full_name": "Anonymous Date"},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newBuyersCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--product", "p1"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp buyersResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if len(resp.Buyers) != 1 || resp.Buyers[0].Name != "Anonymous Date" {
+		t.Fatalf("expected name captured even without created_at, got %+v", resp.Buyers)
 	}
 }
 

--- a/internal/cmd/sales/buyers_test.go
+++ b/internal/cmd/sales/buyers_test.go
@@ -1,0 +1,472 @@
+package sales
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestBuyers_AggregatesAndDedupesAcrossPages(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Query().Get("page_key") {
+		case "":
+			testutil.JSON(t, w, map[string]any{
+				"sales": []map[string]any{
+					{"email": "a@example.com", "full_name": "Alice", "created_at": "2024-01-10"},
+				},
+				"next_page_key": "cursor1",
+			})
+		case "cursor1":
+			testutil.JSON(t, w, map[string]any{
+				"sales": []map[string]any{
+					{"email": "a@example.com", "full_name": "Alice Anderson", "created_at": "2024-03-01"},
+					{"email": "b@example.com", "full_name": "Bob", "created_at": "2024-02-01"},
+				},
+			})
+		default:
+			t.Fatalf("unexpected page_key %q", r.URL.Query().Get("page_key"))
+		}
+	})
+
+	cmd := testutil.Command(newBuyersCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--product", "p1"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp buyersResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if !resp.Success {
+		t.Fatalf("expected success, got %+v", resp)
+	}
+	want := []buyer{
+		{Email: "a@example.com", Name: "Alice Anderson", PurchaseCount: 2, LastPurchaseDate: "2024-03-01"},
+		{Email: "b@example.com", Name: "Bob", PurchaseCount: 1, LastPurchaseDate: "2024-02-01"},
+	}
+	if len(resp.Buyers) != len(want) {
+		t.Fatalf("got %d buyers, want %d: %+v", len(resp.Buyers), len(want), resp.Buyers)
+	}
+	for i, b := range want {
+		if resp.Buyers[i] != b {
+			t.Fatalf("buyer %d = %+v, want %+v", i, resp.Buyers[i], b)
+		}
+	}
+}
+
+func TestBuyers_SortsByLastPurchaseDateDescendingThenEmail(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"sales": []map[string]any{
+				{"email": "old@example.com", "full_name": "Old", "created_at": "2024-01-01"},
+				{"email": "newer@example.com", "full_name": "Newer", "created_at": "2024-05-01"},
+				{"email": "alpha@example.com", "full_name": "Alpha", "created_at": "2024-05-01"},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newBuyersCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--product", "p1"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp buyersResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	gotEmails := make([]string, 0, len(resp.Buyers))
+	for _, b := range resp.Buyers {
+		gotEmails = append(gotEmails, b.Email)
+	}
+	wantEmails := []string{"alpha@example.com", "newer@example.com", "old@example.com"}
+	if strings.Join(gotEmails, ",") != strings.Join(wantEmails, ",") {
+		t.Fatalf("got order %v, want %v", gotEmails, wantEmails)
+	}
+}
+
+func TestBuyers_UnionsAcrossProductsAndDedupes(t *testing.T) {
+	var requestedProducts []string
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		product := r.URL.Query().Get("product_id")
+		requestedProducts = append(requestedProducts, product)
+		switch product {
+		case "p1":
+			testutil.JSON(t, w, map[string]any{
+				"sales": []map[string]any{
+					{"email": "a@example.com", "full_name": "Alice", "created_at": "2024-01-10"},
+				},
+			})
+		case "p2":
+			testutil.JSON(t, w, map[string]any{
+				"sales": []map[string]any{
+					{"email": "a@example.com", "full_name": "Alice", "created_at": "2024-02-10"},
+					{"email": "c@example.com", "full_name": "Carol", "created_at": "2024-02-15"},
+				},
+			})
+		default:
+			t.Fatalf("unexpected product_id %q", product)
+		}
+	})
+
+	cmd := testutil.Command(newBuyersCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--product", "p1", "--product", "p2"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp buyersResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	byEmail := map[string]buyer{}
+	for _, b := range resp.Buyers {
+		byEmail[b.Email] = b
+	}
+	if got := byEmail["a@example.com"]; got.PurchaseCount != 2 || got.LastPurchaseDate != "2024-02-10" {
+		t.Fatalf("buyer a aggregated wrong: %+v", got)
+	}
+	if got := byEmail["c@example.com"]; got.PurchaseCount != 1 {
+		t.Fatalf("buyer c aggregated wrong: %+v", got)
+	}
+
+	sort.Strings(requestedProducts)
+	if strings.Join(requestedProducts, ",") != "p1,p2" {
+		t.Fatalf("got requested products %v, want one p1 and one p2", requestedProducts)
+	}
+}
+
+func TestBuyers_DuplicateProductFlagsCountedOnce(t *testing.T) {
+	requests := 0
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if got := r.URL.Query().Get("product_id"); got != "p1" {
+			t.Fatalf("got product_id=%q, want p1", got)
+		}
+		testutil.JSON(t, w, map[string]any{
+			"sales": []map[string]any{
+				{"email": "a@example.com", "full_name": "Alice", "created_at": "2024-01-10"},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newBuyersCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--product", "p1", "--product", "p1"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if requests != 1 {
+		t.Fatalf("got %d requests, want 1 (duplicate --product must be deduped)", requests)
+	}
+	var resp buyersResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if len(resp.Buyers) != 1 || resp.Buyers[0].PurchaseCount != 1 {
+		t.Fatalf("expected single buyer counted once, got %+v", resp.Buyers)
+	}
+}
+
+func TestBuyers_DedupesEmailCaseInsensitively(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"sales": []map[string]any{
+				{"email": "Buyer@Example.com", "full_name": "Buyer", "created_at": "2024-01-10"},
+				{"email": "buyer@example.com", "full_name": "Buyer", "created_at": "2024-02-10"},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newBuyersCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--product", "p1"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp buyersResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if len(resp.Buyers) != 1 {
+		t.Fatalf("expected 1 deduped buyer, got %+v", resp.Buyers)
+	}
+	if resp.Buyers[0].PurchaseCount != 2 {
+		t.Fatalf("got count %d, want 2", resp.Buyers[0].PurchaseCount)
+	}
+	if resp.Buyers[0].Email != "Buyer@Example.com" {
+		t.Fatalf("got email %q, want first-seen Buyer@Example.com", resp.Buyers[0].Email)
+	}
+}
+
+func TestBuyers_KeepsLatestNonEmptyName(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"sales": []map[string]any{
+				{"email": "d@example.com", "full_name": "Dave", "created_at": "2024-01-01"},
+				{"email": "d@example.com", "full_name": "", "created_at": "2024-05-01"},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newBuyersCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--product", "p1"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp buyersResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if len(resp.Buyers) != 1 {
+		t.Fatalf("expected 1 buyer, got %+v", resp.Buyers)
+	}
+	got := resp.Buyers[0]
+	if got.Name != "Dave" {
+		t.Fatalf("got name %q, want Dave (latest non-empty)", got.Name)
+	}
+	if got.LastPurchaseDate != "2024-05-01" {
+		t.Fatalf("got last purchase %q, want 2024-05-01", got.LastPurchaseDate)
+	}
+}
+
+func TestBuyers_SkipsRowsWithoutEmail(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"sales": []map[string]any{
+				{"email": "", "full_name": "Anonymous", "created_at": "2024-01-10"},
+				{"email": "a@example.com", "full_name": "Alice", "created_at": "2024-01-11"},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newBuyersCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--product", "p1"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp buyersResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if len(resp.Buyers) != 1 || resp.Buyers[0].Email != "a@example.com" {
+		t.Fatalf("expected only the buyer with an email, got %+v", resp.Buyers)
+	}
+}
+
+func TestBuyers_SendsDateFilters(t *testing.T) {
+	var gotQuery string
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		testutil.JSON(t, w, map[string]any{"sales": []any{}})
+	})
+
+	cmd := testutil.Command(newBuyersCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--product", "p1", "--before", "2024-12-31", "--after", "2024-01-01"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	for _, param := range []string{"product_id=p1", "before=2024-12-31", "after=2024-01-01"} {
+		if !strings.Contains(gotQuery, param) {
+			t.Errorf("query missing param %q in %q", param, gotQuery)
+		}
+	}
+}
+
+func TestBuyers_NoProductAggregatesAllSales(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("product_id"); got != "" {
+			t.Fatalf("expected no product_id filter, got %q", got)
+		}
+		testutil.JSON(t, w, map[string]any{
+			"sales": []map[string]any{
+				{"email": "a@example.com", "full_name": "Alice", "created_at": "2024-01-10"},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newBuyersCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp buyersResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if len(resp.Buyers) != 1 {
+		t.Fatalf("expected 1 buyer, got %+v", resp.Buyers)
+	}
+}
+
+func TestBuyers_CSVOutput(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"sales": []map[string]any{
+				{"email": "a@example.com", "full_name": "Alice, Jr", "created_at": "2024-03-01"},
+				{"email": "a@example.com", "full_name": "Alice, Jr", "created_at": "2024-01-01"},
+				{"email": "b@example.com", "full_name": "Bob", "created_at": "2024-02-01"},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newBuyersCmd())
+	cmd.SetArgs([]string{"--product", "p1", "--csv"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	records := readCSVRecords(t, out)
+	want := [][]string{
+		{"email", "name", "purchase_count", "last_purchase_date"},
+		{"a@example.com", "Alice, Jr", "2", "2024-03-01"},
+		{"b@example.com", "Bob", "1", "2024-02-01"},
+	}
+	assertCSVRecords(t, records, want)
+}
+
+func TestBuyers_EmptyCSVWritesHeader(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{"sales": []any{}})
+	})
+
+	cmd := testutil.Command(newBuyersCmd())
+	cmd.SetArgs([]string{"--product", "p1", "--csv"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	records := readCSVRecords(t, out)
+	want := [][]string{{"email", "name", "purchase_count", "last_purchase_date"}}
+	assertCSVRecords(t, records, want)
+}
+
+func TestBuyers_Plain(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"sales": []map[string]any{
+				{"email": "a@example.com", "full_name": "Alice", "created_at": "2024-03-01"},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newBuyersCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{"--product", "p1"})
+	out := strings.TrimSpace(testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) }))
+
+	want := "a@example.com\tAlice\t1\t2024-03-01"
+	if out != want {
+		t.Fatalf("got plain output %q, want %q", out, want)
+	}
+}
+
+func TestBuyers_Table(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"sales": []map[string]any{
+				{"email": "a@example.com", "full_name": "Alice", "created_at": "2024-03-01"},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newBuyersCmd(), testutil.Quiet(false), testutil.NoColor(true))
+	cmd.SetArgs([]string{"--product", "p1"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	for _, want := range []string{"EMAIL", "NAME", "PURCHASES", "LAST PURCHASE", "a@example.com", "Alice", "2024-03-01"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in table output %q", want, out)
+		}
+	}
+}
+
+func TestBuyers_JQ(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"sales": []map[string]any{
+				{"email": "a@example.com", "full_name": "Alice", "created_at": "2024-03-01"},
+				{"email": "b@example.com", "full_name": "Bob", "created_at": "2024-02-01"},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newBuyersCmd(), testutil.JQ(".buyers | length"))
+	cmd.SetArgs([]string{"--product", "p1"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if strings.TrimSpace(out) != "2" {
+		t.Fatalf("got %q, want 2", out)
+	}
+}
+
+func TestBuyers_Empty(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{"sales": []any{}})
+	})
+
+	cmd := testutil.Command(newBuyersCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--product", "p1"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if !strings.Contains(out, "No buyers found.") {
+		t.Fatalf("expected empty message, got %q", out)
+	}
+}
+
+func TestBuyers_EmptyJSONReturnsEmptyArray(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{"sales": []any{}})
+	})
+
+	cmd := testutil.Command(newBuyersCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--product", "p1"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, `"buyers": []`) {
+		t.Fatalf("expected empty buyers array, got %q", out)
+	}
+}
+
+func TestBuyers_CSVRejectsOtherOutputModes(t *testing.T) {
+	tests := []struct {
+		name    string
+		command *cobra.Command
+	}{
+		{"json", testutil.Command(newBuyersCmd(), testutil.JSONOutput())},
+		{"jq", testutil.Command(newBuyersCmd(), testutil.JQ(".buyers"))},
+		{"plain", testutil.Command(newBuyersCmd(), testutil.PlainOutput())},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+				t.Error("should not reach API with conflicting output flags")
+			})
+
+			tt.command.SetArgs([]string{"--product", "p1", "--csv"})
+			err := tt.command.Execute()
+			if err == nil {
+				t.Fatal("expected conflicting output mode error")
+			}
+			if !strings.Contains(err.Error(), "--csv cannot be combined with --json, --jq, or --plain") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestBuyers_InvalidAfterDate(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API with invalid date")
+	})
+
+	cmd := newBuyersCmd()
+	cmd.SetArgs([]string{"--after", "2024-13-01"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !strings.Contains(err.Error(), "--after must be a valid date in YYYY-MM-DD format") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBuyers_InvalidJSON(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.RawJSON(t, w, `{"sales":`)
+	})
+
+	cmd := testutil.Command(newBuyersCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--product", "p1"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "could not parse response") {
+		t.Fatalf("expected parse error, got: %v", err)
+	}
+}

--- a/internal/cmd/sales/sales.go
+++ b/internal/cmd/sales/sales.go
@@ -9,6 +9,7 @@ func NewSalesCmd() *cobra.Command {
 		Use:   "sales",
 		Short: "Manage sales",
 		Example: `  gumroad sales list
+  gumroad sales buyers --product <id>
   gumroad sales summary
   gumroad sales export --from 2026-01-01 --to 2026-05-21
   gumroad sales view <id>
@@ -16,6 +17,7 @@ func NewSalesCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(newListCmd())
+	cmd.AddCommand(newBuyersCmd())
 	cmd.AddCommand(newSummaryCmd())
 	cmd.AddCommand(newExportCmd())
 	cmd.AddCommand(newViewCmd())

--- a/internal/cmd/sales/sales_test.go
+++ b/internal/cmd/sales/sales_test.go
@@ -1461,7 +1461,7 @@ func TestNewSalesCmd_Subcommands(t *testing.T) {
 	if cmd.Use != "sales" {
 		t.Fatalf("got use=%q, want %q", cmd.Use, "sales")
 	}
-	for _, name := range []string{"list", "summary", "export", "view", "refund", "ship", "resend-receipt"} {
+	for _, name := range []string{"list", "buyers", "summary", "export", "view", "refund", "ship", "resend-receipt"} {
 		if child, _, err := cmd.Find([]string{name}); err != nil || child == nil || child.Name() != name {
 			t.Fatalf("expected subcommand %q to be registered, got child=%v err=%v", name, child, err)
 		}

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -55,6 +55,7 @@ Most responses are wrapped in `{"success": true, ...}` with resource-specific ke
 - `products content get` → rich content page array directly
 - `products content set` → mutation envelope with `.result`
 - `sales list` → `.sales[]`
+- `sales buyers` → `.buyers[]`
 - `sales view` → `.sale`
 - `sales export` → `.status`, `.recipient_email`
 - `sales summary` → `.gross_cents`, `.net_cents`, `.breakdown[]`
@@ -329,6 +330,12 @@ gumroad sales list --after 2024-01-01 --before 2024-01-31 --csv --no-input
 
 # Find a sale by email
 gumroad sales list --json --jq '.sales[] | select(.email == "user@example.com")' --no-input
+
+# Deduplicated buyer list for one or more products (email, name, purchase count, last purchase date)
+gumroad sales buyers --product <id> --json --no-input
+gumroad sales buyers --product <old-id> --product <new-id> --json --no-input
+gumroad sales buyers --product <id> --after 2024-01-01 --csv --no-input
+gumroad sales buyers --product <id> --json --jq '.buyers[].email' --no-input
 
 # Show sales totals
 gumroad sales summary --json --no-input


### PR DESCRIPTION
Closes #135

## What

Adds `gumroad sales buyers`, a buyer-centric shortcut that returns the deduplicated list of people who purchased one or more products — email, name, purchase count, and last purchase date — in table (default), `--csv`, `--json`/`--jq`, and `--plain` modes.

- **`--product` is repeatable** — unions buyers across a relaunched listing's old and new IDs and dedupes them in one shot. Duplicate `--product` values are collapsed so a buyer is never double-counted.
- **Dedup by email, case-insensitively** — displays the first-seen casing; `purchase_count` sums across all matching rows and products; `last_purchase_date` is the max `created_at`; name is taken from the most recent purchase that has a non-empty name; rows without an email are skipped.
- **`--before` / `--after`** date filters, consistent with `sales list`.
- Buyers always aggregate across every page, so there is no `--all` flag — the command inherently fetches everything for the given product(s) before rendering.

## Why

A creator relaunched a listing and had ~10 buyers on the old one they wanted to make an offer to, but had to pull emails out of the raw `sales list --csv --all` output and dedupe by hand. A direct, deduplicated buyer export is the natural primitive for "email my past customers about the new thing."

I chose a dedicated `sales buyers` subcommand over a `--previous-buyers` flag on `list` (the issue offered both). A flag would force `list` to silently switch from per-row to aggregated output, which conflicts with its streaming/pagination contract; a separate command keeps each command's output shape clean.

<img width="842" height="144" alt="image" src="https://github.com/user-attachments/assets/773d6eef-2608-4fb8-8138-d887b6e5c7e7" />

.

<img width="1102" height="161" alt="image" src="https://github.com/user-attachments/assets/f3080e08-677e-45e1-8c67-cb8c86578235" />

.

<img width="868" height="144" alt="image" src="https://github.com/user-attachments/assets/c4ecbf81-a5d2-44ee-b7b4-3745591679a0" />

.

<img width="1066" height="126" alt="image" src="https://github.com/user-attachments/assets/3ab2bba5-c20b-45f1-91da-98d9e707014b" />

---

AI disclosure: implemented with Claude Opus 4.8 (1M context) via Claude Code.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad-cli/pr/141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783594378&installation_id=134400930&pr_number=141&repository=antiwork%2Fgumroad-cli&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad-cli%2Fpull%2F141&signature=9a11f87f92c6cbfc5ba528bec9e0fac199676bd7d9ae3d992719d660b079457a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Read-only CLI that aggregates buyer emails (PII) from sales API; behavior is well-tested but wrong dedupe rules could mislead outreach lists.
> 
> **Overview**
> Adds **`gumroad sales buyers`**, a new `sales` subcommand that walks all `/sales` pages and returns a **deduplicated buyer list** (email, name, purchase count, last purchase date) instead of raw per-sale rows.
> 
> Aggregation is **by email** (case-insensitive): counts stack across pages and products, **repeatable `--product`** unions multiple product IDs (duplicate flags collapsed), and **`--before` / `--after`** match `sales list`. Output supports table (default), `--csv`, `--json` / `--jq` (`.buyers[]`), and `--plain`; the command always fetches every page—there is no `--all` flag.
> 
> `sales` registration, subcommand tests, and **`skills/gumroad/SKILL.md`** are updated to document the new command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4f7db3bbb16e965081c5ec516b87e8de5c95ea7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->