### PR TITLE
products list: add --all and --page-key pagination flags

### DIFF
--- a/internal/cmd/products/list.go
+++ b/internal/cmd/products/list.go
@@ -78,15 +78,7 @@ func renderProductsList(opts cmdutil.Options, resp productsListResponse) error {
 	}
 
 	if opts.PlainOutput {
-		var rows [][]string
-		for _, p := range resp.Products {
-			status := "draft"
-			if p.Published {
-				status = "published"
-			}
-			rows = append(rows, []string{p.ID, p.Name, status, p.FormattedPrice, fmt.Sprintf("%d", p.SalesCount)})
-		}
-		return output.PrintPlain(opts.Out(), rows)
+		return writeProductsPlain(opts.Out(), resp.Products)
 	}
 
 	style := opts.Style()
@@ -101,13 +93,7 @@ func renderProductsList(opts cmdutil.Options, resp productsListResponse) error {
 
 	buildTable := func(items []productListItem, countHeader string) *output.Table {
 		tbl := output.NewStyledTable(style, "ID", "NAME", "STATUS", "PRICE", countHeader)
-		for _, p := range items {
-			status := style.Yellow("draft")
-			if p.Published {
-				status = style.Green("published")
-			}
-			tbl.AddRow(p.ID, p.Name, status, p.FormattedPrice, fmt.Sprintf("%d", p.SalesCount))
-		}
+		addProductRows(tbl, style, items)
 		return tbl
 	}
 
@@ -214,6 +200,11 @@ func writeProductsPlain(w io.Writer, products []productListItem) error {
 
 func writeProductsTable(w io.Writer, style output.Styler, products []productListItem) error {
 	tbl := output.NewStyledTable(style, "ID", "NAME", "STATUS", "PRICE", "SALES")
+	addProductRows(tbl, style, products)
+	return tbl.Render(w)
+}
+
+func addProductRows(tbl *output.Table, style output.Styler, products []productListItem) {
 	for _, p := range products {
 		status := style.Yellow("draft")
 		if p.Published {
@@ -221,7 +212,6 @@ func writeProductsTable(w io.Writer, style output.Styler, products []productList
 		}
 		tbl.AddRow(p.ID, p.Name, status, p.FormattedPrice, fmt.Sprintf("%d", p.SalesCount))
 	}
-	return tbl.Render(w)
 }
 
 func productsPaginationHint(nextPageKey string) string {

--- a/internal/cmd/products/list.go
+++ b/internal/cmd/products/list.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/antiwork/gumroad-cli/internal/api"
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/config"
 	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -21,88 +22,210 @@ type productListItem struct {
 }
 
 type productsListResponse struct {
-	Products []productListItem `json:"products"`
+	Products    []productListItem `json:"products"`
+	NextPageKey string            `json:"next_page_key,omitempty"`
 }
 
 func newListCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:     "list",
-		Short:   "List products",
-		Args:    cmdutil.ExactArgs(0),
-		Example: `  gumroad products list`,
+	var pageKey string
+	var all bool
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List products",
+		Args:  cmdutil.ExactArgs(0),
+		Example: `  gumroad products list
+  gumroad products list --all
+  gumroad products list --page-key <cursor>
+  gumroad products list --json --jq '.products[0].id'`,
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
-			return cmdutil.RunRequestDecoded[productsListResponse](opts, "Fetching products...", "GET", "/products", url.Values{}, func(resp productsListResponse) error {
-				if len(resp.Products) == 0 {
-					return cmdutil.PrintInfo(opts, "No products found.")
-				}
 
-				if opts.PlainOutput {
-					var rows [][]string
-					for _, p := range resp.Products {
-						status := "draft"
-						if p.Published {
-							status = "published"
-						}
-						rows = append(rows, []string{p.ID, p.Name, status, p.FormattedPrice, fmt.Sprintf("%d", p.SalesCount)})
-					}
-					return output.PrintPlain(opts.Out(), rows)
-				}
+			params := url.Values{}
+			if pageKey != "" {
+				params.Set("page_key", pageKey)
+			}
+			if all {
+				return streamProductsListAll(opts, params)
+			}
 
-				style := opts.Style()
-				var memberships, standard []productListItem
-				for _, p := range resp.Products {
-					if p.IsTieredMembership {
-						memberships = append(memberships, p)
-					} else {
-						standard = append(standard, p)
-					}
-				}
-
-				buildTable := func(items []productListItem, countHeader string) *output.Table {
-					tbl := output.NewStyledTable(style, "ID", "NAME", "STATUS", "PRICE", countHeader)
-					for _, p := range items {
-						status := style.Yellow("draft")
-						if p.Published {
-							status = style.Green("published")
-						}
-						tbl.AddRow(p.ID, p.Name, status, p.FormattedPrice, fmt.Sprintf("%d", p.SalesCount))
-					}
-					return tbl
-				}
-
-				return output.WithPager(opts.Out(), opts.Err(), func(w io.Writer) error {
-					split := len(memberships) > 0 && len(standard) > 0
-					if split {
-						if err := output.Writeln(w, style.Bold("Memberships")); err != nil {
-							return err
-						}
-						if err := buildTable(memberships, "MEMBERS").Render(w); err != nil {
-							return err
-						}
-						if err := output.Writeln(w, "\n"+style.Bold("Products")); err != nil {
-							return err
-						}
-						if err := buildTable(standard, "SALES").Render(w); err != nil {
-							return err
-						}
-					} else {
-						items := standard
-						header := "SALES"
-						if len(memberships) > 0 {
-							items = memberships
-							header = "MEMBERS"
-						}
-						if err := buildTable(items, header).Render(w); err != nil {
-							return err
-						}
-					}
-					if !opts.Quiet {
-						return output.Writeln(w, style.Dim("\nTip: view a product with  gumroad products view <id>"))
-					}
-					return nil
-				})
+			return cmdutil.RunRequestDecoded[productsListResponse](opts, "Fetching products...", "GET", "/products", params, func(resp productsListResponse) error {
+				return renderProductsList(opts, resp)
 			})
 		},
 	}
+
+	cmd.Flags().StringVar(&pageKey, "page-key", "", "Pagination cursor")
+	cmd.Flags().BoolVar(&all, "all", false, "Fetch all pages")
+	cmd.MarkFlagsMutuallyExclusive("all", "page-key")
+
+	return cmd
+}
+
+func renderProductsList(opts cmdutil.Options, resp productsListResponse) error {
+	if len(resp.Products) == 0 {
+		if resp.NextPageKey != "" && !opts.PlainOutput && !opts.Quiet {
+			style := opts.Style()
+			hint := productsPaginationHint(resp.NextPageKey)
+			return output.WithPager(opts.Out(), opts.Err(), func(w io.Writer) error {
+				if err := output.Writeln(w, "No products found on this page."); err != nil {
+					return err
+				}
+				return output.Writeln(w, style.Dim("More results available: "+hint))
+			})
+		}
+		return cmdutil.PrintInfo(opts, "No products found.")
+	}
+
+	if opts.PlainOutput {
+		var rows [][]string
+		for _, p := range resp.Products {
+			status := "draft"
+			if p.Published {
+				status = "published"
+			}
+			rows = append(rows, []string{p.ID, p.Name, status, p.FormattedPrice, fmt.Sprintf("%d", p.SalesCount)})
+		}
+		return output.PrintPlain(opts.Out(), rows)
+	}
+
+	style := opts.Style()
+	var memberships, standard []productListItem
+	for _, p := range resp.Products {
+		if p.IsTieredMembership {
+			memberships = append(memberships, p)
+		} else {
+			standard = append(standard, p)
+		}
+	}
+
+	buildTable := func(items []productListItem, countHeader string) *output.Table {
+		tbl := output.NewStyledTable(style, "ID", "NAME", "STATUS", "PRICE", countHeader)
+		for _, p := range items {
+			status := style.Yellow("draft")
+			if p.Published {
+				status = style.Green("published")
+			}
+			tbl.AddRow(p.ID, p.Name, status, p.FormattedPrice, fmt.Sprintf("%d", p.SalesCount))
+		}
+		return tbl
+	}
+
+	return output.WithPager(opts.Out(), opts.Err(), func(w io.Writer) error {
+		split := len(memberships) > 0 && len(standard) > 0
+		if split {
+			if err := output.Writeln(w, style.Bold("Memberships")); err != nil {
+				return err
+			}
+			if err := buildTable(memberships, "MEMBERS").Render(w); err != nil {
+				return err
+			}
+			if err := output.Writeln(w, "\n"+style.Bold("Products")); err != nil {
+				return err
+			}
+			if err := buildTable(standard, "SALES").Render(w); err != nil {
+				return err
+			}
+		} else {
+			items := standard
+			header := "SALES"
+			if len(memberships) > 0 {
+				items = memberships
+				header = "MEMBERS"
+			}
+			if err := buildTable(items, header).Render(w); err != nil {
+				return err
+			}
+		}
+		if resp.NextPageKey != "" && !opts.Quiet {
+			hint := productsPaginationHint(resp.NextPageKey)
+			return output.Writeln(w, style.Dim("\nMore results available: "+hint))
+		}
+		if !opts.Quiet {
+			return output.Writeln(w, style.Dim("\nTip: view a product with  gumroad products view <id>"))
+		}
+		return nil
+	})
+}
+
+func streamProductsListAll(opts cmdutil.Options, params url.Values) error {
+	token, err := config.Token()
+	if err != nil {
+		return err
+	}
+
+	sp := output.NewSpinnerTo("Fetching products...", opts.Err())
+	if cmdutil.ShouldShowSpinner(opts) {
+		sp.Start()
+	}
+	defer sp.Stop()
+
+	client := cmdutil.NewAPIClient(opts, token)
+	style := opts.Style()
+	walkPages := func(visit cmdutil.PageVisitor[productsListResponse]) error {
+		return walkProductsPages(opts, client, params, visit)
+	}
+
+	return cmdutil.StreamPaginatedPages(opts, cmdutil.PaginatedPageOutputConfig[productsListResponse]{
+		JSONKey:      "products",
+		EmptyMessage: "No products found.",
+		Walk:         walkPages,
+		HasItems:     hasProducts,
+		WriteItems:   writeProductItems,
+		WritePlainPage: func(w io.Writer, page productsListResponse) error {
+			return writeProductsPlain(w, page.Products)
+		},
+		WriteTablePage: func(w io.Writer, page productsListResponse) error {
+			return writeProductsTable(w, style, page.Products)
+		},
+	})
+}
+
+func walkProductsPages(opts cmdutil.Options, client *api.Client, params url.Values, visit cmdutil.PageVisitor[productsListResponse]) error {
+	return cmdutil.WalkPagesWithDelay[productsListResponse](opts.Context, opts.PageDelay, client, "/products", params, func(page productsListResponse) string {
+		return page.NextPageKey
+	}, visit)
+}
+
+func hasProducts(page productsListResponse) bool {
+	return len(page.Products) > 0
+}
+
+func writeProductItems(page productsListResponse, writeItem func(any) error) error {
+	for _, p := range page.Products {
+		if err := writeItem(p); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeProductsPlain(w io.Writer, products []productListItem) error {
+	var rows [][]string
+	for _, p := range products {
+		status := "draft"
+		if p.Published {
+			status = "published"
+		}
+		rows = append(rows, []string{p.ID, p.Name, status, p.FormattedPrice, fmt.Sprintf("%d", p.SalesCount)})
+	}
+	return output.PrintPlain(w, rows)
+}
+
+func writeProductsTable(w io.Writer, style output.Styler, products []productListItem) error {
+	tbl := output.NewStyledTable(style, "ID", "NAME", "STATUS", "PRICE", "SALES")
+	for _, p := range products {
+		status := style.Yellow("draft")
+		if p.Published {
+			status = style.Green("published")
+		}
+		tbl.AddRow(p.ID, p.Name, status, p.FormattedPrice, fmt.Sprintf("%d", p.SalesCount))
+	}
+	return tbl.Render(w)
+}
+
+func productsPaginationHint(nextPageKey string) string {
+	return cmdutil.ReplayCommand("gumroad products list",
+		cmdutil.CommandArg{Flag: "--page-key", Value: nextPageKey},
+	)
 }

--- a/internal/cmd/products/products_test.go
+++ b/internal/cmd/products/products_test.go
@@ -1370,6 +1370,249 @@ func TestUnpublish_JSONExposesFlatProduct(t *testing.T) {
 	}
 }
 
+func TestList_PaginationHint(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"products": []map[string]any{
+				{"id": "p1", "name": "Art Pack", "published": true, "formatted_price": "$10", "sales_count": 42},
+			},
+			"next_page_key": "cursor123",
+		})
+	})
+
+	cmd := testutil.Command(newListCmd(), testutil.Quiet(false))
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if !strings.Contains(out, "cursor123") {
+		t.Errorf("expected pagination hint with cursor, got: %q", out)
+	}
+	if !strings.Contains(out, "More results available") {
+		t.Errorf("expected pagination message, got: %q", out)
+	}
+}
+
+func TestList_PageKeyPassedToAPI(t *testing.T) {
+	var gotQuery url.Values
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		testutil.JSON(t, w, map[string]any{
+			"products": []map[string]any{
+				{"id": "p2", "name": "Book", "published": true, "formatted_price": "$25", "sales_count": 10},
+			},
+		})
+	})
+
+	cmd := newListCmd()
+	cmd.SetArgs([]string{"--page-key", "cursor123"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if gotQuery.Get("page_key") != "cursor123" {
+		t.Errorf("got page_key=%q, want cursor123", gotQuery.Get("page_key"))
+	}
+}
+
+func TestList_AllFetchesAllPages(t *testing.T) {
+	requests := 0
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		switch r.URL.Query().Get("page_key") {
+		case "":
+			testutil.JSON(t, w, map[string]any{
+				"products": []map[string]any{
+					{"id": "p1", "name": "Art Pack", "published": true, "formatted_price": "$10", "sales_count": 42},
+				},
+				"next_page_key": "cursor123",
+			})
+		case "cursor123":
+			testutil.JSON(t, w, map[string]any{
+				"products": []map[string]any{
+					{"id": "p2", "name": "Book", "published": false, "formatted_price": "$25", "sales_count": 0},
+				},
+			})
+		default:
+			t.Fatalf("unexpected page_key %q", r.URL.Query().Get("page_key"))
+		}
+	})
+
+	cmd := testutil.Command(newListCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--all"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp struct {
+		Products []map[string]any `json:"products"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if len(resp.Products) != 2 {
+		t.Fatalf("got %d products, want 2", len(resp.Products))
+	}
+	if requests != 2 {
+		t.Fatalf("got %d requests, want 2", requests)
+	}
+}
+
+func TestList_AllPlainOutputStreamsAllPages(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Query().Get("page_key") {
+		case "":
+			testutil.JSON(t, w, map[string]any{
+				"products": []map[string]any{
+					{"id": "p1", "name": "Art Pack", "published": true, "formatted_price": "$10", "sales_count": 42},
+				},
+				"next_page_key": "cursor123",
+			})
+		case "cursor123":
+			testutil.JSON(t, w, map[string]any{
+				"products": []map[string]any{
+					{"id": "p2", "name": "Book", "published": false, "formatted_price": "$25", "sales_count": 0},
+				},
+			})
+		default:
+			t.Fatalf("unexpected page_key %q", r.URL.Query().Get("page_key"))
+		}
+	})
+
+	cmd := testutil.Command(newListCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{"--all"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if !strings.Contains(out, "p1") || !strings.Contains(out, "p2") {
+		t.Fatalf("expected both pages in plain output, got %q", out)
+	}
+}
+
+func TestList_AllTableOutputStreamsAllPages(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Query().Get("page_key") {
+		case "":
+			testutil.JSON(t, w, map[string]any{
+				"products": []map[string]any{
+					{"id": "p1", "name": "Art Pack", "published": true, "formatted_price": "$10", "sales_count": 42},
+				},
+				"next_page_key": "cursor123",
+			})
+		case "cursor123":
+			testutil.JSON(t, w, map[string]any{
+				"products": []map[string]any{
+					{"id": "p2", "name": "Book", "published": false, "formatted_price": "$25", "sales_count": 0},
+				},
+			})
+		default:
+			t.Fatalf("unexpected page_key %q", r.URL.Query().Get("page_key"))
+		}
+	})
+
+	cmd := testutil.Command(newListCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--all"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if !strings.Contains(out, "p1") || !strings.Contains(out, "p2") {
+		t.Fatalf("expected streamed table output with both pages, got %q", out)
+	}
+}
+
+func TestList_AllOutputEmpty(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{"products": []any{}})
+	})
+
+	cmd := testutil.Command(newListCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--all"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if !strings.Contains(out, "No products found") {
+		t.Fatalf("expected empty message, got %q", out)
+	}
+}
+
+func TestList_AllAndPageKeyMutuallyExclusive(t *testing.T) {
+	cmd := newListCmd()
+	cmd.SetArgs([]string{"--all", "--page-key", "abc"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for mutually exclusive flags")
+	}
+}
+
+func TestList_SinglePageDoesNotWalkPages(t *testing.T) {
+	requests := 0
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if pageKey := r.URL.Query().Get("page_key"); pageKey != "" {
+			t.Fatalf("unexpected page_key %q", pageKey)
+		}
+		testutil.JSON(t, w, map[string]any{
+			"products": []map[string]any{
+				{"id": "p1", "name": "Art Pack", "published": true, "formatted_price": "$10", "sales_count": 42},
+			},
+			"next_page_key": "cursor123",
+		})
+	})
+
+	cmd := testutil.Command(newListCmd(), testutil.JSONOutput())
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp struct {
+		Products    []map[string]any `json:"products"`
+		NextPageKey string           `json:"next_page_key"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if requests != 1 {
+		t.Fatalf("got %d requests, want 1", requests)
+	}
+	if len(resp.Products) != 1 {
+		t.Fatalf("got %d products, want 1", len(resp.Products))
+	}
+	if resp.NextPageKey != "cursor123" {
+		t.Fatalf("got next_page_key=%q, want cursor123", resp.NextPageKey)
+	}
+}
+
+func TestList_EmptyWithNextPageKey(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"products":      []any{},
+			"next_page_key": "cursor123",
+		})
+	})
+
+	cmd := testutil.Command(newListCmd(), testutil.Quiet(false))
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if !strings.Contains(out, "No products found on this page") {
+		t.Errorf("expected empty page message, got: %q", out)
+	}
+	if !strings.Contains(out, "More results available") {
+		t.Errorf("expected pagination hint, got: %q", out)
+	}
+}
+
+func TestList_AllJQFetchesAllPages(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Query().Get("page_key") {
+		case "":
+			testutil.JSON(t, w, map[string]any{
+				"products": []map[string]any{
+					{"id": "p1", "name": "Art Pack", "published": true, "formatted_price": "$10", "sales_count": 42},
+				},
+				"next_page_key": "cursor123",
+			})
+		case "cursor123":
+			testutil.JSON(t, w, map[string]any{
+				"products": []map[string]any{
+					{"id": "p2", "name": "Book", "published": false, "formatted_price": "$25", "sales_count": 0},
+				},
+			})
+		default:
+			t.Fatalf("unexpected page_key %q", r.URL.Query().Get("page_key"))
+		}
+	})
+
+	cmd := testutil.Command(newListCmd(), testutil.JQ(".products[].id"))
+	cmd.SetArgs([]string{"--all"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if !strings.Contains(out, "p1") || !strings.Contains(out, "p2") {
+		t.Fatalf("expected both product IDs in JQ output, got %q", out)
+	}
+}
+
 func TestList_APIError(t *testing.T) {
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(500)

--- a/internal/cmd/products/products_test.go
+++ b/internal/cmd/products/products_test.go
@@ -1401,7 +1401,7 @@ func TestList_PageKeyPassedToAPI(t *testing.T) {
 		})
 	})
 
-	cmd := newListCmd()
+	cmd := testutil.Command(newListCmd(), testutil.JSONOutput())
 	cmd.SetArgs([]string{"--page-key", "cursor123"})
 	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 	if gotQuery.Get("page_key") != "cursor123" {

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -228,8 +228,10 @@ gumroad admin users unwatch --user-id 2245593582708 --expected-email seller@exam
 ### products — Manage products
 
 ```sh
-# List all products
+# List products (paginated)
 gumroad products list --json --no-input
+gumroad products list --all --json --no-input
+gumroad products list --page-key <cursor> --json --no-input
 
 # View a product
 gumroad products view <id> --json --no-input
@@ -307,6 +309,8 @@ In custom HTML, use Gumroad data attributes for live product values and checkout
 <button data-gumroad-action="buy" data-gumroad-quantity="2">Buy 2 seats</button>
 <button data-gumroad-action="buy" data-gumroad-price="19.99">Pay $19.99</button>
 ```
+
+**List flags:** `--all`, `--page-key`.
 
 **Categories:** `products categories [--search <term>]` returns label, path, and numeric ID. Prefer `--category <path>` for product create/update. `--taxonomy-id` remains supported when you already have the numeric ID, but it cannot be combined with `--category`.
 
@@ -534,6 +538,6 @@ gumroad webhooks delete <id> --yes --json --no-input
 
 ## Tips
 
-- Use `--all` with `sales list`, `subscribers list`, `payouts list` to fetch every page automatically.
+- Use `--all` with `products list`, `sales list`, `subscribers list`, `payouts list` to fetch every page automatically.
 - Use `--plain` for tab-separated output suitable for `cut`, `awk`, and other Unix tools.
 - Run `gumroad <command> --help` for full flag details on any command.


### PR DESCRIPTION
Closes #163

## What

Adds `--all` and `--page-key` pagination flags to `gumroad products list`, bringing it to parity with `gumroad sales list`.

```
gumroad products list                          # first page + "more results" hint
gumroad products list --page-key <cursor>      # a single page at a cursor
gumroad products list --all                    # auto-paginate every page
gumroad products list --all --json --jq '.products[].id'
```

- `--page-key <cursor>` sets the `page_key` query param for a single page.
- `--all` streams every page across table, `--plain`, `--json`, and `--jq` output.
- The default single-page view now surfaces `next_page_key` in JSON and prints `More results available: gumroad products list --page-key <cursor>` in table mode (including the empty-page-but-more-results case).
- `--all` and `--page-key` are mutually exclusive.

## Why

A creator reported that `products list` could only return the first page — users with many products had to manually parse `next_page_key` out of the JSON and call the v2 API directly. `sales list` already solved this exact problem, so rather than invent a new mechanism this reuses the shared pagination plumbing (`StreamPaginatedPages`, `WalkPagesWithDelay`, `ReplayCommand`, `PaginatedPageOutputConfig`). Mirroring `sales list` is what "parity" means here and keeps the two commands consistent for the agents that drive this CLI.

One deliberate behavior difference: the default single-page view splits results into separate **Memberships** and **Products** tables, but `--all` renders one flat table per page. The shared streaming helper writes page-by-page, so per-page section splitting would repeat headers across pages — a flat table is the cleaner choice when paginating the full catalog.

## Before/After

- Before: `products list` returned only the first page; the cursor had to be parsed from JSON and the v2 API called directly.
- After: `--page-key` fetches a specific page, `--all` streams them all, and the default view advertises the next cursor.

Terminal recording to be attached.

## Test Results

```
make test-cover   all packages ok; internal/cmd/products 85.7% (gate 85%)
make lint         golangci-lint v1.64.8, no findings
gofmt -l / go vet clean
```

Added 10 tests in `products_test.go`: pagination hint, empty-page-with-cursor, `--page-key` passthrough, `--all` streaming across table/plain/json/jq, `--all` empty result, `--all`/`--page-key` mutual exclusivity, and a regression guard confirming the default mode makes a single request and still exposes `next_page_key`. Also documented the new flags in `skills/gumroad/SKILL.md`.

---

🤖 AI disclosure: drafted with Claude Opus 4.8 via Claude Code. Reviewed the implementation for parity with `sales list`, added the pagination tests and skill docs, and ran the full check suite locally.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad-cli/pr/165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784726506&installation_id=134400930&pr_number=165&repository=antiwork%2Fgumroad-cli&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad-cli%2Fpull%2F165&signature=7f022d9d4d91181e425feb7c2516a6dd417056f029df5816c9020f389f66cfa5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only listing and pagination behavior with established shared helpers; no auth, payment, or data-model changes.
> 
> **Overview**
> Adds **`--page-key`** and **`--all`** to `gumroad products list`, aligned with **`sales list`** and the shared **`StreamPaginatedPages`** / **`WalkPagesWithDelay`** helpers.
> 
> **`--page-key`** sends `page_key` on `GET /products` for one page. The default single-page path still splits memberships vs products in table output, exposes **`next_page_key`** in JSON, and prints a replay hint when more pages exist (including empty pages with a cursor). **`--all`** walks every page and streams results for table, plain, JSON, and jq; table mode uses a flat per-page table instead of the membership/product split.
> 
> **`--all`** and **`--page-key`** are mutually exclusive. Tests cover hints, API passthrough, multi-page **`--all`**, exclusivity, and single-request default behavior. **`skills/gumroad/SKILL.md`** documents the new flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 097b9de7ab2d6d985f2feed8a7ed8e7af80e18a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->