### PR TITLE
admin: surface Stripe Connect state and payout bank details (#530)

### DIFF
--- a/internal/cmd/admin/payouts/list.go
+++ b/internal/cmd/admin/payouts/list.go
@@ -24,14 +24,28 @@ type payoutsResponse struct {
 }
 
 type payout struct {
-	ExternalID        string      `json:"external_id"`
-	AmountCents       api.JSONInt `json:"amount_cents"`
-	Currency          string      `json:"currency"`
-	State             string      `json:"state"`
-	CreatedAt         string      `json:"created_at"`
-	Processor         string      `json:"processor"`
-	BankAccountVisual string      `json:"bank_account_visual"`
-	PaypalEmail       string      `json:"paypal_email"`
+	ExternalID        string       `json:"external_id"`
+	AmountCents       api.JSONInt  `json:"amount_cents"`
+	Currency          string       `json:"currency"`
+	State             string       `json:"state"`
+	CreatedAt         string       `json:"created_at"`
+	Processor         string       `json:"processor"`
+	BankAccountVisual string       `json:"bank_account_visual"`
+	PaypalEmail       string       `json:"paypal_email"`
+	TraceID           string       `json:"trace_id"`
+	StripeTransferID  string       `json:"stripe_transfer_id"`
+	BankAccount       *bankAccount `json:"bank_account"`
+}
+
+type bankAccount struct {
+	BankNumber            string `json:"bank_number"`
+	AccountHolderFullName string `json:"account_holder_full_name"`
+	AccountType           string `json:"account_type"`
+	Currency              string `json:"currency"`
+}
+
+func (p payout) hasDetails() bool {
+	return p.TraceID != "" || p.StripeTransferID != "" || p.BankAccount != nil
 }
 
 func newListCmd() *cobra.Command {
@@ -43,7 +57,17 @@ func newListCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List recent payouts for a user",
-		Args:  cmdutil.ExactArgs(0),
+		Long: `List recent payouts for a user as a compact table (id, amount, state, date,
+processor, destination).
+
+Stripe and bank payouts also render a per-row detail block below the table with
+the Stripe transfer id and, for bank payouts, the destination bank account
+(routing/BIC number, account holder, account type, currency) so support can
+confirm where money landed without opening the Stripe dashboard. PayPal and
+debit-card payouts carry no bank account and are omitted from the detail block.
+
+Identify the user with --email or --user-id.`,
+		Args: cmdutil.ExactArgs(0),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
 			target, err := resolveLookupTarget(c, lookup)
@@ -114,17 +138,21 @@ func renderPayouts(opts cmdutil.Options, identifier string, resp payoutsResponse
 		if err := writePayoutsTable(w, style, resp.RecentPayouts); err != nil {
 			return err
 		}
+		if err := writePayoutDetails(w, resp.RecentPayouts); err != nil {
+			return err
+		}
 		return cursor.WriteMoreFooter(w, resp.Pagination)
 	})
 }
 
 func writePayoutsPlain(w io.Writer, identifier string, resp payoutsResponse) error {
 	if len(resp.RecentPayouts) == 0 {
-		return output.PrintPlain(w, [][]string{{identifier, "", "", "", "", "", "", resp.NextPayoutDate, resp.BalanceForNextPayout, resp.PayoutNote}})
+		return output.PrintPlain(w, [][]string{{identifier, "", "", "", "", "", "", resp.NextPayoutDate, resp.BalanceForNextPayout, resp.PayoutNote, "", "", "", "", ""}})
 	}
 
 	rows := make([][]string, 0, len(resp.RecentPayouts))
 	for _, p := range resp.RecentPayouts {
+		bankNumber, accountHolder, accountType, bankCurrency := bankAccountFields(p.BankAccount)
 		rows = append(rows, []string{
 			identifier,
 			p.ExternalID,
@@ -136,9 +164,21 @@ func writePayoutsPlain(w io.Writer, identifier string, resp payoutsResponse) err
 			resp.NextPayoutDate,
 			resp.BalanceForNextPayout,
 			resp.PayoutNote,
+			p.StripeTransferID,
+			bankNumber,
+			accountHolder,
+			accountType,
+			bankCurrency,
 		})
 	}
 	return output.PrintPlain(w, rows)
+}
+
+func bankAccountFields(ba *bankAccount) (bankNumber, accountHolder, accountType, currency string) {
+	if ba == nil {
+		return "", "", "", ""
+	}
+	return ba.BankNumber, ba.AccountHolderFullName, ba.AccountType, ba.Currency
 }
 
 func writePayoutsTable(w io.Writer, style output.Styler, payouts []payout) error {
@@ -147,6 +187,46 @@ func writePayoutsTable(w io.Writer, style output.Styler, payouts []payout) error
 		tbl.AddRow(p.ExternalID, formatAmount(p), p.State, p.CreatedAt, p.Processor, payoutDestination(p))
 	}
 	return tbl.Render(w)
+}
+
+func writePayoutDetails(w io.Writer, payouts []payout) error {
+	var b strings.Builder
+	for _, p := range payouts {
+		if !p.hasDetails() {
+			continue
+		}
+		fmt.Fprintf(&b, "  %s\n", p.ExternalID)
+		if p.TraceID != "" {
+			fmt.Fprintf(&b, "    trace: %s\n", p.TraceID)
+		}
+		if p.StripeTransferID != "" {
+			fmt.Fprintf(&b, "    stripe transfer: %s\n", p.StripeTransferID)
+		}
+		if ba := p.BankAccount; ba != nil {
+			if ba.BankNumber != "" {
+				fmt.Fprintf(&b, "    routing/BIC: %s\n", ba.BankNumber)
+			}
+			if ba.AccountHolderFullName != "" {
+				fmt.Fprintf(&b, "    account holder: %s\n", ba.AccountHolderFullName)
+			}
+			if ba.AccountType != "" {
+				fmt.Fprintf(&b, "    account type: %s\n", ba.AccountType)
+			}
+			if ba.Currency != "" {
+				fmt.Fprintf(&b, "    currency: %s\n", strings.ToUpper(ba.Currency))
+			}
+		}
+	}
+	if b.Len() == 0 {
+		return nil
+	}
+	if err := output.Writeln(w, ""); err != nil {
+		return err
+	}
+	if err := output.Writeln(w, "Details:"); err != nil {
+		return err
+	}
+	return output.Writef(w, "%s", b.String())
 }
 
 func formatAmount(p payout) string {

--- a/internal/cmd/admin/payouts/list.go
+++ b/internal/cmd/admin/payouts/list.go
@@ -178,7 +178,7 @@ func bankAccountFields(ba *bankAccount) (bankNumber, accountHolder, accountType,
 	if ba == nil {
 		return "", "", "", ""
 	}
-	return ba.BankNumber, ba.AccountHolderFullName, ba.AccountType, ba.Currency
+	return ba.BankNumber, ba.AccountHolderFullName, ba.AccountType, strings.ToUpper(ba.Currency)
 }
 
 func writePayoutsTable(w io.Writer, style output.Styler, payouts []payout) error {

--- a/internal/cmd/admin/payouts/payouts_test.go
+++ b/internal/cmd/admin/payouts/payouts_test.go
@@ -199,6 +199,109 @@ func TestListPlainOutputWithNoPayouts(t *testing.T) {
 	}
 }
 
+func TestListRendersStripeTransferAndBankAccountDetails(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"user_id": "2245593582708",
+			"recent_payouts": []map[string]any{
+				{
+					"external_id": "pay_123", "amount_cents": 5000, "currency": "usd",
+					"state": "completed", "created_at": "2026-04-24T12:00:00Z",
+					"processor": "stripe", "bank_account_visual": "******6789",
+					"trace_id": nil, "stripe_transfer_id": "po_1Test",
+					"bank_account": map[string]any{
+						"bank_number":              "110000000",
+						"account_holder_full_name": "Stripe Test Account",
+						"account_type":             "checking",
+						"currency":                 "usd",
+					},
+				},
+			},
+			"pagination": map[string]any{"next": nil, "limit": 20},
+		})
+	})
+
+	cmd := testutil.Command(newListCmd())
+	cmd.SetArgs([]string{"--email", "seller@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	for _, want := range []string{
+		"pay_123",
+		"Details:",
+		"stripe transfer: po_1Test",
+		"routing/BIC: 110000000",
+		"account holder: Stripe Test Account",
+		"account type: checking",
+		"currency: USD",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q: %q", want, out)
+		}
+	}
+	if strings.Contains(out, "trace:") {
+		t.Fatalf("null trace_id must not render: %q", out)
+	}
+}
+
+func TestListOmitsDetailsForPayoutsWithoutBankOrTransfer(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"recent_payouts": []map[string]any{
+				{
+					"external_id": "pay_pp", "amount_cents": 5000,
+					"state": "completed", "created_at": "2026-04-24T12:00:00Z",
+					"processor": "paypal", "paypal_email": "payme@example.com",
+					"trace_id": nil, "stripe_transfer_id": nil, "bank_account": nil,
+				},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newListCmd())
+	cmd.SetArgs([]string{"--email", "seller@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "pay_pp") {
+		t.Fatalf("expected payout row in output: %q", out)
+	}
+	if strings.Contains(out, "Details:") {
+		t.Fatalf("payouts without bank account or transfer id must not render a Details section: %q", out)
+	}
+}
+
+func TestListPlainOutputCarriesStripeTransferAndBankFields(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"recent_payouts": []map[string]any{
+				{
+					"external_id": "pay_123", "amount_cents": 5000, "currency": "usd",
+					"state": "completed", "created_at": "2026-04-24T12:00:00Z",
+					"processor": "stripe", "bank_account_visual": "******6789",
+					"trace_id": nil, "stripe_transfer_id": "po_1Test",
+					"bank_account": map[string]any{
+						"bank_number":              "110000000",
+						"account_holder_full_name": "Stripe Test Account",
+						"account_type":             "checking",
+						"currency":                 "usd",
+					},
+				},
+			},
+			"next_payout_date":        "2026-04-30",
+			"balance_for_next_payout": "$25.00",
+			"payout_note":             "Manual review",
+		})
+	})
+
+	cmd := testutil.Command(newListCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{"--email", "seller@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	want := "seller@example.com\tpay_123\t5000 USD cents\tcompleted\t2026-04-24T12:00:00Z\tstripe\t******6789\t2026-04-30\t$25.00\tManual review\tpo_1Test\t110000000\tStripe Test Account\tchecking\tusd"
+	if strings.TrimSpace(out) != want {
+		t.Fatalf("unexpected plain output: %q", out)
+	}
+}
+
 func TestFormatAmountTrimsCurrency(t *testing.T) {
 	p := payout{AmountCents: 5000, Currency: " usd "}
 	if got := formatAmount(p); got != "5000 USD cents" {

--- a/internal/cmd/admin/payouts/payouts_test.go
+++ b/internal/cmd/admin/payouts/payouts_test.go
@@ -296,7 +296,7 @@ func TestListPlainOutputCarriesStripeTransferAndBankFields(t *testing.T) {
 	cmd.SetArgs([]string{"--email", "seller@example.com"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	want := "seller@example.com\tpay_123\t5000 USD cents\tcompleted\t2026-04-24T12:00:00Z\tstripe\t******6789\t2026-04-30\t$25.00\tManual review\tpo_1Test\t110000000\tStripe Test Account\tchecking\tusd"
+	want := "seller@example.com\tpay_123\t5000 USD cents\tcompleted\t2026-04-24T12:00:00Z\tstripe\t******6789\t2026-04-30\t$25.00\tManual review\tpo_1Test\t110000000\tStripe Test Account\tchecking\tUSD"
 	if strings.TrimSpace(out) != want {
 		t.Fatalf("unexpected plain output: %q", out)
 	}

--- a/internal/cmd/admin/users/info.go
+++ b/internal/cmd/admin/users/info.go
@@ -17,22 +17,24 @@ type infoResponse struct {
 }
 
 type userInfo struct {
-	Email                          string           `json:"email"`
-	Name                           string           `json:"name"`
-	Username                       string           `json:"username"`
-	ProfileURL                     string           `json:"profile_url"`
-	Country                        string           `json:"country"`
-	Locale                         string           `json:"locale"`
-	Timezone                       string           `json:"timezone"`
-	CreatedAt                      string           `json:"created_at"`
-	DeletedAt                      string           `json:"deleted_at"`
-	RiskState                      riskState        `json:"risk_state"`
-	ActiveWatchedUser              *watchedUserInfo `json:"active_watched_user"`
-	TwoFactorAuthenticationEnabled bool             `json:"two_factor_authentication_enabled"`
-	SignIn                         signInInfo       `json:"sign_in"`
-	Social                         socialInfo       `json:"social"`
-	Payouts                        payoutsInfo      `json:"payouts"`
-	Stats                          statsInfo        `json:"stats"`
+	Email                          string            `json:"email"`
+	Name                           string            `json:"name"`
+	Username                       string            `json:"username"`
+	ProfileURL                     string            `json:"profile_url"`
+	Country                        string            `json:"country"`
+	Locale                         string            `json:"locale"`
+	Timezone                       string            `json:"timezone"`
+	CreatedAt                      string            `json:"created_at"`
+	DeletedAt                      string            `json:"deleted_at"`
+	RiskState                      riskState         `json:"risk_state"`
+	ActiveWatchedUser              *watchedUserInfo  `json:"active_watched_user"`
+	TwoFactorAuthenticationEnabled bool              `json:"two_factor_authentication_enabled"`
+	SignIn                         signInInfo        `json:"sign_in"`
+	Social                         socialInfo        `json:"social"`
+	Payouts                        payoutsInfo       `json:"payouts"`
+	Stats                          statsInfo         `json:"stats"`
+	Stripe                         stripeInfo        `json:"stripe"`
+	AdminLinks                     map[string]string `json:"admin_links"`
 }
 
 type signInInfo struct {
@@ -85,6 +87,24 @@ type statsInfo struct {
 	CommentsCount          int    `json:"comments_count"`
 }
 
+type stripeInfo struct {
+	Connected              bool                `json:"connected"`
+	StripeConnectAccountID string              `json:"stripe_connect_account_id"`
+	StripeDashboardURL     string              `json:"stripe_dashboard_url"`
+	Verification           *stripeVerification `json:"verification"`
+}
+
+type stripeVerification struct {
+	Error                    string `json:"error"`
+	ChargesEnabled           bool   `json:"charges_enabled"`
+	PayoutsEnabled           bool   `json:"payouts_enabled"`
+	DetailsSubmitted         bool   `json:"details_submitted"`
+	DisabledReason           string `json:"disabled_reason"`
+	CurrentlyDueCount        int    `json:"currently_due_count"`
+	PastDueCount             int    `json:"past_due_count"`
+	PendingVerificationCount int    `json:"pending_verification_count"`
+}
+
 func newInfoCmd() *cobra.Command {
 	var lookup userLookupFlags
 
@@ -92,9 +112,17 @@ func newInfoCmd() *cobra.Command {
 		Use:   "info",
 		Short: "View a comprehensive admin info payload for a user",
 		Long: `View a comprehensive admin info payload for a user, combining identity,
-risk state, two-factor state, payouts state, and earnings/sales stats into a
-single response. Mirrors the admin web user-detail page so support workflows
-can resolve from a single CLI invocation.
+risk state, two-factor state, payouts state, earnings/sales stats, Stripe
+Connect verification, and admin deep-links into a single response. Mirrors the
+admin web user-detail page so support workflows can resolve from a single CLI
+invocation without round-tripping to Stripe or the admin dashboard.
+
+The Stripe section reports whether a Stripe Connect account is attached and,
+when it is, its account id, dashboard URL, and live verification flags
+(charges/payouts enabled, details submitted) plus any outstanding requirement
+counts. If the live Stripe lookup fails it degrades to a verification error
+line instead. Admin links carry impersonate, user, purchases, and (when a
+Stripe account exists) Stripe-dashboard helper URLs.
 
 Identify the user with --email or --user-id. When both are supplied, the
 server resolves by --user-id.`,
@@ -135,6 +163,8 @@ func renderInfo(opts cmdutil.Options, identifier, userID string, info userInfo) 
 			strconv.Itoa(info.Stats.SalesCount),
 			info.Stats.TotalEarningsFormatted,
 			info.CreatedAt,
+			strconv.FormatBool(info.Stripe.Connected),
+			info.Stripe.StripeConnectAccountID,
 		}})
 	}
 
@@ -194,7 +224,15 @@ func renderInfo(opts cmdutil.Options, identifier, userID string, info userInfo) 
 	writePayouts(&b, info.Payouts)
 
 	fmt.Fprintln(&b)
+	writeStripe(&b, info.Stripe)
+
+	fmt.Fprintln(&b)
 	writeStats(&b, info.Stats)
+
+	if len(info.AdminLinks) > 0 {
+		fmt.Fprintln(&b)
+		writeAdminLinks(&b, info.AdminLinks)
+	}
 
 	return output.Writef(opts.Out(), "%s", b.String())
 }
@@ -393,6 +431,54 @@ func payoutsHeadlineState(p payoutsInfo) string {
 		return "paused (by user)"
 	default:
 		return "active"
+	}
+}
+
+func writeStripe(b *strings.Builder, s stripeInfo) {
+	if !s.Connected {
+		fmt.Fprintln(b, "Stripe: not connected")
+		return
+	}
+
+	fmt.Fprintln(b, "Stripe: connected")
+	if s.StripeConnectAccountID != "" {
+		fmt.Fprintf(b, "  account: %s\n", s.StripeConnectAccountID)
+	}
+	if s.StripeDashboardURL != "" {
+		fmt.Fprintf(b, "  dashboard: %s\n", s.StripeDashboardURL)
+	}
+	if s.Verification == nil {
+		return
+	}
+	if s.Verification.Error != "" {
+		fmt.Fprintf(b, "  verification error: %s\n", s.Verification.Error)
+		return
+	}
+
+	v := s.Verification
+	fmt.Fprintf(b, "  charges enabled: %s\n", strconv.FormatBool(v.ChargesEnabled))
+	fmt.Fprintf(b, "  payouts enabled: %s\n", strconv.FormatBool(v.PayoutsEnabled))
+	fmt.Fprintf(b, "  details submitted: %s\n", strconv.FormatBool(v.DetailsSubmitted))
+	if v.DisabledReason != "" {
+		fmt.Fprintf(b, "  disabled reason: %s\n", v.DisabledReason)
+	}
+	if v.CurrentlyDueCount > 0 {
+		fmt.Fprintf(b, "  currently due: %d\n", v.CurrentlyDueCount)
+	}
+	if v.PastDueCount > 0 {
+		fmt.Fprintf(b, "  past due: %d\n", v.PastDueCount)
+	}
+	if v.PendingVerificationCount > 0 {
+		fmt.Fprintf(b, "  pending verification: %d\n", v.PendingVerificationCount)
+	}
+}
+
+func writeAdminLinks(b *strings.Builder, links map[string]string) {
+	fmt.Fprintln(b, "Admin links:")
+	for _, key := range []string{"impersonate", "admin_user", "admin_purchases", "stripe_dashboard"} {
+		if value := links[key]; value != "" {
+			fmt.Fprintf(b, "  %s: %s\n", key, value)
+		}
 	}
 }
 

--- a/internal/cmd/admin/users/info.go
+++ b/internal/cmd/admin/users/info.go
@@ -33,7 +33,7 @@ type userInfo struct {
 	Social                         socialInfo        `json:"social"`
 	Payouts                        payoutsInfo       `json:"payouts"`
 	Stats                          statsInfo         `json:"stats"`
-	Stripe                         stripeInfo        `json:"stripe"`
+	Stripe                         *stripeInfo       `json:"stripe"`
 	AdminLinks                     map[string]string `json:"admin_links"`
 }
 
@@ -151,6 +151,11 @@ server resolves by --user-id.`,
 
 func renderInfo(opts cmdutil.Options, identifier, userID string, info userInfo) error {
 	if opts.PlainOutput {
+		stripeConnected, stripeAccountID := "", ""
+		if info.Stripe != nil {
+			stripeConnected = strconv.FormatBool(info.Stripe.Connected)
+			stripeAccountID = info.Stripe.StripeConnectAccountID
+		}
 		return output.PrintPlain(opts.Out(), [][]string{{
 			fallback(info.Email, identifier),
 			info.Name,
@@ -163,8 +168,8 @@ func renderInfo(opts cmdutil.Options, identifier, userID string, info userInfo) 
 			strconv.Itoa(info.Stats.SalesCount),
 			info.Stats.TotalEarningsFormatted,
 			info.CreatedAt,
-			strconv.FormatBool(info.Stripe.Connected),
-			info.Stripe.StripeConnectAccountID,
+			stripeConnected,
+			stripeAccountID,
 		}})
 	}
 
@@ -223,8 +228,10 @@ func renderInfo(opts cmdutil.Options, identifier, userID string, info userInfo) 
 	fmt.Fprintln(&b)
 	writePayouts(&b, info.Payouts)
 
-	fmt.Fprintln(&b)
-	writeStripe(&b, info.Stripe)
+	if info.Stripe != nil {
+		fmt.Fprintln(&b)
+		writeStripe(&b, *info.Stripe)
+	}
 
 	fmt.Fprintln(&b)
 	writeStats(&b, info.Stats)

--- a/internal/cmd/admin/users/info_test.go
+++ b/internal/cmd/admin/users/info_test.go
@@ -468,7 +468,7 @@ func TestInfoPlainOutput(t *testing.T) {
 	cmd.SetArgs([]string{"--email", "seller@example.com"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	want := "seller@example.com\tSeller One\tsellerone\tCompliant\ttrue\tfalse\tfalse\t2026-05-15\t42\t$1,234.56\t2024-01-01T00:00:00Z"
+	want := "seller@example.com\tSeller One\tsellerone\tCompliant\ttrue\tfalse\tfalse\t2026-05-15\t42\t$1,234.56\t2024-01-01T00:00:00Z\tfalse"
 	if strings.TrimSpace(out) != want {
 		t.Fatalf("unexpected plain output: %q", out)
 	}
@@ -505,6 +505,145 @@ func TestInfoJSONPreservesResponse(t *testing.T) {
 	}
 	if stats["total_earnings_formatted"] != "$1,234.56" {
 		t.Errorf("expected stats.total_earnings_formatted=$1,234.56, got %v", stats["total_earnings_formatted"])
+	}
+}
+
+func TestInfoRendersStripeConnectedVerificationAndAdminLinks(t *testing.T) {
+	payload := sampleInfoPayload()
+	user := payload["user"].(map[string]any)
+	user["stripe"] = map[string]any{
+		"connected":                 true,
+		"stripe_connect_account_id": "acct_123abc",
+		"stripe_dashboard_url":      "https://dashboard.stripe.com/connect/accounts/acct_123abc",
+		"verification": map[string]any{
+			"charges_enabled":            true,
+			"payouts_enabled":            false,
+			"details_submitted":          true,
+			"disabled_reason":            "requirements.past_due",
+			"currently_due_count":        1,
+			"past_due_count":             1,
+			"pending_verification_count": 0,
+		},
+	}
+	user["admin_links"] = map[string]any{
+		"impersonate":      "https://app.example.com/admin/helper_actions/impersonate/u_abc",
+		"admin_user":       "https://app.example.com/admin/users/123",
+		"admin_purchases":  "https://app.example.com/admin/search/purchases?query=seller@example.com",
+		"stripe_dashboard": "https://app.example.com/admin/helper_actions/stripe_dashboard/u_abc",
+	}
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, payload)
+	})
+
+	cmd := testutil.Command(newInfoCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--email", "seller@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	for _, want := range []string{
+		"Stripe: connected",
+		"account: acct_123abc",
+		"dashboard: https://dashboard.stripe.com/connect/accounts/acct_123abc",
+		"charges enabled: true",
+		"payouts enabled: false",
+		"details submitted: true",
+		"disabled reason: requirements.past_due",
+		"currently due: 1",
+		"past due: 1",
+		"Admin links:",
+		"impersonate: https://app.example.com/admin/helper_actions/impersonate/u_abc",
+		"admin_user: https://app.example.com/admin/users/123",
+		"admin_purchases: https://app.example.com/admin/search/purchases?query=seller@example.com",
+		"stripe_dashboard: https://app.example.com/admin/helper_actions/stripe_dashboard/u_abc",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q: %q", want, out)
+		}
+	}
+	if strings.Contains(out, "pending verification:") {
+		t.Errorf("zero pending-verification count must be suppressed: %q", out)
+	}
+}
+
+func TestInfoStripeConnectedPlainOutputCarriesAccountID(t *testing.T) {
+	payload := sampleInfoPayload()
+	user := payload["user"].(map[string]any)
+	user["stripe"] = map[string]any{
+		"connected":                 true,
+		"stripe_connect_account_id": "acct_123abc",
+		"stripe_dashboard_url":      "https://dashboard.stripe.com/connect/accounts/acct_123abc",
+		"verification": map[string]any{
+			"charges_enabled":   true,
+			"payouts_enabled":   true,
+			"details_submitted": true,
+		},
+	}
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, payload)
+	})
+
+	cmd := testutil.Command(newInfoCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{"--email", "seller@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	want := "seller@example.com\tSeller One\tsellerone\tCompliant\ttrue\tfalse\tfalse\t2026-05-15\t42\t$1,234.56\t2024-01-01T00:00:00Z\ttrue\tacct_123abc"
+	if strings.TrimSpace(out) != want {
+		t.Fatalf("unexpected plain output: %q", out)
+	}
+}
+
+func TestInfoDegradesToVerificationErrorWhenStripeCallFailed(t *testing.T) {
+	payload := sampleInfoPayload()
+	user := payload["user"].(map[string]any)
+	user["stripe"] = map[string]any{
+		"connected":                 true,
+		"stripe_connect_account_id": "acct_revoked",
+		"stripe_dashboard_url":      "https://dashboard.stripe.com/connect/accounts/acct_revoked",
+		"verification":              map[string]any{"error": "access revoked"},
+	}
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, payload)
+	})
+
+	cmd := testutil.Command(newInfoCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--email", "seller@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	for _, want := range []string{
+		"Stripe: connected",
+		"account: acct_revoked",
+		"verification error: access revoked",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q: %q", want, out)
+		}
+	}
+	if strings.Contains(out, "charges enabled:") {
+		t.Errorf("degraded verification must not print Stripe flags: %q", out)
+	}
+}
+
+func TestInfoReportsUnconnectedStripeWithoutInnerBlock(t *testing.T) {
+	payload := sampleInfoPayload()
+	payload["user"].(map[string]any)["stripe"] = map[string]any{"connected": false}
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, payload)
+	})
+
+	cmd := testutil.Command(newInfoCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--email", "seller@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "Stripe: not connected") {
+		t.Errorf("expected unconnected Stripe headline: %q", out)
+	}
+	for _, unwanted := range []string{"charges enabled:", "dashboard:", "Admin links:"} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("unconnected Stripe / absent admin links must not render %q: %q", unwanted, out)
+		}
 	}
 }
 

--- a/internal/cmd/admin/users/info_test.go
+++ b/internal/cmd/admin/users/info_test.go
@@ -468,7 +468,7 @@ func TestInfoPlainOutput(t *testing.T) {
 	cmd.SetArgs([]string{"--email", "seller@example.com"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	want := "seller@example.com\tSeller One\tsellerone\tCompliant\ttrue\tfalse\tfalse\t2026-05-15\t42\t$1,234.56\t2024-01-01T00:00:00Z\tfalse"
+	want := "seller@example.com\tSeller One\tsellerone\tCompliant\ttrue\tfalse\tfalse\t2026-05-15\t42\t$1,234.56\t2024-01-01T00:00:00Z"
 	if strings.TrimSpace(out) != want {
 		t.Fatalf("unexpected plain output: %q", out)
 	}
@@ -622,6 +622,28 @@ func TestInfoDegradesToVerificationErrorWhenStripeCallFailed(t *testing.T) {
 	}
 	if strings.Contains(out, "charges enabled:") {
 		t.Errorf("degraded verification must not print Stripe flags: %q", out)
+	}
+}
+
+func TestInfoOmitsStripeSectionWhenServerOmitsField(t *testing.T) {
+	payload := sampleInfoPayload()
+	if _, ok := payload["user"].(map[string]any)["stripe"]; ok {
+		t.Fatal("sample payload must not include a stripe key for this test")
+	}
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, payload)
+	})
+
+	cmd := testutil.Command(newInfoCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--email", "seller@example.com"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if strings.Contains(out, "Stripe:") {
+		t.Errorf("Stripe section must be omitted when the server omits the stripe field (e.g. CLI ahead of server): %q", out)
+	}
+	if !strings.Contains(out, "Sales: 42") {
+		t.Errorf("downstream sections must still render: %q", out)
 	}
 }
 

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -78,7 +78,7 @@ Most responses are wrapped in `{"success": true, ...}` with resource-specific ke
 - `products update --custom-html` → `.product.custom_html`, `.product.landing_url`, `.previous_custom_html`, `.sanitization_report`
 - Not every `products` write verb is flat: `create`, `update`, `unpublish`, and `delete` return top-level fields, but `covers add`, `thumbnail set`, and `content set` still wrap their payload in the `{success, …, result}` envelope — read those under `.result`
 - `webhooks list` → `.resource_subscriptions[]`
-- `admin users info` → `.user`
+- `admin users info` → `.user` (includes `.user.stripe` Stripe Connect state — `connected`, and when connected `stripe_connect_account_id`, `stripe_dashboard_url`, and a `verification` block of flags/counts or an `error` subfield when the live Stripe lookup failed — and `.user.admin_links` impersonate/user/purchases/stripe-dashboard URLs)
 - `admin users affiliates` → `.affiliates[]`
 - `admin users comments list` → `.comments[]`
 - `admin users comments add` → `.comment`
@@ -90,6 +90,7 @@ Most responses are wrapped in `{"success": true, ...}` with resource-specific ke
 - `admin users related` → `.related_users[]`, `.truncated`, `.per_signal_limit`
 - `admin users mark-compliant`, `admin users suspend`, `admin users suspend-for-tos-violation` → `.status`, `.message`, `.user_id`
 - `admin products flag-for-tos-violation` → `.status`, `.message`, `.user_id`, `.product_id`
+- `admin payouts list` → `.recent_payouts[]`, `.pagination.next`. Each payout carries `stripe_transfer_id` (a `po_…` payout or `py_…` destination payment, or null), `bank_account` (null for PayPal and debit-card payouts; otherwise `bank_number` routing/BIC, `account_holder_full_name`, `account_type`, `currency`), and `trace_id` (currently always null).
 - `admin payouts scheduled create` → `.message`, `.user_id`, `.scheduled_payout`
 - `admin users refund-balance` → `.status`, `.message`, `.user_id`, `.count`, `.total_amount_cents`, `.currency`
 - `admin purchases view` → `.purchase`
@@ -199,6 +200,9 @@ gumroad admin users suspend-for-tos-violation --user-id 2245593582708 --expected
 gumroad admin products flag-for-tos-violation <product-id> --user-id 2245593582708 --expected-email seller@example.com --yes --json --non-interactive --no-input
 gumroad admin payouts scheduled create --user-id 2245593582708 --expected-email seller@example.com --processor stripe --payout-date 2026-06-15 --note "Appeal window closes before payout." --yes --json --non-interactive --no-input
 gumroad admin payouts scheduled list --status pending --user-id 2245593582708 --json --non-interactive --no-input
+
+# Recent payouts, with Stripe transfer id and destination bank account per row
+gumroad admin payouts list --user-id 2245593582708 --limit 25 --json --jq '.recent_payouts[] | {external_id, stripe_transfer_id, bank_account}' --non-interactive --no-input
 
 # Refund-balance dry-run still calls the preview GET, but skips the guarded POST.
 gumroad admin users refund-balance --user-id 2245593582708 --expected-email seller@example.com --dry-run --json --non-interactive --no-input


### PR DESCRIPTION
## What

Decodes and renders the new admin-API fields that server PR antiwork/gumroad#5496 (issue antiwork/gumroad-private#530) added to two existing internal admin endpoints. The CLI's Go structs didn't decode them, so `encoding/json` silently dropped them and support still had to round-trip to Helper tRPC, Metabase, and the Stripe dashboard.

**`admin users info` → `.user`**
- **`stripe`** — a "Stripe" section showing connection state. When connected, renders account id, dashboard URL, and live verification flags (charges/payouts enabled, details submitted) plus outstanding requirement counts. When the server's live Stripe call fails, verification degrades to an `{error}` subfield — decoded as a pointer so the error line renders in place of the flag block. The inner block is suppressed when `connected: false`.
- **`admin_links`** — an "Admin links" section (impersonate / user / purchases / stripe-dashboard). Decoded as `map[string]string` since `stripe_dashboard` is present only when a Stripe account exists; rendered in a fixed key order for deterministic output.
- Plain output appends stripe-connected and account-id columns (existing column indices preserved).

**`admin payouts list` → each `recent_payouts[]` row**
- **`stripe_transfer_id`** (`po_…` payout or `py_…` destination payment) and **`bank_account`** (routing/BIC, holder, type, currency) render as a per-row **detail block below the compact table** rather than new columns. `bank_account` is a pointer because it's `null` for PayPal and debit-card payouts.
- **`trace_id`** is decoded as nullable but rendered only when non-empty (server always returns `null` today).
- Plain output appends the transfer id and bank-account columns.

## Why

The issue's goal is to let CLI-driven support resolve Stripe verification status and confirm payout destinations without leaving the terminal. The field is named `stripe_transfer_id` (not `stripe_payout_id`) to match the underlying column, since the value is a `po_…` payout for Gumroad-managed accounts but a `py_…` destination payment for Connect standard accounts.

**Rendering choice — bank details shown by default, no `--reveal` gate.** The whole `admin` command tree is already internal-admin-token-gated, and the issue explicitly wants support to stop guessing bank names, so gating bank number + holder behind another flag would only add friction without adding a real trust boundary. Both new payout fields render as a detail block keyed by external id rather than table columns, keeping the compact table readable.

---

AI disclosure: implemented by Claude Opus 4.8 (1M context) via Claude Code.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad-cli/pr/159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784277753&installation_id=134400930&pr_number=159&repository=antiwork%2Fgumroad-cli&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad-cli%2Fpull%2F159&signature=ea575e02fb2068684f2519e4e87d44c31abd7372cd247fb2d594b27b5bd05b3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Admin-only output now includes routing/BIC and account-holder bank fields by design; risk is sensitive data in logs/terminals rather than changes to payout or auth logic.
> 
> **Overview**
> Extends **admin CLI** decoding and human/plain output for new admin API fields so support can see Stripe and payout destination data without leaving the terminal.
> 
> **`admin users info`** now decodes and prints **Stripe Connect** (`connected`, account id, dashboard URL, verification flags/counts, or a verification **error** when the live lookup fails) and an **Admin links** block (impersonate, user, purchases, stripe-dashboard). Plain TSV adds stripe-connected and account-id columns.
> 
> **`admin payouts list`** decodes **`stripe_transfer_id`**, **`bank_account`**, and **`trace_id`**, keeps the summary table unchanged, and appends a per-payout **Details** section (transfer id, routing/BIC, holder, type, currency); PayPal rows without bank/transfer data skip that block. Plain output adds matching columns.
> 
> **`skills/gumroad/SKILL.md`** documents the new JSON shapes and an example `payouts list` jq query. Tests cover rendering, omission, degradation, and plain formats.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4dfb4c4abbee9d8f1ba7cbd1cf25c0f34a25385. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->