### PR TITLE
Add a release skill for date tags

### DIFF
--- a/.claude/skills/gumroad-cli-release
+++ b/.claude/skills/gumroad-cli-release
@@ -1,0 +1,1 @@
+../../skills/gumroad-cli-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+      - run: ./script/validate-release-tag.sh "${GITHUB_REF_NAME}"
       - run: echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
       - run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
       - run: make test-cover

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,6 +149,15 @@ The CLI is used mostly by AI agents, so the canonical command reference lives wh
 - When you add or change a command, update its `--help` and `skills/gumroad/SKILL.md`. Do **not** add a per-command section to the README.
 - If you're about to explain a command's flags, behavior, or examples in the README, that content belongs in `--help` or the skill instead.
 
+## Releases
+
+Releases are tag-driven and use Go-compatible date versioning: `v0.YYYYMMDD.N`.
+
+- `YYYYMMDD` is the UTC release date.
+- `N` starts at `0` and increments only when multiple releases ship on the same UTC date.
+- `make release-tag` prints today's default tag, for example `v0.20260609.0`; use `make release-tag RELEASE_SEQ=1` for a second release on the same day.
+- The binary and Homebrew formula display date versions as `YYYY.MM.DD` or `YYYY.MM.DD.N`.
+
 ## Gumroad API quirks
 
 Non-obvious behaviors that directly affect how you write code:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 BINARY := gumroad
 VERSION ?= dev
+RELEASE_DATE ?= $(shell date -u +%Y%m%d)
+RELEASE_SEQ ?= 0
 LDFLAGS := -ldflags "-s -w -X github.com/antiwork/gumroad-cli/internal/cmd.Version=$(VERSION)"
 PREFIX ?= /usr/local
 DESTDIR ?=
@@ -12,7 +14,7 @@ FISH_COMPLETION_DIR := $(SHARE_DIR)/fish/vendor_completions.d
 POWERSHELL_COMPLETION_DIR := $(SHARE_DIR)/powershell/Modules/gumroad
 INSTALL ?= install
 
-.PHONY: build install test test-cover test-race test-smoke lint clean snapshot man
+.PHONY: build install test test-cover test-race test-smoke lint clean snapshot man release-tag
 
 build:
 	go build $(LDFLAGS) -o $(BINARY) ./cmd/gumroad
@@ -78,3 +80,6 @@ clean:
 
 snapshot:
 	goreleaser release --snapshot --clean
+
+release-tag:
+	@echo v0.$(RELEASE_DATE).$(RELEASE_SEQ)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -28,6 +28,7 @@ import (
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/antiwork/gumroad-cli/internal/updatecheck"
+	"github.com/antiwork/gumroad-cli/internal/version"
 	"github.com/spf13/cobra"
 )
 
@@ -85,10 +86,10 @@ func NewRootCmd() *cobra.Command {
 			notifyUpdate(opts, cmd.CommandPath())
 			return nil
 		},
-		Version: Version,
+		Version: version.Display(Version),
 	}
 
-	cmd.SetVersionTemplate(fmt.Sprintf("gumroad version %s\n", Version))
+	cmd.SetVersionTemplate(fmt.Sprintf("gumroad version %s\n", version.Display(Version)))
 	cmd.SetFlagErrorFunc(func(c *cobra.Command, err error) error {
 		if err == nil {
 			return nil

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -231,6 +231,25 @@ func TestRootCmd_VersionFlag(t *testing.T) {
 	}
 }
 
+func TestRootCmd_VersionFlagDisplaysDateVersion(t *testing.T) {
+	previous := Version
+	Version = "0.20260609.0"
+	t.Cleanup(func() { Version = previous })
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"--version"})
+
+	var out strings.Builder
+	cmd.SetOut(&out)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.String() != "gumroad version 2026.06.09\n" {
+		t.Fatalf("expected date version output, got %q", out.String())
+	}
+}
+
 func TestRootCmd_UpdateNoticeUsesStderrWithJSONOutput(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 

--- a/internal/updatecheck/updatecheck.go
+++ b/internal/updatecheck/updatecheck.go
@@ -9,12 +9,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/config"
+	"github.com/antiwork/gumroad-cli/internal/version"
 )
 
 const (
@@ -49,12 +49,6 @@ type releaseResponse struct {
 	TagName string `json:"tag_name"`
 }
 
-type semver struct {
-	Major int
-	Minor int
-	Patch int
-}
-
 // Notify prints a low-noise update notice to stderr when a newer release exists.
 // It never returns an error; update checks should not affect the requested command.
 func Notify(opts cmdutil.Options, commandPath string) {
@@ -62,7 +56,7 @@ func Notify(opts cmdutil.Options, commandPath string) {
 		return
 	}
 
-	current, ok := parseVersion(opts.Version)
+	current, ok := version.Parse(opts.Version)
 	if !ok {
 		return
 	}
@@ -81,8 +75,8 @@ func Notify(opts cmdutil.Options, commandPath string) {
 		defer startRefresh()
 	}
 
-	latest, ok := parseVersion(state.LatestVersion)
-	if !ok || compareVersions(latest, current) <= 0 || !shouldShowNotice(state, t) {
+	latest, ok := version.Parse(state.LatestVersion)
+	if !ok || version.Compare(latest, current) <= 0 || !shouldShowNotice(state, t) {
 		return
 	}
 
@@ -91,7 +85,7 @@ func Notify(opts cmdutil.Options, commandPath string) {
 	if err := saveCache(path, state); err != nil {
 		return
 	}
-	fmt.Fprintf(opts.Err(), "warning: gumroad %s is available; you have %s. Update: %s\n", state.LatestVersion, opts.Version, updateCommand())
+	fmt.Fprintf(opts.Err(), "warning: gumroad %s is available; you have %s. Update: %s\n", version.Display(state.LatestVersion), version.Display(opts.Version), updateCommand())
 }
 
 // Refresh updates the cache for the hidden background refresh command. It is
@@ -251,42 +245,6 @@ func fetchLatestVersion(ctx context.Context) (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(release.TagName), nil
-}
-
-func parseVersion(version string) (semver, bool) {
-	version = strings.TrimSpace(version)
-	version = strings.TrimPrefix(version, "v")
-	if i := strings.IndexAny(version, "-+"); i >= 0 {
-		version = version[:i]
-	}
-	parts := strings.Split(version, ".")
-	if len(parts) != 3 {
-		return semver{}, false
-	}
-	major, err := strconv.Atoi(parts[0])
-	if err != nil {
-		return semver{}, false
-	}
-	minor, err := strconv.Atoi(parts[1])
-	if err != nil {
-		return semver{}, false
-	}
-	patch, err := strconv.Atoi(parts[2])
-	if err != nil {
-		return semver{}, false
-	}
-	return semver{Major: major, Minor: minor, Patch: patch}, true
-}
-
-func compareVersions(a, b semver) int {
-	switch {
-	case a.Major != b.Major:
-		return a.Major - b.Major
-	case a.Minor != b.Minor:
-		return a.Minor - b.Minor
-	default:
-		return a.Patch - b.Patch
-	}
 }
 
 func updateCommand() string {

--- a/internal/updatecheck/updatecheck_test.go
+++ b/internal/updatecheck/updatecheck_test.go
@@ -196,6 +196,56 @@ func TestNotifyUsesFreshCachedLatestWithoutNetwork(t *testing.T) {
 	}
 }
 
+func TestNotifyDisplaysDateBasedVersions(t *testing.T) {
+	dir := t.TempDir()
+	replaceConfigDir(t, dir)
+	t0 := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
+	replaceNow(t, t0)
+	writeCache(t, dir, cacheState{
+		LatestVersion: "v0.20260609.0",
+		CheckedAt:     t0,
+	})
+	replaceStartRefresh(t, func() {
+		t.Fatal("fresh cache should not refresh")
+	})
+
+	opts := testOptions(&bytes.Buffer{})
+	opts.Version = "0.20260608.0"
+
+	var stderr bytes.Buffer
+	opts.Stderr = &stderr
+	Notify(opts, "gumroad products list")
+
+	if !strings.Contains(stderr.String(), "warning: gumroad 2026.06.09 is available; you have 2026.06.08.") {
+		t.Fatalf("expected date-based warning, got %q", stderr.String())
+	}
+}
+
+func TestNotifyTreatsDateBasedVersionAsNewerThanLegacySemver(t *testing.T) {
+	dir := t.TempDir()
+	replaceConfigDir(t, dir)
+	t0 := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
+	replaceNow(t, t0)
+	writeCache(t, dir, cacheState{
+		LatestVersion: "v0.20260609.0",
+		CheckedAt:     t0,
+	})
+	replaceStartRefresh(t, func() {
+		t.Fatal("fresh cache should not refresh")
+	})
+
+	opts := testOptions(&bytes.Buffer{})
+	opts.Version = "0.21.0"
+
+	var stderr bytes.Buffer
+	opts.Stderr = &stderr
+	Notify(opts, "gumroad products list")
+
+	if !strings.Contains(stderr.String(), "warning: gumroad 2026.06.09 is available; you have 0.21.0.") {
+		t.Fatalf("expected date release to supersede legacy semver, got %q", stderr.String())
+	}
+}
+
 func TestNotifyStartsRefreshWithoutBlockingForStaleCache(t *testing.T) {
 	dir := t.TempDir()
 	replaceConfigDir(t, dir)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,100 @@
+package version
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Version struct {
+	Major int
+	Minor int
+	Patch int
+}
+
+func Parse(raw string) (Version, bool) {
+	raw = strings.TrimSpace(raw)
+	raw = strings.TrimPrefix(raw, "v")
+	if i := strings.IndexAny(raw, "-+"); i >= 0 {
+		raw = raw[:i]
+	}
+
+	parts := strings.Split(raw, ".")
+	if len(parts) != 3 {
+		return Version{}, false
+	}
+
+	major, ok := parsePart(parts[0])
+	if !ok {
+		return Version{}, false
+	}
+	minor, ok := parsePart(parts[1])
+	if !ok {
+		return Version{}, false
+	}
+	patch, ok := parsePart(parts[2])
+	if !ok {
+		return Version{}, false
+	}
+
+	return Version{Major: major, Minor: minor, Patch: patch}, true
+}
+
+func Compare(a, b Version) int {
+	switch {
+	case a.Major != b.Major:
+		return a.Major - b.Major
+	case a.Minor != b.Minor:
+		return a.Minor - b.Minor
+	default:
+		return a.Patch - b.Patch
+	}
+}
+
+func Display(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	parts := displayParts(trimmed)
+	if len(parts) != 3 || parts[0] != "0" || len(parts[1]) != 8 {
+		return trimmed
+	}
+
+	releaseDate, err := time.Parse("20060102", parts[1])
+	if err != nil {
+		return trimmed
+	}
+	patch, ok := parsePart(parts[2])
+	if !ok {
+		return trimmed
+	}
+
+	display := releaseDate.Format("2006.01.02")
+	if patch > 0 {
+		display = fmt.Sprintf("%s.%d", display, patch)
+	}
+	return display
+}
+
+func displayParts(raw string) []string {
+	raw = strings.TrimPrefix(raw, "v")
+	if i := strings.IndexAny(raw, "-+"); i >= 0 {
+		raw = raw[:i]
+	}
+	return strings.Split(raw, ".")
+}
+
+func parsePart(part string) (int, bool) {
+	if part == "" {
+		return 0, false
+	}
+	for _, r := range part {
+		if r < '0' || r > '9' {
+			return 0, false
+		}
+	}
+	n, err := strconv.Atoi(part)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,99 @@
+package version
+
+import "testing"
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		raw  string
+		want Version
+		ok   bool
+	}{
+		{raw: "v0.20260609.0", want: Version{Major: 0, Minor: 20260609, Patch: 0}, ok: true},
+		{raw: "0.20260609.1", want: Version{Major: 0, Minor: 20260609, Patch: 1}, ok: true},
+		{raw: "v0.20260609.0+build", want: Version{Major: 0, Minor: 20260609, Patch: 0}, ok: true},
+		{raw: "v0.21.0", want: Version{Major: 0, Minor: 21, Patch: 0}, ok: true},
+		{raw: "not-semver", ok: false},
+		{raw: "v0.20260609", ok: false},
+		{raw: "v0.20260609.x", ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			got, ok := Parse(tt.raw)
+			if ok != tt.ok {
+				t.Fatalf("ok = %v, want %v", ok, tt.ok)
+			}
+			if got != tt.want {
+				t.Fatalf("got %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompare(t *testing.T) {
+	tests := []struct {
+		name string
+		a    Version
+		b    Version
+		want int
+	}{
+		{
+			name: "date release after legacy semver",
+			a:    Version{Major: 0, Minor: 20260609, Patch: 0},
+			b:    Version{Major: 0, Minor: 21, Patch: 0},
+			want: 1,
+		},
+		{
+			name: "same day sequence",
+			a:    Version{Major: 0, Minor: 20260609, Patch: 1},
+			b:    Version{Major: 0, Minor: 20260609, Patch: 0},
+			want: 1,
+		},
+		{
+			name: "older date",
+			a:    Version{Major: 0, Minor: 20260608, Patch: 0},
+			b:    Version{Major: 0, Minor: 20260609, Patch: 0},
+			want: -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := compareSign(Compare(tt.a, tt.b)); got != tt.want {
+				t.Fatalf("got %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDisplay(t *testing.T) {
+	tests := map[string]string{
+		"v0.20260609.0":       "2026.06.09",
+		"0.20260609.1":        "2026.06.09.1",
+		"v0.20280229.0":       "2028.02.29",
+		"v0.20261309.0":       "v0.20261309.0",
+		"v0.21.0":             "v0.21.0",
+		"0.21.0":              "0.21.0",
+		"not-semver":          "not-semver",
+		" v0.20260609.0 \n\t": "2026.06.09",
+	}
+
+	for raw, want := range tests {
+		t.Run(raw, func(t *testing.T) {
+			if got := Display(raw); got != want {
+				t.Fatalf("got %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func compareSign(n int) int {
+	switch {
+	case n > 0:
+		return 1
+	case n < 0:
+		return -1
+	default:
+		return 0
+	}
+}

--- a/script/install.sh
+++ b/script/install.sh
@@ -42,7 +42,7 @@ main() {
     install_binary
     setup_path
 
-    echo "gumroad ${VERSION} installed to ${BIN_DIR}/$(binary_name)"
+    echo "gumroad $(display_version "$VERSION") installed to ${BIN_DIR}/$(binary_name)"
 }
 
 check_requirements() {
@@ -110,12 +110,27 @@ resolve_version() {
 
     version="${url##*/}"
 
-    if [[ ! $version =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+    if [[ ! $version =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
         echo "Error: no published release found. Check https://github.com/${REPO}/releases" >&2
         exit 1
     fi
 
     VERSION="$version"
+}
+
+display_version() {
+    local version=${1#v}
+
+    if [[ $version =~ ^0\.([0-9]{4})([0-9]{2})([0-9]{2})\.([0-9]+)$ ]]; then
+        local display="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}"
+        if [[ "${BASH_REMATCH[4]}" != "0" ]]; then
+            display="${display}.${BASH_REMATCH[4]}"
+        fi
+        printf '%s\n' "$display"
+        return
+    fi
+
+    printf '%s\n' "$version"
 }
 
 download_and_verify() {

--- a/script/install.sh
+++ b/script/install.sh
@@ -122,15 +122,41 @@ display_version() {
     local version=${1#v}
 
     if [[ $version =~ ^0\.([0-9]{4})([0-9]{2})([0-9]{2})\.([0-9]+)$ ]]; then
-        local display="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}"
-        if [[ "${BASH_REMATCH[4]}" != "0" ]]; then
-            display="${display}.${BASH_REMATCH[4]}"
+        local year="${BASH_REMATCH[1]}"
+        local month="${BASH_REMATCH[2]}"
+        local day="${BASH_REMATCH[3]}"
+        local sequence="${BASH_REMATCH[4]}"
+        if valid_date "$year" "$month" "$day"; then
+            local display="${year}.${month}.${day}"
+            if [[ "$sequence" != "0" ]]; then
+                display="${display}.${sequence}"
+            fi
+            printf '%s\n' "$display"
+            return
         fi
-        printf '%s\n' "$display"
-        return
     fi
 
     printf '%s\n' "$version"
+}
+
+valid_date() {
+    local year=$1
+    local month=$2
+    local day=$3
+    local year_num=$((10#$year))
+    local month_num=$((10#$month))
+    local day_num=$((10#$day))
+
+    if (( month_num < 1 || month_num > 12 )); then
+        return 1
+    fi
+
+    local days_in_month=(0 31 28 31 30 31 30 31 31 30 31 30 31)
+    if (( month_num == 2 && (year_num % 400 == 0 || (year_num % 4 == 0 && year_num % 100 != 0)) )); then
+        days_in_month[2]=29
+    fi
+
+    (( day_num >= 1 && day_num <= days_in_month[month_num] ))
 }
 
 download_and_verify() {
@@ -142,7 +168,7 @@ download_and_verify() {
     local archive="gumroad-cli_${OS}_${ARCH}.${ext}"
     local base_url="https://github.com/${REPO}/releases/download/${VERSION}"
 
-    echo "Downloading gumroad ${VERSION} for ${OS}/${ARCH}..."
+    echo "Downloading gumroad $(display_version "$VERSION") for ${OS}/${ARCH}..."
 
     local pid_archive pid_checksums
     curl -fsSL "${base_url}/${archive}" -o "${WORK_DIR}/${archive}" &

--- a/script/render-homebrew-formula.sh
+++ b/script/render-homebrew-formula.sh
@@ -12,7 +12,23 @@ OUTPUT_FILE=$3
 
 PROJECT_NAME="gumroad-cli"
 REPOSITORY="antiwork/gumroad-cli"
-VERSION="${TAG#v}"
+
+display_version() {
+    local version=${1#v}
+
+    if [[ $version =~ ^0\.([0-9]{4})([0-9]{2})([0-9]{2})\.([0-9]+)$ ]]; then
+        local display="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}"
+        if [[ "${BASH_REMATCH[4]}" != "0" ]]; then
+            display="${display}.${BASH_REMATCH[4]}"
+        fi
+        printf '%s\n' "$display"
+        return
+    fi
+
+    printf '%s\n' "$version"
+}
+
+VERSION="$(display_version "$TAG")"
 
 checksum_for() {
     local archive=$1

--- a/script/render-homebrew-formula.sh
+++ b/script/render-homebrew-formula.sh
@@ -17,15 +17,41 @@ display_version() {
     local version=${1#v}
 
     if [[ $version =~ ^0\.([0-9]{4})([0-9]{2})([0-9]{2})\.([0-9]+)$ ]]; then
-        local display="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}"
-        if [[ "${BASH_REMATCH[4]}" != "0" ]]; then
-            display="${display}.${BASH_REMATCH[4]}"
+        local year="${BASH_REMATCH[1]}"
+        local month="${BASH_REMATCH[2]}"
+        local day="${BASH_REMATCH[3]}"
+        local sequence="${BASH_REMATCH[4]}"
+        if valid_date "$year" "$month" "$day"; then
+            local display="${year}.${month}.${day}"
+            if [[ "$sequence" != "0" ]]; then
+                display="${display}.${sequence}"
+            fi
+            printf '%s\n' "$display"
+            return
         fi
-        printf '%s\n' "$display"
-        return
     fi
 
     printf '%s\n' "$version"
+}
+
+valid_date() {
+    local year=$1
+    local month=$2
+    local day=$3
+    local year_num=$((10#$year))
+    local month_num=$((10#$month))
+    local day_num=$((10#$day))
+
+    if (( month_num < 1 || month_num > 12 )); then
+        return 1
+    fi
+
+    local days_in_month=(0 31 28 31 30 31 30 31 31 30 31 30 31)
+    if (( month_num == 2 && (year_num % 400 == 0 || (year_num % 4 == 0 && year_num % 100 != 0)) )); then
+        days_in_month[2]=29
+    fi
+
+    (( day_num >= 1 && day_num <= days_in_month[month_num] ))
 }
 
 VERSION="$(display_version "$TAG")"

--- a/script/validate-release-tag.sh
+++ b/script/validate-release-tag.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "usage: $0 <tag>" >&2
+    exit 1
+fi
+
+tag=$1
+
+if [[ ! $tag =~ ^v0\.([0-9]{4})([0-9]{2})([0-9]{2})\.([0-9]|[1-9][0-9]*)$ ]]; then
+    cat >&2 <<'EOF'
+Error: release tags must use Go-compatible date versioning.
+
+Expected: v0.YYYYMMDD.N
+Example:  v0.20260609.0
+
+N starts at 0 and increments only for multiple releases on the same UTC date.
+EOF
+    exit 1
+fi
+
+year=${BASH_REMATCH[1]}
+month=${BASH_REMATCH[2]}
+day=${BASH_REMATCH[3]}
+
+year_num=$((10#$year))
+month_num=$((10#$month))
+day_num=$((10#$day))
+
+if (( month_num < 1 || month_num > 12 )); then
+    echo "Error: ${year}-${month}-${day} is not a valid UTC release date." >&2
+    exit 1
+fi
+
+days_in_month=(0 31 28 31 30 31 30 31 31 30 31 30 31)
+if (( month_num == 2 && (year_num % 400 == 0 || (year_num % 4 == 0 && year_num % 100 != 0)) )); then
+    days_in_month[2]=29
+fi
+
+if (( day_num < 1 || day_num > days_in_month[month_num] )); then
+    echo "Error: ${year}-${month}-${day} is not a valid UTC release date." >&2
+    exit 1
+fi

--- a/skills/gumroad-cli-release/SKILL.md
+++ b/skills/gumroad-cli-release/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: gumroad-cli-release
+description: Release gumroad-cli after a PR lands by inspecting origin/main, creating the next Go-compatible date tag, pushing only that tag, and verifying GitHub release/Homebrew follow-through. Use for requests like "cut a gumroad-cli release", "push the release tag", or "release the merged gumroad-cli changes".
+---
+
+# Gumroad CLI Release
+
+## Use When
+
+Use this only after the intended changes are merged to `origin/main`.
+
+Do not use it to release from a feature branch, local `HEAD`, or an unmerged PR branch. The release workflow is tag-driven: push an annotated tag that points at the current `origin/main` commit.
+
+## Version Format
+
+Tags use Go-compatible date versioning:
+
+```text
+v0.YYYYMMDD.N
+```
+
+- `YYYYMMDD` is the UTC release date.
+- `N` starts at `0` and increments only for multiple releases on the same UTC date.
+- The binary and Homebrew formula display `v0.20260609.0` as `2026.06.09`.
+- Do not create `v2026.06.09`; it is not a valid Go module release shape for this repo.
+
+## Workflow
+
+1. Confirm repository and state:
+
+```bash
+git status --short --branch
+git remote -v
+```
+
+2. Fetch current main and tags:
+
+```bash
+git fetch origin main --tags
+```
+
+3. Inspect what will be released:
+
+```bash
+latest_tag="$(git describe --tags --abbrev=0 origin/main)"
+git log --oneline --first-parent "${latest_tag}..origin/main"
+git rev-parse origin/main
+```
+
+If there are no first-parent changes since `latest_tag`, stop and report that no new release is needed.
+
+4. Choose the next tag:
+
+```bash
+release_date="$(date -u +%Y%m%d)"
+release_seq=0
+tag="$(make release-tag RELEASE_DATE="$release_date" RELEASE_SEQ="$release_seq")"
+
+while git rev-parse -q --verify "refs/tags/${tag}" >/dev/null ||
+  git ls-remote --exit-code --tags origin "${tag}" >/dev/null 2>&1; do
+  release_seq=$((release_seq + 1))
+  tag="$(make release-tag RELEASE_DATE="$release_date" RELEASE_SEQ="$release_seq")"
+done
+```
+
+5. Validate and create the annotated tag on `origin/main` explicitly:
+
+```bash
+./script/validate-release-tag.sh "$tag"
+git tag -a "$tag" origin/main -m "Release $tag"
+```
+
+6. Push only the tag:
+
+```bash
+git push origin "refs/tags/${tag}"
+```
+
+Never force-push or rewrite an existing release tag unless the user explicitly asks for a tag repair and understands the release artifact implications.
+
+7. Verify the remote tag peels to `origin/main`:
+
+```bash
+main_sha="$(git rev-parse origin/main)"
+local_tag_sha="$(git rev-parse "${tag}^{}")"
+remote_tag_sha="$(git ls-remote --tags origin "${tag}^{}" | awk '{print $1}')"
+
+test "$main_sha" = "$local_tag_sha"
+test "$main_sha" = "$remote_tag_sha"
+```
+
+8. Check release automation:
+
+```bash
+gh run list --workflow Release --event push --limit 5
+gh release view "$tag" --json tagName,name,isDraft,isPrerelease,publishedAt,url
+```
+
+If the workflow is still running, watch the relevant run:
+
+```bash
+gh run watch <run-id>
+```
+
+## Closeout
+
+Report:
+
+- tag pushed
+- commit SHA it points to
+- first-parent changes released
+- release workflow status
+- GitHub release URL, once available
+
+If Homebrew publishing is part of the workflow result, verify it from the workflow logs or the `antiwork/homebrew-cli` update before calling the release complete.


### PR DESCRIPTION
Closes #148

## What

This PR switches gumroad-cli's release contract from arbitrary semver increments to date-based release identity while keeping tags Go-module-compatible.

It adds a shared version parser/display helper so update checks compare `v0.YYYYMMDD.N` tags correctly, `gumroad --version` displays `YYYY.MM.DD`, and legacy `v0.21.0` installs can still see date releases as newer. It also teaches the installer and Homebrew formula generator to display the date form, validates release tags in the Release workflow, adds `make release-tag`, and documents the release operation in a repo-local skill linked into `.claude/skills`.

## Why

Issue #148 is right that `0.21.0` tells users almost nothing about age. A pure `v2026.06.09` tag would be prettier, but it would fight Go's module version rules and break `go install ...@latest` semantics. `v0.20260609.N` preserves Go's required semantic shape while showing humans the useful date.

The release skill is included because the operational constraint is easy to forget: releases still happen by pushing an annotated tag that points at `origin/main`, but the tag must be generated, validated, and verified rather than hand-typed.

## Before/After

Before: release tags looked like `v0.21.0`, update checks only understood semver-style tags, and release closeout lived in maintainer memory.

After: release tags use `v0.YYYYMMDD.N`, user-facing output displays `YYYY.MM.DD`, update notices compare old and new formats correctly, and Codex/Claude both have the same repo-local release workflow.

## Test Results

No screenshot attached yet. Passed locally:

- `go test ./...`
- `make test-cover`
- `make lint`
- `bash -n script/install.sh script/render-homebrew-formula.sh script/update-homebrew-tap.sh script/validate-release-tag.sh`
- `./script/validate-release-tag.sh v0.20260609.0`
- negative invalid-date check for `v0.20260229.0`
- `make build VERSION=0.20260609.0 && ./gumroad --version && make clean`

---

This PR was implemented with AI assistance using gpt-5.5 xhigh.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release tagging, version comparison for update notices, and CI release gates; incorrect version logic could mis-rank updates or block valid releases, but behavior is covered by new tests and tag validation.
> 
> **Overview**
> **Adopts Go-compatible date release tags** (`v0.YYYYMMDD.N`) instead of opaque semver bumps like `v0.21.0`, with maintainer docs and a **`gumroad-cli-release` agent skill** for tag-driven releases from `origin/main`.
> 
> Adds **`internal/version`** for parse/compare/display: `gumroad --version` and update notices show **`YYYY.MM.DD`** (or `.N` for same-day releases), while numeric comparison treats date tags as newer than legacy `0.21.0`-style builds. Update check logic moves off inline semver helpers to this package.
> 
> **Release tooling:** `make release-tag`, **`script/validate-release-tag.sh`** (enforced in the Release workflow before tests/goreleaser), and matching **display-version** logic in **`install.sh`** and **`render-homebrew-formula.sh`**. **CONTRIBUTING** documents the versioning contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 736584cd0bd37d9cbe5333bcb712e0711d5f27e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->