### PR TITLE
Simplify product file rolls in update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,11 +114,11 @@ gumroad files upload ./pack.zip
 # Create a product with an attached file
 gumroad products create --name "Art Pack" --price 10.00 --file ./pack.zip --file-name "Art Pack.zip"
 
-# Add a new file to a product while keeping its current attachments
+# Roll the file embeds in a shared product content document
 gumroad products update <product_id> --file ./pack.zip
 ```
 
-`gumroad files upload` prints the canonical `file_url`; product create/update commands accept repeatable `--file` flags. Run command help for metadata, removal, replacement, and per-variant content options.
+`gumroad files upload` prints the canonical `file_url`; product create/update commands accept repeatable `--file` flags. On update, `--file` replaces existing rich content file embeds in place when they exist, or creates file embeds when the document has none. Pass one `--file` per existing file embed; use `products content get/set` for structural content edits. For per-variant content, use `variants update ... --file` on the target variant.
 
 ## Product content
 

--- a/internal/cmd/products/file_updates.go
+++ b/internal/cmd/products/file_updates.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -43,11 +42,6 @@ type productFileUpdateState struct {
 	RichContent                      []map[string]any             `json:"rich_content"`
 	HasSameRichContentForAllVariants bool                         `json:"has_same_rich_content_for_all_variants"`
 	Variants                         *[]productVariantCategoryRef `json:"variants"`
-}
-
-type productFileSelections struct {
-	Keep   map[string]struct{}
-	Remove map[string]struct{}
 }
 
 type productVariantCategoryRef struct {
@@ -141,71 +135,12 @@ func productHasVariants(variants []productVariantCategoryRef) bool {
 	return false
 }
 
-func planProductFileUpdate(
-	cmd *cobra.Command,
-	existing []existingProductFile,
-	uploads []requestedProductUpload,
-	selections productFileSelections,
-	replaceFiles bool,
-) (productFileUpdatePlan, error) {
-	existingByID := make(map[string]existingProductFile, len(existing))
-	for _, file := range existing {
-		existingByID[file.ID] = file
-	}
-
-	if err := ensureKnownFileIDs(cmd, "--keep-file", selections.Keep, existingByID); err != nil {
-		return productFileUpdatePlan{}, err
-	}
-	if err := ensureKnownFileIDs(cmd, "--remove-file", selections.Remove, existingByID); err != nil {
-		return productFileUpdatePlan{}, err
-	}
-
+func planProductFileRoll(existing []existingProductFile, uploads []requestedProductUpload) productFileUpdatePlan {
 	plan := productFileUpdatePlan{
-		Uploads: uploads,
+		Preserved: append([]existingProductFile(nil), existing...),
+		Uploads:   uploads,
 	}
-
-	for _, file := range existing {
-		_, explicitlyRemoved := selections.Remove[file.ID]
-		preserve := !replaceFiles
-		if replaceFiles {
-			_, preserve = selections.Keep[file.ID]
-		}
-		if explicitlyRemoved {
-			preserve = false
-		}
-
-		if preserve {
-			plan.Preserved = append(plan.Preserved, file)
-		} else {
-			plan.Removed = append(plan.Removed, file)
-		}
-	}
-
-	return plan, nil
-}
-
-func ensureKnownFileIDs(
-	cmd *cobra.Command,
-	flagName string,
-	requested map[string]struct{},
-	existing map[string]existingProductFile,
-) error {
-	if len(requested) == 0 {
-		return nil
-	}
-
-	var unknown []string
-	for id := range requested {
-		if _, ok := existing[id]; !ok {
-			unknown = append(unknown, id)
-		}
-	}
-	if len(unknown) == 0 {
-		return nil
-	}
-
-	sort.Strings(unknown)
-	return cmdutil.UsageErrorf(cmd, "unknown %s id(s): %s", flagName, joinComma(unknown))
+	return plan
 }
 
 func describeProductUploads(uploads []requestedProductUpload) ([]plannedProductUpload, error) {
@@ -222,44 +157,6 @@ func describeProductUploads(uploads []requestedProductUpload) ([]plannedProductU
 		}
 	}
 	return planned, nil
-}
-
-func validateProductFileSelections(
-	cmd *cobra.Command,
-	keepIDs, removeIDs []string,
-	replaceFiles bool,
-) (productFileSelections, error) {
-	if len(keepIDs) > 0 && !replaceFiles {
-		return productFileSelections{}, cmdutil.UsageErrorf(cmd,
-			"--keep-file can only be used together with --replace-files")
-	}
-
-	keepSet := make(map[string]struct{}, len(keepIDs))
-	for _, id := range keepIDs {
-		keepSet[id] = struct{}{}
-	}
-	removeSet := make(map[string]struct{}, len(removeIDs))
-	for _, id := range removeIDs {
-		removeSet[id] = struct{}{}
-	}
-
-	var conflicts []string
-	for id := range keepSet {
-		if _, ok := removeSet[id]; ok {
-			conflicts = append(conflicts, id)
-		}
-	}
-	if len(conflicts) > 0 {
-		sort.Strings(conflicts)
-		return productFileSelections{}, cmdutil.UsageErrorf(cmd,
-			"cannot use --keep-file and --remove-file for the same id(s): %s",
-			joinComma(conflicts))
-	}
-
-	return productFileSelections{
-		Keep:   keepSet,
-		Remove: removeSet,
-	}, nil
 }
 
 func buildProductUpdateJSONBody(
@@ -585,10 +482,6 @@ func productFileRemovalMessage(productID string, removed []existingProductFile) 
 		message = fmt.Sprintf("Update product %s and remove %s: %s?", productID, label, summary)
 	}
 	return message
-}
-
-func joinComma(values []string) string {
-	return strings.Join(values, ", ")
 }
 
 func productBatchUploadInputs(uploads []plannedProductUpload) []batchUploadInput {

--- a/internal/cmd/products/product_media_test.go
+++ b/internal/cmd/products/product_media_test.go
@@ -469,6 +469,108 @@ func TestUpdate_WithPreviewImageDryRunJSONShowsDirectUploadAndAttachRequests(t *
 	}
 }
 
+func TestCoversAdd_WithImageDryRunStandaloneShowsUploadAndAttachRequests(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		mutators []testutil.OptionsMutator
+		assert   func(t *testing.T, out string, path string)
+	}{
+		{
+			name:     "json",
+			mutators: []testutil.OptionsMutator{testutil.DryRun(true), testutil.JSONOutput()},
+			assert: func(t *testing.T, out string, path string) {
+				t.Helper()
+
+				var payload dryRunCreatePayload
+				if err := json.Unmarshal([]byte(out), &payload); err != nil {
+					t.Fatalf("parse JSON dry-run output: %v\n%s", err, out)
+				}
+				if !payload.DryRun {
+					t.Fatal("expected dry_run to be true")
+				}
+				if len(payload.Uploads) != 1 {
+					t.Fatalf("uploads = %d, want 1", len(payload.Uploads))
+				}
+				upload := payload.Uploads[0]
+				if upload.Action != "direct_upload" || upload.Kind != "cover" || upload.Path != path || upload.Filename != "cover.jpg" || upload.ContentType != "image/jpeg" {
+					t.Fatalf("unexpected upload plan: %+v", upload)
+				}
+				if upload.Size != int64(len(jpegFixtureContents())) || upload.PartCount != 1 || upload.PartSize != upload.Size || upload.Checksum == "" {
+					t.Fatalf("unexpected upload sizing/checksum: %+v", upload)
+				}
+
+				requests := append([]dryRunCreateRequest{payload.Request}, payload.FollowUpRequests...)
+				if len(requests) != 2 {
+					t.Fatalf("requests = %d, want 2", len(requests))
+				}
+				if requests[0].Method != http.MethodPost || requests[0].Path != "/direct_uploads" {
+					t.Fatalf("unexpected direct upload request: %+v", requests[0])
+				}
+				blob, ok := requests[0].Body["blob"].(map[string]any)
+				if !ok || blob["filename"] != "cover.jpg" || blob["content_type"] != "image/jpeg" {
+					t.Fatalf("unexpected direct upload body: %#v", requests[0].Body)
+				}
+				if requests[1].Method != http.MethodPost || requests[1].Path != "/products/prod1/covers" || requests[1].Body["signed_blob_id"] != "<signed_blob:cover:0>" {
+					t.Fatalf("unexpected attach request: %+v", requests[1])
+				}
+			},
+		},
+		{
+			name:     "plain",
+			mutators: []testutil.OptionsMutator{testutil.DryRun(true), testutil.PlainOutput()},
+			assert: func(t *testing.T, out string, path string) {
+				t.Helper()
+
+				for _, want := range []string{
+					"direct_upload\tcover\t" + path + "\tcover.jpg",
+					"\timage/jpeg",
+					"POST\t/direct_uploads\t",
+					"POST\t/products/prod1/covers\t",
+					"signed_blob:cover:0",
+				} {
+					if !strings.Contains(out, want) {
+						t.Fatalf("expected %q in plain output:\n%s", want, out)
+					}
+				}
+			},
+		},
+		{
+			name:     "human",
+			mutators: []testutil.OptionsMutator{testutil.DryRun(true)},
+			assert: func(t *testing.T, out string, path string) {
+				t.Helper()
+
+				for _, want := range []string{
+					"Dry run: direct upload " + path,
+					"Filename: cover.jpg",
+					"Content type: image/jpeg",
+					"Size: 12 B",
+					"Dry run: POST /direct_uploads",
+					"Dry run: POST /products/prod1/covers",
+					"signed_blob:cover:0",
+				} {
+					if !strings.Contains(out, want) {
+						t.Fatalf("expected %q in human output:\n%s", want, out)
+					}
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
+				t.Fatal("dry run must not reach the API")
+			})
+
+			path := writeMediaFixture(t, "cover.jpg", jpegFixtureContents())
+			cmd := testutil.Command(newCoversAddCmd(), tc.mutators...)
+			cmd.SetArgs([]string{"prod1", "--image", path})
+			out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+			tc.assert(t, out, path)
+		})
+	}
+}
+
 func TestCreate_WithMediaDryRunPlainAndHumanShowsDirectUploadFlow(t *testing.T) {
 	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
 		t.Fatal("dry run must not reach the API")

--- a/internal/cmd/products/product_media_test.go
+++ b/internal/cmd/products/product_media_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/antiwork/gumroad-cli/internal/api"
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/config"
+	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/antiwork/gumroad-cli/internal/testutil"
 )
 
@@ -522,7 +523,7 @@ func TestCoversAdd_WithImageDryRunStandaloneShowsUploadAndAttachRequests(t *test
 				t.Helper()
 
 				for _, want := range []string{
-					"direct_upload\tcover\t" + path + "\tcover.jpg",
+					"direct_upload\tcover\t" + output.EscapePlainField(path) + "\tcover.jpg",
 					"\timage/jpeg",
 					"POST\t/direct_uploads\t",
 					"POST\t/products/prod1/covers\t",

--- a/internal/cmd/products/products.go
+++ b/internal/cmd/products/products.go
@@ -26,7 +26,6 @@ func NewProductsCmd() *cobra.Command {
   gumroad products covers add <product_id> --image ./cover.jpg
   gumroad products thumbnail set <product_id> --image ./thumb.jpg
   gumroad products update <product_id> --file ./pack.zip
-  gumroad products update <product_id> --replace-files --keep-file file_123 --file ./new-pack.zip
   gumroad products content get <product_id> > content.json
   gumroad products content get <product_id> --variant <variant_id> --category <cat_id> > content.json
   gumroad products content set <product_id> content.json --dry-run

--- a/internal/cmd/products/rich_content.go
+++ b/internal/cmd/products/rich_content.go
@@ -1,8 +1,6 @@
 package products
 
 import (
-	"sort"
-
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/richcontent"
 	"github.com/spf13/cobra"
@@ -23,72 +21,22 @@ func buildFileRichContent(fileRefs []richContentFileRef) []map[string]any {
 func buildProductUpdateRichContent(
 	cmd *cobra.Command,
 	existingRichContent []map[string]any,
-	filePlan productFileUpdatePlan,
+	existingFiles []existingProductFile,
 	fileRefs []richContentFileRef,
 ) ([]map[string]any, bool, error) {
-	removedEmbeddedIDs := removedFileEmbedIDs(existingRichContent, filePlan.Removed)
-	if len(removedEmbeddedIDs) > 0 {
-		if len(fileRefs) == 0 {
-			richContent, err := cloneRichContent(existingRichContent)
-			if err != nil {
-				return nil, false, err
-			}
-			stripFileEmbedIDs(richContent, removedEmbeddedIDs)
-			return richContent, true, nil
-		}
-		if len(removedEmbeddedIDs) != 1 || len(fileRefs) != 1 {
-			return nil, false, cmdutil.UsageErrorf(cmd,
-				"cannot automatically update rich_content for embedded file removal (%s); replace one embedded file at a time with exactly one --remove-file and one --file",
-				joinComma(removedEmbeddedIDs))
-		}
-
-		richContent, err := cloneRichContent(existingRichContent)
-		if err != nil {
-			return nil, false, err
-		}
-		replaceFileEmbedID(richContent, removedEmbeddedIDs[0], fileRefs[0].FileID)
-		return richContent, true, nil
-	}
-
 	if len(fileRefs) == 0 {
 		return nil, false, nil
 	}
 
-	richContent, err := appendFileEmbeds(existingRichContent, filePlan.Preserved, fileRefs)
+	richContent, err := rollFileEmbeds(existingRichContent, existingFiles, fileRefs)
 	if err != nil {
-		return nil, false, err
+		return nil, false, cmdutil.UsageErrorf(cmd, "%s; pass one --file per existing file embed, or use products content get/set for structural content changes", err.Error())
 	}
 	return richContent, true, nil
 }
 
-func removedFileEmbedIDs(richContent []map[string]any, removed []existingProductFile) []string {
-	if len(richContent) == 0 || len(removed) == 0 {
-		return nil
-	}
-
-	removedIDs := make(map[string]struct{}, len(removed))
-	for _, file := range removed {
-		removedIDs[file.ID] = struct{}{}
-	}
-
-	seen := map[string]struct{}{}
-	for _, id := range fileEmbedIDs(richContent) {
-		if _, ok := removedIDs[id]; !ok {
-			continue
-		}
-		seen[id] = struct{}{}
-	}
-
-	ids := make([]string, 0, len(seen))
-	for id := range seen {
-		ids = append(ids, id)
-	}
-	sort.Strings(ids)
-	return ids
-}
-
-func appendFileEmbeds(richContent []map[string]any, preserved []existingProductFile, fileRefs []richContentFileRef) ([]map[string]any, error) {
-	return richcontent.AppendFileEmbeds(richContent, preservedProductFileIDs(preserved), fileRefs)
+func rollFileEmbeds(richContent []map[string]any, preserved []existingProductFile, fileRefs []richContentFileRef) ([]map[string]any, error) {
+	return richcontent.RollFileEmbeds(richContent, preservedProductFileIDs(preserved), fileRefs)
 }
 
 func preservedProductFileIDs(files []existingProductFile) []string {
@@ -99,18 +47,6 @@ func preservedProductFileIDs(files []existingProductFile) []string {
 	return ids
 }
 
-func cloneRichContent(richContent []map[string]any) ([]map[string]any, error) {
-	return richcontent.Clone(richContent)
-}
-
 func fileEmbedIDs(richContent []map[string]any) []string {
 	return richcontent.FileEmbedIDs(richContent)
-}
-
-func replaceFileEmbedID(richContent []map[string]any, oldID, newID string) {
-	richcontent.ReplaceFileEmbedID(richContent, oldID, newID)
-}
-
-func stripFileEmbedIDs(richContent []map[string]any, ids []string) {
-	richcontent.StripFileEmbedIDs(richContent, ids)
 }

--- a/internal/cmd/products/update.go
+++ b/internal/cmd/products/update.go
@@ -21,9 +21,6 @@ func newUpdateCmd() *cobra.Command {
 	var files []string
 	var fileNames []string
 	var fileDescriptions []string
-	var keepFileIDs []string
-	var removeFileIDs []string
-	var replaceFiles bool
 	var coverImage, thumbnail string
 	var previewImages []string
 	var customHTML string
@@ -39,8 +36,7 @@ func newUpdateCmd() *cobra.Command {
   gumroad products update <id> --preview-image ./gallery-1.jpg --preview-image ./gallery-2.jpg
   gumroad products update <id> --file ./pack.zip
   gumroad products update <id> --custom-html ./landing.html
-  gumroad products update <id> --custom-html ''
-  gumroad products update <id> --replace-files --keep-file file_123 --file ./new-pack.zip`,
+  gumroad products update <id> --custom-html ''`,
 		Args: cmdutil.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
@@ -52,7 +48,6 @@ func newUpdateCmd() *cobra.Command {
 				"pay-what-you-want", "suggested-price", "max-purchase-count",
 				"category", "taxonomy-id", "tag",
 				"file", "file-name", "file-description",
-				"keep-file", "remove-file", "replace-files",
 				"cover-image", "preview-image", "thumbnail",
 				"custom-html",
 			); err != nil {
@@ -145,10 +140,7 @@ func newUpdateCmd() *cobra.Command {
 			productFieldsChanged := productUpdateFieldFlagsChanged(c)
 			fileFlagsChanged := flags.Changed("file") ||
 				flags.Changed("file-name") ||
-				flags.Changed("file-description") ||
-				flags.Changed("keep-file") ||
-				flags.Changed("remove-file") ||
-				flags.Changed("replace-files")
+				flags.Changed("file-description")
 			if !fileFlagsChanged {
 				if len(media) > 0 {
 					if opts.DryRun {
@@ -199,10 +191,6 @@ func newUpdateCmd() *cobra.Command {
 					args[0], "Product "+args[0]+" updated.")
 			}
 
-			selections, err := validateProductFileSelections(c, keepFileIDs, removeFileIDs, replaceFiles)
-			if err != nil {
-				return err
-			}
 			plannedUploads, err := describeProductUploads(requestedUploads)
 			if err != nil {
 				return err
@@ -218,10 +206,7 @@ func newUpdateCmd() *cobra.Command {
 				return err
 			}
 
-			filePlan, err := planProductFileUpdate(c, existingState.Files, requestedUploads, selections, replaceFiles)
-			if err != nil {
-				return err
-			}
+			filePlan := planProductFileRoll(existingState.Files, requestedUploads)
 
 			fileRefs, err := newRichContentFileRefs(len(plannedUploads))
 			if err != nil {
@@ -233,7 +218,7 @@ func newUpdateCmd() *cobra.Command {
 					args[0], args[0])
 			}
 
-			richContent, includeRichContent, err := buildProductUpdateRichContent(c, existingState.RichContent, filePlan, fileRefs)
+			richContent, includeRichContent, err := buildProductUpdateRichContent(c, existingState.RichContent, existingState.Files, fileRefs)
 			if err != nil {
 				return err
 			}
@@ -287,12 +272,9 @@ func newUpdateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&category, "category", "", "New product category path (for example: design/ui-and-web/figma)")
 	cmd.Flags().StringVar(&taxonomyID, "taxonomy-id", "", "New numeric taxonomy/category ID")
 	cmd.Flags().StringArrayVar(&tags, "tag", nil, "Tag (repeatable, replaces all existing tags)")
-	cmd.Flags().StringArrayVar(&files, "file", nil, "Attach a new local file (repeatable)")
+	cmd.Flags().StringArrayVar(&files, "file", nil, "Roll a local file into rich content file embeds (repeatable)")
 	cmd.Flags().StringArrayVar(&fileNames, "file-name", nil, "Display name for the matching --file (repeatable)")
 	cmd.Flags().StringArrayVar(&fileDescriptions, "file-description", nil, "Description for the matching --file (repeatable)")
-	cmd.Flags().StringArrayVar(&keepFileIDs, "keep-file", nil, "Existing file ID to preserve when using --replace-files (repeatable)")
-	cmd.Flags().StringArrayVar(&removeFileIDs, "remove-file", nil, "Existing file ID to remove (repeatable)")
-	cmd.Flags().BoolVar(&replaceFiles, "replace-files", false, "Replace the current file set instead of preserving existing files by default")
 	cmd.Flags().StringVar(&coverImage, "cover-image", "", "Local JPEG, PNG, or GIF cover image to upload")
 	cmd.Flags().StringArrayVar(&previewImages, "preview-image", nil, "Additional local JPEG, PNG, or GIF preview image to upload as a product cover (repeatable)")
 	cmd.Flags().StringVar(&thumbnail, "thumbnail", "", "Local JPEG, PNG, or GIF thumbnail image to upload")

--- a/internal/cmd/products/update_files_test.go
+++ b/internal/cmd/products/update_files_test.go
@@ -515,7 +515,7 @@ func TestUpdate_FileUploadUsesExternalIDForNewFiles(t *testing.T) {
 	}
 }
 
-func TestUpdate_FileSwapsRemovedRichContentEmbed(t *testing.T) {
+func TestUpdate_FileRollsExistingRichContentEmbed(t *testing.T) {
 	srv := newProductUpdateFileServers(t)
 	srv.existingFiles = []existingProductFile{
 		{ID: "file_old", Name: "Old Pack.zip"},
@@ -550,20 +550,22 @@ func TestUpdate_FileSwapsRemovedRichContentEmbed(t *testing.T) {
 	cmd := testutil.Command(newUpdateCmd(), testutil.Yes(true))
 	cmd.SetArgs([]string{
 		"prod1",
-		"--remove-file", "file_old",
 		"--file", path,
 		"--file-name", "New Pack.zip",
 	})
 	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
 	files := productUpdateJSONFiles(t, srv.putJSON)
-	if len(files) != 2 {
-		t.Fatalf("files payload len = %d, want 2", len(files))
+	if len(files) != 3 {
+		t.Fatalf("files payload len = %d, want 3", len(files))
 	}
-	if got := files[0]["id"]; got != "file_keep" {
-		t.Fatalf("files[0].id = %#v, want file_keep", got)
+	if got := files[0]["id"]; got != "file_old" {
+		t.Fatalf("files[0].id = %#v, want file_old", got)
 	}
-	newFileID := productUpdateNewUploadExternalID(t, files[1], "files[1]")
+	if got := files[1]["id"]; got != "file_keep" {
+		t.Fatalf("files[1].id = %#v, want file_keep", got)
+	}
+	newFileID := productUpdateNewUploadExternalID(t, files[2], "files[2]")
 
 	richContent := productUpdateJSONRichContent(t, srv.putJSON)
 	if len(richContent) != 1 {
@@ -577,145 +579,7 @@ func TestUpdate_FileSwapsRemovedRichContentEmbed(t *testing.T) {
 	}
 }
 
-func TestUpdate_RemoveEmbeddedFileStripsRichContentEmbed(t *testing.T) {
-	srv := newProductUpdateFileServers(t)
-	srv.existingFiles = []existingProductFile{
-		{ID: "file_old", Name: "Old Pack.zip"},
-		{ID: "file_keep", Name: "Keep.pdf"},
-	}
-	srv.existingRichContent = []map[string]any{{
-		"id":    "page_1",
-		"title": "Existing page",
-		"description": map[string]any{
-			"type": "doc",
-			"content": []any{
-				map[string]any{
-					"type": "paragraph",
-					"content": []any{
-						map[string]any{"type": "text", "text": "Download below"},
-					},
-				},
-				map[string]any{
-					"type": "fileEmbed",
-					"attrs": map[string]any{
-						"id":        "file_old",
-						"uid":       "old-uid",
-						"collapsed": false,
-					},
-				},
-			},
-		},
-	}}
-	testutil.Setup(t, srv.dispatch(t))
-
-	cmd := testutil.Command(newUpdateCmd(), testutil.Yes(true))
-	cmd.SetArgs([]string{
-		"prod1",
-		"--remove-file", "file_old",
-	})
-	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
-
-	files := productUpdateJSONFiles(t, srv.putJSON)
-	if len(files) != 1 || files[0]["id"] != "file_keep" {
-		t.Fatalf("files payload = %#v, want only file_keep", files)
-	}
-	if ids := richContentFileEmbedIDsFromBody(t, srv.putJSON); len(ids) != 0 {
-		t.Fatalf("rich_content fileEmbed ids = %#v, want none", ids)
-	}
-	if srv.s3Calls.Load() != 0 {
-		t.Fatalf("unexpected S3 calls: %d", srv.s3Calls.Load())
-	}
-}
-
-func TestUpdate_ReplaceFilesClearAllStripsEmbeddedRichContent(t *testing.T) {
-	srv := newProductUpdateFileServers(t)
-	srv.existingFiles = []existingProductFile{
-		{ID: "file_a", Name: "Old A.zip"},
-		{ID: "file_b", Name: "Old B.zip"},
-	}
-	srv.existingRichContent = []map[string]any{{
-		"id":    "page_1",
-		"title": "Existing page",
-		"description": map[string]any{
-			"type": "doc",
-			"content": []any{
-				map[string]any{"type": "fileEmbed", "attrs": map[string]any{"id": "file_a"}},
-				map[string]any{
-					"type": "fileEmbedGroup",
-					"content": []any{
-						map[string]any{"type": "fileEmbed", "attrs": map[string]any{"id": "file_b"}},
-					},
-				},
-				map[string]any{"type": "paragraph"},
-			},
-		},
-	}}
-	testutil.Setup(t, srv.dispatch(t))
-
-	cmd := testutil.Command(newUpdateCmd(), testutil.Yes(true))
-	cmd.SetArgs([]string{
-		"prod1",
-		"--replace-files",
-	})
-	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
-
-	files := productUpdateJSONFiles(t, srv.putJSON)
-	if len(files) != 0 {
-		t.Fatalf("files payload = %#v, want empty array", files)
-	}
-	if ids := richContentFileEmbedIDsFromBody(t, srv.putJSON); len(ids) != 0 {
-		t.Fatalf("rich_content fileEmbed ids = %#v, want none", ids)
-	}
-	if types := firstRichContentNodeTypesFromBody(t, srv.putJSON); !reflect.DeepEqual(types, []string{"paragraph"}) {
-		t.Fatalf("rich_content node types = %#v, want only trailing paragraph", types)
-	}
-	if srv.s3Calls.Load() != 0 {
-		t.Fatalf("unexpected S3 calls: %d", srv.s3Calls.Load())
-	}
-}
-
-func TestUpdate_RemoveEmbeddedFileLeavesParagraphWhenPageWouldBeEmpty(t *testing.T) {
-	srv := newProductUpdateFileServers(t)
-	srv.existingFiles = []existingProductFile{
-		{ID: "file_old", Name: "Old Pack.zip"},
-	}
-	srv.existingRichContent = []map[string]any{{
-		"id":    "page_1",
-		"title": "Existing page",
-		"description": map[string]any{
-			"type": "doc",
-			"content": []any{
-				map[string]any{
-					"type": "fileEmbedGroup",
-					"content": []any{
-						map[string]any{"type": "fileEmbed", "attrs": map[string]any{"id": "file_old"}},
-					},
-				},
-			},
-		},
-	}}
-	testutil.Setup(t, srv.dispatch(t))
-
-	cmd := testutil.Command(newUpdateCmd(), testutil.Yes(true))
-	cmd.SetArgs([]string{
-		"prod1",
-		"--remove-file", "file_old",
-	})
-	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
-
-	files := productUpdateJSONFiles(t, srv.putJSON)
-	if len(files) != 0 {
-		t.Fatalf("files payload = %#v, want empty array", files)
-	}
-	if ids := richContentFileEmbedIDsFromBody(t, srv.putJSON); len(ids) != 0 {
-		t.Fatalf("rich_content fileEmbed ids = %#v, want none", ids)
-	}
-	if types := firstRichContentNodeTypesFromBody(t, srv.putJSON); !reflect.DeepEqual(types, []string{"paragraph"}) {
-		t.Fatalf("rich_content node types = %#v, want fallback paragraph", types)
-	}
-}
-
-func TestUpdate_FileAppendsBeforeTrailingParagraph(t *testing.T) {
+func TestUpdate_FileRollsBeforeTrailingParagraph(t *testing.T) {
 	srv := newProductUpdateFileServers(t)
 	srv.existingFiles = []existingProductFile{
 		{ID: "file_old", Name: "Old Pack.zip"},
@@ -747,15 +611,15 @@ func TestUpdate_FileAppendsBeforeTrailingParagraph(t *testing.T) {
 		t.Fatalf("files payload len = %d, want 2", len(files))
 	}
 	newFileID := productUpdateNewUploadExternalID(t, files[1], "files[1]")
-	if ids := richContentFileEmbedIDsFromBody(t, srv.putJSON); !reflect.DeepEqual(ids, []string{"file_old", newFileID}) {
-		t.Fatalf("rich_content fileEmbed ids = %#v, want existing file then new upload", ids)
+	if ids := richContentFileEmbedIDsFromBody(t, srv.putJSON); !reflect.DeepEqual(ids, []string{newFileID}) {
+		t.Fatalf("rich_content fileEmbed ids = %#v, want new upload only", ids)
 	}
-	if types := firstRichContentNodeTypesFromBody(t, srv.putJSON); !reflect.DeepEqual(types, []string{"fileEmbed", "fileEmbed", "paragraph"}) {
-		t.Fatalf("rich_content node types = %#v, want adjacent file embeds then one trailing paragraph", types)
+	if types := firstRichContentNodeTypesFromBody(t, srv.putJSON); !reflect.DeepEqual(types, []string{"fileEmbed", "paragraph"}) {
+		t.Fatalf("rich_content node types = %#v, want file embed then one trailing paragraph", types)
 	}
 }
 
-func TestUpdate_FileAppendsToPageWithExistingEmbed(t *testing.T) {
+func TestUpdate_FileRollsOnPageWithExistingEmbed(t *testing.T) {
 	srv := newProductUpdateFileServers(t)
 	srv.existingFiles = []existingProductFile{
 		{ID: "file_old", Name: "Old Pack.zip"},
@@ -808,18 +672,18 @@ func TestUpdate_FileAppendsToPageWithExistingEmbed(t *testing.T) {
 	if ids := fileEmbedIDs([]map[string]any{richContent[0]}); len(ids) != 0 {
 		t.Fatalf("page 1 fileEmbed ids = %#v, want none", ids)
 	}
-	if ids := fileEmbedIDs([]map[string]any{richContent[1]}); !reflect.DeepEqual(ids, []string{"file_old", newFileID}) {
-		t.Fatalf("page 2 fileEmbed ids = %#v, want existing file then new upload", ids)
+	if ids := fileEmbedIDs([]map[string]any{richContent[1]}); !reflect.DeepEqual(ids, []string{newFileID}) {
+		t.Fatalf("page 2 fileEmbed ids = %#v, want new upload only", ids)
 	}
 	if types := richContentNodeTypes(t, richContent[0]); !reflect.DeepEqual(types, []string{"paragraph", "paragraph"}) {
 		t.Fatalf("page 1 node types = %#v, want unchanged paragraphs", types)
 	}
-	if types := richContentNodeTypes(t, richContent[1]); !reflect.DeepEqual(types, []string{"fileEmbed", "fileEmbed", "paragraph"}) {
-		t.Fatalf("page 2 node types = %#v, want adjacent file embeds then one trailing paragraph", types)
+	if types := richContentNodeTypes(t, richContent[1]); !reflect.DeepEqual(types, []string{"fileEmbed", "paragraph"}) {
+		t.Fatalf("page 2 node types = %#v, want file embed then one trailing paragraph", types)
 	}
 }
 
-func TestUpdate_FileAppendsInsideExistingFileEmbedGroup(t *testing.T) {
+func TestUpdate_FileRollsMultipleEmbedsInsideExistingFileEmbedGroup(t *testing.T) {
 	srv := newProductUpdateFileServers(t)
 	srv.existingFiles = []existingProductFile{
 		{ID: "file_a", Name: "Old A.zip"},
@@ -844,20 +708,24 @@ func TestUpdate_FileAppendsInsideExistingFileEmbedGroup(t *testing.T) {
 	}}
 	testutil.Setup(t, srv.dispatch(t))
 
-	path := writeProductUploadFixture(t, "fresh bytes")
+	firstPath := writeProductUploadFixture(t, "first bytes")
+	secondPath := writeProductUploadFixture(t, "second bytes")
 	cmd := testutil.Command(newUpdateCmd(), testutil.Yes(true))
 	cmd.SetArgs([]string{
 		"prod1",
-		"--file", path,
-		"--file-name", "New Pack.zip",
+		"--file", firstPath,
+		"--file", secondPath,
+		"--file-name", "New A.zip",
+		"--file-name", "New B.zip",
 	})
 	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
 	files := productUpdateJSONFiles(t, srv.putJSON)
-	if len(files) != 3 {
-		t.Fatalf("files payload len = %d, want 3", len(files))
+	if len(files) != 4 {
+		t.Fatalf("files payload len = %d, want 4", len(files))
 	}
-	newFileID := productUpdateNewUploadExternalID(t, files[2], "files[2]")
+	firstNewFileID := productUpdateNewUploadExternalID(t, files[2], "files[2]")
+	secondNewFileID := productUpdateNewUploadExternalID(t, files[3], "files[3]")
 
 	richContent := productUpdateJSONRichContent(t, srv.putJSON)
 	if types := richContentNodeTypes(t, richContent[0]); !reflect.DeepEqual(types, []string{"fileEmbedGroup", "paragraph"}) {
@@ -869,8 +737,8 @@ func TestUpdate_FileAppendsInsideExistingFileEmbedGroup(t *testing.T) {
 		t.Fatalf("first rich_content node = %#v, want fileEmbedGroup", content[0])
 	}
 	groupIDs := fileEmbedIDs([]map[string]any{{"description": group}})
-	if !reflect.DeepEqual(groupIDs, []string{"file_a", "file_b", newFileID}) {
-		t.Fatalf("fileEmbedGroup ids = %#v, want existing files then new upload", groupIDs)
+	if !reflect.DeepEqual(groupIDs, []string{firstNewFileID, secondNewFileID}) {
+		t.Fatalf("fileEmbedGroup ids = %#v, want new upload ids", groupIDs)
 	}
 }
 
@@ -911,16 +779,16 @@ func TestUpdate_FilePreservesAuthoredTrailingParagraph(t *testing.T) {
 		t.Fatalf("files payload len = %d, want 2", len(files))
 	}
 	newFileID := productUpdateNewUploadExternalID(t, files[1], "files[1]")
-	if ids := richContentFileEmbedIDsFromBody(t, srv.putJSON); !reflect.DeepEqual(ids, []string{"file_old", newFileID}) {
-		t.Fatalf("rich_content fileEmbed ids = %#v, want existing file then new upload", ids)
+	if ids := richContentFileEmbedIDsFromBody(t, srv.putJSON); !reflect.DeepEqual(ids, []string{newFileID}) {
+		t.Fatalf("rich_content fileEmbed ids = %#v, want new upload only", ids)
 	}
 
 	richContent := productUpdateJSONRichContent(t, srv.putJSON)
-	if types := richContentNodeTypes(t, richContent[0]); !reflect.DeepEqual(types, []string{"fileEmbed", "fileEmbed", "paragraph"}) {
-		t.Fatalf("rich_content node types = %#v, want file embeds then authored paragraph", types)
+	if types := richContentNodeTypes(t, richContent[0]); !reflect.DeepEqual(types, []string{"fileEmbed", "paragraph"}) {
+		t.Fatalf("rich_content node types = %#v, want file embed then authored paragraph", types)
 	}
 	content := richContentPageContent(t, richContent[0])
-	paragraph := content[2].(map[string]any)
+	paragraph := content[1].(map[string]any)
 	textNodes, ok := paragraph["content"].([]any)
 	if !ok || len(textNodes) != 1 {
 		t.Fatalf("trailing paragraph content = %#v, want one text node", paragraph["content"])
@@ -954,15 +822,14 @@ func TestUpdate_FileAmbiguousEmbeddedReplacementErrorsBeforeUpload(t *testing.T)
 	cmd := testutil.Command(newUpdateCmd(), testutil.Yes(true))
 	cmd.SetArgs([]string{
 		"prod1",
-		"--replace-files",
 		"--file", path,
 	})
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected ambiguous rich_content replacement error")
 	}
-	if !strings.Contains(err.Error(), "replace one embedded file at a time") {
-		t.Fatalf("expected rich_content disambiguation error, got %v", err)
+	if !strings.Contains(err.Error(), "rich_content has 2 file embeds") || !strings.Contains(err.Error(), "pass one --file per existing file embed") {
+		t.Fatalf("expected rich_content count error, got %v", err)
 	}
 	if srv.s3Calls.Load() != 0 {
 		t.Fatalf("unexpected S3 calls: %d", srv.s3Calls.Load())
@@ -972,127 +839,24 @@ func TestUpdate_FileAmbiguousEmbeddedReplacementErrorsBeforeUpload(t *testing.T)
 	}
 }
 
-func TestUpdate_RemoveFilePreservesOthers(t *testing.T) {
-	srv := newProductUpdateFileServers(t)
-	srv.existingFiles = []existingProductFile{
-		{ID: "file_a"},
-		{ID: "file_b"},
-	}
-	testutil.Setup(t, srv.dispatch(t))
-
-	cmd := testutil.Command(newUpdateCmd(), testutil.Yes(true))
-	cmd.SetArgs([]string{"prod1", "--remove-file", "file_a"})
-	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
-
-	files := productUpdateJSONFiles(t, srv.putJSON)
-	if len(files) != 1 || files[0]["id"] != "file_b" {
-		t.Fatalf("files payload = %#v, want only file_b", files)
-	}
-}
-
-func TestUpdate_ReplaceFilesKeepsOnlyRequestedIDs(t *testing.T) {
-	srv := newProductUpdateFileServers(t)
-	srv.existingFiles = []existingProductFile{
-		{ID: "file_a"},
-		{ID: "file_b"},
-		{ID: "file_c"},
-	}
-	testutil.Setup(t, srv.dispatch(t))
-
-	cmd := testutil.Command(newUpdateCmd(), testutil.Yes(true))
-	cmd.SetArgs([]string{"prod1", "--replace-files", "--keep-file", "file_b"})
-	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
-
-	files := productUpdateJSONFiles(t, srv.putJSON)
-	if len(files) != 1 || files[0]["id"] != "file_b" {
-		t.Fatalf("files payload = %#v, want only file_b", files)
-	}
-}
-
-func TestUpdate_KeepAndRemoveSameIDErrors(t *testing.T) {
+func TestUpdate_FileSurgeryFlagsAreRemoved(t *testing.T) {
 	srv := newProductUpdateFileServers(t)
 	srv.existingFiles = []existingProductFile{{ID: "file_a"}}
 	testutil.Setup(t, srv.dispatch(t))
 
-	cmd := newUpdateCmd()
-	cmd.SetArgs([]string{"prod1", "--replace-files", "--keep-file", "file_a", "--remove-file", "file_a"})
-	err := cmd.Execute()
-	if err == nil {
-		t.Fatal("expected usage error")
+	for _, flag := range []string{"--replace-files", "--remove-file", "--keep-file"} {
+		cmd := newUpdateCmd()
+		cmd.SetArgs([]string{"prod1", flag, "file_a"})
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatalf("expected %s to be removed", flag)
+		}
+		if !strings.Contains(err.Error(), "unknown flag") {
+			t.Fatalf("expected unknown flag error for %s, got %v", flag, err)
+		}
 	}
-	if !strings.Contains(err.Error(), "--keep-file") || !strings.Contains(err.Error(), "--remove-file") {
-		t.Fatalf("expected conflict error, got %v", err)
-	}
-	if srv.getCalls.Load() != 0 {
-		t.Fatalf("unexpected GET calls: %d", srv.getCalls.Load())
-	}
-	if srv.putCalls.Load() != 0 {
-		t.Fatalf("unexpected PUT calls: %d", srv.putCalls.Load())
-	}
-}
-
-func TestUpdate_UnknownRemoveFileErrorsAfterPrefetch(t *testing.T) {
-	srv := newProductUpdateFileServers(t)
-	srv.existingFiles = []existingProductFile{{ID: "file_a"}}
-	testutil.Setup(t, srv.dispatch(t))
-
-	cmd := newUpdateCmd()
-	cmd.SetArgs([]string{"prod1", "--remove-file", "missing"})
-	err := cmd.Execute()
-	if err == nil {
-		t.Fatal("expected usage error")
-	}
-	if !strings.Contains(err.Error(), "unknown --remove-file") {
-		t.Fatalf("expected unknown remove-file error, got %v", err)
-	}
-	if srv.getCalls.Load() != 1 {
-		t.Fatalf("GET calls = %d, want 1", srv.getCalls.Load())
-	}
-	if srv.putCalls.Load() != 0 {
-		t.Fatalf("unexpected PUT calls: %d", srv.putCalls.Load())
-	}
-}
-
-func TestUpdate_ReplaceFilesClearAllUsesJSONBody(t *testing.T) {
-	srv := newProductUpdateFileServers(t)
-	srv.existingFiles = []existingProductFile{
-		{ID: "file_a", Name: "Old A.pdf"},
-		{ID: "file_b", Name: "Old B.pdf"},
-	}
-	testutil.Setup(t, srv.dispatch(t))
-
-	cmd := testutil.Command(newUpdateCmd(), testutil.Yes(true))
-	cmd.SetArgs([]string{"prod1", "--replace-files"})
-	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
-
-	if srv.jsonPutCalls.Load() != 1 {
-		t.Fatalf("JSON PUT calls = %d, want 1", srv.jsonPutCalls.Load())
-	}
-	files, ok := srv.putJSON["files"].([]any)
-	if !ok {
-		t.Fatalf("files payload has wrong type: %T", srv.putJSON["files"])
-	}
-	if len(files) != 0 {
-		t.Fatalf("files payload = %#v, want empty array", files)
-	}
-}
-
-func TestUpdate_ReplaceFilesNoInputRequiresYes(t *testing.T) {
-	srv := newProductUpdateFileServers(t)
-	srv.existingFiles = []existingProductFile{{ID: "file_a"}}
-	testutil.Setup(t, srv.dispatch(t))
-
-	cmd := testutil.Command(newUpdateCmd(), testutil.NoInput(true))
-	cmd.SetArgs([]string{"prod1", "--replace-files"})
-	err := cmd.Execute()
-	if err == nil {
-		t.Fatal("expected confirmation error")
-	}
-	if !strings.Contains(err.Error(), "--yes") {
-		t.Fatalf("expected --yes hint, got %v", err)
-	}
-	if srv.putCalls.Load() != 0 {
-		t.Fatalf("unexpected PUT calls: %d", srv.putCalls.Load())
+	if srv.getCalls.Load() != 0 || srv.putCalls.Load() != 0 {
+		t.Fatalf("unexpected API calls: get=%d put=%d", srv.getCalls.Load(), srv.putCalls.Load())
 	}
 }
 
@@ -1102,11 +866,22 @@ func TestUpdate_FileDryRunPrefetchesButDoesNotUploadOrPut(t *testing.T) {
 		{ID: "file_a", Name: "Old A.pdf"},
 		{ID: "file_b", Name: "Old B.pdf"},
 	}
+	srv.existingRichContent = []map[string]any{{
+		"id":    "page_1",
+		"title": "Existing page",
+		"description": map[string]any{
+			"type": "doc",
+			"content": []any{
+				map[string]any{"type": "fileEmbed", "attrs": map[string]any{"id": "file_a"}},
+				map[string]any{"type": "paragraph"},
+			},
+		},
+	}}
 	testutil.Setup(t, srv.dispatch(t))
 
 	path := writeProductUploadFixture(t, "fresh bytes")
 	cmd := testutil.Command(newUpdateCmd(), testutil.DryRun(true), testutil.JSONOutput())
-	cmd.SetArgs([]string{"prod1", "--file", path, "--remove-file", "file_a"})
+	cmd.SetArgs([]string{"prod1", "--file", path})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
 	if srv.getCalls.Load() != 1 {
@@ -1137,23 +912,23 @@ func TestUpdate_FileDryRunPrefetchesButDoesNotUploadOrPut(t *testing.T) {
 	if payload.Uploads[0].PartCount != 1 {
 		t.Fatalf("upload part count = %d, want 1", payload.Uploads[0].PartCount)
 	}
-	if len(payload.Preserved) != 1 || payload.Preserved[0].ID != "file_b" || payload.Preserved[0].Name != "Old B.pdf" {
+	if len(payload.Preserved) != 2 || payload.Preserved[0].ID != "file_a" || payload.Preserved[1].ID != "file_b" {
 		t.Fatalf("preserved = %+v", payload.Preserved)
 	}
-	if len(payload.Removed) != 1 || payload.Removed[0].ID != "file_a" || payload.Removed[0].Name != "Old A.pdf" {
+	if len(payload.Removed) != 0 {
 		t.Fatalf("removed = %+v", payload.Removed)
 	}
 	files := productUpdateJSONFiles(t, payload.Request.Body)
-	if len(files) != 2 || files[0]["id"] != "file_b" {
+	if len(files) != 3 || files[0]["id"] != "file_a" || files[1]["id"] != "file_b" {
 		t.Fatalf("dry-run files payload = %#v", files)
 	}
-	if files[1]["url"] != "<uploaded:file:0>" {
-		t.Fatalf("dry-run upload placeholder = %#v", files[1]["url"])
+	if files[2]["url"] != "<uploaded:file:0>" {
+		t.Fatalf("dry-run upload placeholder = %#v", files[2]["url"])
 	}
-	newFileID := productUpdateNewUploadExternalID(t, files[1], "files[1]")
+	newFileID := productUpdateNewUploadExternalID(t, files[2], "files[2]")
 	richContent := productUpdateJSONRichContent(t, payload.Request.Body)
-	if ids := fileEmbedIDs(richContent); !reflect.DeepEqual(ids, []string{"file_b", newFileID}) {
-		t.Fatalf("dry-run fileEmbed ids = %#v, want preserved file then new upload", ids)
+	if ids := fileEmbedIDs(richContent); !reflect.DeepEqual(ids, []string{newFileID}) {
+		t.Fatalf("dry-run fileEmbed ids = %#v, want new upload only", ids)
 	}
 }
 
@@ -1205,7 +980,7 @@ func TestUpdate_FileDryRunHumanIncludesUploadPlan(t *testing.T) {
 	}
 }
 
-func TestUpdate_DryRunHumanIncludesExistingFileNames(t *testing.T) {
+func TestUpdate_FileDryRunHumanIncludesExistingFileNames(t *testing.T) {
 	srv := newProductUpdateFileServers(t)
 	srv.existingFiles = []existingProductFile{
 		{ID: "file_a", Name: "Old A.pdf"},
@@ -1213,34 +988,18 @@ func TestUpdate_DryRunHumanIncludesExistingFileNames(t *testing.T) {
 	}
 	testutil.Setup(t, srv.dispatch(t))
 
+	path := writeProductUploadFixture(t, "fresh bytes")
 	cmd := testutil.Command(newUpdateCmd(), testutil.DryRun(true))
-	cmd.SetArgs([]string{"prod1", "--remove-file", "file_a"})
+	cmd.SetArgs([]string{"prod1", "--file", path})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	if !strings.Contains(out, "Preserve existing file: Old B.pdf (file_b)") {
-		t.Fatalf("human dry-run missing preserved file: %q", out)
-	}
-	if !strings.Contains(out, "Remove existing file: Old A.pdf (file_a)") {
-		t.Fatalf("human dry-run missing removed file: %q", out)
-	}
-}
-
-func TestUpdate_KeepFileRequiresReplaceFiles(t *testing.T) {
-	srv := newProductUpdateFileServers(t)
-	srv.existingFiles = []existingProductFile{{ID: "file_a"}}
-	testutil.Setup(t, srv.dispatch(t))
-
-	cmd := newUpdateCmd()
-	cmd.SetArgs([]string{"prod1", "--keep-file", "file_a"})
-	err := cmd.Execute()
-	if err == nil {
-		t.Fatal("expected usage error")
-	}
-	if !strings.Contains(err.Error(), "--replace-files") {
-		t.Fatalf("expected keep-file usage error, got %v", err)
-	}
-	if srv.getCalls.Load() != 0 {
-		t.Fatalf("unexpected GET calls: %d", srv.getCalls.Load())
+	for _, expected := range []string{
+		"Preserve existing file: Old A.pdf (file_a)",
+		"Preserve existing file: Old B.pdf (file_b)",
+	} {
+		if !strings.Contains(out, expected) {
+			t.Fatalf("human dry-run missing %q: %q", expected, out)
+		}
 	}
 }
 
@@ -1270,14 +1029,14 @@ func TestCollectRequestedProductUploads_TrimsDisplayName(t *testing.T) {
 	}
 }
 
-func TestUpdate_InvalidUploadFailsBeforeRemovalConfirmation(t *testing.T) {
+func TestUpdate_InvalidUploadFailsBeforePrefetch(t *testing.T) {
 	srv := newProductUpdateFileServers(t)
 	srv.existingFiles = []existingProductFile{{ID: "file_a"}}
 	testutil.Setup(t, srv.dispatch(t))
 
 	missingPath := filepath.Join(t.TempDir(), "missing.bin")
 	cmd := testutil.Command(newUpdateCmd(), testutil.NoInput(true))
-	cmd.SetArgs([]string{"prod1", "--replace-files", "--file", missingPath})
+	cmd.SetArgs([]string{"prod1", "--file", missingPath})
 
 	err := cmd.Execute()
 	if err == nil {
@@ -1285,9 +1044,6 @@ func TestUpdate_InvalidUploadFailsBeforeRemovalConfirmation(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "could not stat file") {
 		t.Fatalf("expected stat error, got %v", err)
-	}
-	if strings.Contains(err.Error(), "--yes") {
-		t.Fatalf("expected validation to happen before confirmation, got %v", err)
 	}
 	if srv.getCalls.Load() != 0 {
 		t.Fatalf("unexpected GET calls: %d", srv.getCalls.Load())
@@ -1373,74 +1129,6 @@ func TestUpdate_RenderFailureDoesNotIncludeUploadedURLs(t *testing.T) {
 	}
 	if srv.putCalls.Load() != 1 {
 		t.Fatalf("PUT calls = %d, want 1", srv.putCalls.Load())
-	}
-}
-
-func TestUpdate_ReplaceFilesClearAllDryRunJSON(t *testing.T) {
-	srv := newProductUpdateFileServers(t)
-	srv.existingFiles = []existingProductFile{{ID: "file_a"}}
-	testutil.Setup(t, srv.dispatch(t))
-
-	cmd := testutil.Command(newUpdateCmd(), testutil.DryRun(true), testutil.JSONOutput())
-	cmd.SetArgs([]string{"prod1", "--replace-files"})
-	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
-
-	var payload dryRunUpdateBody
-	if err := json.Unmarshal([]byte(out), &payload); err != nil {
-		t.Fatalf("parse JSON: %v\n%s", err, out)
-	}
-	if payload.Request.Method != http.MethodPut || payload.Request.Path != "/products/prod1" {
-		t.Fatalf("unexpected dry-run envelope: %+v", payload)
-	}
-	if len(payload.Uploads) != 0 {
-		t.Fatalf("expected no uploads, got %+v", payload.Uploads)
-	}
-	if len(payload.Preserved) != 0 {
-		t.Fatalf("expected no preserved files, got %+v", payload.Preserved)
-	}
-	if len(payload.Removed) != 1 || payload.Removed[0].ID != "file_a" {
-		t.Fatalf("removed = %+v", payload.Removed)
-	}
-	files, ok := payload.Request.Body["files"].([]any)
-	if !ok {
-		t.Fatalf("files payload has wrong type: %T", payload.Request.Body["files"])
-	}
-	if len(files) != 0 {
-		t.Fatalf("expected empty files array, got %#v", files)
-	}
-}
-
-func TestUpdate_ReplaceFilesClearAllDryRunPlain(t *testing.T) {
-	srv := newProductUpdateFileServers(t)
-	srv.existingFiles = []existingProductFile{{ID: "file_a"}}
-	testutil.Setup(t, srv.dispatch(t))
-
-	cmd := testutil.Command(newUpdateCmd(), testutil.DryRun(true), testutil.PlainOutput())
-	cmd.SetArgs([]string{"prod1", "--replace-files"})
-	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
-
-	if !strings.Contains(out, "PUT\t/products/prod1\t") {
-		t.Fatalf("plain dry-run missing request line: %q", out)
-	}
-	if !strings.Contains(out, "\"files\":[]") {
-		t.Fatalf("plain dry-run missing empty files array: %q", out)
-	}
-}
-
-func TestUpdate_ReplaceFilesClearAllDryRunHuman(t *testing.T) {
-	srv := newProductUpdateFileServers(t)
-	srv.existingFiles = []existingProductFile{{ID: "file_a"}}
-	testutil.Setup(t, srv.dispatch(t))
-
-	cmd := testutil.Command(newUpdateCmd(), testutil.DryRun(true))
-	cmd.SetArgs([]string{"prod1", "--replace-files"})
-	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
-
-	if !strings.Contains(out, "Dry run: PUT /products/prod1") {
-		t.Fatalf("human dry-run missing request line: %q", out)
-	}
-	if !strings.Contains(out, "\"files\": []") {
-		t.Fatalf("human dry-run missing empty files array: %q", out)
 	}
 }
 

--- a/internal/cmd/variants/file_updates.go
+++ b/internal/cmd/variants/file_updates.go
@@ -158,9 +158,9 @@ func runVariantUpdateWithFiles(
 	if err != nil {
 		return err
 	}
-	richContent, err := richcontent.AppendFileEmbeds(variantState.RichContent, nil, fileRefs)
+	richContent, err := richcontent.RollFileEmbeds(variantState.RichContent, nil, fileRefs)
 	if err != nil {
-		return err
+		return cmdutil.InvalidInputErrorf("%s; pass one --file per existing file embed, or use products content get/set for structural content changes", err.Error())
 	}
 
 	productPath := cmdutil.JoinPath("products", productID)

--- a/internal/cmd/variants/update.go
+++ b/internal/cmd/variants/update.go
@@ -85,7 +85,7 @@ func newUpdateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&description, "description", "", "New description")
 	cmd.Flags().StringVar(&priceDifference, "price-difference", "", "New price difference (e.g. 5.00, -1.50)")
 	cmd.Flags().IntVar(&maxPurchaseCount, "max-purchase-count", 0, "New max purchase count")
-	cmd.Flags().StringArrayVar(&files, "file", nil, "Attach a new local file to this variant's content (repeatable)")
+	cmd.Flags().StringArrayVar(&files, "file", nil, "Roll a local file into this variant's content file embeds (repeatable)")
 	cmd.Flags().StringArrayVar(&fileNames, "file-name", nil, "Display name for the matching --file (repeatable)")
 	cmd.Flags().StringArrayVar(&fileDescriptions, "file-description", nil, "Description for the matching --file (repeatable)")
 

--- a/internal/cmd/variants/variants_test.go
+++ b/internal/cmd/variants/variants_test.go
@@ -965,7 +965,7 @@ func TestUpdate_MaxPurchaseCountZero(t *testing.T) {
 	}
 }
 
-func TestUpdate_FileAttachesToVariantRichContent(t *testing.T) {
+func TestUpdate_FileRollsVariantRichContent(t *testing.T) {
 	srv := newVariantFileAttachServers(t)
 	testutil.Setup(t, srv.dispatch(t))
 
@@ -1009,8 +1009,8 @@ func TestUpdate_FileAttachesToVariantRichContent(t *testing.T) {
 	}
 
 	richContentPages := variantUpdateJSONRichContent(t, srv.variantJSON)
-	if ids := richcontent.FileEmbedIDs(richContentPages); !reflect.DeepEqual(ids, []string{"file_existing", newFileID}) {
-		t.Fatalf("variant rich_content fileEmbed ids = %#v, want existing file then new upload", ids)
+	if ids := richcontent.FileEmbedIDs(richContentPages); !reflect.DeepEqual(ids, []string{newFileID}) {
+		t.Fatalf("variant rich_content fileEmbed ids = %#v, want new upload only", ids)
 	}
 }
 
@@ -1130,6 +1130,10 @@ func TestUpdate_FileDryRunJSONShowsProductAndVariantRequests(t *testing.T) {
 	}
 	if payload.VariantRequest.Body["description"] != "Updated variant" {
 		t.Fatalf("variant description = %#v, want Updated variant", payload.VariantRequest.Body["description"])
+	}
+	richContentPages := variantUpdateJSONRichContent(t, payload.VariantRequest.Body)
+	if ids := richcontent.FileEmbedIDs(richContentPages); len(ids) != 1 || !strings.HasPrefix(ids[0], "cli-upload-") {
+		t.Fatalf("dry-run variant rich_content fileEmbed ids = %#v, want one generated upload id", ids)
 	}
 	if srv.s3Calls.Load() != 0 {
 		t.Fatalf("S3 calls = %d, want 0", srv.s3Calls.Load())

--- a/internal/richcontent/files.go
+++ b/internal/richcontent/files.go
@@ -90,6 +90,33 @@ func AppendFileEmbeds(richContent []map[string]any, preservedFileIDs []string, f
 	return cloned, nil
 }
 
+func RollFileEmbeds(richContent []map[string]any, preservedFileIDs []string, fileRefs []FileRef) ([]map[string]any, error) {
+	if len(fileRefs) == 0 {
+		return Clone(richContent)
+	}
+
+	existingIDs := FileEmbedIDs(richContent)
+	if len(existingIDs) == 0 {
+		return AppendFileEmbeds(richContent, preservedFileIDs, fileRefs)
+	}
+	if len(existingIDs) != len(fileRefs) {
+		return nil, fmt.Errorf("rich_content has %d file embeds; got %d replacement files", len(existingIDs), len(fileRefs))
+	}
+
+	cloned, err := Clone(richContent)
+	if err != nil {
+		return nil, err
+	}
+	nextRef := 0
+	for _, page := range cloned {
+		replaceFileEmbedRefsInNode(page["description"], fileRefs, &nextRef)
+	}
+	if nextRef != len(fileRefs) {
+		return nil, fmt.Errorf("could not replace all file embeds in rich_content")
+	}
+	return cloned, nil
+}
+
 func Clone(richContent []map[string]any) ([]map[string]any, error) {
 	data, err := json.Marshal(richContent)
 	if err != nil {
@@ -108,28 +135,6 @@ func FileEmbedIDs(richContent []map[string]any) []string {
 		collectFileEmbedIDs(page["description"], &ids)
 	}
 	return ids
-}
-
-func ReplaceFileEmbedID(richContent []map[string]any, oldID, newID string) {
-	for _, page := range richContent {
-		replaceFileEmbedIDInNode(page["description"], oldID, newID)
-	}
-}
-
-func StripFileEmbedIDs(richContent []map[string]any, ids []string) {
-	if len(ids) == 0 {
-		return
-	}
-	idSet := make(map[string]struct{}, len(ids))
-	for _, id := range ids {
-		idSet[id] = struct{}{}
-	}
-	for _, page := range richContent {
-		if description, ok := page["description"].(map[string]any); ok {
-			stripFileEmbedIDsInNode(description, idSet)
-			ensureDescriptionContent(description)
-		}
-	}
 }
 
 func refsForExistingFiles(fileIDs []string) ([]FileRef, error) {
@@ -203,16 +208,20 @@ func appendFileEmbedsToContent(content []any, fileRefs []FileRef) []any {
 func fileEmbedNodes(fileRefs []FileRef) []any {
 	nodes := make([]any, len(fileRefs))
 	for i, ref := range fileRefs {
-		nodes[i] = map[string]any{
-			"type": "fileEmbed",
-			"attrs": map[string]any{
-				"id":        ref.FileID,
-				"uid":       ref.EmbedUID,
-				"collapsed": false,
-			},
-		}
+		nodes[i] = fileEmbedNode(ref)
 	}
 	return nodes
+}
+
+func fileEmbedNode(ref FileRef) map[string]any {
+	return map[string]any{
+		"type": "fileEmbed",
+		"attrs": map[string]any{
+			"id":        ref.FileID,
+			"uid":       ref.EmbedUID,
+			"collapsed": false,
+		},
+	}
 }
 
 func collectFileEmbedIDs(node any, ids *[]string) {
@@ -220,12 +229,8 @@ func collectFileEmbedIDs(node any, ids *[]string) {
 	if !ok {
 		return
 	}
-	if current["type"] == "fileEmbed" {
-		if attrs, ok := current["attrs"].(map[string]any); ok {
-			if id, ok := attrs["id"].(string); ok && id != "" {
-				*ids = append(*ids, id)
-			}
-		}
+	if id, ok := fileEmbedID(current); ok {
+		*ids = append(*ids, id)
 	}
 	if children, ok := current["content"].([]any); ok {
 		for _, child := range children {
@@ -234,24 +239,7 @@ func collectFileEmbedIDs(node any, ids *[]string) {
 	}
 }
 
-func replaceFileEmbedIDInNode(node any, oldID, newID string) {
-	current, ok := node.(map[string]any)
-	if !ok {
-		return
-	}
-	if current["type"] == "fileEmbed" {
-		if attrs, ok := current["attrs"].(map[string]any); ok && attrs["id"] == oldID {
-			attrs["id"] = newID
-		}
-	}
-	if children, ok := current["content"].([]any); ok {
-		for _, child := range children {
-			replaceFileEmbedIDInNode(child, oldID, newID)
-		}
-	}
-}
-
-func stripFileEmbedIDsInNode(node any, ids map[string]struct{}) {
+func replaceFileEmbedRefsInNode(node any, fileRefs []FileRef, nextRef *int) {
 	current, ok := node.(map[string]any)
 	if !ok {
 		return
@@ -261,42 +249,37 @@ func stripFileEmbedIDsInNode(node any, ids map[string]struct{}) {
 		return
 	}
 
-	kept := make([]any, 0, len(children))
 	for _, child := range children {
-		if childMap, ok := child.(map[string]any); ok {
-			if childMap["type"] == "fileEmbed" {
-				if attrs, ok := childMap["attrs"].(map[string]any); ok {
-					if id, ok := attrs["id"].(string); ok {
-						if _, remove := ids[id]; remove {
-							continue
-						}
-					}
-				}
-			}
-			stripFileEmbedIDsInNode(childMap, ids)
-			if isEmptyFileEmbedGroup(childMap) {
-				continue
-			}
+		childMap, ok := child.(map[string]any)
+		if !ok {
+			continue
 		}
-		kept = append(kept, child)
+		if _, ok := fileEmbedID(childMap); ok {
+			rollFileEmbedNode(childMap, fileRefs[*nextRef])
+			*nextRef += 1
+			continue
+		}
+		replaceFileEmbedRefsInNode(childMap, fileRefs, nextRef)
 	}
-	current["content"] = kept
+	current["content"] = children
 }
 
-func isEmptyFileEmbedGroup(node map[string]any) bool {
-	if node["type"] != "fileEmbedGroup" {
-		return false
-	}
-	children, ok := node["content"].([]any)
-	return !ok || len(children) == 0
+func rollFileEmbedNode(node map[string]any, ref FileRef) {
+	attrs, _ := node["attrs"].(map[string]any)
+	attrs["id"] = ref.FileID
+	attrs["uid"] = ref.EmbedUID
 }
 
-func ensureDescriptionContent(description map[string]any) {
-	content, ok := description["content"].([]any)
-	if ok && len(content) > 0 {
-		return
+func fileEmbedID(node map[string]any) (string, bool) {
+	if node["type"] != "fileEmbed" {
+		return "", false
 	}
-	description["content"] = []any{map[string]any{"type": "paragraph"}}
+	attrs, ok := node["attrs"].(map[string]any)
+	if !ok {
+		return "", false
+	}
+	id, ok := attrs["id"].(string)
+	return id, ok && id != ""
 }
 
 func nodeHasType(node any, typ string) bool {

--- a/internal/richcontent/files_test.go
+++ b/internal/richcontent/files_test.go
@@ -1,0 +1,58 @@
+package richcontent
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestRollFileEmbedsReplacesOnlyCountedEmbeds(t *testing.T) {
+	richContent := []map[string]any{{
+		"description": map[string]any{
+			"type": "doc",
+			"content": []any{
+				map[string]any{"type": "fileEmbed", "attrs": map[string]any{"id": "file_old", "uid": "old-uid", "collapsed": true, "label": "Keep me"}},
+				map[string]any{"type": "fileEmbed", "attrs": map[string]any{"uid": "missing-id"}},
+				map[string]any{"type": "paragraph"},
+			},
+		},
+	}}
+
+	next, err := RollFileEmbeds(richContent, nil, []FileRef{{FileID: "file_new", EmbedUID: "new-uid"}})
+	if err != nil {
+		t.Fatalf("RollFileEmbeds failed: %v", err)
+	}
+	if ids := FileEmbedIDs(next); !reflect.DeepEqual(ids, []string{"file_new"}) {
+		t.Fatalf("file embed ids = %#v, want new counted embed only", ids)
+	}
+
+	content := next[0]["description"].(map[string]any)["content"].([]any)
+	replaced := content[0].(map[string]any)
+	if attrs := replaced["attrs"].(map[string]any); attrs["id"] != "file_new" || attrs["uid"] != "new-uid" || attrs["collapsed"] != true || attrs["label"] != "Keep me" {
+		t.Fatalf("replaced attrs = %#v", attrs)
+	}
+	malformed := content[1].(map[string]any)
+	if attrs := malformed["attrs"].(map[string]any); attrs["id"] != nil || attrs["uid"] != "missing-id" {
+		t.Fatalf("malformed embed should remain untouched, got %#v", attrs)
+	}
+}
+
+func TestRollFileEmbedsErrorsOnReplacementCountMismatch(t *testing.T) {
+	richContent := []map[string]any{{
+		"description": map[string]any{
+			"type": "doc",
+			"content": []any{
+				map[string]any{"type": "fileEmbed", "attrs": map[string]any{"id": "file_a"}},
+				map[string]any{"type": "fileEmbed", "attrs": map[string]any{"id": "file_b"}},
+			},
+		},
+	}}
+
+	_, err := RollFileEmbeds(richContent, nil, []FileRef{{FileID: "file_new", EmbedUID: "new-uid"}})
+	if err == nil {
+		t.Fatal("expected replacement count mismatch")
+	}
+	if !strings.Contains(err.Error(), "rich_content has 2 file embeds; got 1 replacement files") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -251,8 +251,6 @@ gumroad products page publish <id> - --json --no-input < landing.html
 gumroad products page clear <id> --yes --json --no-input
 gumroad products page url <id> --no-input
 gumroad products page url <id> --json --jq '.product.landing_url' --no-input
-gumroad products update <id> --replace-files --keep-file file_123 --file ./new-pack.zip --yes --json --no-input
-gumroad products update <id> --remove-file file_456 --yes --json --no-input
 
 # Product covers and thumbnail
 gumroad products covers add <id> --image ./cover.jpg --json --no-input
@@ -306,9 +304,9 @@ In custom HTML, use Gumroad data attributes for live product values and checkout
 
 **Create flags:** `--name` (required), `--price`, `--type` (digital|course|ebook|membership|bundle|coffee|call|commission), `--currency`, `--pay-what-you-want`, `--suggested-price`, `--description`, `--custom-summary`, `--custom-permalink`, `--custom-receipt`, `--max-purchase-count`, `--category`, `--taxonomy-id`, `--tag` (repeatable), `--file` (repeatable), `--file-name` (repeatable, aligned to `--file`), `--file-description` (repeatable, aligned to `--file`), `--cover-image`, `--preview-image` (repeatable), `--thumbnail`.
 
-**Update flags:** `--name`, `--price`, `--currency`, `--description`, `--custom-summary`, `--custom-permalink`, `--custom-receipt`, `--max-purchase-count`, `--category`, `--taxonomy-id`, `--tag` (repeatable), `--custom-html`, `--file` (repeatable), `--file-name`, `--file-description`, `--remove-file` (repeatable), `--replace-files`, `--keep-file` (repeatable with `--replace-files`), `--cover-image`, `--preview-image` (repeatable), `--thumbnail`. Updates preserve existing files by default unless `--replace-files` is set. Prefer `products page preview/publish/clear/url` for custom HTML page workflows; `products update --custom-html` remains supported as a low-level product update flag.
+**Update flags:** `--name`, `--price`, `--currency`, `--description`, `--custom-summary`, `--custom-permalink`, `--custom-receipt`, `--max-purchase-count`, `--category`, `--taxonomy-id`, `--tag` (repeatable), `--custom-html`, `--file` (repeatable), `--file-name`, `--file-description`, `--cover-image`, `--preview-image` (repeatable), `--thumbnail`. Prefer `products page preview/publish/clear/url` for custom HTML page workflows; `products update --custom-html` remains supported as a low-level product update flag.
 
-Use `products update --file` for shared product Content. For products with per-variant Content, use `variants update ... --file` for the specific variant you want to change.
+Use `products update --file` for shared product Content. It replaces existing rich content file embeds in place when they exist, or creates file embeds when the document has none; pass one `--file` per existing file embed and use `products content get/set` for structural content edits. For products with per-variant Content, use `variants update ... --file` for the specific variant you want to change.
 
 Use `--cover-image` for the primary cover, repeat `--preview-image` for additional gallery/preview images, and `--thumbnail` for the card/library thumbnail. These media flags run the required two-step API flow: direct upload first, then attach by signed blob ID. For an existing product, `products thumbnail set --url` asks Gumroad to download and attach a public HTTP(S) image directly.
 
@@ -470,7 +468,7 @@ gumroad variants delete <var_id> --product <id> --category <cat_id> --yes --json
 
 **All subcommands require** `--product` and `--category`.
 
-**Update flags:** `--name`, `--description`, `--price-difference`, `--max-purchase-count`, `--file` (repeatable), `--file-name`, `--file-description`. Use `variants update --file` only for products with per-variant Content; for shared Content, attach at the product level with `products update --file`.
+**Update flags:** `--name`, `--description`, `--price-difference`, `--max-purchase-count`, `--file` (repeatable), `--file-name`, `--file-description`. Use `variants update --file` only for products with per-variant Content; for shared Content, roll files at the product level with `products update --file`.
 
 ### custom-fields — Manage custom fields
 


### PR DESCRIPTION
Ref #129

## What

This makes `products update --file` and `variants update --file` work through rich content instead of the old file-list surgery model. File embeds are rolled in place when content already has them, and new embeds are created when content has none. The old product file surgery flags were removed from the command surface and docs.

## Why

Gumroad products are content documents, not plain bags of files. This makes the "ship a new build" workflow match the current product model, including per-variant content, while preserving authored page structure and embed metadata.

## Before/After

Before, product and variant file updates treated files as a mutable file list and exposed file-surgery flags like `--replace-files`, `--keep-file`, and `--remove-file`.

After, `products update --file` and `variants update --file` roll uploads through `rich_content` file embeds. Existing embeds are replaced in place one-for-one, products with no embeds get new file embeds, and structural content edits are handled by `products content get/set`.


---

This PR was implemented with AI assistance using gpt-5.5 xhigh.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how product and variant file updates mutate Gumroad payloads; behavior is well covered by tests but is a breaking CLI change for anyone relying on the removed file-surgery flags.
> 
> **Overview**
> **`products update --file`** and **`variants update --file`** now treat uploads as **rich content file rolls** instead of mutating the product file list with surgery flags.
> 
> On update, **`--file`** replaces existing **`fileEmbed`** nodes in place (one **`--file`** per embed, preserving page structure and embed attrs), or **appends** embeds when the document has none. **`--replace-files`**, **`--keep-file`**, and **`--remove-file`** are removed from the CLI and docs; structural edits are directed to **`products content get/set`**.
> 
> Implementation adds **`richcontent.RollFileEmbeds`**, simplifies product file planning to preserve all existing files while rolling content, and updates README/skill help plus broad product/variant file tests (including **`covers add`** dry-run output coverage).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fedf21cb700c9eb84feed3da90dff590d4706880. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
