### PR TITLE
Add buyer-level UTM fields to sales buyers

### DIFF
--- a/internal/cmd/sales/buyers.go
+++ b/internal/cmd/sales/buyers.go
@@ -18,9 +18,14 @@ import (
 )
 
 type buyersSaleItem struct {
-	Email     string `json:"email"`
-	FullName  string `json:"full_name"`
-	CreatedAt string `json:"created_at"`
+	Email       string `json:"email"`
+	FullName    string `json:"full_name"`
+	CreatedAt   string `json:"created_at"`
+	UTMSource   string `json:"utm_source"`
+	UTMMedium   string `json:"utm_medium"`
+	UTMCampaign string `json:"utm_campaign"`
+	UTMTerm     string `json:"utm_term"`
+	UTMContent  string `json:"utm_content"`
 }
 
 type buyersSalesPage struct {
@@ -34,6 +39,11 @@ type buyer struct {
 	Name             string `json:"name"`
 	PurchaseCount    int    `json:"purchase_count"`
 	LastPurchaseDate string `json:"last_purchase_date"`
+	UTMSource        string `json:"utm_source"`
+	UTMMedium        string `json:"utm_medium"`
+	UTMCampaign      string `json:"utm_campaign"`
+	UTMTerm          string `json:"utm_term"`
+	UTMContent       string `json:"utm_content"`
 }
 
 type buyersResponse struct {
@@ -42,6 +52,20 @@ type buyersResponse struct {
 }
 
 func (b buyer) fields() []string {
+	return []string{
+		b.Email,
+		b.Name,
+		strconv.Itoa(b.PurchaseCount),
+		b.LastPurchaseDate,
+		b.UTMSource,
+		b.UTMMedium,
+		b.UTMCampaign,
+		b.UTMTerm,
+		b.UTMContent,
+	}
+}
+
+func (b buyer) tableFields() []string {
 	return []string{b.Email, b.Name, strconv.Itoa(b.PurchaseCount), b.LastPurchaseDate}
 }
 
@@ -58,8 +82,13 @@ func newBuyersCmd() *cobra.Command {
 
 Buyers are deduplicated by email and aggregated across every page, so a buyer
 who purchased more than once appears a single time with a purchase count and
-their most recent purchase date. Pass --product more than once to union buyers
-across a relaunched listing's old and new IDs and dedupe them in one shot.`,
+their most recent purchase date. UTM fields in JSON, CSV, and plain output come
+from the buyer's most recent attributed purchase, and stay empty when no
+purchase came through a UTM link. Use gumroad sales export for the full per-sale
+web CSV by email.
+
+Pass --product more than once to union buyers across a relaunched listing's old
+and new IDs and dedupe them in one shot.`,
 		Example: `  gumroad sales buyers --product <id>
   gumroad sales buyers --product <old-id> --product <new-id>
   gumroad sales buyers --product <id> --after 2024-01-01 --csv
@@ -173,6 +202,13 @@ type buyerAggregate struct {
 	nameDate         string
 	count            int
 	lastPurchaseDate string
+	utmSource        string
+	utmMedium        string
+	utmCampaign      string
+	utmTerm          string
+	utmContent       string
+	utmDate          string
+	utmCaptured      bool
 }
 
 func newBuyerIndex() *buyerIndex {
@@ -202,6 +238,27 @@ func (i *buyerIndex) add(sale buyersSaleItem) {
 		aggregate.name = name
 		aggregate.nameDate = sale.CreatedAt
 	}
+
+	utmSource, utmMedium, utmCampaign, utmTerm, utmContent, hasUTM := sale.utmFields()
+	if hasUTM && (!aggregate.utmCaptured || sale.CreatedAt > aggregate.utmDate) {
+		aggregate.utmSource = utmSource
+		aggregate.utmMedium = utmMedium
+		aggregate.utmCampaign = utmCampaign
+		aggregate.utmTerm = utmTerm
+		aggregate.utmContent = utmContent
+		aggregate.utmDate = sale.CreatedAt
+		aggregate.utmCaptured = true
+	}
+}
+
+func (s buyersSaleItem) utmFields() (source, medium, campaign, term, content string, ok bool) {
+	source = strings.TrimSpace(s.UTMSource)
+	medium = strings.TrimSpace(s.UTMMedium)
+	campaign = strings.TrimSpace(s.UTMCampaign)
+	term = strings.TrimSpace(s.UTMTerm)
+	content = strings.TrimSpace(s.UTMContent)
+	ok = source != "" || medium != "" || campaign != "" || term != "" || content != ""
+	return source, medium, campaign, term, content, ok
 }
 
 func (i *buyerIndex) sorted() []buyer {
@@ -212,6 +269,11 @@ func (i *buyerIndex) sorted() []buyer {
 			Name:             aggregate.name,
 			PurchaseCount:    aggregate.count,
 			LastPurchaseDate: aggregate.lastPurchaseDate,
+			UTMSource:        aggregate.utmSource,
+			UTMMedium:        aggregate.utmMedium,
+			UTMCampaign:      aggregate.utmCampaign,
+			UTMTerm:          aggregate.utmTerm,
+			UTMContent:       aggregate.utmContent,
 		})
 	}
 
@@ -252,7 +314,17 @@ func printBuyersJSON(opts cmdutil.Options, buyers []buyer) error {
 	return output.PrintJSON(opts.Out(), data, opts.JQExpr)
 }
 
-var buyersCSVHeader = []string{"email", "name", "purchase_count", "last_purchase_date"}
+var buyersCSVHeader = []string{
+	"email",
+	"name",
+	"purchase_count",
+	"last_purchase_date",
+	"utm_source",
+	"utm_medium",
+	"utm_campaign",
+	"utm_term",
+	"utm_content",
+}
 
 func writeBuyersCSV(w io.Writer, buyers []buyer) error {
 	cw := csv.NewWriter(w)
@@ -279,7 +351,7 @@ func writeBuyersPlain(w io.Writer, buyers []buyer) error {
 func writeBuyersTable(w io.Writer, style output.Styler, buyers []buyer) error {
 	tbl := output.NewStyledTable(style, "EMAIL", "NAME", "PURCHASES", "LAST PURCHASE")
 	for _, b := range buyers {
-		tbl.AddRow(b.fields()...)
+		tbl.AddRow(b.tableFields()...)
 	}
 	return tbl.Render(w)
 }

--- a/internal/cmd/sales/buyers.go
+++ b/internal/cmd/sales/buyers.go
@@ -84,8 +84,9 @@ Buyers are deduplicated by email and aggregated across every page, so a buyer
 who purchased more than once appears a single time with a purchase count and
 their most recent purchase date. UTM fields in JSON, CSV, and plain output come
 from the buyer's most recent attributed purchase, and stay empty when no
-purchase came through a UTM link. Use gumroad sales export for the full per-sale
-web CSV by email.
+purchase came through a UTM link. If attributed purchases have the same
+timestamp, the first sale returned by the API wins. Use gumroad sales export for
+the full per-sale web CSV by email.
 
 Pass --product more than once to union buyers across a relaunched listing's old
 and new IDs and dedupe them in one shot.`,

--- a/internal/cmd/sales/buyers_test.go
+++ b/internal/cmd/sales/buyers_test.go
@@ -92,12 +92,25 @@ func TestBuyers_AggregatesAndDedupesAcrossPages(t *testing.T) {
 	if err := json.Unmarshal([]byte(out), &raw); err != nil {
 		t.Fatalf("not valid raw JSON: %v\n%s", err, out)
 	}
+	bob, ok := rawBuyerByEmail(raw.Buyers, "b@example.com")
+	if !ok {
+		t.Fatalf("raw buyer JSON missing b@example.com: %+v", raw.Buyers)
+	}
 	for _, key := range []string{"utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content"} {
-		value, ok := raw.Buyers[1][key]
+		value, ok := bob[key]
 		if !ok || value != "" {
 			t.Fatalf("raw buyer JSON %s = %v, present %t; want present empty string", key, value, ok)
 		}
 	}
+}
+
+func rawBuyerByEmail(buyers []map[string]any, email string) (map[string]any, bool) {
+	for _, buyer := range buyers {
+		if buyer["email"] == email {
+			return buyer, true
+		}
+	}
+	return nil, false
 }
 
 func TestBuyers_SortsByLastPurchaseDateDescendingThenEmail(t *testing.T) {
@@ -349,6 +362,45 @@ func TestBuyers_UsesLatestAttributedPurchaseForUTMAtomically(t *testing.T) {
 	}
 	if got.UTMSource != "linkedin" || got.UTMMedium != "" || got.UTMCampaign != "launch" || got.UTMTerm != "" || got.UTMContent != "" {
 		t.Fatalf("UTM fields = %+v, want latest attributed purchase fields without mixing older values", got)
+	}
+}
+
+func TestBuyers_SameDateUTMTieKeepsFirstSeen(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"sales": []map[string]any{
+				{
+					"email":        "tie@example.com",
+					"full_name":    "Tie",
+					"created_at":   "2024-03-01",
+					"utm_source":   "first",
+					"utm_campaign": "kept",
+				},
+				{
+					"email":        "tie@example.com",
+					"full_name":    "Tie",
+					"created_at":   "2024-03-01",
+					"utm_source":   "second",
+					"utm_campaign": "ignored",
+				},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newBuyersCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--product", "p1"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp buyersResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if len(resp.Buyers) != 1 {
+		t.Fatalf("expected 1 buyer, got %+v", resp.Buyers)
+	}
+	got := resp.Buyers[0]
+	if got.UTMSource != "first" || got.UTMCampaign != "kept" {
+		t.Fatalf("UTM fields = %+v, want first same-date attributed sale", got)
 	}
 }
 

--- a/internal/cmd/sales/buyers_test.go
+++ b/internal/cmd/sales/buyers_test.go
@@ -18,14 +18,32 @@ func TestBuyers_AggregatesAndDedupesAcrossPages(t *testing.T) {
 		case "":
 			testutil.JSON(t, w, map[string]any{
 				"sales": []map[string]any{
-					{"email": "a@example.com", "full_name": "Alice", "created_at": "2024-01-10"},
+					{
+						"email":        "a@example.com",
+						"full_name":    "Alice",
+						"created_at":   "2024-01-10",
+						"utm_source":   "newsletter",
+						"utm_medium":   "email",
+						"utm_campaign": "winter",
+						"utm_term":     "buyers",
+						"utm_content":  "hero",
+					},
 				},
 				"next_page_key": "cursor1",
 			})
 		case "cursor1":
 			testutil.JSON(t, w, map[string]any{
 				"sales": []map[string]any{
-					{"email": "a@example.com", "full_name": "Alice Anderson", "created_at": "2024-03-01"},
+					{
+						"email":        "a@example.com",
+						"full_name":    "Alice Anderson",
+						"created_at":   "2024-03-01",
+						"utm_source":   "adwords",
+						"utm_medium":   "cpc",
+						"utm_campaign": "spring",
+						"utm_term":     "template",
+						"utm_content":  "footer",
+					},
 					{"email": "b@example.com", "full_name": "Bob", "created_at": "2024-02-01"},
 				},
 			})
@@ -46,7 +64,17 @@ func TestBuyers_AggregatesAndDedupesAcrossPages(t *testing.T) {
 		t.Fatalf("expected success, got %+v", resp)
 	}
 	want := []buyer{
-		{Email: "a@example.com", Name: "Alice Anderson", PurchaseCount: 2, LastPurchaseDate: "2024-03-01"},
+		{
+			Email:            "a@example.com",
+			Name:             "Alice Anderson",
+			PurchaseCount:    2,
+			LastPurchaseDate: "2024-03-01",
+			UTMSource:        "adwords",
+			UTMMedium:        "cpc",
+			UTMCampaign:      "spring",
+			UTMTerm:          "template",
+			UTMContent:       "footer",
+		},
 		{Email: "b@example.com", Name: "Bob", PurchaseCount: 1, LastPurchaseDate: "2024-02-01"},
 	}
 	if len(resp.Buyers) != len(want) {
@@ -55,6 +83,19 @@ func TestBuyers_AggregatesAndDedupesAcrossPages(t *testing.T) {
 	for i, b := range want {
 		if resp.Buyers[i] != b {
 			t.Fatalf("buyer %d = %+v, want %+v", i, resp.Buyers[i], b)
+		}
+	}
+
+	var raw struct {
+		Buyers []map[string]any `json:"buyers"`
+	}
+	if err := json.Unmarshal([]byte(out), &raw); err != nil {
+		t.Fatalf("not valid raw JSON: %v\n%s", err, out)
+	}
+	for _, key := range []string{"utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content"} {
+		value, ok := raw.Buyers[1][key]
+		if !ok || value != "" {
+			t.Fatalf("raw buyer JSON %s = %v, present %t; want present empty string", key, value, ok)
 		}
 	}
 }
@@ -265,6 +306,52 @@ func TestBuyers_KeepsLatestNonEmptyName(t *testing.T) {
 	}
 }
 
+func TestBuyers_UsesLatestAttributedPurchaseForUTMAtomically(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"sales": []map[string]any{
+				{
+					"email":        "d@example.com",
+					"full_name":    "Dave",
+					"created_at":   "2024-01-01",
+					"utm_source":   "newsletter",
+					"utm_medium":   "email",
+					"utm_campaign": "winter",
+					"utm_term":     "discount",
+					"utm_content":  "hero",
+				},
+				{
+					"email":        "d@example.com",
+					"full_name":    "Dave",
+					"created_at":   "2024-03-01",
+					"utm_source":   "linkedin",
+					"utm_campaign": "launch",
+				},
+				{"email": "d@example.com", "full_name": "Dave", "created_at": "2024-05-01"},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newBuyersCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--product", "p1"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp buyersResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if len(resp.Buyers) != 1 {
+		t.Fatalf("expected 1 buyer, got %+v", resp.Buyers)
+	}
+	got := resp.Buyers[0]
+	if got.LastPurchaseDate != "2024-05-01" {
+		t.Fatalf("got last purchase %q, want latest sale 2024-05-01", got.LastPurchaseDate)
+	}
+	if got.UTMSource != "linkedin" || got.UTMMedium != "" || got.UTMCampaign != "launch" || got.UTMTerm != "" || got.UTMContent != "" {
+		t.Fatalf("UTM fields = %+v, want latest attributed purchase fields without mixing older values", got)
+	}
+}
+
 func TestBuyers_SkipsRowsWithoutEmail(t *testing.T) {
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
 		testutil.JSON(t, w, map[string]any{
@@ -335,7 +422,16 @@ func TestBuyers_CSVOutput(t *testing.T) {
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
 		testutil.JSON(t, w, map[string]any{
 			"sales": []map[string]any{
-				{"email": "a@example.com", "full_name": "Alice, Jr", "created_at": "2024-03-01"},
+				{
+					"email":        "a@example.com",
+					"full_name":    "Alice, Jr",
+					"created_at":   "2024-03-01",
+					"utm_source":   "newsletter",
+					"utm_medium":   "email",
+					"utm_campaign": "launch",
+					"utm_term":     "buyers",
+					"utm_content":  "header",
+				},
 				{"email": "a@example.com", "full_name": "Alice, Jr", "created_at": "2024-01-01"},
 				{"email": "b@example.com", "full_name": "Bob", "created_at": "2024-02-01"},
 			},
@@ -348,9 +444,9 @@ func TestBuyers_CSVOutput(t *testing.T) {
 
 	records := readCSVRecords(t, out)
 	want := [][]string{
-		{"email", "name", "purchase_count", "last_purchase_date"},
-		{"a@example.com", "Alice, Jr", "2", "2024-03-01"},
-		{"b@example.com", "Bob", "1", "2024-02-01"},
+		{"email", "name", "purchase_count", "last_purchase_date", "utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content"},
+		{"a@example.com", "Alice, Jr", "2", "2024-03-01", "newsletter", "email", "launch", "buyers", "header"},
+		{"b@example.com", "Bob", "1", "2024-02-01", "", "", "", "", ""},
 	}
 	assertCSVRecords(t, records, want)
 }
@@ -365,7 +461,7 @@ func TestBuyers_EmptyCSVWritesHeader(t *testing.T) {
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
 	records := readCSVRecords(t, out)
-	want := [][]string{{"email", "name", "purchase_count", "last_purchase_date"}}
+	want := [][]string{{"email", "name", "purchase_count", "last_purchase_date", "utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content"}}
 	assertCSVRecords(t, records, want)
 }
 
@@ -373,7 +469,16 @@ func TestBuyers_Plain(t *testing.T) {
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
 		testutil.JSON(t, w, map[string]any{
 			"sales": []map[string]any{
-				{"email": "a@example.com", "full_name": "Alice", "created_at": "2024-03-01"},
+				{
+					"email":        "a@example.com",
+					"full_name":    "Alice",
+					"created_at":   "2024-03-01",
+					"utm_source":   "newsletter",
+					"utm_medium":   "email",
+					"utm_campaign": "launch",
+					"utm_term":     "buyers",
+					"utm_content":  "header",
+				},
 			},
 		})
 	})
@@ -382,7 +487,7 @@ func TestBuyers_Plain(t *testing.T) {
 	cmd.SetArgs([]string{"--product", "p1"})
 	out := strings.TrimSpace(testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) }))
 
-	want := "a@example.com\tAlice\t1\t2024-03-01"
+	want := "a@example.com\tAlice\t1\t2024-03-01\tnewsletter\temail\tlaunch\tbuyers\theader"
 	if out != want {
 		t.Fatalf("got plain output %q, want %q", out, want)
 	}
@@ -392,7 +497,16 @@ func TestBuyers_Table(t *testing.T) {
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
 		testutil.JSON(t, w, map[string]any{
 			"sales": []map[string]any{
-				{"email": "a@example.com", "full_name": "Alice", "created_at": "2024-03-01"},
+				{
+					"email":        "a@example.com",
+					"full_name":    "Alice",
+					"created_at":   "2024-03-01",
+					"utm_source":   "newsletter",
+					"utm_medium":   "email",
+					"utm_campaign": "launch",
+					"utm_term":     "buyers",
+					"utm_content":  "header",
+				},
 			},
 		})
 	})
@@ -404,6 +518,11 @@ func TestBuyers_Table(t *testing.T) {
 	for _, want := range []string{"EMAIL", "NAME", "PURCHASES", "LAST PURCHASE", "a@example.com", "Alice", "2024-03-01"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("missing %q in table output %q", want, out)
+		}
+	}
+	for _, notWant := range []string{"UTM", "newsletter", "launch"} {
+		if strings.Contains(out, notWant) {
+			t.Fatalf("table output should stay four columns, but found %q in %q", notWant, out)
 		}
 	}
 }

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -342,7 +342,8 @@ gumroad sales list --after 2024-01-01 --before 2024-01-31 --csv --no-input
 gumroad sales list --json --jq '.sales[] | select(.email == "user@example.com")' --no-input
 
 # Deduplicated buyer list for one or more products.
-# JSON/CSV/plain include buyer-level last-touch UTM fields; use sales export for the full per-sale web CSV.
+# JSON/CSV/plain include buyer-level last-touch UTM fields; same-timestamp ties keep the first API result.
+# Use sales export for the full per-sale web CSV.
 gumroad sales buyers --product <id> --json --no-input
 gumroad sales buyers --product <old-id> --product <new-id> --json --no-input
 gumroad sales buyers --product <id> --after 2024-01-01 --csv --no-input

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -56,7 +56,7 @@ Most responses are wrapped in `{"success": true, ...}` with resource-specific ke
 - `products content list` → rich content page summary array directly
 - `products content set` → mutation envelope with `.result`
 - `sales list` → `.sales[]`
-- `sales buyers` → `.buyers[]`
+- `sales buyers` → `.buyers[]` (`email`, `name`, `purchase_count`, `last_purchase_date`, `utm_source`, `utm_medium`, `utm_campaign`, `utm_term`, `utm_content`)
 - `sales view` → `.sale`
 - `sales export` → `.status`, `.recipient_email`
 - `sales summary` → `.gross_cents`, `.net_cents`, `.breakdown[]`
@@ -341,7 +341,8 @@ gumroad sales list --after 2024-01-01 --before 2024-01-31 --csv --no-input
 # Find a sale by email
 gumroad sales list --json --jq '.sales[] | select(.email == "user@example.com")' --no-input
 
-# Deduplicated buyer list for one or more products (email, name, purchase count, last purchase date)
+# Deduplicated buyer list for one or more products.
+# JSON/CSV/plain include buyer-level last-touch UTM fields; use sales export for the full per-sale web CSV.
 gumroad sales buyers --product <id> --json --no-input
 gumroad sales buyers --product <old-id> --product <new-id> --json --no-input
 gumroad sales buyers --product <id> --after 2024-01-01 --csv --no-input


### PR DESCRIPTION
Ref #151

## What
- Buyer output now carries the latest attributed UTM values alongside deduped purchase totals.
- JSON, CSV, and plain output include the buyer-level UTM fields, while the table view stays compact.
- The command docs now describe the new buyer-level attribution behavior.

## Why
- This makes `sales buyers` useful for understanding which campaigns drove each buyer, not just how many purchases they made.
- Keeping the table at four columns preserves the existing quick-scan view while richer formats expose the attribution data.

## Testing
- Unit tests added and updated for aggregation, latest-UTM selection, and output formatting.
- Not run (not requested).

---

This PR was implemented with AI assistance using gpt-5.5 xhigh and Fable 5.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive CLI output and aggregation only; no auth or API contract changes. CSV consumers may need to handle five new columns.
> 
> **Overview**
> **`gumroad sales buyers`** now surfaces five **buyer-level UTM fields** (`utm_source` through `utm_content`) in JSON, CSV, and `--plain` output, so deduped buyer rows can show which campaign last attributed each email—not only purchase count and last purchase date.
> 
> During aggregation, UTM values come from the **most recent sale that has any UTM data**; all five fields are taken from that sale together (no mixing across purchases). Sales with no UTM stay empty; equal `created_at` on attributed sales keeps the **first** sale the API returns. The **table** view is unchanged (four columns via `tableFields()`).
> 
> Command help and **`skills/gumroad/SKILL.md`** document the new fields and point to **`sales export`** for full per-sale CSV. Tests cover cross-page aggregation, latest-UTM selection, same-date ties, and format-specific output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7313bdb2bfa1843f770aabe0e72c65b79f97d28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->