### PR TITLE
offer-codes: add --minimum-amount flag for conditional discounts

### DIFF
--- a/internal/cmd/offercodes/create.go
+++ b/internal/cmd/offercodes/create.go
@@ -17,7 +17,7 @@ type createOfferCodeResponse struct {
 }
 
 func newCreateCmd() *cobra.Command {
-	var product, name, amount string
+	var product, name, amount, minimumAmount string
 	var percentOff, maxPurchaseCount int
 	var universal bool
 
@@ -27,7 +27,10 @@ func newCreateCmd() *cobra.Command {
 		Args:  cmdutil.ExactArgs(0),
 		Long: `Create an offer code for a product.
 
-Use either --amount (flat discount) or --percent-off (percentage discount), not both.`,
+Use either --amount (flat discount) or --percent-off (percentage discount), not both.
+
+Use --minimum-amount to require a minimum order total before the discount applies
+(e.g. "spend over $100 to get 10% off").`,
 		RunE: func(c *cobra.Command, args []string) error {
 			if err := cmdutil.RequirePercentFlag(c, "percent-off", percentOff); err != nil {
 				return err
@@ -46,6 +49,7 @@ Use either --amount (flat discount) or --percent-off (percentage discount), not 
 			hasAmount := flags.Changed("amount")
 			hasPercentOff := flags.Changed("percent-off")
 			hasMaxPurchaseCount := flags.Changed("max-purchase-count")
+			hasMinimumAmount := flags.Changed("minimum-amount")
 
 			if hasAmount && hasPercentOff {
 				return cmdutil.UsageErrorf(c, "flags --amount and --percent-off cannot be used together")
@@ -73,6 +77,16 @@ Use either --amount (flat discount) or --percent-off (percentage discount), not 
 			if hasMaxPurchaseCount {
 				params.Set("max_purchase_count", strconv.Itoa(maxPurchaseCount))
 			}
+			if hasMinimumAmount {
+				cents, err := cmdutil.ParseMoney("minimum-amount", minimumAmount, "minimum amount", "")
+				if err != nil {
+					return cmdutil.UsageErrorf(c, "%s", err.Error())
+				}
+				if cents <= 0 {
+					return cmdutil.UsageErrorf(c, "--minimum-amount must be greater than 0")
+				}
+				params.Set("minimum_amount_cents", strconv.Itoa(cents))
+			}
 			if universal {
 				params.Set("universal", "true")
 			}
@@ -98,6 +112,7 @@ Use either --amount (flat discount) or --percent-off (percentage discount), not 
 	cmd.Flags().StringVar(&product, "product", "", "Product ID (required)")
 	cmd.Flags().StringVar(&name, "name", "", "Offer code name (required)")
 	cmd.Flags().StringVar(&amount, "amount", "", "Flat discount amount (e.g. 5, 5.00)")
+	cmd.Flags().StringVar(&minimumAmount, "minimum-amount", "", "Minimum order total required for the discount to apply (e.g. 100, 100.00)")
 	cmd.Flags().IntVar(&percentOff, "percent-off", 0, "Percentage discount")
 	cmd.Flags().IntVar(&maxPurchaseCount, "max-purchase-count", 0, "Maximum number of uses")
 	cmd.Flags().BoolVar(&universal, "universal", false, "Universal offer code")

--- a/internal/cmd/offercodes/offercodes_test.go
+++ b/internal/cmd/offercodes/offercodes_test.go
@@ -592,6 +592,114 @@ func TestCreate_MaxPurchaseCountZero(t *testing.T) {
 	}
 }
 
+func TestCreate_MinimumAmountWithPercentOff(t *testing.T) {
+	var gotMinimum, gotAmountOff, gotOfferType string
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm failed: %v", err)
+		}
+		gotMinimum = r.PostForm.Get("minimum_amount_cents")
+		gotAmountOff = r.PostForm.Get("amount_off")
+		gotOfferType = r.PostForm.Get("offer_type")
+		testutil.JSON(t, w, map[string]any{"offer_code": map[string]any{"id": "oc1", "name": "SUMMER"}})
+	})
+
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--product", "p1", "--name", "SUMMER", "--percent-off", "10", "--minimum-amount", "100.00"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMinimum != "10000" {
+		t.Errorf("got minimum_amount_cents=%q, want 10000", gotMinimum)
+	}
+	if gotAmountOff != "10" {
+		t.Errorf("got amount_off=%q, want 10", gotAmountOff)
+	}
+	if gotOfferType != "percent" {
+		t.Errorf("got offer_type=%q, want percent", gotOfferType)
+	}
+}
+
+func TestCreate_MinimumAmountWithFlatAmount(t *testing.T) {
+	var gotMinimum string
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm failed: %v", err)
+		}
+		gotMinimum = r.PostForm.Get("minimum_amount_cents")
+		testutil.JSON(t, w, map[string]any{"offer_code": map[string]any{"id": "oc1", "name": "FLAT5"}})
+	})
+
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--product", "p1", "--name", "FLAT5", "--amount", "5", "--minimum-amount", "50"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMinimum != "5000" {
+		t.Errorf("got minimum_amount_cents=%q, want 5000", gotMinimum)
+	}
+}
+
+func TestCreate_NoMinimumAmountOmitsParam(t *testing.T) {
+	var minimumSent bool
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm failed: %v", err)
+		}
+		_, minimumSent = r.PostForm["minimum_amount_cents"]
+		testutil.JSON(t, w, map[string]any{"offer_code": map[string]any{"id": "oc1", "name": "X"}})
+	})
+
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--product", "p1", "--name", "X", "--percent-off", "10"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if minimumSent {
+		t.Error("minimum_amount_cents should not be sent when --minimum-amount is omitted")
+	}
+}
+
+func TestCreate_MinimumAmountZeroRejected(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API")
+	})
+
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--product", "p1", "--name", "X", "--percent-off", "10", "--minimum-amount", "0"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--minimum-amount must be greater than 0") {
+		t.Fatalf("expected minimum amount validation error, got: %v", err)
+	}
+}
+
+func TestCreate_MinimumAmountNegativeRejected(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API")
+	})
+
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--product", "p1", "--name", "X", "--percent-off", "10", "--minimum-amount", "-5"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--minimum-amount cannot be negative") {
+		t.Fatalf("expected minimum amount negative error, got: %v", err)
+	}
+	var usageErr *cmdutil.UsageError
+	if !errors.As(err, &usageErr) {
+		t.Fatalf("expected *cmdutil.UsageError, got %T", err)
+	}
+}
+
+func TestCreate_MinimumAmountInvalidInput(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API")
+	})
+
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--product", "p1", "--name", "X", "--percent-off", "10", "--minimum-amount", "abc"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "not a valid minimum amount") {
+		t.Fatalf("expected minimum amount validation error, got: %v", err)
+	}
+}
+
 func TestCreate_JSON(t *testing.T) {
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
 		testutil.JSON(t, w, map[string]any{"offer_code": map[string]any{"id": "oc1"}})

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -439,13 +439,16 @@ gumroad offer-codes list --product <id> --json --no-input
 gumroad offer-codes create --product <id> --name SAVE10 --percent-off 10 --json --no-input
 gumroad offer-codes create --product <id> --name FLAT5 --amount 5.00 --json --no-input
 
+# Conditional discount: require a minimum order total (e.g. spend $100 -> 10% off)
+gumroad offer-codes create --product <id> --name SUMMER --percent-off 10 --minimum-amount 100.00 --json --no-input
+
 # View / update / delete
 gumroad offer-codes view <code_id> --product <id> --json --no-input
 gumroad offer-codes update <code_id> --product <id> --max-purchase-count 100 --json --no-input
 gumroad offer-codes delete <code_id> --product <id> --yes --json --no-input
 ```
 
-**Create flags:** `--product` (required), `--name` (required), `--percent-off` OR `--amount`, `--max-purchase-count`, `--universal`.
+**Create flags:** `--product` (required), `--name` (required), `--percent-off` OR `--amount`, `--minimum-amount` (minimum order total before the discount applies, e.g. `100.00`), `--max-purchase-count`, `--universal`.
 
 ### variant-categories — Manage variant categories
 


### PR DESCRIPTION
## What

Adds a `--minimum-amount` flag to `offer-codes create`, exposing **conditional / minimum-spend discounts** through the CLI — e.g. "spend over $100 to get 10% off".

```
gumroad offer-codes create --product <id> --name SUMMER --percent-off 10 --minimum-amount 100.00
```

- Parses a money string exactly like `--amount` (dollars → cents) and sends it as `minimum_amount_cents`.
- Works with both `--percent-off` and `--amount` discounts.
- Omitted entirely when the flag isn't passed, so existing behavior is unchanged.
- Validation mirrors `--amount`: rejects zero, negative, and non-numeric input before hitting the API.

## Why

The `minimum_amount_cents` capability already exists in the Gumroad model and DB column, and the web Discounts editor sets it — but it was unreachable for CLI users and API clients. `offer-codes create` only exposed `--amount` / `--percent-off` / `--max-purchase-count`.

While wiring this up I found the API itself silently dropped the field: the v2 `OfferCodesController#create` built `OfferCode.new(...)` with a hardcoded attribute list that omitted `minimum_amount_cents`, and never returned it. So a CLI flag alone would have "succeeded" while producing a discount with no minimum — a silent-success bug. The matching API fix is **antiwork/gumroad#5469** (accept + return `minimum_amount_cents`). This CLI flag depends on that landing.

I reused `cmdutil.ParseMoney` and the existing `flags.Changed(...)` gating pattern rather than introducing a new money type, to stay consistent with how `--amount` is handled.

## Before / After

`--dry-run` shows the new param flowing into the request body:

```
$ gumroad offer-codes create --product demo123 --name SUMMER --percent-off 10 --minimum-amount 100.00 --dry-run
Dry run: POST /products/demo123/offer_codes
amount_off: 10
minimum_amount_cents: 10000
name: SUMMER
offer_type: percent
```

Before this PR there was no `--minimum-amount` flag, so the threshold could not be set at all.

> No screen recording — this was authored in a headless agent environment. The `--dry-run` transcript above and the test output below stand in for the walkthrough.

## Test Results

`go test ./internal/cmd/offercodes/...` — **ok**, coverage **90.2%** (above the 85% cmd gate). Six new tests cover: percent+minimum, flat+minimum, omitted (param not sent), and zero / negative / non-numeric rejection. `gofmt -l` and `go vet` clean.

```
ok  github.com/antiwork/gumroad-cli/internal/cmd/offercodes  coverage: 90.2% of statements
```

(The pre-existing `test/` integration package fails on `main` too — it needs a live authenticated backend / `GUMROAD_ACCESS_TOKEN` — so it's unrelated to this change.)

Docs: updated `skills/gumroad/SKILL.md` (the AI-agent command reference) with the new flag and an example, per CONTRIBUTING. README intentionally untouched.

---

🤖 AI disclosure: authored by Gumclaw (autonomous agent operating the Gumroad/Antiwork stack) using **Claude Opus 4.8**. Prompt: "Do this: github.com/antiwork/gumroad-cli/issues/152".

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad-cli/pr/156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783949470&installation_id=134400930&pr_number=156&repository=antiwork%2Fgumroad-cli&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad-cli%2Fpull%2F156&signature=45c642bc7f9a608b37a9bce035386eac08ef74d964de2644443a758be7488ec9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CLI flag and request mapping with validation before the API; no auth or core infrastructure changes. Effective behavior depends on the related API accepting `minimum_amount_cents`.
> 
> **Overview**
> Adds **`--minimum-amount`** to `gumroad offer-codes create` so CLI users can set a minimum order total before a discount applies (e.g. 10% off when spend is over $100).
> 
> When the flag is set, the command parses dollars like `--amount` via `cmdutil.ParseMoney`, validates zero/negative/invalid input locally, and sends **`minimum_amount_cents`** on the create POST. The parameter is omitted when the flag is not passed, so existing create flows stay unchanged. Works alongside either `--percent-off` or `--amount`.
> 
> Six new tests cover encoding, omission, and validation errors. **`skills/gumroad/SKILL.md`** documents the flag and an example command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f39ff805e0859090f7fc78bd2a1864df91d1ca4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->