### PR TITLE
Normalize products write verbs to a flat JSON envelope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Binaries
-/gr
+/gumroad
 /dist/
 /man/
 *.exe

--- a/internal/cmd/products/delete.go
+++ b/internal/cmd/products/delete.go
@@ -22,7 +22,7 @@ func newDeleteCmd() *cobra.Command {
 				return cmdutil.PrintCancelledAction(opts, "delete product "+args[0], args[0])
 			}
 
-			return cmdutil.RunRequestWithSuccess(opts, "Deleting product...", "DELETE", cmdutil.JoinPath("products", args[0]), url.Values{}, args[0], "Product "+args[0]+" deleted.")
+			return cmdutil.RunRequestWithResource(opts, "Deleting product...", "DELETE", cmdutil.JoinPath("products", args[0]), url.Values{}, args[0], "Product "+args[0]+" deleted.")
 		},
 	}
 }

--- a/internal/cmd/products/product_media_attach.go
+++ b/internal/cmd/products/product_media_attach.go
@@ -138,9 +138,9 @@ func mergeProductMediaResult(data json.RawMessage, media []productMediaAttachmen
 	}
 	trimmed := bytes.TrimSpace(normalized)
 	if len(trimmed) == 0 || string(trimmed) == "null" {
-		return appendJSONField(nil, "media", mediaData)
+		return cmdutil.AppendJSONField(nil, "media", mediaData)
 	}
-	return appendJSONField(trimmed, "media", mediaData)
+	return cmdutil.AppendJSONField(trimmed, "media", mediaData)
 }
 
 func productMediaSingleAttachResult(media []productMediaAttachmentResult) (json.RawMessage, error) {
@@ -149,42 +149,6 @@ func productMediaSingleAttachResult(media []productMediaAttachmentResult) (json.
 		data = media[0].Response
 	}
 	return mergeProductMediaResult(data, media)
-}
-
-func appendJSONField(object json.RawMessage, key string, value json.RawMessage) (json.RawMessage, error) {
-	if len(object) == 0 {
-		keyData, err := json.Marshal(key)
-		if err != nil {
-			return nil, fmt.Errorf("could not encode response key: %w", err)
-		}
-		out := make([]byte, 0, len(keyData)+len(value)+4)
-		out = append(out, '{')
-		out = append(out, keyData...)
-		out = append(out, ':')
-		out = append(out, value...)
-		out = append(out, '}')
-		return out, nil
-	}
-
-	if !json.Valid(object) || len(object) < 2 || object[0] != '{' || object[len(object)-1] != '}' {
-		return nil, fmt.Errorf("could not parse response: expected JSON object")
-	}
-	keyData, err := json.Marshal(key)
-	if err != nil {
-		return nil, fmt.Errorf("could not encode response key: %w", err)
-	}
-	inner := bytes.TrimSpace(object[1 : len(object)-1])
-	out := make([]byte, 0, len(object)+len(keyData)+len(value)+2)
-	out = append(out, '{')
-	if len(inner) > 0 {
-		out = append(out, inner...)
-		out = append(out, ',')
-	}
-	out = append(out, keyData...)
-	out = append(out, ':')
-	out = append(out, value...)
-	out = append(out, '}')
-	return out, nil
 }
 
 func productMediaOnlyUpdateResult(productID string) (json.RawMessage, error) {

--- a/internal/cmd/products/product_media_test.go
+++ b/internal/cmd/products/product_media_test.go
@@ -353,18 +353,20 @@ func TestUpdate_WithPreviewImageOnly_DoesNotPutProduct(t *testing.T) {
 		t.Fatalf("attached signed IDs = %#v", signedIDs)
 	}
 	var payload struct {
-		Result struct {
-			Success bool `json:"success"`
-			Product struct {
-				ID string `json:"id"`
-			} `json:"product"`
-			Media []productMediaAttachmentResult `json:"media"`
-		} `json:"result"`
+		Success bool `json:"success"`
+		Product struct {
+			ID string `json:"id"`
+		} `json:"product"`
+		Media  []productMediaAttachmentResult `json:"media"`
+		Result json.RawMessage                `json:"result"`
 	}
 	if err := json.Unmarshal([]byte(out), &payload); err != nil {
 		t.Fatalf("parse JSON output: %v\n%s", err, out)
 	}
-	if !payload.Result.Success || payload.Result.Product.ID != "prod1" || len(payload.Result.Media) != 1 {
+	if len(payload.Result) != 0 {
+		t.Fatalf("update --json must not nest under a result envelope: %s", out)
+	}
+	if !payload.Success || payload.Product.ID != "prod1" || len(payload.Media) != 1 {
 		t.Fatalf("unexpected JSON output: %+v", payload)
 	}
 }

--- a/internal/cmd/products/products_test.go
+++ b/internal/cmd/products/products_test.go
@@ -443,6 +443,29 @@ func TestDelete_WithYes(t *testing.T) {
 	}
 }
 
+func TestDelete_JSONPassesThroughAPIResponse(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{"message": "The product was deleted successfully."})
+	})
+
+	cmd := testutil.Command(newDeleteCmd(), testutil.Yes(true), testutil.JSONOutput())
+	out := testutil.CaptureStdout(func() { _ = cmd.RunE(cmd, []string{"prod1"}) })
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("parse JSON output: %v\n%s", err, out)
+	}
+	if _, ok := resp["result"]; ok {
+		t.Fatalf("delete --json must not nest under a result envelope: %s", out)
+	}
+	if resp["success"] != true {
+		t.Fatalf("expected success true at top level, got: %s", out)
+	}
+	if resp["id"] != "prod1" {
+		t.Fatalf("delete --json must expose the deleted product id at top level, got: %s", out)
+	}
+}
+
 func TestPublish_CorrectEndpoint(t *testing.T) {
 	var gotMethod, gotPath string
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
@@ -1082,14 +1105,25 @@ func TestUpdate_JPYRejectsDecimals(t *testing.T) {
 
 func TestUpdate_JSON(t *testing.T) {
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
-		testutil.JSON(t, w, map[string]any{})
+		testutil.JSON(t, w, map[string]any{
+			"product": map[string]any{"id": "prod1", "name": "X"},
+		})
 	})
 
 	cmd := testutil.Command(newUpdateCmd(), testutil.JSONOutput())
 	cmd.SetArgs([]string{"prod1", "--name", "X"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
-	if !strings.Contains(out, "true") {
-		t.Errorf("expected JSON with success, got: %q", out)
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("parse JSON output: %v\n%s", err, out)
+	}
+	if _, ok := resp["result"]; ok {
+		t.Fatalf("update --json must not nest under a result envelope: %s", out)
+	}
+	product, ok := resp["product"].(map[string]any)
+	if !ok || product["id"] != "prod1" {
+		t.Fatalf("expected product.id at top level, got: %s", out)
 	}
 }
 
@@ -1310,6 +1344,29 @@ func TestUnpublish_Output(t *testing.T) {
 	out := testutil.CaptureStdout(func() { _ = cmd.RunE(cmd, []string{"p1"}) })
 	if !strings.Contains(out, "unpublished") {
 		t.Errorf("expected unpublished message, got: %q", out)
+	}
+}
+
+func TestUnpublish_JSONExposesFlatProduct(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"product": map[string]any{"id": "p1", "published": false},
+		})
+	})
+
+	cmd := testutil.Command(newUnpublishCmd(), testutil.JSONOutput())
+	out := testutil.CaptureStdout(func() { _ = cmd.RunE(cmd, []string{"p1"}) })
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("parse JSON output: %v\n%s", err, out)
+	}
+	if _, ok := resp["result"]; ok {
+		t.Fatalf("unpublish --json must not nest under a result envelope: %s", out)
+	}
+	product, ok := resp["product"].(map[string]any)
+	if !ok || product["id"] != "p1" {
+		t.Fatalf("expected product.id at top level, got: %s", out)
 	}
 }
 

--- a/internal/cmd/products/unpublish.go
+++ b/internal/cmd/products/unpublish.go
@@ -14,7 +14,7 @@ func newUnpublishCmd() *cobra.Command {
 		Args:  cmdutil.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
-			return cmdutil.RunRequestWithSuccess(opts, "Unpublishing product...", "PUT", cmdutil.JoinPath("products", args[0], "disable"), url.Values{}, args[0], "Product "+args[0]+" unpublished.")
+			return cmdutil.RunRequestWithResource(opts, "Unpublishing product...", "PUT", cmdutil.JoinPath("products", args[0], "disable"), url.Values{}, "", "Product "+args[0]+" unpublished.")
 		},
 	}
 }

--- a/internal/cmd/products/update.go
+++ b/internal/cmd/products/update.go
@@ -189,14 +189,14 @@ func newUpdateCmd() *cobra.Command {
 					if err != nil {
 						return err
 					}
-					return cmdutil.PrintMutationSuccess(opts, data, args[0], "Product "+args[0]+" updated.")
+					return cmdutil.PrintResourceSuccess(opts, data, "", "Product "+args[0]+" updated.")
 				}
 				if opts.DryRun && opts.UsesJSONOutput() {
 					return renderProductUpdateDryRun(opts, path, productFileUpdatePlan{}, nil, buildProductJSONBody(params, nil))
 				}
-				return cmdutil.RunRequestWithSuccess(opts,
+				return cmdutil.RunRequestWithResource(opts,
 					"Updating product...", "PUT", path, params,
-					args[0], "Product "+args[0]+" updated.")
+					"", "Product "+args[0]+" updated.")
 			}
 
 			selections, err := validateProductFileSelections(c, keepFileIDs, removeFileIDs, replaceFiles)
@@ -270,7 +270,7 @@ func newUpdateCmd() *cobra.Command {
 					return err
 				}
 			}
-			return cmdutil.PrintMutationSuccess(opts, data, args[0], "Product "+args[0]+" updated.")
+			return cmdutil.PrintResourceSuccess(opts, data, "", "Product "+args[0]+" updated.")
 		},
 	}
 

--- a/internal/cmdutil/extra_test.go
+++ b/internal/cmdutil/extra_test.go
@@ -508,3 +508,189 @@ func TestRunRequestWithSuccess_DryRunSkipsAuth(t *testing.T) {
 		t.Fatalf("unexpected dry-run output: %q", out.String())
 	}
 }
+
+func TestRunRequestWithResource_JSONPassesThroughFlatResponse(t *testing.T) {
+	setupAuthedAPI(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSuccessJSON(t, w, map[string]any{"product": map[string]any{"id": "prod_123"}})
+	})
+
+	opts := DefaultOptions()
+	opts.JSONOutput = true
+	opts.Version = "test"
+	var out bytes.Buffer
+	opts.Stdout = &out
+
+	if err := RunRequestWithResource(opts, "Updating...", "PUT", "/products/prod_123", nil, "", "Product updated."); err != nil {
+		t.Fatalf("RunRequestWithResource failed: %v", err)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(out.Bytes(), &resp); err != nil {
+		t.Fatalf("resource JSON output is invalid: %v\n%s", err, out.String())
+	}
+	if _, ok := resp["result"]; ok {
+		t.Fatalf("resource mutation must not nest under a result envelope: %s", out.String())
+	}
+	if _, ok := resp["id"]; ok {
+		t.Fatalf("empty id must not inject a top-level id: %s", out.String())
+	}
+	product, ok := resp["product"].(map[string]any)
+	if !ok || product["id"] != "prod_123" {
+		t.Fatalf("expected product.id at top level: %s", out.String())
+	}
+}
+
+func TestRunRequestWithResource_JSONMergesIDWhenResponseOmitsResource(t *testing.T) {
+	setupAuthedAPI(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSuccessJSON(t, w, map[string]any{"message": "The product was deleted successfully."})
+	})
+
+	opts := DefaultOptions()
+	opts.JSONOutput = true
+	opts.Version = "test"
+	var out bytes.Buffer
+	opts.Stdout = &out
+
+	if err := RunRequestWithResource(opts, "Deleting...", "DELETE", "/products/prod_123", nil, "prod_123", "Product deleted."); err != nil {
+		t.Fatalf("RunRequestWithResource failed: %v", err)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(out.Bytes(), &resp); err != nil {
+		t.Fatalf("resource JSON output is invalid: %v\n%s", err, out.String())
+	}
+	if _, ok := resp["result"]; ok {
+		t.Fatalf("resource mutation must not nest under a result envelope: %s", out.String())
+	}
+	if resp["id"] != "prod_123" {
+		t.Fatalf("expected merged top-level id for resource-less response: %s", out.String())
+	}
+}
+
+func TestRunRequestWithResource_PlainOutput(t *testing.T) {
+	setupAuthedAPI(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSuccessJSON(t, w, map[string]any{})
+	})
+
+	opts := DefaultOptions()
+	opts.PlainOutput = true
+	opts.Version = "test"
+	var out bytes.Buffer
+	opts.Stdout = &out
+
+	if err := RunRequestWithResource(opts, "Deleting...", "DELETE", "/products/prod_123", nil, "prod_123", "Product deleted."); err != nil {
+		t.Fatalf("RunRequestWithResource failed: %v", err)
+	}
+
+	if strings.TrimSpace(out.String()) != "true\tProduct deleted." {
+		t.Fatalf("unexpected plain output: %q", out.String())
+	}
+}
+
+func TestRunRequestWithResource_HumanShowsMessage(t *testing.T) {
+	setColorEnabledForTest(t, false)
+	setupAuthedAPI(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSuccessJSON(t, w, map[string]any{"product": map[string]any{"id": "prod_123"}})
+	})
+
+	opts := DefaultOptions()
+	opts.Quiet = false
+	opts.Version = "test"
+	var out bytes.Buffer
+	opts.Stdout = &out
+
+	if err := RunRequestWithResource(opts, "Unpublishing...", "PUT", "/products/prod_123/disable", nil, "", "Product unpublished."); err != nil {
+		t.Fatalf("RunRequestWithResource failed: %v", err)
+	}
+	if !strings.Contains(out.String(), "Product unpublished.") {
+		t.Fatalf("expected success message, got %q", out.String())
+	}
+}
+
+func TestRunRequestWithResource_DryRunSkipsAuth(t *testing.T) {
+	opts := DefaultOptions()
+	opts.DryRun = true
+	var out bytes.Buffer
+	opts.Stdout = &out
+
+	if err := RunRequestWithResource(opts, "Deleting...", "DELETE", "/products/prod_123", nil, "prod_123", "Product deleted."); err != nil {
+		t.Fatalf("RunRequestWithResource failed: %v", err)
+	}
+
+	if !strings.Contains(out.String(), "Dry run") || !strings.Contains(out.String(), "DELETE /products/prod_123") {
+		t.Fatalf("unexpected dry-run output: %q", out.String())
+	}
+}
+
+func TestPrintResourceSuccess_JSONPassesThroughMergedData(t *testing.T) {
+	opts := DefaultOptions()
+	opts.JSONOutput = true
+	var out bytes.Buffer
+	opts.Stdout = &out
+
+	data := json.RawMessage(`{"success":true,"product":{"id":"prod_123"},"media":[{"kind":"cover"}]}`)
+	if err := PrintResourceSuccess(opts, data, "", "Product updated."); err != nil {
+		t.Fatalf("PrintResourceSuccess failed: %v", err)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(out.Bytes(), &resp); err != nil {
+		t.Fatalf("resource JSON output is invalid: %v\n%s", err, out.String())
+	}
+	if _, ok := resp["result"]; ok {
+		t.Fatalf("resource mutation must not nest under a result envelope: %s", out.String())
+	}
+	if resp["media"] == nil {
+		t.Fatalf("expected merged media to survive passthrough: %s", out.String())
+	}
+}
+
+func TestPrintResourceSuccess_JSONMergesIDIntoEmptyOrNullBody(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		data json.RawMessage
+	}{
+		{name: "nil body", data: nil},
+		{name: "empty body", data: json.RawMessage("")},
+		{name: "null body", data: json.RawMessage("null")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := DefaultOptions()
+			opts.JSONOutput = true
+			var out bytes.Buffer
+			opts.Stdout = &out
+
+			if err := PrintResourceSuccess(opts, tc.data, "prod1", "Product deleted."); err != nil {
+				t.Fatalf("PrintResourceSuccess failed: %v", err)
+			}
+
+			var resp map[string]any
+			if err := json.Unmarshal(out.Bytes(), &resp); err != nil {
+				t.Fatalf("resource JSON output is invalid: %v\n%s", err, out.String())
+			}
+			if resp["id"] != "prod1" {
+				t.Fatalf("expected merged top-level id for empty body, got: %s", out.String())
+			}
+		})
+	}
+}
+
+func TestPrintResourceSuccess_JSONKeepsExistingTopLevelID(t *testing.T) {
+	opts := DefaultOptions()
+	opts.JSONOutput = true
+	var out bytes.Buffer
+	opts.Stdout = &out
+
+	data := json.RawMessage(`{"success":true,"id":"from_api"}`)
+	if err := PrintResourceSuccess(opts, data, "override", "Done."); err != nil {
+		t.Fatalf("PrintResourceSuccess failed: %v", err)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(out.Bytes(), &resp); err != nil {
+		t.Fatalf("resource JSON output is invalid: %v\n%s", err, out.String())
+	}
+	if resp["id"] != "from_api" {
+		t.Fatalf("must not overwrite an existing top-level id: %s", out.String())
+	}
+}

--- a/internal/cmdutil/extra_test.go
+++ b/internal/cmdutil/extra_test.go
@@ -565,6 +565,9 @@ func TestRunRequestWithResource_JSONMergesIDWhenResponseOmitsResource(t *testing
 	if resp["id"] != "prod_123" {
 		t.Fatalf("expected merged top-level id for resource-less response: %s", out.String())
 	}
+	if body := out.String(); strings.Index(body, `"id"`) < strings.Index(body, `"success"`) {
+		t.Fatalf("merged id must be appended after existing fields, not reordered to the front: %s", body)
+	}
 }
 
 func TestRunRequestWithResource_PlainOutput(t *testing.T) {
@@ -692,5 +695,33 @@ func TestPrintResourceSuccess_JSONKeepsExistingTopLevelID(t *testing.T) {
 	}
 	if resp["id"] != "from_api" {
 		t.Fatalf("must not overwrite an existing top-level id: %s", out.String())
+	}
+}
+
+func TestAppendJSONField(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		object json.RawMessage
+		want   string
+	}{
+		{name: "nil object", object: nil, want: `{"id":"p1"}`},
+		{name: "whitespace only", object: json.RawMessage("  \n"), want: `{"id":"p1"}`},
+		{name: "empty object", object: json.RawMessage(`{}`), want: `{"id":"p1"}`},
+		{name: "populated object", object: json.RawMessage(`{"success":true}`), want: `{"success":true,"id":"p1"}`},
+		{name: "object with surrounding whitespace", object: json.RawMessage(" {\"success\":true} \n"), want: `{"success":true,"id":"p1"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := AppendJSONField(tc.object, "id", json.RawMessage(`"p1"`))
+			if err != nil {
+				t.Fatalf("AppendJSONField: %v", err)
+			}
+			if string(got) != tc.want {
+				t.Fatalf("got %s, want %s", got, tc.want)
+			}
+		})
+	}
+
+	if _, err := AppendJSONField(json.RawMessage(`[1,2]`), "id", json.RawMessage(`"p1"`)); err == nil {
+		t.Fatal("expected error appending to a non-object JSON value")
 	}
 }

--- a/internal/cmdutil/read.go
+++ b/internal/cmdutil/read.go
@@ -197,9 +197,81 @@ func printMutationPayload(opts Options, payload mutationOutput) error {
 }
 
 // PrintMutationSuccess renders a successful mutating command with the shared
-// human/plain/JSON envelope used across the CLI.
+// {success, message, id, result} envelope used across most of the CLI. Prefer
+// PrintResourceSuccess when the API already returns the resource at the top
+// level and the write verb should match the read verbs' shape.
 func PrintMutationSuccess(opts Options, data json.RawMessage, id, successMessage string) error {
 	return renderMutationSuccess(opts, data, id, successMessage)
+}
+
+// PrintResourceSuccess renders a successful mutation by passing the API response
+// through unchanged in JSON mode, with no result envelope. Write verbs then
+// match their read verbs: a resource stays at the same top-level path (e.g.
+// product), and a response that carries only a message (e.g. delete) surfaces
+// that message verbatim. Human and plain output show successMessage.
+//
+// When id is non-empty and the JSON response has no top-level "id", id is merged
+// in so callers can still correlate the affected resource. This matters for
+// irreversible verbs whose response omits the resource entirely (delete returns
+// only {success, message}); pass an empty id for verbs that already return the
+// resource, leaving the response byte-for-byte unchanged.
+func PrintResourceSuccess(opts Options, data json.RawMessage, id, successMessage string) error {
+	if opts.UsesJSONOutput() {
+		merged, err := withTopLevelID(data, id)
+		if err != nil {
+			return err
+		}
+		return PrintJSONResponse(opts, merged)
+	}
+	if opts.PlainOutput {
+		return output.PrintPlain(opts.Out(), [][]string{{"true", successMessage}})
+	}
+	return PrintSuccess(opts, successMessage)
+}
+
+// RunRequestWithResource executes a mutating API request and renders it with
+// PrintResourceSuccess, passing the API response through unchanged in JSON mode.
+// It is the envelope-free counterpart to RunRequestWithSuccess. See
+// PrintResourceSuccess for the id parameter's semantics.
+func RunRequestWithResource(opts Options, spinnerMessage, method, path string, params url.Values, id, successMessage string) error {
+	if opts.DryRun && method != http.MethodGet {
+		return PrintDryRunRequest(opts, method, path, params)
+	}
+
+	data, err := runAuthenticatedData(opts, spinnerMessage, requestRunner(method, path, params))
+	if err != nil {
+		return err
+	}
+	return PrintResourceSuccess(opts, data, id, successMessage)
+}
+
+// withTopLevelID returns data with a top-level "id" field set to id. It is a
+// no-op when id is empty or the response already carries a top-level "id", so
+// responses that already expose the resource pass through unchanged.
+func withTopLevelID(data json.RawMessage, id string) (json.RawMessage, error) {
+	if id == "" {
+		return data, nil
+	}
+	fields := map[string]json.RawMessage{}
+	if err := json.Unmarshal(normalizeJSONBody(data), &fields); err != nil {
+		return nil, fmt.Errorf("could not parse response: %w", err)
+	}
+	if fields == nil {
+		fields = map[string]json.RawMessage{}
+	}
+	if _, ok := fields["id"]; ok {
+		return data, nil
+	}
+	idData, err := json.Marshal(id)
+	if err != nil {
+		return nil, fmt.Errorf("could not encode id: %w", err)
+	}
+	fields["id"] = idData
+	merged, err := json.Marshal(fields)
+	if err != nil {
+		return nil, fmt.Errorf("could not encode JSON output: %w", err)
+	}
+	return merged, nil
 }
 
 func renderMutationSuccess(opts Options, data json.RawMessage, id, successMessage string) error {

--- a/internal/cmdutil/read.go
+++ b/internal/cmdutil/read.go
@@ -247,17 +247,16 @@ func RunRequestWithResource(opts Options, spinnerMessage, method, path string, p
 
 // withTopLevelID returns data with a top-level "id" field set to id. It is a
 // no-op when id is empty or the response already carries a top-level "id", so
-// responses that already expose the resource pass through unchanged.
+// responses that already expose the resource pass through unchanged. The id is
+// appended after the existing fields, preserving the API's original key order.
 func withTopLevelID(data json.RawMessage, id string) (json.RawMessage, error) {
 	if id == "" {
 		return data, nil
 	}
+	normalized := normalizeJSONBody(data)
 	fields := map[string]json.RawMessage{}
-	if err := json.Unmarshal(normalizeJSONBody(data), &fields); err != nil {
+	if err := json.Unmarshal(normalized, &fields); err != nil {
 		return nil, fmt.Errorf("could not parse response: %w", err)
-	}
-	if fields == nil {
-		fields = map[string]json.RawMessage{}
 	}
 	if _, ok := fields["id"]; ok {
 		return data, nil
@@ -266,12 +265,47 @@ func withTopLevelID(data json.RawMessage, id string) (json.RawMessage, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not encode id: %w", err)
 	}
-	fields["id"] = idData
-	merged, err := json.Marshal(fields)
-	if err != nil {
-		return nil, fmt.Errorf("could not encode JSON output: %w", err)
+	object := normalized
+	if bytes.Equal(bytes.TrimSpace(object), []byte("null")) {
+		object = nil
 	}
-	return merged, nil
+	return AppendJSONField(object, "id", idData)
+}
+
+// AppendJSONField returns object with key:value appended as a top-level field,
+// preserving the order of any existing fields. A nil, empty, or whitespace-only
+// object yields {"key":value}. It returns an error when object is non-empty but
+// not a JSON object. Surrounding whitespace is tolerated.
+func AppendJSONField(object json.RawMessage, key string, value json.RawMessage) (json.RawMessage, error) {
+	keyData, err := json.Marshal(key)
+	if err != nil {
+		return nil, fmt.Errorf("could not encode response key: %w", err)
+	}
+	object = bytes.TrimSpace(object)
+	if len(object) == 0 {
+		out := make([]byte, 0, len(keyData)+len(value)+4)
+		out = append(out, '{')
+		out = append(out, keyData...)
+		out = append(out, ':')
+		out = append(out, value...)
+		out = append(out, '}')
+		return out, nil
+	}
+	if !json.Valid(object) || len(object) < 2 || object[0] != '{' || object[len(object)-1] != '}' {
+		return nil, fmt.Errorf("could not parse response: expected JSON object")
+	}
+	inner := bytes.TrimSpace(object[1 : len(object)-1])
+	out := make([]byte, 0, len(object)+len(keyData)+len(value)+2)
+	out = append(out, '{')
+	if len(inner) > 0 {
+		out = append(out, inner...)
+		out = append(out, ',')
+	}
+	out = append(out, keyData...)
+	out = append(out, ':')
+	out = append(out, value...)
+	out = append(out, '}')
+	return out, nil
 }
 
 func renderMutationSuccess(opts Options, data json.RawMessage, id, successMessage string) error {

--- a/skills/embed_test.go
+++ b/skills/embed_test.go
@@ -95,7 +95,7 @@ func TestSkillMarkdown_ContainsProductMediaAndBulkGuidance(t *testing.T) {
 		"gumroad products thumbnail set <id> --image ./thumb.jpg --json --no-input",
 		"gumroad products thumbnail set <id> --url https://example.com/thumb.png --json --no-input",
 		"WebP is not supported by the API",
-		"`products update` with media flags → mutation envelope with `.result.media[]`",
+		"`products update` with media flags → `.product` plus `.media[]`",
 		"`products covers add --url` → `.result.covers[]`, `.result.main_cover_id`",
 		"`products thumbnail set --url` → `.result.thumbnail`",
 		"Check existing products and permalinks first",

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -67,14 +67,14 @@ Most responses are wrapped in `{"success": true, ...}` with resource-specific ke
 - `variants list` → `.variants[]`
 - `files upload` / `files complete` → `.file_url`
 - `products create` with media flags → `.product` plus `.media[]`
-- `products update` with media flags → mutation envelope with `.result.media[]`
+- `products update` with media flags → `.product` plus `.media[]`
 - `products covers add --image` → `.result.covers[]`, `.result.main_cover_id`, plus `.result.media[]`
 - `products covers add --url` → `.result.covers[]`, `.result.main_cover_id`
 - `products thumbnail set --image` → `.result.thumbnail`, plus `.result.media[]`
 - `products thumbnail set --url` → `.result.thumbnail`
 - `products page preview` → `.custom_html`, `.sanitization_report`
 - `products page publish` / `products page clear` → `.product.custom_html`, `.product.landing_url`, `.previous_custom_html`, `.sanitization_report`
-- `products update --custom-html` → mutation envelope with `.result.product.custom_html`, `.result.product.landing_url`, `.result.previous_custom_html`, `.result.sanitization_report`
+- `products update --custom-html` → `.product.custom_html`, `.product.landing_url`, `.previous_custom_html`, `.sanitization_report`
 - `webhooks list` → `.resource_subscriptions[]`
 - `admin users info` → `.user`
 - `admin users affiliates` → `.affiliates[]`

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -75,6 +75,7 @@ Most responses are wrapped in `{"success": true, ...}` with resource-specific ke
 - `products page preview` → `.custom_html`, `.sanitization_report`
 - `products page publish` / `products page clear` → `.product.custom_html`, `.product.landing_url`, `.previous_custom_html`, `.sanitization_report`
 - `products update --custom-html` → `.product.custom_html`, `.product.landing_url`, `.previous_custom_html`, `.sanitization_report`
+- Not every `products` write verb is flat: `create`, `update`, `unpublish`, and `delete` return top-level fields, but `covers add`, `thumbnail set`, and `content set` still wrap their payload in the `{success, …, result}` envelope — read those under `.result`
 - `webhooks list` → `.resource_subscriptions[]`
 - `admin users info` → `.user`
 - `admin users affiliates` → `.affiliates[]`


### PR DESCRIPTION
Fixes #125

## What

`products update`, `unpublish`, and `delete` wrapped their `--json` output in a `{success, message, id, result}` envelope, while `create`, `view`, and `publish` return the flat `{success, product}` the v2 API actually sends. This drops the envelope so all `products` write verbs match the read verbs:

- `update` / `unpublish` → `{success, product}` (pass the API response through unchanged).
- `delete` → `{success, message, id}`; the API returns no resource, so the CLI merges a top-level `id` for the deleted product.

Scope is limited to `products`; other resources keep the existing envelope. Adds `RunRequestWithResource` / `PrintResourceSuccess` to `cmdutil` and finishes the migration `publish` started in #137.

## Why

Found during agent dogfooding: an agent that read `.product.published` after a publish got `null` after an update or unpublish, because the data was nested under `.result.product`, and could wrongly conclude a successful write had failed. The envelope was a CLI artifact — the raw API has no `result` wrapper. `delete` keeps a top-level `id` because the product is gone afterward, so there's no other way to correlate the result with the request.

## Before/After

`products update <id> --json` (also `unpublish`):

```diff
-{ "success": true, "message": "…", "id": "J333…", "result": { "success": true, "product": { … } } }
+{ "success": true, "product": { … } }
```

Human and `--plain` output are unchanged.

---

This PR was implemented with AI assistance using Claude Opus 4.8.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad-cli/pr/145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783609736&installation_id=134400930&pr_number=145&repository=antiwork%2Fgumroad-cli&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad-cli%2Fpull%2F145&signature=3480c4bd40d4130d2576afd71a50fe567c5d5f2480b5b0be1447b227057de628"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for `--json` scripts/agents on three product commands; scope is limited to products and is heavily tested, with no API or auth changes.
> 
> **Overview**
> **`products update`**, **`unpublish`**, and **`delete`** now emit flat `--json` that matches the v2 API (and read verbs like **`view`** / **`publish`**) instead of wrapping payloads in `{success, message, id, result}`.
> 
> New **`cmdutil`** helpers **`PrintResourceSuccess`** and **`RunRequestWithResource`** pass API JSON through unchanged; **`delete`** still merges a top-level **`id`** when the response has no resource. **`AppendJSONField`** moves to **`cmdutil`** for shared use (e.g. media merge on update). Human and **`--plain`** output are unchanged.
> 
> Tests and **`skills/gumroad/SKILL.md`** document the new paths (e.g. **`.product`** instead of **`.result.product`**). **`.gitignore`** ignores **`/gumroad`** instead of **`/gr`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03d3fa6bdf933c9496df00a75af6ca51df2dc34d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->