### PR TITLE
Surface admin-vs-creator token mismatch on auth failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ Run `gumroad --help` and `gumroad <command> --help` for subcommands, usage detai
 
 Admin commands use a separate internal token. Run `gumroad auth login --web` and check the admin box to store one locally, or use `GUMROAD_ADMIN_TOKEN` with `--non-interactive` in CI and agent runs. For local testing, set `GUMROAD_ADMIN_API_BASE_URL`.
 
+### Which token does a command use?
+
+| Command group | Token | Env var |
+|---|---|---|
+| `user`, `products`, `sales`, `files`, `subscribers`, `payouts`, `licenses`, `offercodes`, `webhooks`, … | Seller access token | `GUMROAD_ACCESS_TOKEN` |
+| `gumroad admin …` | Admin token (separate credential) | `GUMROAD_ADMIN_TOKEN` |
+
+The two are not interchangeable. If a seller command fails with `not_authenticated` while `GUMROAD_ADMIN_TOKEN` is set — either alone, or copied into `GUMROAD_ACCESS_TOKEN` — you need a seller token: set `GUMROAD_ACCESS_TOKEN` to a seller token or run `gumroad auth login`.
+
 ## Refund policy
 
 ```sh

--- a/internal/cmd/errors.go
+++ b/internal/cmd/errors.go
@@ -175,7 +175,7 @@ func classifyPrimaryCause(err error) commandErrorDetail {
 			Type:       "api_error",
 			Code:       apiErrorCode(apiErr.StatusCode),
 			Message:    apiErr.Error(),
-			Hint:       apiErr.GetHint(),
+			Hint:       sellerAuthHint(apiErr),
 			StatusCode: apiErr.StatusCode,
 		}
 	case errors.Is(err, adminconfig.ErrNotAuthenticated):
@@ -193,6 +193,9 @@ func classifyPrimaryCause(err error) commandErrorDetail {
 		hint := api.HintRunAuthLogin
 		if strings.Contains(err.Error(), "gumroad auth login") {
 			hint = ""
+		}
+		if errors.Is(err, config.ErrNotAuthenticated) && adminEnvTokenButNoSellerEnv() {
+			hint = crossTokenAuthHintNoSellerEnv
 		}
 		return commandErrorDetail{
 			Type:    "auth_error",
@@ -225,6 +228,34 @@ func invalidInputErrorDetail(message string) commandErrorDetail {
 		Code:    "invalid_input",
 		Message: message,
 	}
+}
+
+const crossTokenAuthHintTail = " This is a seller command and needs a seller access token (a different credential). " +
+	"Run `gumroad auth login`, or set " + config.EnvAccessToken + " to a seller token. " +
+	"Admin commands use `gumroad admin ...`."
+
+const crossTokenAuthHintNoSellerEnv = adminconfig.EnvAccessToken + " is set but " + config.EnvAccessToken + " is not." + crossTokenAuthHintTail
+
+const crossTokenAuthHintAdminInAccessSlot = config.EnvAccessToken + " is set to your admin token." + crossTokenAuthHintTail
+
+// Guards on HintRunAuthLogin so admin-surface 401s are left alone: adminapi
+// rewrites their hint to HintSetAdminToken.
+func sellerAuthHint(apiErr *api.APIError) string {
+	if apiErr.StatusCode == 401 && apiErr.GetHint() == api.HintRunAuthLogin && sellerEnvTokenIsAdminToken() {
+		return crossTokenAuthHintAdminInAccessSlot
+	}
+	return apiErr.GetHint()
+}
+
+func adminEnvTokenButNoSellerEnv() bool {
+	return adminconfig.HasEnvToken() && strings.TrimSpace(os.Getenv(config.EnvAccessToken)) == ""
+}
+
+// Requires an exact env match, not just an empty access var: on a 401 the
+// rejected token may have been a stored seller token, which is no mismatch.
+func sellerEnvTokenIsAdminToken() bool {
+	access := strings.TrimSpace(os.Getenv(config.EnvAccessToken))
+	return access != "" && access == strings.TrimSpace(os.Getenv(adminconfig.EnvAccessToken))
 }
 
 // mergeCleanupRecovery attaches cleanup orphan handles as secondary recovery
@@ -385,7 +416,7 @@ func completeRejectedClassification(err error, rejected *files.CompleteRejectedE
 				Type:       "api_error",
 				Code:       code,
 				Message:    apiErr.Error(),
-				Hint:       apiErr.GetHint(),
+				Hint:       sellerAuthHint(apiErr),
 				StatusCode: apiErr.StatusCode,
 				Recovery:   recovery,
 			}

--- a/internal/cmd/errors_test.go
+++ b/internal/cmd/errors_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -20,6 +21,14 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
+
+// Pin an empty auth env so the env-aware hint tests ignore the runner's
+// ambient tokens; per-test t.Setenv restores to this baseline.
+func TestMain(m *testing.M) {
+	os.Unsetenv(config.EnvAccessToken)
+	os.Unsetenv(adminconfig.EnvAccessToken)
+	os.Exit(m.Run())
+}
 
 func TestPrintStructuredCommandError(t *testing.T) {
 	var buf bytes.Buffer
@@ -67,6 +76,90 @@ func TestClassifyCommandError_AuthHint(t *testing.T) {
 	detail := classifyCommandError(config.ErrNotAuthenticated)
 	if detail.Hint != api.HintRunAuthLogin {
 		t.Errorf("got hint %q, want %q", detail.Hint, api.HintRunAuthLogin)
+	}
+}
+
+func TestClassifySellerAuthErrorWithOnlyAdminTokenAddsCrossTokenHint(t *testing.T) {
+	t.Setenv(adminconfig.EnvAccessToken, "admin-tok")
+	t.Setenv(config.EnvAccessToken, "")
+	detail := classifyCommandError(config.ErrNotAuthenticated)
+	if detail.Hint != crossTokenAuthHintNoSellerEnv {
+		t.Fatalf("expected Path-A cross-token hint, got %q", detail.Hint)
+	}
+}
+
+func TestClassifyConfigAuthWithRemediationAndAdminTokenShowsCrossTokenHint(t *testing.T) {
+	t.Setenv(adminconfig.EnvAccessToken, "admin-tok")
+	t.Setenv(config.EnvAccessToken, "")
+	wrapped := fmt.Errorf("%w. Run `gumroad auth login`, set `GUMROAD_ACCESS_TOKEN`, or pipe an existing token into `gumroad auth login --with-token`", config.ErrNotAuthenticated)
+	detail := classifyCommandError(wrapped)
+	if detail.Hint != crossTokenAuthHintNoSellerEnv {
+		t.Fatalf("expected cross-token hint to override suppressed hint, got %q", detail.Hint)
+	}
+}
+
+func TestClassifySeller401WithAdminTokenInAccessSlotAddsCrossTokenHint(t *testing.T) {
+	t.Setenv(adminconfig.EnvAccessToken, "tok")
+	t.Setenv(config.EnvAccessToken, "tok")
+	detail := classifyCommandError(&api.APIError{StatusCode: 401, Message: "Not authenticated.", Hint: api.HintRunAuthLogin})
+	if detail.Hint != crossTokenAuthHintAdminInAccessSlot {
+		t.Fatalf("expected Path-B cross-token hint, got %q", detail.Hint)
+	}
+}
+
+func TestClassifyCompleteRejected401WithAdminTokenInAccessSlotAddsCrossTokenHint(t *testing.T) {
+	t.Setenv(adminconfig.EnvAccessToken, "tok")
+	t.Setenv(config.EnvAccessToken, "tok")
+	rejected := &files.CompleteRejectedError{
+		UploadID:       "up-x",
+		Key:            "attachments/u/k/original/p.bin",
+		CompletedParts: []upload.CompletedPart{{PartNumber: 1, ETag: "e1"}},
+		Cause:          &api.APIError{StatusCode: 401, Message: "Not authenticated.", Hint: api.HintRunAuthLogin},
+	}
+	detail := classifyCommandError(rejected)
+	if detail.Hint != crossTokenAuthHintAdminInAccessSlot {
+		t.Fatalf("expected Path-B cross-token hint on complete-rejected, got %q", detail.Hint)
+	}
+	if detail.Recovery == nil || detail.Recovery.UploadID != "up-x" {
+		t.Fatalf("recovery handles must be preserved, got %+v", detail.Recovery)
+	}
+}
+
+func TestClassifySeller401WithStoredSellerTokenKeepsGenericHint(t *testing.T) {
+	t.Setenv(adminconfig.EnvAccessToken, "admin-tok")
+	t.Setenv(config.EnvAccessToken, "")
+	detail := classifyCommandError(&api.APIError{StatusCode: 401, Message: "Not authenticated.", Hint: api.HintRunAuthLogin})
+	if detail.Hint != api.HintRunAuthLogin {
+		t.Fatalf("empty access env must not trigger cross-token hint on 401, got %q", detail.Hint)
+	}
+}
+
+func TestClassifySeller401WithDistinctSellerTokenKeepsGenericHint(t *testing.T) {
+	t.Setenv(adminconfig.EnvAccessToken, "admin-tok")
+	t.Setenv(config.EnvAccessToken, "some-other-seller-tok")
+	detail := classifyCommandError(&api.APIError{StatusCode: 401, Message: "Not authenticated.", Hint: api.HintRunAuthLogin})
+	if detail.Hint != api.HintRunAuthLogin {
+		t.Fatalf("expected generic hint, got %q", detail.Hint)
+	}
+}
+
+func TestClassifyAdminSurface401KeepsAdminHint(t *testing.T) {
+	t.Setenv(adminconfig.EnvAccessToken, "admin-tok")
+	t.Setenv(config.EnvAccessToken, "admin-tok")
+	detail := classifyCommandError(&api.APIError{StatusCode: 401, Message: "Not authenticated.", Hint: adminconfig.HintSetAdminToken})
+	if detail.Hint != adminconfig.HintSetAdminToken {
+		t.Fatalf("admin hint must be preserved, got %q", detail.Hint)
+	}
+}
+
+func TestClassifySellerAuthErrorsWithoutAdminTokenKeepGenericHint(t *testing.T) {
+	t.Setenv(adminconfig.EnvAccessToken, "")
+	t.Setenv(config.EnvAccessToken, "")
+	if got := classifyCommandError(&api.APIError{StatusCode: 401, Message: "x", Hint: api.HintRunAuthLogin}).Hint; got != api.HintRunAuthLogin {
+		t.Fatalf("401 without admin token: expected generic hint, got %q", got)
+	}
+	if got := classifyCommandError(config.ErrNotAuthenticated).Hint; got != api.HintRunAuthLogin {
+		t.Fatalf("config.ErrNotAuthenticated without admin token: expected generic hint, got %q", got)
 	}
 }
 


### PR DESCRIPTION
Fixes #124

## What

When a creator command fails auth while `GUMROAD_ADMIN_TOKEN` is in the environment, the `not_authenticated` error now says the command needs a creator token (`GUMROAD_ACCESS_TOKEN`), not the admin token — in both human and `--json` output. Two cases are detected: no creator token with an admin env token set, and `GUMROAD_ACCESS_TOKEN` set to the admin token's value. The README documents which commands use which token.

## Why

The admin and creator tokens are intentionally distinct, but a bare `not_authenticated` gave no hint about *which* token surface was in play, so agents and operators with both configured debugged the wrong credential. Found during a dogfooding agent run (antiwork/gumroad-private#452).

Detection is env-token-only (matching the CI/agent scope) and lives at the error-classification layer, the single sync point for human and JSON hints. Admin commands are unaffected — their 401 hint is rewritten separately in `adminapi`.

## Before/After

Before:
```
Error: not authenticated. Run `gumroad auth login`, set `GUMROAD_ACCESS_TOKEN`, ...
```

After:
```
Error: not authenticated. Run `gumroad auth login`, set `GUMROAD_ACCESS_TOKEN`, ...
Hint: GUMROAD_ADMIN_TOKEN is set but GUMROAD_ACCESS_TOKEN is not. This is a creator command and needs a creator access token (a different credential). Run `gumroad auth login`, or set GUMROAD_ACCESS_TOKEN to a creator token. Admin commands use `gumroad admin ...`.
```

---

This PR was implemented with AI assistance using Claude Opus 4.8.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only error hints and README guidance; credential resolution and API behavior are unchanged, with env-based guards to avoid false positives on stored seller tokens.
> 
> **Overview**
> Seller **`not_authenticated`** failures now get **cross-token hints** when env setup suggests an admin/seller mix-up, so human and **`--json`** output explain that seller commands need **`GUMROAD_ACCESS_TOKEN`**, not the admin credential.
> 
> **`classifyCommandError`** adds two env-only cases: **`GUMROAD_ADMIN_TOKEN`** set with no seller env var, and **`GUMROAD_ACCESS_TOKEN`** equal to the admin token. **`sellerAuthHint`** applies the same logic to seller **401** API errors (including upload **complete-rejected** auth paths) while leaving admin-surface hints unchanged. The README adds a **which token does a command use?** table and a short troubleshooting note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3102c64d9bcb7b59927701fd71972da758182b85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad-cli/pr/144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783608795&installation_id=134400930&pr_number=144&repository=antiwork%2Fgumroad-cli&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad-cli%2Fpull%2F144&signature=11a3b3865099fb78056fad6acf016c7f682021fca5044034a3806a964ae976d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->