### PR TITLE
Add --force to admin payouts issue to release below-minimum balances

### DIFF
--- a/internal/cmd/admin/payouts/issue.go
+++ b/internal/cmd/admin/payouts/issue.go
@@ -21,6 +21,7 @@ type issueRequest struct {
 	PayoutProcessor      string `json:"payout_processor"`
 	PayoutPeriodEndDate  string `json:"payout_period_end_date"`
 	ShouldSplitTheAmount bool   `json:"should_split_the_amount,omitempty"`
+	BypassMinimumPayout  bool   `json:"bypass_minimum_payout,omitempty"`
 }
 
 type issueResponse struct {
@@ -44,6 +45,7 @@ func newIssueCmd() *cobra.Command {
 		through     string
 		processor   string
 		split       bool
+		force       bool
 	)
 
 	cmd := &cobra.Command{
@@ -55,9 +57,14 @@ The --through date is the payout period end date and must be in the past
 (YYYY-MM-DD). --split is only valid with --processor paypal and asks the
 server to split the payout amount across multiple PayPal transfers.
 
+--force releases a balance below the $100 payout minimum (e.g. a compliant
+creator discontinuing a product who won't reach the threshold). Without it,
+sub-minimum balances are rejected, unchanged.
+
 This moves money. --yes is required.`,
 		Example: `  gumroad admin payouts issue --user-id 2245593582708 --through 2026-04-30 --processor stripe --yes
-  gumroad admin payouts issue --user-id 2245593582708 --expected-email seller@example.com --through 2026-04-30 --processor paypal --split --yes`,
+  gumroad admin payouts issue --user-id 2245593582708 --expected-email seller@example.com --through 2026-04-30 --processor paypal --split --yes
+  gumroad admin payouts issue --user-id 2245593582708 --through 2026-04-30 --processor stripe --force --yes`,
 		Args: cmdutil.ExactArgs(0),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
@@ -93,9 +100,13 @@ This moves money. --yes is required.`,
 				PayoutProcessor:      normalizedProcessor,
 				PayoutPeriodEndDate:  through,
 				ShouldSplitTheAmount: split,
+				BypassMinimumPayout:  force,
 			}
 
 			confirmMsg := "Issue manual " + normalizedProcessor + " payout for user_id " + target.UserID + " through " + through + "? This moves money."
+			if force {
+				confirmMsg += " (forcing past the $100 payout minimum)"
+			}
 			ok, err := cmdutil.ConfirmAction(opts, confirmMsg)
 			if err != nil {
 				return err
@@ -131,6 +142,7 @@ This moves money. --yes is required.`,
 	cmd.Flags().StringVar(&through, "through", "", "Payout period end date in YYYY-MM-DD (required, must be in the past)")
 	cmd.Flags().StringVar(&processor, "processor", "", "Payout processor: stripe or paypal (required)")
 	cmd.Flags().BoolVar(&split, "split", false, "Split the amount across multiple PayPal transfers (paypal only)")
+	cmd.Flags().BoolVar(&force, "force", false, "Release a balance below the $100 payout minimum")
 
 	return cmd
 }
@@ -145,6 +157,9 @@ func issueDryRunParams(req issueRequest) url.Values {
 	params.Set("payout_period_end_date", req.PayoutPeriodEndDate)
 	if req.ShouldSplitTheAmount {
 		params.Set("should_split_the_amount", "true")
+	}
+	if req.BypassMinimumPayout {
+		params.Set("bypass_minimum_payout", "true")
 	}
 	return params
 }

--- a/internal/cmd/admin/payouts/issue_test.go
+++ b/internal/cmd/admin/payouts/issue_test.go
@@ -156,6 +156,70 @@ func TestIssue_SendsRequestAndShowsResult(t *testing.T) {
 	}
 }
 
+func TestIssue_ForceSendsBypassMinimumPayout(t *testing.T) {
+	var body issueRequest
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if err := json.Unmarshal(raw, &body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		testutil.JSON(t, w, map[string]any{
+			"success": true,
+			"payout":  map[string]any{"external_id": "pay_abc", "amount_cents": 5000, "currency": "usd", "state": "processing", "processor": "stripe"},
+		})
+	})
+
+	cmd := testutil.Command(newIssueCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--through", "2020-01-01", "--processor", "stripe", "--force"})
+	testutil.MustExecute(t, cmd)
+
+	if !body.BypassMinimumPayout {
+		t.Fatalf("expected --force to send bypass_minimum_payout=true, got body: %+v", body)
+	}
+}
+
+func TestIssue_OmitsBypassMinimumPayoutByDefault(t *testing.T) {
+	var raw []byte
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		raw, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		testutil.JSON(t, w, map[string]any{
+			"success": true,
+			"payout":  map[string]any{"external_id": "pay_abc", "amount_cents": 5000},
+		})
+	})
+
+	cmd := testutil.Command(newIssueCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--through", "2020-01-01", "--processor", "stripe"})
+	testutil.MustExecute(t, cmd)
+
+	if strings.Contains(string(raw), "bypass_minimum_payout") {
+		t.Fatalf("bypass_minimum_payout must be omitted when --force is absent, got body: %s", raw)
+	}
+}
+
+func TestIssue_DryRunIncludesBypassMinimumPayout(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("dry-run must not POST to the issue endpoint")
+	})
+
+	cmd := testutil.Command(newIssueCmd(), testutil.DryRun(true), testutil.NoInput(true))
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--through", "2020-01-01", "--processor", "stripe", "--force"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "bypass_minimum_payout: true") {
+		t.Errorf("dry-run output missing bypass_minimum_payout: %q", out)
+	}
+}
+
 func TestIssue_ServerErrorSurfacesMessageAndNonZeroExit(t *testing.T) {
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnprocessableEntity)


### PR DESCRIPTION
Closes #161

## What

Adds `--force` to `gumroad admin payouts issue` to release a balance **below the $100 payout minimum**.

```
gumroad admin payouts issue --user-id <id> --through <YYYY-MM-DD> --processor stripe --force --yes
```

- `--force` sends `bypass_minimum_payout: true` to `POST /internal/admin/payouts/issue`.
- Without it, behavior is unchanged — sub-minimum balances are still rejected (default safe path).
- The confirmation prompt gains `(forcing past the $100 payout minimum)` and `--dry-run` shows `bypass_minimum_payout: true`.
- Documented in `--help` alongside the existing flags.

Requires the server-side change in antiwork/gumroad#5518, which adds the `bypass_minimum_payout` param. Until that ships, `--force` is sent but ignored.

## Why

`payouts issue` couldn't release a sub-$100 balance, so the single most common "automation gets 95% of the way, then needs a human" support case — a compliant creator discontinuing a product who asks for their remaining balance — bounced to an engineer for a one-line Rails console call:

```ruby
PayoutUsersService.new(date_string: "<date>", processor_type: "STRIPE", user_ids: <id>).process
```

`--force` closes that gap so verify → mark-compliant → pay out runs end-to-end. It mirrors the established `--force` on `purchases refund` (relax one specific guard, keep the rest), so the pattern and safety story are already familiar.

## Before/After

- Before: `payouts issue` on a sub-$100 account → `Error: Payment was not sent.`, no override.
- After: `payouts issue --force` releases it; without `--force`, still rejected.

A terminal recording (dry-run + against a staging server) will be attached.

## Test Results

```
go test ./...        all packages ok
go vet / gofmt       clean
go build ./...       ok
```

New tests in `issue_test.go`:
- `--force` sends `bypass_minimum_payout=true`.
- The field is omitted from the request body when `--force` is absent.
- `--dry-run --force` prints `bypass_minimum_payout: true`.

## QA steps

1. `gumroad admin payouts issue --user-id <id> --through <past-date> --processor stripe --force --dry-run` → output includes `bypass_minimum_payout: true`.
2. Against a staging server with the paired backend change, on a compliant sub-$100 account: run with `--force --yes` → payout issued; run without `--force` → rejected.

---

🤖 AI disclosure: drafted with the help of Claude Opus 4.8.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad-cli/pr/162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784403943&installation_id=134400930&pr_number=162&repository=antiwork%2Fgumroad-cli&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad-cli%2Fpull%2F162&signature=18a5f5f0b26e00ee6bf407621d25eba355ffcba5f63b281a476e609acaaa3e19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a money-moving admin path with a new override for payout minimum rules; risk is mitigated by requiring `--yes` and unchanged default when `--force` is omitted, but it depends on paired server support.
> 
> **Overview**
> Adds **`--force`** to `gumroad admin payouts issue` so admins can issue payouts when the seller balance is **below the $100 minimum**. With `--force`, the CLI sends `bypass_minimum_payout: true` on `POST /internal/admin/payouts/issue`; without it, behavior is unchanged.
> 
> The confirmation prompt notes when the minimum is being bypassed, `--dry-run` includes `bypass_minimum_payout`, and help/examples document the flag. Tests cover the POST body, omission by default, and dry-run output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 206b57d989da019f7a1aae350f02ff881dd3b782. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->