### PR TITLE
admin users: add --username lookup to read commands

### DIFF
--- a/internal/cmd/admin/users/affiliates.go
+++ b/internal/cmd/admin/users/affiliates.go
@@ -69,6 +69,7 @@ func newAffiliatesCmd() *cobra.Command {
 --direction granted when the user is the seller granting affiliate access, or
 --direction received when the user is the affiliate receiving access.`,
 		Example: `  gumroad admin users affiliates --user-id 2245593582708 --direction granted
+  gumroad admin users affiliates --username sellerone --direction granted
   gumroad admin users affiliates --email user@example.com --direction received --limit 50
   gumroad admin users affiliates --email user@example.com --direction received --cursor cur-next`,
 		Args: cmdutil.ExactArgs(0),

--- a/internal/cmd/admin/users/affiliates_test.go
+++ b/internal/cmd/admin/users/affiliates_test.go
@@ -106,7 +106,7 @@ func TestAffiliatesShowsNextCursorFooter(t *testing.T) {
 	}
 }
 
-func TestAffiliatesRequiresEmailOrUserID(t *testing.T) {
+func TestAffiliatesRequiresUserLookup(t *testing.T) {
 	cmd := newAffiliatesCmd()
 	cmd.SetArgs([]string{"--direction", "granted"})
 

--- a/internal/cmd/admin/users/affiliates_test.go
+++ b/internal/cmd/admin/users/affiliates_test.go
@@ -111,7 +111,7 @@ func TestAffiliatesRequiresEmailOrUserID(t *testing.T) {
 	cmd.SetArgs([]string{"--direction", "granted"})
 
 	err := cmd.Execute()
-	if err == nil || !strings.Contains(err.Error(), "supply --email or --user-id") {
+	if err == nil || !strings.Contains(err.Error(), "supply --email, --user-id, or --username") {
 		t.Fatalf("expected missing identifier error, got %v", err)
 	}
 }

--- a/internal/cmd/admin/users/comments/comments.go
+++ b/internal/cmd/admin/users/comments/comments.go
@@ -7,6 +7,7 @@ func NewCommentsCmd() *cobra.Command {
 		Use:   "comments",
 		Short: "Read and add admin comments on users",
 		Example: `  gumroad admin users comments list --user-id 2245593582708
+  gumroad admin users comments list --username sellerone --type note
   gumroad admin users comments list --email user@example.com --type note --type suspension_note --limit 50
   gumroad admin users comments add --user-id 2245593582708 --content "VAT exempt confirmed"`,
 	}

--- a/internal/cmd/admin/users/comments/list.go
+++ b/internal/cmd/admin/users/comments/list.go
@@ -32,6 +32,7 @@ func newListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List admin comments for a user",
 		Example: `  gumroad admin users comments list --user-id 2245593582708
+  gumroad admin users comments list --username sellerone --type note
   gumroad admin users comments list --email user@example.com --type note --type suspension_note --limit 50
   gumroad admin users comments list --email user@example.com --cursor cur-next`,
 		Args: cmdutil.ExactArgs(0),

--- a/internal/cmd/admin/users/comments/list_test.go
+++ b/internal/cmd/admin/users/comments/list_test.go
@@ -109,7 +109,7 @@ func TestListShowsNextCursorFooter(t *testing.T) {
 	}
 }
 
-func TestListRequiresEmailOrUserID(t *testing.T) {
+func TestListRequiresUserLookup(t *testing.T) {
 	cmd := newListCmd()
 	cmd.SetArgs([]string{})
 

--- a/internal/cmd/admin/users/comments/list_test.go
+++ b/internal/cmd/admin/users/comments/list_test.go
@@ -114,7 +114,7 @@ func TestListRequiresEmailOrUserID(t *testing.T) {
 	cmd.SetArgs([]string{})
 
 	err := cmd.Execute()
-	if err == nil || !strings.Contains(err.Error(), "supply --email or --user-id") {
+	if err == nil || !strings.Contains(err.Error(), "supply --email, --user-id, or --username") {
 		t.Fatalf("expected missing identifier error, got %v", err)
 	}
 }

--- a/internal/cmd/admin/users/compliance.go
+++ b/internal/cmd/admin/users/compliance.go
@@ -80,9 +80,11 @@ func newComplianceCmd() *cobra.Command {
 		Short: "View a user's submitted compliance info",
 		Long: `View a user's submitted KYC data and open compliance info requests.
 
-Identify the user with --email or --user-id. When both are supplied, the
-server resolves by --user-id.`,
+Identify the user with --email, --user-id, or --username. When more than one
+is supplied, the server resolves by --user-id first, then --email, then
+--username.`,
 		Example: `  gumroad admin users compliance --user-id 2245593582708
+  gumroad admin users compliance --username sellerone
   gumroad admin users compliance --email user@example.com --json`,
 		Args: cmdutil.ExactArgs(0),
 		RunE: func(c *cobra.Command, args []string) error {

--- a/internal/cmd/admin/users/compliance_test.go
+++ b/internal/cmd/admin/users/compliance_test.go
@@ -128,7 +128,7 @@ func TestComplianceRequiresEmailOrUserID(t *testing.T) {
 	cmd.SetArgs([]string{})
 
 	err := cmd.Execute()
-	if err == nil || !strings.Contains(err.Error(), "supply --email or --user-id") {
+	if err == nil || !strings.Contains(err.Error(), "supply --email, --user-id, or --username") {
 		t.Fatalf("expected missing identifier error, got %v", err)
 	}
 }

--- a/internal/cmd/admin/users/compliance_test.go
+++ b/internal/cmd/admin/users/compliance_test.go
@@ -123,7 +123,7 @@ func TestCompliancePassesUserIDAndEmail(t *testing.T) {
 	}
 }
 
-func TestComplianceRequiresEmailOrUserID(t *testing.T) {
+func TestComplianceRequiresUserLookup(t *testing.T) {
 	cmd := newComplianceCmd()
 	cmd.SetArgs([]string{})
 

--- a/internal/cmd/admin/users/credits.go
+++ b/internal/cmd/admin/users/credits.go
@@ -53,6 +53,7 @@ func newCreditsCmd() *cobra.Command {
 		Use:   "credits",
 		Short: "List and issue user credits",
 		Example: `  gumroad admin users credits list --user-id 2245593582708
+  gumroad admin users credits list --username sellerone
   gumroad admin users credits list --email seller@example.com --cursor cur-next
   gumroad admin users credits add --user-id 2245593582708 --amount-cents 1000 --reason "Goodwill for checkout bug" --dry-run
   gumroad admin users credits add --user-id 2245593582708 --expected-email seller@example.com --amount-cents 1000 --reason "Goodwill for checkout bug" --yes`,
@@ -174,6 +175,7 @@ func newCreditsListCmd() *cobra.Command {
 		Short: "List credits for a user",
 		Long:  `List a user's account credits, newest first.`,
 		Example: `  gumroad admin users credits list --user-id 2245593582708
+  gumroad admin users credits list --username sellerone
   gumroad admin users credits list --email seller@example.com --limit 50
   gumroad admin users credits list --user-id 2245593582708 --cursor cur-next`,
 		Args: cmdutil.ExactArgs(0),

--- a/internal/cmd/admin/users/credits_test.go
+++ b/internal/cmd/admin/users/credits_test.go
@@ -475,7 +475,7 @@ func TestCreditsListRequiresEmailOrUserID(t *testing.T) {
 	cmd.SetArgs([]string{})
 
 	err := cmd.Execute()
-	if err == nil || !strings.Contains(err.Error(), "supply --email or --user-id") {
+	if err == nil || !strings.Contains(err.Error(), "supply --email, --user-id, or --username") {
 		t.Fatalf("expected missing identifier error, got %v", err)
 	}
 }

--- a/internal/cmd/admin/users/credits_test.go
+++ b/internal/cmd/admin/users/credits_test.go
@@ -470,7 +470,7 @@ func TestCreditsListEmptyResultShowsFooter(t *testing.T) {
 	}
 }
 
-func TestCreditsListRequiresEmailOrUserID(t *testing.T) {
+func TestCreditsListRequiresUserLookup(t *testing.T) {
 	cmd := newCreditsListCmd()
 	cmd.SetArgs([]string{})
 

--- a/internal/cmd/admin/users/info.go
+++ b/internal/cmd/admin/users/info.go
@@ -124,10 +124,12 @@ counts. If the live Stripe lookup fails it degrades to a verification error
 line instead. Admin links carry impersonate, user, purchases, and (when a
 Stripe account exists) Stripe-dashboard helper URLs.
 
-Identify the user with --email or --user-id. When both are supplied, the
-server resolves by --user-id.`,
+Identify the user with --email, --user-id, or --username. When more than one
+is supplied, the server resolves by --user-id first, then --email, then
+--username.`,
 		Example: `  gumroad admin users info --email user@example.com
   gumroad admin users info --user-id 2245593582708
+  gumroad admin users info --username sellerone
   gumroad admin users info --email user@example.com --json`,
 		Args: cmdutil.ExactArgs(0),
 		RunE: func(c *cobra.Command, args []string) error {

--- a/internal/cmd/admin/users/info_test.go
+++ b/internal/cmd/admin/users/info_test.go
@@ -51,7 +51,7 @@ func sampleInfoPayload() map[string]any {
 	}
 }
 
-func TestInfoRequiresEmailOrUserID(t *testing.T) {
+func TestInfoRequiresUserLookup(t *testing.T) {
 	cmd := newInfoCmd()
 	cmd.SetArgs([]string{})
 

--- a/internal/cmd/admin/users/info_test.go
+++ b/internal/cmd/admin/users/info_test.go
@@ -59,8 +59,36 @@ func TestInfoRequiresEmailOrUserID(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected missing identifier error")
 	}
-	if !strings.Contains(err.Error(), "supply --email or --user-id") {
+	if !strings.Contains(err.Error(), "supply --email, --user-id, or --username") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestInfoResolvesByUsername(t *testing.T) {
+	var gotEmail, gotUserID, gotUsername string
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotEmail = r.URL.Query().Get("email")
+		gotUserID = r.URL.Query().Get("user_id")
+		gotUsername = r.URL.Query().Get("username")
+		testutil.JSON(t, w, sampleInfoPayload())
+	})
+
+	cmd := testutil.Command(newInfoCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--username", "sellerone"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotUsername != "sellerone" {
+		t.Fatalf("got username %q, want sellerone", gotUsername)
+	}
+	if gotEmail != "" {
+		t.Errorf("expected email to be empty, got %q", gotEmail)
+	}
+	if gotUserID != "" {
+		t.Errorf("expected user_id to be empty, got %q", gotUserID)
+	}
+	if !strings.Contains(out, "Seller One") {
+		t.Errorf("expected resolved user info in output: %q", out)
 	}
 }
 

--- a/internal/cmd/admin/users/purchases.go
+++ b/internal/cmd/admin/users/purchases.go
@@ -43,6 +43,7 @@ func newPurchasesCmd() *cobra.Command {
 Status filters are sent as purchase_state values. Use --chargedback,
 --has-early-fraud-warning, and --has-affiliate for the boolean risk filters.`,
 		Example: `  gumroad admin users purchases --user-id 2245593582708
+  gumroad admin users purchases --username sellerone
   gumroad admin users purchases --email buyer@example.com --status successful --status failed
   gumroad admin users purchases --user-id 2245593582708 --start-at 2026-01-01T00:00:00Z
   gumroad admin users purchases --user-id 2245593582708 --chargedback=false --limit 50`,

--- a/internal/cmd/admin/users/purchases_test.go
+++ b/internal/cmd/admin/users/purchases_test.go
@@ -228,7 +228,7 @@ func TestUserPurchasesPlainOutput(t *testing.T) {
 	}
 }
 
-func TestUserPurchasesRequiresEmailOrUserID(t *testing.T) {
+func TestUserPurchasesRequiresUserLookup(t *testing.T) {
 	cmd := newPurchasesCmd()
 	cmd.SetArgs([]string{})
 

--- a/internal/cmd/admin/users/purchases_test.go
+++ b/internal/cmd/admin/users/purchases_test.go
@@ -233,7 +233,7 @@ func TestUserPurchasesRequiresEmailOrUserID(t *testing.T) {
 	cmd.SetArgs([]string{})
 
 	err := cmd.Execute()
-	if err == nil || !strings.Contains(err.Error(), "supply --email or --user-id") {
+	if err == nil || !strings.Contains(err.Error(), "supply --email, --user-id, or --username") {
 		t.Fatalf("expected missing identifier error, got %v", err)
 	}
 }

--- a/internal/cmd/admin/users/radar.go
+++ b/internal/cmd/admin/users/radar.go
@@ -53,9 +53,11 @@ func newRadarCmd() *cobra.Command {
 		Short: "View seller-level Radar and early fraud warning stats",
 		Long: `View seller-level Radar aggregates and recent early fraud warnings.
 
-Identify the seller with --email or --user-id. When both are supplied, the
-server resolves by --user-id.`,
+Identify the seller with --email, --user-id, or --username. When more than one
+is supplied, the server resolves by --user-id first, then --email, then
+--username.`,
 		Example: `  gumroad admin users radar --user-id 2245593582708
+  gumroad admin users radar --username sellerone
   gumroad admin users radar --email seller@example.com --limit 50
   gumroad admin users radar --user-id 2245593582708 --cursor cur-next --json`,
 		Args: cmdutil.ExactArgs(0),

--- a/internal/cmd/admin/users/radar_test.go
+++ b/internal/cmd/admin/users/radar_test.go
@@ -164,7 +164,7 @@ func TestRadarRequiresEmailOrUserID(t *testing.T) {
 	cmd.SetArgs([]string{})
 
 	err := cmd.Execute()
-	if err == nil || !strings.Contains(err.Error(), "supply --email or --user-id") {
+	if err == nil || !strings.Contains(err.Error(), "supply --email, --user-id, or --username") {
 		t.Fatalf("expected missing identifier error, got %v", err)
 	}
 }

--- a/internal/cmd/admin/users/radar_test.go
+++ b/internal/cmd/admin/users/radar_test.go
@@ -159,7 +159,7 @@ func TestRadarPlainOutputWithoutRecentEFWs(t *testing.T) {
 	}
 }
 
-func TestRadarRequiresEmailOrUserID(t *testing.T) {
+func TestRadarRequiresUserLookup(t *testing.T) {
 	cmd := newRadarCmd()
 	cmd.SetArgs([]string{})
 

--- a/internal/cmd/admin/users/related.go
+++ b/internal/cmd/admin/users/related.go
@@ -60,6 +60,7 @@ func newRelatedCmd() *cobra.Command {
 fingerprint. By default the server evaluates all available signals; repeat
 --signal to restrict the search to one or more signals.`,
 		Example: `  gumroad admin users related --user-id 2245593582708
+  gumroad admin users related --username sellerone --signal ip
   gumroad admin users related --email user@example.com --signal ip --signal payment_address
   gumroad admin users related --email user@example.com --limit 25 --json`,
 		Args: cmdutil.ExactArgs(0),

--- a/internal/cmd/admin/users/related_test.go
+++ b/internal/cmd/admin/users/related_test.go
@@ -111,7 +111,7 @@ func TestRelatedRequiresEmailOrUserID(t *testing.T) {
 	cmd.SetArgs([]string{"--signal", "ip"})
 
 	err := cmd.Execute()
-	if err == nil || !strings.Contains(err.Error(), "supply --email or --user-id") {
+	if err == nil || !strings.Contains(err.Error(), "supply --email, --user-id, or --username") {
 		t.Fatalf("expected missing identifier error, got %v", err)
 	}
 }

--- a/internal/cmd/admin/users/related_test.go
+++ b/internal/cmd/admin/users/related_test.go
@@ -106,7 +106,7 @@ func TestRelatedDefaultOmitsSignalsAndLimit(t *testing.T) {
 	}
 }
 
-func TestRelatedRequiresEmailOrUserID(t *testing.T) {
+func TestRelatedRequiresUserLookup(t *testing.T) {
 	cmd := newRelatedCmd()
 	cmd.SetArgs([]string{"--signal", "ip"})
 

--- a/internal/cmd/admin/users/suspension.go
+++ b/internal/cmd/admin/users/suspension.go
@@ -22,10 +22,12 @@ func newSuspensionCmd() *cobra.Command {
 		Short: "View a user's suspension status",
 		Long: `View a user's suspension status.
 
-Identify the user with --email or --user-id. When both are supplied, the
-server resolves by --user-id.`,
+Identify the user with --email, --user-id, or --username. When more than one
+is supplied, the server resolves by --user-id first, then --email, then
+--username.`,
 		Example: `  gumroad admin users suspension --email user@example.com
-  gumroad admin users suspension --user-id 2245593582708`,
+  gumroad admin users suspension --user-id 2245593582708
+  gumroad admin users suspension --username sellerone`,
 		Args: cmdutil.ExactArgs(0),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)

--- a/internal/cmd/admin/users/users.go
+++ b/internal/cmd/admin/users/users.go
@@ -12,6 +12,7 @@ func NewUsersCmd() *cobra.Command {
 		Short: "Read and manage admin user records",
 		Example: `  gumroad admin users info --email user@example.com
   gumroad admin users info --user-id 2245593582708
+  gumroad admin users info --username sellerone
   gumroad admin users affiliates --user-id 2245593582708 --direction granted
   gumroad admin users comments list --user-id 2245593582708
   gumroad admin users comments add --user-id 2245593582708 --content "VAT exempt confirmed"

--- a/internal/cmd/admin/users/users_test.go
+++ b/internal/cmd/admin/users/users_test.go
@@ -51,7 +51,7 @@ func TestSuspensionRequiresEmailOrUserID(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected missing identifier error")
 	}
-	if !strings.Contains(err.Error(), "supply --email or --user-id") {
+	if !strings.Contains(err.Error(), "supply --email, --user-id, or --username") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/cmd/admin/users/users_test.go
+++ b/internal/cmd/admin/users/users_test.go
@@ -43,7 +43,7 @@ func TestSuspensionUsesInternalAdminEndpoint(t *testing.T) {
 	}
 }
 
-func TestSuspensionRequiresEmailOrUserID(t *testing.T) {
+func TestSuspensionRequiresUserLookup(t *testing.T) {
 	cmd := newSuspensionCmd()
 	cmd.SetArgs([]string{})
 

--- a/internal/cmd/admin/users/usertarget/target.go
+++ b/internal/cmd/admin/users/usertarget/target.go
@@ -10,17 +10,20 @@ import (
 type LookupFlags struct {
 	Email           string
 	UserID          string
+	Username        string
 	ExternalIDAlias string
 }
 
 type LookupTarget struct {
-	Email  string
-	UserID string
+	Email    string
+	UserID   string
+	Username string
 }
 
 func AddLookupFlags(cmd *cobra.Command, flags *LookupFlags) {
 	cmd.Flags().StringVar(&flags.Email, "email", "", "User email")
 	cmd.Flags().StringVar(&flags.UserID, "user-id", "", "User external ID")
+	cmd.Flags().StringVar(&flags.Username, "username", "", "User username")
 	cmd.Flags().StringVar(&flags.ExternalIDAlias, "external-id", "", "Alias for --user-id")
 	_ = cmd.Flags().MarkHidden("external-id")
 }
@@ -30,14 +33,14 @@ func ResolveLookupTarget(cmd *cobra.Command, flags LookupFlags) (LookupTarget, e
 	if err != nil {
 		return LookupTarget{}, err
 	}
-	if err := RequireEmailOrUserID(cmd, flags.Email, userID); err != nil {
+	if err := RequireUserLookup(cmd, flags.Email, userID, flags.Username); err != nil {
 		return LookupTarget{}, err
 	}
-	return LookupTarget{Email: flags.Email, UserID: userID}, nil
+	return LookupTarget{Email: flags.Email, UserID: userID, Username: flags.Username}, nil
 }
 
 func (t LookupTarget) Identifier() string {
-	return UserIdentifier(t.Email, t.UserID)
+	return UserIdentifier(t.Email, t.UserID, t.Username)
 }
 
 func (t LookupTarget) Values() url.Values {
@@ -47,6 +50,9 @@ func (t LookupTarget) Values() url.Values {
 	}
 	if t.UserID != "" {
 		params.Set("user_id", t.UserID)
+	}
+	if t.Username != "" {
+		params.Set("username", t.Username)
 	}
 	return params
 }
@@ -111,16 +117,19 @@ func Fallback(value, alt string) string {
 	return value
 }
 
-func UserIdentifier(email, externalID string) string {
+func UserIdentifier(email, externalID, username string) string {
 	if externalID != "" {
 		return externalID
 	}
-	return email
+	if email != "" {
+		return email
+	}
+	return username
 }
 
-func RequireEmailOrUserID(cmd *cobra.Command, email, userID string) error {
-	if email == "" && userID == "" {
-		return cmdutil.UsageErrorf(cmd, "supply --email or --user-id")
+func RequireUserLookup(cmd *cobra.Command, email, userID, username string) error {
+	if email == "" && userID == "" && username == "" {
+		return cmdutil.UsageErrorf(cmd, "supply --email, --user-id, or --username")
 	}
 	return nil
 }

--- a/internal/cmd/admin/users/usertarget/target_test.go
+++ b/internal/cmd/admin/users/usertarget/target_test.go
@@ -1,6 +1,7 @@
 package usertarget
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -8,6 +9,37 @@ import (
 
 func newTestCmd() *cobra.Command {
 	return &cobra.Command{Use: "test"}
+}
+
+func TestAddLookupFlags(t *testing.T) {
+	cmd := newTestCmd()
+	var flags LookupFlags
+
+	AddLookupFlags(cmd, &flags)
+
+	for _, name := range []string{"email", "user-id", "username", "external-id"} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Fatalf("missing --%s flag", name)
+		}
+	}
+	if !cmd.Flags().Lookup("external-id").Hidden {
+		t.Fatal("expected --external-id to be hidden")
+	}
+
+	for flag, value := range map[string]string{
+		"email":       "seller@example.com",
+		"user-id":     "2245593582708",
+		"username":    "sellerone",
+		"external-id": "legacy-id",
+	} {
+		if err := cmd.Flags().Set(flag, value); err != nil {
+			t.Fatalf("set --%s: %v", flag, err)
+		}
+	}
+
+	if flags.Email != "seller@example.com" || flags.UserID != "2245593582708" || flags.Username != "sellerone" || flags.ExternalIDAlias != "legacy-id" {
+		t.Fatalf("flags not wired correctly: %+v", flags)
+	}
 }
 
 func TestResolveLookupTargetByUsername(t *testing.T) {
@@ -54,12 +86,153 @@ func TestResolveLookupTargetPrecedence(t *testing.T) {
 	}
 }
 
+func TestResolveLookupTargetUsesExternalIDAlias(t *testing.T) {
+	cmd := newTestCmd()
+	flags := LookupFlags{ExternalIDAlias: "2245593582708"}
+
+	target, err := ResolveLookupTarget(cmd, flags)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if target.UserID != "2245593582708" {
+		t.Fatalf("got user_id %q, want 2245593582708", target.UserID)
+	}
+}
+
+func TestResolveLookupTargetRejectsConflictingUserIDAliases(t *testing.T) {
+	cmd := newTestCmd()
+	flags := LookupFlags{UserID: "2245593582708", ExternalIDAlias: "other-id"}
+
+	_, err := ResolveLookupTarget(cmd, flags)
+	if err == nil || !strings.Contains(err.Error(), "--user-id and --external-id must match") {
+		t.Fatalf("expected conflicting alias error, got %v", err)
+	}
+}
+
 func TestResolveLookupTargetRequiresOne(t *testing.T) {
 	cmd := newTestCmd()
 
 	_, err := ResolveLookupTarget(cmd, LookupFlags{})
 	if err == nil {
 		t.Fatal("expected error when no lookup flag is provided")
+	}
+}
+
+func TestAddMutationFlags(t *testing.T) {
+	cmd := newTestCmd()
+	var flags MutationFlags
+
+	AddMutationFlags(cmd, &flags)
+
+	for _, name := range []string{"user-id", "expected-email", "external-id", "email"} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Fatalf("missing --%s flag", name)
+		}
+	}
+	for _, name := range []string{"external-id", "email"} {
+		if !cmd.Flags().Lookup(name).Hidden {
+			t.Fatalf("expected --%s to be hidden", name)
+		}
+	}
+
+	for flag, value := range map[string]string{
+		"user-id":        "2245593582708",
+		"expected-email": "seller@example.com",
+		"external-id":    "legacy-id",
+		"email":          "legacy@example.com",
+	} {
+		if err := cmd.Flags().Set(flag, value); err != nil {
+			t.Fatalf("set --%s: %v", flag, err)
+		}
+	}
+
+	if flags.UserID != "2245593582708" || flags.ExpectedEmail != "seller@example.com" || flags.ExternalIDAlias != "legacy-id" || flags.ExpectedEmailAlias != "legacy@example.com" {
+		t.Fatalf("flags not wired correctly: %+v", flags)
+	}
+}
+
+func TestResolveMutationTarget(t *testing.T) {
+	tests := []struct {
+		name              string
+		flags             MutationFlags
+		wantUserID        string
+		wantExpectedEmail string
+	}{
+		{
+			name:              "direct flags",
+			flags:             MutationFlags{UserID: "2245593582708", ExpectedEmail: "seller@example.com"},
+			wantUserID:        "2245593582708",
+			wantExpectedEmail: "seller@example.com",
+		},
+		{
+			name:              "hidden aliases",
+			flags:             MutationFlags{ExternalIDAlias: "2245593582708", ExpectedEmailAlias: "seller@example.com"},
+			wantUserID:        "2245593582708",
+			wantExpectedEmail: "seller@example.com",
+		},
+		{
+			name:       "expected email omitted",
+			flags:      MutationFlags{UserID: "2245593582708"},
+			wantUserID: "2245593582708",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target, err := ResolveMutationTarget(newTestCmd(), tt.flags)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if target.UserID != tt.wantUserID {
+				t.Fatalf("got user_id %q, want %q", target.UserID, tt.wantUserID)
+			}
+			if target.ExpectedEmail != tt.wantExpectedEmail {
+				t.Fatalf("got expected_email %q, want %q", target.ExpectedEmail, tt.wantExpectedEmail)
+			}
+			if target.Identifier() != tt.wantUserID {
+				t.Fatalf("got identifier %q, want %q", target.Identifier(), tt.wantUserID)
+			}
+			if target.Subject() != "user_id "+tt.wantUserID {
+				t.Fatalf("got subject %q, want user_id %s", target.Subject(), tt.wantUserID)
+			}
+
+			params := MutationParams(target)
+			if params.Get("user_id") != tt.wantUserID {
+				t.Fatalf("got user_id param %q, want %q", params.Get("user_id"), tt.wantUserID)
+			}
+			if params.Get("expected_email") != tt.wantExpectedEmail {
+				t.Fatalf("got expected_email param %q, want %q", params.Get("expected_email"), tt.wantExpectedEmail)
+			}
+		})
+	}
+}
+
+func TestResolveMutationTargetRequiresUserID(t *testing.T) {
+	_, err := ResolveMutationTarget(newTestCmd(), MutationFlags{})
+	if err == nil || !strings.Contains(err.Error(), "missing required flag: --user-id") {
+		t.Fatalf("expected missing user-id error, got %v", err)
+	}
+}
+
+func TestResolveMutationTargetRejectsConflictingUserIDAliases(t *testing.T) {
+	flags := MutationFlags{UserID: "2245593582708", ExternalIDAlias: "other-id"}
+
+	_, err := ResolveMutationTarget(newTestCmd(), flags)
+	if err == nil || !strings.Contains(err.Error(), "--user-id and --external-id must match") {
+		t.Fatalf("expected conflicting user-id alias error, got %v", err)
+	}
+}
+
+func TestResolveMutationTargetRejectsConflictingExpectedEmailAliases(t *testing.T) {
+	flags := MutationFlags{
+		UserID:             "2245593582708",
+		ExpectedEmail:      "seller@example.com",
+		ExpectedEmailAlias: "other@example.com",
+	}
+
+	_, err := ResolveMutationTarget(newTestCmd(), flags)
+	if err == nil || !strings.Contains(err.Error(), "--expected-email and --email must match") {
+		t.Fatalf("expected conflicting expected-email alias error, got %v", err)
 	}
 }
 
@@ -72,5 +245,14 @@ func TestUserIdentifierFallback(t *testing.T) {
 	}
 	if got := UserIdentifier("seller@example.com", "uid", "sellerone"); got != "uid" {
 		t.Errorf("user_id precedence: got %q", got)
+	}
+}
+
+func TestFallback(t *testing.T) {
+	if got := Fallback("", "alt"); got != "alt" {
+		t.Errorf("empty value: got %q, want alt", got)
+	}
+	if got := Fallback("value", "alt"); got != "value" {
+		t.Errorf("present value: got %q, want value", got)
 	}
 }

--- a/internal/cmd/admin/users/usertarget/target_test.go
+++ b/internal/cmd/admin/users/usertarget/target_test.go
@@ -1,0 +1,76 @@
+package usertarget
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newTestCmd() *cobra.Command {
+	return &cobra.Command{Use: "test"}
+}
+
+func TestResolveLookupTargetByUsername(t *testing.T) {
+	cmd := newTestCmd()
+	flags := LookupFlags{Username: "sellerone"}
+
+	target, err := ResolveLookupTarget(cmd, flags)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if target.Username != "sellerone" {
+		t.Fatalf("got username %q, want sellerone", target.Username)
+	}
+	if got := target.Values().Get("username"); got != "sellerone" {
+		t.Fatalf("got username param %q, want sellerone", got)
+	}
+	if target.Identifier() != "sellerone" {
+		t.Fatalf("got identifier %q, want sellerone", target.Identifier())
+	}
+}
+
+func TestResolveLookupTargetPrecedence(t *testing.T) {
+	cmd := newTestCmd()
+	flags := LookupFlags{Email: "seller@example.com", UserID: "2245593582708", Username: "sellerone"}
+
+	target, err := ResolveLookupTarget(cmd, flags)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	values := target.Values()
+	if values.Get("email") != "seller@example.com" {
+		t.Errorf("missing email param: %v", values)
+	}
+	if values.Get("user_id") != "2245593582708" {
+		t.Errorf("missing user_id param: %v", values)
+	}
+	if values.Get("username") != "sellerone" {
+		t.Errorf("missing username param: %v", values)
+	}
+	// Identifier prefers user_id over email/username.
+	if target.Identifier() != "2245593582708" {
+		t.Errorf("got identifier %q, want 2245593582708", target.Identifier())
+	}
+}
+
+func TestResolveLookupTargetRequiresOne(t *testing.T) {
+	cmd := newTestCmd()
+
+	_, err := ResolveLookupTarget(cmd, LookupFlags{})
+	if err == nil {
+		t.Fatal("expected error when no lookup flag is provided")
+	}
+}
+
+func TestUserIdentifierFallback(t *testing.T) {
+	if got := UserIdentifier("seller@example.com", "", ""); got != "seller@example.com" {
+		t.Errorf("email fallback: got %q", got)
+	}
+	if got := UserIdentifier("", "", "sellerone"); got != "sellerone" {
+		t.Errorf("username fallback: got %q", got)
+	}
+	if got := UserIdentifier("seller@example.com", "uid", "sellerone"); got != "uid" {
+		t.Errorf("user_id precedence: got %q", got)
+	}
+}

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -171,7 +171,9 @@ gumroad refund-policy set --period none --fine-print "" --json --no-input
 # In agents/CI, set GUMROAD_ADMIN_TOKEN and pass --non-interactive.
 
 # Inspect user identity, sign-in, social, risk, payout, and watchlist state
+# Look up by --email, --user-id, or --username (resolves user_id > email > username)
 gumroad admin users info --email seller@example.com --json --non-interactive --no-input
+gumroad admin users info --username sellerone --json --non-interactive --no-input
 
 # Review affiliate relationships
 gumroad admin users affiliates --user-id 2245593582708 --direction granted --limit 50 --json --non-interactive --no-input

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -177,25 +177,33 @@ gumroad admin users info --username sellerone --json --non-interactive --no-inpu
 
 # Review affiliate relationships
 gumroad admin users affiliates --user-id 2245593582708 --direction granted --limit 50 --json --non-interactive --no-input
+gumroad admin users affiliates --username sellerone --direction granted --limit 50 --json --non-interactive --no-input
 gumroad admin users affiliates --email seller@example.com --direction received --cursor cur-next --json --non-interactive --no-input
 
 # Read and add admin comments
 gumroad admin users comments list --user-id 2245593582708 --type note --limit 50 --json --non-interactive --no-input
+gumroad admin users comments list --username sellerone --type note --limit 50 --json --non-interactive --no-input
 gumroad admin users comments add --user-id 2245593582708 --content "VAT exempt confirmed" --yes --json --non-interactive --no-input
 
 # Account credits. credits add is a high-stakes write: dry-run first, then issue with explicit --yes.
 # Amounts are cents, positive only, capped at $1,000 unless --allow-large-amount is explicitly passed.
 gumroad admin users credits list --user-id 2245593582708 --limit 50 --json --non-interactive --no-input
+gumroad admin users credits list --username sellerone --limit 50 --json --non-interactive --no-input
 gumroad admin users credits add --user-id 2245593582708 --expected-email seller@example.com --amount-cents 1000 --reason "Goodwill for checkout bug" --dry-run --json --non-interactive --no-input
 gumroad admin users credits add --user-id 2245593582708 --expected-email seller@example.com --amount-cents 1000 --reason "Goodwill for checkout bug" --yes --json --non-interactive --no-input
 
 # Inspect compliance, Radar risk, and buyer history
 gumroad admin users compliance --user-id 2245593582708 --json --non-interactive --no-input
+gumroad admin users compliance --username sellerone --json --non-interactive --no-input
 gumroad admin users radar --user-id 2245593582708 --limit 50 --json --non-interactive --no-input
+gumroad admin users radar --username sellerone --limit 50 --json --non-interactive --no-input
 gumroad admin users purchases --user-id 2245593582708 --status successful --has-early-fraud-warning=false --limit 50 --json --non-interactive --no-input
+gumroad admin users purchases --username sellerone --status successful --limit 50 --json --non-interactive --no-input
+gumroad admin users suspension --username sellerone --json --non-interactive --no-input
 
 # Find related accounts by risk signals
 gumroad admin users related --email seller@example.com --signal ip --signal payment_address --json --non-interactive --no-input
+gumroad admin users related --username sellerone --signal ip --json --non-interactive --no-input
 gumroad admin users related --email seller@example.com --json --jq '{related_users, truncated, per_signal_limit}' --non-interactive --no-input
 
 # Mutate user compliance and suspension state


### PR DESCRIPTION
## What

Adds `--username` as a third user-lookup flag on the admin **read** commands (`gumroad admin users info`, `affiliates`, `comments list`, `compliance`, `radar`, `purchases`, `related`, `credits list`), alongside the existing `--email` and `--user-id`.

```
gumroad admin users info --username sellerone --json
```

The CLI forwards whichever lookup flags are set; the server resolves with precedence `user_id` > `email` > `username`.

## Why

Support/risk work often starts from a **storefront username** (impersonation reports, takedown notices citing `<handle>.gumroad.com`, sellers signing with their handle). Without this, resolving a username means a Rails-console round-trip just to get the `external_id` before any CLI call. `--username` removes that detour.

## Depends on

⚠️ **Requires antiwork/gumroad#5554** (teaches the internal admin read endpoints to resolve by `username`). Until that merges, the CLI sends `username=...` but the server ignores it and returns "not found". Merge the API PR first.

## Implementation notes

- `--username` added to the shared `usertarget.LookupFlags` so every read command that already uses the shared resolver gets it for free.
- `RequireEmailOrUserID` (now unused) replaced by `RequireUserLookup`; usage hint updated to `supply --email, --user-id, or --username`.
- `UserIdentifier` falls back email → username for display when no `user_id`.
- Mutation commands are untouched — still `--user-id` only.

## Test plan

- `go build ./...`, `go vet ./...`, `gofmt -l` clean.
- `go test ./internal/cmd/admin/users/...` → all pass.
- New `TestInfoResolvesByUsername` (asserts `username` reaches the query string) + new `usertarget` package tests (precedence, Values(), Identifier, require-one).
- Updated the shared "supply --email or --user-id" assertions across the affected read-command tests to the new message.
- Pre-existing failures in `internal/cmd/auth`, `internal/config`, and `test/` are environmental (keychain access + live-backend integration) and fail identically on clean `main` — unrelated to this change.

Coverage: `internal/cmd/admin/users` 86.2%, `comments` 86.4% (both ≥ the 85% cmd gate).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad-cli/pr/167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784776743&installation_id=134400930&pr_number=167&repository=antiwork%2Fgumroad-cli&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad-cli%2Fpull%2F167&signature=216bfb94dd3d4f8bfcd3408785d8d6515b9a21bd32adbab2abf0c5ab27c66140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only lookup and query forwarding for existing read endpoints; no mutation or auth logic changes. Effective resolution depends on the paired server PR for username support.
> 
> **Overview**
> Adds **`--username`** as a third way to identify users on admin **read** commands (`info`, `affiliates`, `comments list`, `compliance`, `credits list`, `radar`, `purchases`, `related`, `suspension`), alongside `--email` and `--user-id`.
> 
> The shared **`usertarget`** resolver now registers the flag, requires at least one of the three identifiers (`RequireUserLookup`), forwards `username` on API query params, and uses **user_id → email → username** for display via `UserIdentifier`. Help text and examples document that when multiple flags are set, the **server** resolves with precedence **user_id > email > username**. **Mutation** commands are unchanged (`--user-id` only).
> 
> Tests assert the new usage message, add `TestInfoResolvesByUsername`, and expand **`usertarget`** package tests; **`skills/gumroad/SKILL.md`** documents the new lookup option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d418fb639696785e507e7f0e8378b9dbfce7c81e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->