### PR TITLE
Add `gumroad upsells` command for upsells and cross-sells

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -23,6 +23,7 @@ import (
 	"github.com/antiwork/gumroad-cli/internal/cmd/sales"
 	"github.com/antiwork/gumroad-cli/internal/cmd/skill"
 	"github.com/antiwork/gumroad-cli/internal/cmd/subscribers"
+	"github.com/antiwork/gumroad-cli/internal/cmd/upsells"
 	"github.com/antiwork/gumroad-cli/internal/cmd/user"
 	"github.com/antiwork/gumroad-cli/internal/cmd/variants"
 	"github.com/antiwork/gumroad-cli/internal/cmd/webhooks"
@@ -123,6 +124,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(subscribers.NewSubscribersCmd())
 	cmd.AddCommand(licenses.NewLicensesCmd())
 	cmd.AddCommand(offercodes.NewOfferCodesCmd())
+	cmd.AddCommand(upsells.NewUpsellsCmd())
 	cmd.AddCommand(emails.NewEmailsCmd())
 	cmd.AddCommand(categories.NewCategoriesCmd())
 	cmd.AddCommand(variants.NewVariantsCmd())

--- a/internal/cmd/upsells/create.go
+++ b/internal/cmd/upsells/create.go
@@ -40,6 +40,14 @@ products). Add an optional discount with --amount or --percent-off.`,
 			if err := cmdutil.RequirePercentFlag(c, "percent-off", percentOff); err != nil {
 				return err
 			}
+			if len(selectedProducts) > 0 {
+				if !crossSell {
+					return cmdutil.UsageErrorf(c, "--selected-product applies to cross-sells; pass --cross-sell")
+				}
+				if universal {
+					return cmdutil.UsageErrorf(c, "--selected-product cannot be combined with --universal")
+				}
+			}
 
 			offerCode, hasOfferCode, err := offerCodeFromFlags(c, amount, percentOff)
 			if err != nil {
@@ -74,7 +82,7 @@ products). Add an optional discount with --amount or --percent-off.`,
 			if flags.Changed("paused") {
 				body["paused"] = paused
 			}
-			if !universal {
+			if crossSell && !universal {
 				if ids := nonEmptyValues(selectedProducts); len(ids) > 0 {
 					body["product_ids"] = ids
 				}

--- a/internal/cmd/upsells/create.go
+++ b/internal/cmd/upsells/create.go
@@ -74,7 +74,7 @@ products). Add an optional discount with --amount or --percent-off.`,
 			if flags.Changed("paused") {
 				body["paused"] = paused
 			}
-			if len(selectedProducts) > 0 {
+			if !universal && len(selectedProducts) > 0 {
 				body["product_ids"] = selectedProducts
 			}
 			if hasOfferCode {

--- a/internal/cmd/upsells/create.go
+++ b/internal/cmd/upsells/create.go
@@ -1,0 +1,106 @@
+package upsells
+
+import (
+	"net/http"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+func newCreateCmd() *cobra.Command {
+	var name, product, text, description, variant, amount string
+	var selectedProducts, offerVariants []string
+	var percentOff int
+	var crossSell, universal, replaceSelectedProducts, paused bool
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create an upsell or cross-sell",
+		Long: `Create an upsell or cross-sell.
+
+--product is the product being offered. For a version upgrade (an upsell), pass
+one or more --offer-variant <selected_variant_id>:<offered_variant_id> pairs.
+
+For a cross-sell, pass --cross-sell and either --universal (offer it to buyers of
+every product) or one or more --selected-product <id> (offer it to buyers of those
+products). Add an optional discount with --amount or --percent-off.`,
+		Example: `  gumroad upsells create --name "Pro upgrade" --product <id> --offer-variant <selected_id>:<offered_id>
+  gumroad upsells create --name "Audiobook" --product <id> --cross-sell --selected-product <id> --percent-off 50
+  gumroad upsells create --name "Add-on" --product <id> --cross-sell --universal --amount 5`,
+		Args: cmdutil.ExactArgs(0),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+
+			if name == "" {
+				return cmdutil.MissingFlagError(c, "--name")
+			}
+			if product == "" {
+				return cmdutil.MissingFlagError(c, "--product")
+			}
+			if err := cmdutil.RequirePercentFlag(c, "percent-off", percentOff); err != nil {
+				return err
+			}
+
+			offerCode, hasOfferCode, err := offerCodeFromFlags(c, amount, percentOff)
+			if err != nil {
+				return err
+			}
+			upsellVariants, err := parseOfferVariants(c, offerVariants)
+			if err != nil {
+				return err
+			}
+
+			flags := c.Flags()
+			body := map[string]any{
+				"name":       name,
+				"product_id": product,
+				"cross_sell": crossSell,
+			}
+			if flags.Changed("text") {
+				body["text"] = text
+			}
+			if flags.Changed("description") {
+				body["description"] = description
+			}
+			if flags.Changed("variant") {
+				body["variant_id"] = variant
+			}
+			if flags.Changed("universal") {
+				body["universal"] = universal
+			}
+			if flags.Changed("replace-selected-products") {
+				body["replace_selected_products"] = replaceSelectedProducts
+			}
+			if flags.Changed("paused") {
+				body["paused"] = paused
+			}
+			if len(selectedProducts) > 0 {
+				body["product_ids"] = selectedProducts
+			}
+			if hasOfferCode {
+				body["offer_code"] = offerCode
+			}
+			if len(upsellVariants) > 0 {
+				body["upsell_variants"] = upsellVariants
+			}
+
+			return runUpsellWrite(opts, http.MethodPost, "/upsells", body, "Creating upsell...", "Created")
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Upsell name (required)")
+	cmd.Flags().StringVar(&product, "product", "", "Offered product ID (required)")
+	cmd.Flags().BoolVar(&crossSell, "cross-sell", false, "Create a cross-sell instead of a version upsell")
+	cmd.Flags().StringVar(&text, "text", "", "Headline shown to the buyer")
+	cmd.Flags().StringVar(&description, "description", "", "Description shown to the buyer")
+	cmd.Flags().StringVar(&variant, "variant", "", "Offered version ID of the offered product (cross-sell)")
+	cmd.Flags().BoolVar(&universal, "universal", false, "Offer the cross-sell to buyers of every product")
+	cmd.Flags().BoolVar(&replaceSelectedProducts, "replace-selected-products", false, "Replace the selected products in the cart with the offered product")
+	cmd.Flags().BoolVar(&paused, "paused", false, "Create the upsell paused")
+	cmd.Flags().StringVar(&amount, "amount", "", "Flat discount on the offered product (e.g. 5, 5.00)")
+	cmd.Flags().IntVar(&percentOff, "percent-off", 0, "Percentage discount on the offered product")
+	cmd.Flags().StringArrayVar(&selectedProducts, "selected-product", nil, "Product ID whose buyers see the cross-sell (repeatable)")
+	cmd.Flags().StringArrayVar(&offerVariants, "offer-variant", nil, "Version upgrade as <selected_variant_id>:<offered_variant_id> (repeatable)")
+
+	return cmd
+}

--- a/internal/cmd/upsells/create.go
+++ b/internal/cmd/upsells/create.go
@@ -40,13 +40,8 @@ products). Add an optional discount with --amount or --percent-off.`,
 			if err := cmdutil.RequirePercentFlag(c, "percent-off", percentOff); err != nil {
 				return err
 			}
-			if len(selectedProducts) > 0 {
-				if !crossSell {
-					return cmdutil.UsageErrorf(c, "--selected-product applies to cross-sells; pass --cross-sell")
-				}
-				if universal {
-					return cmdutil.UsageErrorf(c, "--selected-product cannot be combined with --universal")
-				}
+			if err := validateFlagConsistency(c, crossSell, universal); err != nil {
+				return err
 			}
 
 			offerCode, hasOfferCode, err := offerCodeFromFlags(c, amount, percentOff)

--- a/internal/cmd/upsells/create.go
+++ b/internal/cmd/upsells/create.go
@@ -43,6 +43,9 @@ products). Add an optional discount with --amount or --percent-off.`,
 			if err := validateFlagConsistency(c, crossSell, universal); err != nil {
 				return err
 			}
+			if crossSell && !universal && len(nonEmptyValues(selectedProducts)) == 0 {
+				return cmdutil.UsageErrorf(c, "a cross-sell needs an audience; pass --universal or --selected-product")
+			}
 
 			offerCode, hasOfferCode, err := offerCodeFromFlags(c, amount, percentOff)
 			if err != nil {

--- a/internal/cmd/upsells/create.go
+++ b/internal/cmd/upsells/create.go
@@ -74,8 +74,10 @@ products). Add an optional discount with --amount or --percent-off.`,
 			if flags.Changed("paused") {
 				body["paused"] = paused
 			}
-			if !universal && len(selectedProducts) > 0 {
-				body["product_ids"] = selectedProducts
+			if !universal {
+				if ids := nonEmptyValues(selectedProducts); len(ids) > 0 {
+					body["product_ids"] = ids
+				}
 			}
 			if hasOfferCode {
 				body["offer_code"] = offerCode

--- a/internal/cmd/upsells/delete.go
+++ b/internal/cmd/upsells/delete.go
@@ -1,0 +1,31 @@
+package upsells
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+func newDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete <upsell_id>",
+		Short: "Delete an upsell or cross-sell",
+		Args:  cmdutil.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			id := args[0]
+
+			ok, err := cmdutil.ConfirmAction(opts, "Delete upsell "+id+"?")
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return cmdutil.PrintCancelledAction(opts, "delete upsell "+id, id)
+			}
+
+			return cmdutil.RunRequestWithSuccess(opts, "Deleting upsell...", http.MethodDelete, cmdutil.JoinPath("upsells", id), url.Values{}, id, "Upsell "+id+" deleted.")
+		},
+	}
+}

--- a/internal/cmd/upsells/list.go
+++ b/internal/cmd/upsells/list.go
@@ -1,0 +1,65 @@
+package upsells
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+func newListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List upsells and cross-sells",
+		Args:  cmdutil.ExactArgs(0),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+
+			return cmdutil.RunRequest(opts, "Fetching upsells...", http.MethodGet, "/upsells", url.Values{}, func(data json.RawMessage) error {
+				var resp struct {
+					Upsells []upsell `json:"upsells"`
+				}
+				if err := json.Unmarshal(data, &resp); err != nil {
+					return fmt.Errorf("could not parse response: %w", err)
+				}
+
+				if len(resp.Upsells) == 0 {
+					return cmdutil.PrintInfo(opts, "No upsells found.")
+				}
+
+				if opts.PlainOutput {
+					var rows [][]string
+					for _, u := range resp.Upsells {
+						rows = append(rows, listRow(u))
+					}
+					return output.PrintPlain(opts.Out(), rows)
+				}
+
+				style := opts.Style()
+				tbl := output.NewStyledTable(style, "ID", "NAME", "TYPE", "PRODUCT", "DISCOUNT", "PAUSED")
+				for _, u := range resp.Upsells {
+					tbl.AddRow(listRow(u)...)
+				}
+				return output.WithPager(opts.Out(), opts.Err(), func(w io.Writer) error {
+					return tbl.Render(w)
+				})
+			})
+		},
+	}
+}
+
+func listRow(u upsell) []string {
+	return []string{
+		u.ID,
+		u.Name,
+		upsellType(u),
+		u.Product.Name,
+		formatDiscount(u.Discount),
+		yesNo(u.Paused),
+	}
+}

--- a/internal/cmd/upsells/update.go
+++ b/internal/cmd/upsells/update.go
@@ -122,11 +122,18 @@ Pass --remove-offer to drop the discount. Passing --selected-product or
 			if flags.Changed("selected-product") && !flags.Changed("universal") {
 				body["universal"] = false
 			}
-			if body["cross_sell"] == true && !flags.Changed("offer-variant") {
-				body["upsell_variants"] = []map[string]any{}
-			}
-			if body["universal"] == true {
+			if finalCrossSell {
+				if !flags.Changed("offer-variant") {
+					body["upsell_variants"] = []map[string]any{}
+				}
+				if body["universal"] == true {
+					body["product_ids"] = []string{}
+				}
+			} else {
+				body["variant_id"] = ""
 				body["product_ids"] = []string{}
+				body["universal"] = false
+				body["replace_selected_products"] = false
 			}
 			if hasOfferCode {
 				body["offer_code"] = offerCode

--- a/internal/cmd/upsells/update.go
+++ b/internal/cmd/upsells/update.go
@@ -45,9 +45,6 @@ Pass --remove-offer to drop the discount. Passing --selected-product or
 			if err := cmdutil.RequirePercentFlag(c, "percent-off", percentOff); err != nil {
 				return err
 			}
-			if c.Flags().Changed("universal") && universal && c.Flags().Changed("selected-product") {
-				return cmdutil.UsageErrorf(c, "--universal and --selected-product cannot be used together")
-			}
 
 			offerCode, hasOfferCode, err := offerCodeFromFlags(c, amount, percentOff)
 			if err != nil {
@@ -71,8 +68,22 @@ Pass --remove-offer to drop the discount. Passing --selected-product or
 				return err
 			}
 
-			body := currentUpsellBody(current)
 			flags := c.Flags()
+			finalCrossSell := current.CrossSell
+			if flags.Changed("cross-sell") {
+				finalCrossSell = crossSell
+			}
+			finalUniversal := current.Universal
+			if flags.Changed("universal") {
+				finalUniversal = universal
+			} else if flags.Changed("selected-product") {
+				finalUniversal = false
+			}
+			if err := validateFlagConsistency(c, finalCrossSell, finalUniversal); err != nil {
+				return err
+			}
+
+			body := currentUpsellBody(current)
 			if flags.Changed("name") {
 				body["name"] = name
 			}

--- a/internal/cmd/upsells/update.go
+++ b/internal/cmd/upsells/update.go
@@ -97,7 +97,7 @@ Pass --remove-offer to drop the discount. Passing --selected-product or
 			if flags.Changed("variant") {
 				body["variant_id"] = variant
 			} else if flags.Changed("product") {
-				delete(body, "variant_id")
+				body["variant_id"] = ""
 			}
 			if flags.Changed("selected-product") {
 				body["product_ids"] = nonEmptyValues(selectedProducts)
@@ -105,14 +105,17 @@ Pass --remove-offer to drop the discount. Passing --selected-product or
 			if flags.Changed("offer-variant") {
 				body["upsell_variants"] = parsedVariants
 			}
-			if body["universal"] == true {
-				delete(body, "product_ids")
+			if body["cross_sell"] == true && !flags.Changed("offer-variant") {
+				body["upsell_variants"] = []map[string]any{}
+			}
+			if body["universal"] == true && !flags.Changed("selected-product") {
+				body["product_ids"] = []string{}
 			}
 			if hasOfferCode {
 				body["offer_code"] = offerCode
 			}
 			if removeOffer {
-				delete(body, "offer_code")
+				body["offer_code"] = map[string]any{}
 			}
 
 			return runUpsellWrite(opts, http.MethodPut, cmdutil.JoinPath("upsells", id), body, "Updating upsell...", "Updated")

--- a/internal/cmd/upsells/update.go
+++ b/internal/cmd/upsells/update.go
@@ -96,18 +96,23 @@ Pass --remove-offer to drop the discount. Passing --selected-product or
 			}
 			if flags.Changed("variant") {
 				body["variant_id"] = variant
+			} else if flags.Changed("product") {
+				delete(body, "variant_id")
 			}
-			if len(selectedProducts) > 0 {
-				body["product_ids"] = selectedProducts
+			if flags.Changed("selected-product") {
+				body["product_ids"] = nonEmptyValues(selectedProducts)
+			}
+			if flags.Changed("offer-variant") {
+				body["upsell_variants"] = parsedVariants
+			}
+			if body["universal"] == true {
+				delete(body, "product_ids")
 			}
 			if hasOfferCode {
 				body["offer_code"] = offerCode
 			}
 			if removeOffer {
 				delete(body, "offer_code")
-			}
-			if len(parsedVariants) > 0 {
-				body["upsell_variants"] = parsedVariants
 			}
 
 			return runUpsellWrite(opts, http.MethodPut, cmdutil.JoinPath("upsells", id), body, "Updating upsell...", "Updated")
@@ -145,6 +150,16 @@ func fetchUpsell(opts cmdutil.Options, token, id string) (upsell, error) {
 		return upsell{}, err
 	}
 	return resp.Upsell, nil
+}
+
+func nonEmptyValues(values []string) []string {
+	result := make([]string, 0, len(values))
+	for _, v := range values {
+		if v != "" {
+			result = append(result, v)
+		}
+	}
+	return result
 }
 
 func currentUpsellBody(u upsell) map[string]any {

--- a/internal/cmd/upsells/update.go
+++ b/internal/cmd/upsells/update.go
@@ -45,6 +45,9 @@ Pass --remove-offer to drop the discount. Passing --selected-product or
 			if err := cmdutil.RequirePercentFlag(c, "percent-off", percentOff); err != nil {
 				return err
 			}
+			if c.Flags().Changed("universal") && universal && c.Flags().Changed("selected-product") {
+				return cmdutil.UsageErrorf(c, "--universal and --selected-product cannot be used together")
+			}
 
 			offerCode, hasOfferCode, err := offerCodeFromFlags(c, amount, percentOff)
 			if err != nil {
@@ -105,10 +108,13 @@ Pass --remove-offer to drop the discount. Passing --selected-product or
 			if flags.Changed("offer-variant") {
 				body["upsell_variants"] = parsedVariants
 			}
+			if flags.Changed("selected-product") && !flags.Changed("universal") {
+				body["universal"] = false
+			}
 			if body["cross_sell"] == true && !flags.Changed("offer-variant") {
 				body["upsell_variants"] = []map[string]any{}
 			}
-			if body["universal"] == true && !flags.Changed("selected-product") {
+			if body["universal"] == true {
 				body["product_ids"] = []string{}
 			}
 			if hasOfferCode {

--- a/internal/cmd/upsells/update.go
+++ b/internal/cmd/upsells/update.go
@@ -82,6 +82,13 @@ Pass --remove-offer to drop the discount. Passing --selected-product or
 			if err := validateFlagConsistency(c, finalCrossSell, finalUniversal); err != nil {
 				return err
 			}
+			if finalCrossSell && !finalUniversal {
+				audience := flags.Changed("selected-product") && len(nonEmptyValues(selectedProducts)) > 0
+				audience = audience || (!flags.Changed("selected-product") && len(current.SelectedProducts) > 0)
+				if !audience {
+					return cmdutil.UsageErrorf(c, "a cross-sell needs an audience; pass --universal or --selected-product")
+				}
+			}
 
 			body := currentUpsellBody(current)
 			if flags.Changed("name") {

--- a/internal/cmd/upsells/update.go
+++ b/internal/cmd/upsells/update.go
@@ -1,0 +1,189 @@
+package upsells
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var updateFields = []string{
+	"name", "product", "text", "description", "cross-sell", "universal",
+	"replace-selected-products", "paused", "variant", "selected-product",
+	"amount", "percent-off", "offer-variant", "remove-offer",
+}
+
+func newUpdateCmd() *cobra.Command {
+	var name, product, text, description, variant, amount string
+	var selectedProducts, offerVariants []string
+	var percentOff int
+	var crossSell, universal, replaceSelectedProducts, paused, removeOffer bool
+
+	cmd := &cobra.Command{
+		Use:   "update <upsell_id>",
+		Short: "Update an upsell or cross-sell",
+		Long: `Update an upsell or cross-sell.
+
+Only the fields you pass are changed; everything else keeps its current value.
+Pass --remove-offer to drop the discount. Passing --selected-product or
+--offer-variant replaces the existing set.`,
+		Example: `  gumroad upsells update <id> --name "New name"
+  gumroad upsells update <id> --percent-off 25
+  gumroad upsells update <id> --paused=false`,
+		Args: cmdutil.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			id := args[0]
+
+			if err := cmdutil.RequireAnyFlagChanged(c, updateFields...); err != nil {
+				return err
+			}
+			if err := cmdutil.RequirePercentFlag(c, "percent-off", percentOff); err != nil {
+				return err
+			}
+
+			offerCode, hasOfferCode, err := offerCodeFromFlags(c, amount, percentOff)
+			if err != nil {
+				return err
+			}
+			if removeOffer && hasOfferCode {
+				return cmdutil.UsageErrorf(c, "--remove-offer cannot be used with --amount or --percent-off")
+			}
+			parsedVariants, err := parseOfferVariants(c, offerVariants)
+			if err != nil {
+				return err
+			}
+
+			token, err := config.Token()
+			if err != nil {
+				return err
+			}
+
+			current, err := fetchUpsell(opts, token, id)
+			if err != nil {
+				return err
+			}
+
+			body := currentUpsellBody(current)
+			flags := c.Flags()
+			if flags.Changed("name") {
+				body["name"] = name
+			}
+			if flags.Changed("product") {
+				body["product_id"] = product
+			}
+			if flags.Changed("text") {
+				body["text"] = text
+			}
+			if flags.Changed("description") {
+				body["description"] = description
+			}
+			if flags.Changed("cross-sell") {
+				body["cross_sell"] = crossSell
+			}
+			if flags.Changed("universal") {
+				body["universal"] = universal
+			}
+			if flags.Changed("replace-selected-products") {
+				body["replace_selected_products"] = replaceSelectedProducts
+			}
+			if flags.Changed("paused") {
+				body["paused"] = paused
+			}
+			if flags.Changed("variant") {
+				body["variant_id"] = variant
+			}
+			if len(selectedProducts) > 0 {
+				body["product_ids"] = selectedProducts
+			}
+			if hasOfferCode {
+				body["offer_code"] = offerCode
+			}
+			if removeOffer {
+				delete(body, "offer_code")
+			}
+			if len(parsedVariants) > 0 {
+				body["upsell_variants"] = parsedVariants
+			}
+
+			return runUpsellWrite(opts, http.MethodPut, cmdutil.JoinPath("upsells", id), body, "Updating upsell...", "Updated")
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Upsell name")
+	cmd.Flags().StringVar(&product, "product", "", "Offered product ID")
+	cmd.Flags().BoolVar(&crossSell, "cross-sell", false, "Whether this is a cross-sell")
+	cmd.Flags().StringVar(&text, "text", "", "Headline shown to the buyer")
+	cmd.Flags().StringVar(&description, "description", "", "Description shown to the buyer")
+	cmd.Flags().StringVar(&variant, "variant", "", "Offered version ID of the offered product (cross-sell)")
+	cmd.Flags().BoolVar(&universal, "universal", false, "Offer the cross-sell to buyers of every product")
+	cmd.Flags().BoolVar(&replaceSelectedProducts, "replace-selected-products", false, "Replace the selected products in the cart with the offered product")
+	cmd.Flags().BoolVar(&paused, "paused", false, "Pause or unpause the upsell")
+	cmd.Flags().StringVar(&amount, "amount", "", "Flat discount on the offered product (e.g. 5, 5.00)")
+	cmd.Flags().IntVar(&percentOff, "percent-off", 0, "Percentage discount on the offered product")
+	cmd.Flags().BoolVar(&removeOffer, "remove-offer", false, "Remove the discount from the upsell")
+	cmd.Flags().StringArrayVar(&selectedProducts, "selected-product", nil, "Product ID whose buyers see the cross-sell (repeatable, replaces the current set)")
+	cmd.Flags().StringArrayVar(&offerVariants, "offer-variant", nil, "Version upgrade as <selected_variant_id>:<offered_variant_id> (repeatable, replaces the current set)")
+
+	return cmd
+}
+
+func fetchUpsell(opts cmdutil.Options, token, id string) (upsell, error) {
+	data, err := cmdutil.RunWithTokenData(opts, token, "Fetching upsell...",
+		func(client *api.Client) (json.RawMessage, error) {
+			return client.Get(cmdutil.JoinPath("upsells", id), url.Values{})
+		})
+	if err != nil {
+		return upsell{}, err
+	}
+	resp, err := cmdutil.DecodeJSON[upsellResponse](data)
+	if err != nil {
+		return upsell{}, err
+	}
+	return resp.Upsell, nil
+}
+
+func currentUpsellBody(u upsell) map[string]any {
+	body := map[string]any{
+		"name":                      u.Name,
+		"product_id":                u.Product.ID,
+		"text":                      u.Text,
+		"description":               u.Description,
+		"cross_sell":                u.CrossSell,
+		"universal":                 u.Universal,
+		"replace_selected_products": u.ReplaceSelectedProducts,
+		"paused":                    u.Paused,
+	}
+	if u.Product.Variant != nil {
+		body["variant_id"] = u.Product.Variant.ID
+	}
+	if len(u.SelectedProducts) > 0 {
+		ids := make([]string, len(u.SelectedProducts))
+		for i, p := range u.SelectedProducts {
+			ids[i] = p.ID
+		}
+		body["product_ids"] = ids
+	}
+	if u.Discount != nil {
+		if u.Discount.Type == "fixed" {
+			body["offer_code"] = map[string]any{"amount_cents": int(u.Discount.Cents)}
+		} else {
+			body["offer_code"] = map[string]any{"amount_percentage": int(u.Discount.Percents)}
+		}
+	}
+	if len(u.UpsellVariants) > 0 {
+		variants := make([]map[string]any, len(u.UpsellVariants))
+		for i, v := range u.UpsellVariants {
+			variants[i] = map[string]any{
+				"selected_variant_id": v.SelectedVariant.ID,
+				"offered_variant_id":  v.OfferedVariant.ID,
+			}
+		}
+		body["upsell_variants"] = variants
+	}
+	return body
+}

--- a/internal/cmd/upsells/update.go
+++ b/internal/cmd/upsells/update.go
@@ -134,6 +134,9 @@ Pass --remove-offer to drop the discount. Passing --selected-product or
 				body["product_ids"] = []string{}
 				body["universal"] = false
 				body["replace_selected_products"] = false
+				if flags.Changed("product") && !flags.Changed("offer-variant") {
+					body["upsell_variants"] = []map[string]any{}
+				}
 			}
 			if hasOfferCode {
 				body["offer_code"] = offerCode

--- a/internal/cmd/upsells/upsells.go
+++ b/internal/cmd/upsells/upsells.go
@@ -187,6 +187,25 @@ func offerCodeFromFlags(c *cobra.Command, amount string, percentOff int) (map[st
 	return nil, false, nil
 }
 
+func validateFlagConsistency(c *cobra.Command, crossSell, universal bool) error {
+	flags := c.Flags()
+	if crossSell {
+		if flags.Changed("offer-variant") {
+			return cmdutil.UsageErrorf(c, "--offer-variant applies to version upsells, not cross-sells")
+		}
+		if universal && flags.Changed("selected-product") {
+			return cmdutil.UsageErrorf(c, "--universal and --selected-product cannot be used together")
+		}
+		return nil
+	}
+	for _, flag := range []string{"variant", "universal", "selected-product", "replace-selected-products"} {
+		if flags.Changed(flag) {
+			return cmdutil.UsageErrorf(c, "--%s applies to cross-sells; pass --cross-sell", flag)
+		}
+	}
+	return nil
+}
+
 func parseOfferVariants(c *cobra.Command, raw []string) ([]map[string]any, error) {
 	variants := make([]map[string]any, 0, len(raw))
 	for _, entry := range raw {

--- a/internal/cmd/upsells/upsells.go
+++ b/internal/cmd/upsells/upsells.go
@@ -1,0 +1,203 @@
+package upsells
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+type variantRef struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type upsellVariant struct {
+	ID              string     `json:"id"`
+	SelectedVariant variantRef `json:"selected_variant"`
+	OfferedVariant  variantRef `json:"offered_variant"`
+}
+
+type upsellProduct struct {
+	ID           string      `json:"id"`
+	Name         string      `json:"name"`
+	CurrencyType string      `json:"currency_type"`
+	Variant      *variantRef `json:"variant"`
+}
+
+type upsellDiscount struct {
+	Type     string      `json:"type"`
+	Cents    api.JSONInt `json:"cents"`
+	Percents api.JSONInt `json:"percents"`
+}
+
+type selectedProduct struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type upsell struct {
+	ID                      string            `json:"id"`
+	Name                    string            `json:"name"`
+	CrossSell               bool              `json:"cross_sell"`
+	ReplaceSelectedProducts bool              `json:"replace_selected_products"`
+	Universal               bool              `json:"universal"`
+	Text                    string            `json:"text"`
+	Description             string            `json:"description"`
+	Paused                  bool              `json:"paused"`
+	Product                 upsellProduct     `json:"product"`
+	Discount                *upsellDiscount   `json:"discount"`
+	SelectedProducts        []selectedProduct `json:"selected_products"`
+	UpsellVariants          []upsellVariant   `json:"upsell_variants"`
+}
+
+type upsellResponse struct {
+	Upsell upsell `json:"upsell"`
+}
+
+func NewUpsellsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "upsells",
+		Aliases: []string{"upsell"},
+		Short:   "Manage upsells and cross-sells",
+		Long: `Manage upsells and cross-sells.
+
+An upsell offers a buyer a different version of the product they are buying.
+A cross-sell offers a different product (optionally discounted) to buyers of
+selected products, or to buyers of every product when it is universal.`,
+		Example: `  gumroad upsells list
+  gumroad upsells create --name "Upgrade" --product <id> --offer-variant <selected_id>:<offered_id>
+  gumroad upsells create --name "Audiobook" --product <id> --cross-sell --selected-product <id> --percent-off 50`,
+	}
+
+	cmd.AddCommand(newListCmd())
+	cmd.AddCommand(newViewCmd())
+	cmd.AddCommand(newCreateCmd())
+	cmd.AddCommand(newUpdateCmd())
+	cmd.AddCommand(newDeleteCmd())
+
+	return cmd
+}
+
+func upsellType(u upsell) string {
+	if u.CrossSell {
+		return "cross-sell"
+	}
+	return "upsell"
+}
+
+func formatDiscount(discount *upsellDiscount) string {
+	if discount == nil {
+		return "none"
+	}
+	if discount.Type == "fixed" {
+		return fmt.Sprintf("%d cents off", discount.Cents)
+	}
+	return fmt.Sprintf("%d%% off", discount.Percents)
+}
+
+func yesNo(value bool) string {
+	if value {
+		return "yes"
+	}
+	return "no"
+}
+
+func runUpsellWrite(opts cmdutil.Options, method, path string, body map[string]any, spinnerMessage, verb string) error {
+	if opts.DryRun {
+		return printUpsellDryRun(opts, method, path, body)
+	}
+
+	return cmdutil.RunDecoded[upsellResponse](opts, spinnerMessage,
+		func(client *api.Client) (json.RawMessage, error) {
+			if method == http.MethodPut {
+				return client.PutJSON(path, body)
+			}
+			return client.PostJSON(path, body)
+		},
+		func(resp upsellResponse) error {
+			return renderUpsellWriteResult(opts, verb, resp.Upsell)
+		})
+}
+
+func renderUpsellWriteResult(opts cmdutil.Options, verb string, u upsell) error {
+	if opts.PlainOutput {
+		return output.PrintPlain(opts.Out(), [][]string{{u.ID, u.Name}})
+	}
+	if opts.Quiet {
+		return nil
+	}
+	s := opts.Style()
+	return output.Writef(opts.Out(), "%s %s (%s)\n", s.Bold(verb+" upsell:"), u.Name, s.Dim(u.ID))
+}
+
+func printUpsellDryRun(opts cmdutil.Options, method, path string, body map[string]any) error {
+	if opts.UsesJSONOutput() {
+		data, err := json.Marshal(map[string]any{
+			"dry_run": true,
+			"method":  method,
+			"path":    path,
+			"body":    body,
+		})
+		if err != nil {
+			return fmt.Errorf("could not encode dry-run output: %w", err)
+		}
+		return output.PrintJSON(opts.Out(), data, opts.JQExpr)
+	}
+
+	encoded, err := json.MarshalIndent(body, "", "  ")
+	if err != nil {
+		return fmt.Errorf("could not encode dry-run output: %w", err)
+	}
+	if opts.PlainOutput {
+		return output.PrintPlain(opts.Out(), [][]string{{method, path, string(encoded)}})
+	}
+	if err := output.Writeln(opts.Out(), opts.Style().Yellow("Dry run")+": "+method+" "+path); err != nil {
+		return err
+	}
+	return output.Writeln(opts.Out(), string(encoded))
+}
+
+func offerCodeFromFlags(c *cobra.Command, amount string, percentOff int) (map[string]any, bool, error) {
+	flags := c.Flags()
+	hasAmount := flags.Changed("amount")
+	hasPercentOff := flags.Changed("percent-off")
+
+	if hasAmount && hasPercentOff {
+		return nil, false, cmdutil.UsageErrorf(c, "flags --amount and --percent-off cannot be used together")
+	}
+	if hasAmount {
+		cents, err := cmdutil.ParseMoney("amount", amount, "amount", "")
+		if err != nil {
+			return nil, false, cmdutil.UsageErrorf(c, "%s", err.Error())
+		}
+		if cents <= 0 {
+			return nil, false, cmdutil.UsageErrorf(c, "--amount must be greater than 0")
+		}
+		return map[string]any{"amount_cents": cents}, true, nil
+	}
+	if hasPercentOff {
+		return map[string]any{"amount_percentage": percentOff}, true, nil
+	}
+	return nil, false, nil
+}
+
+func parseOfferVariants(c *cobra.Command, raw []string) ([]map[string]any, error) {
+	variants := make([]map[string]any, 0, len(raw))
+	for _, entry := range raw {
+		selected, offered, ok := strings.Cut(entry, ":")
+		if !ok || selected == "" || offered == "" {
+			return nil, cmdutil.UsageErrorf(c, "--offer-variant %q must be in the form <selected_variant_id>:<offered_variant_id>", entry)
+		}
+		variants = append(variants, map[string]any{
+			"selected_variant_id": selected,
+			"offered_variant_id":  offered,
+		})
+	}
+	return variants, nil
+}

--- a/internal/cmd/upsells/upsells_test.go
+++ b/internal/cmd/upsells/upsells_test.go
@@ -383,7 +383,7 @@ func TestCreate_DryRun(t *testing.T) {
 	})
 
 	cmd := testutil.Command(newCreateCmd(), testutil.DryRun(true))
-	cmd.SetArgs([]string{"--name", "X", "--product", "p1", "--cross-sell"})
+	cmd.SetArgs([]string{"--name", "X", "--product", "p1", "--cross-sell", "--universal"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
 	if !strings.Contains(out, "Dry run") || !strings.Contains(out, "POST /upsells") {
@@ -612,11 +612,18 @@ func TestUpdate_KeepsVariantWhenProductUnchanged(t *testing.T) {
 	}
 }
 
-func TestUpdate_ClearSelectedProducts(t *testing.T) {
-	body := updatePutBody(t, []string{"up1", "--selected-product", ""}, crossSellWithVariantPayload())
-	ids, ok := body["product_ids"].([]any)
-	if !ok || len(ids) != 0 {
-		t.Errorf("product_ids should be cleared to empty, got %v", body["product_ids"])
+func TestUpdate_ClearingCrossSellAudienceRejected(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			t.Error("should not PUT a no-audience cross-sell")
+		}
+		testutil.JSON(t, w, crossSellWithVariantPayload())
+	})
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{"up1", "--selected-product", ""})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "needs an audience") {
+		t.Fatalf("expected audience error when clearing a cross-sell's only audience, got: %v", err)
 	}
 }
 
@@ -685,10 +692,37 @@ func TestUpdate_SelectedProductMakesTargeted(t *testing.T) {
 }
 
 func TestUpdate_CrossSellClearsUpsellVariants(t *testing.T) {
-	body := updatePutBody(t, []string{"up1", "--cross-sell"}, versionUpsellPayload())
+	body := updatePutBody(t, []string{"up1", "--cross-sell", "--selected-product", "buyer-prod"}, versionUpsellPayload())
 	variants, ok := body["upsell_variants"].([]any)
 	if !ok || len(variants) != 0 {
 		t.Errorf("converting to a cross-sell should clear upsell_variants, got %v", body["upsell_variants"])
+	}
+}
+
+func TestCreate_CrossSellRequiresAudience(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API")
+	})
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--name", "X", "--product", "p1", "--cross-sell"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "needs an audience") {
+		t.Fatalf("expected audience error, got: %v", err)
+	}
+}
+
+func TestUpdate_ConversionToCrossSellRequiresAudience(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			t.Error("should not PUT a no-audience cross-sell")
+		}
+		testutil.JSON(t, w, versionUpsellPayload())
+	})
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{"up1", "--cross-sell"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "needs an audience") {
+		t.Fatalf("expected audience error, got: %v", err)
 	}
 }
 
@@ -817,7 +851,7 @@ func TestCreate_AmountDiscount(t *testing.T) {
 		testutil.JSON(t, w, crossSellPayload())
 	})
 	cmd := newCreateCmd()
-	cmd.SetArgs([]string{"--name", "X", "--product", "p1", "--cross-sell", "--amount", "5"})
+	cmd.SetArgs([]string{"--name", "X", "--product", "p1", "--cross-sell", "--universal", "--amount", "5"})
 	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 	offer, ok := body["offer_code"].(map[string]any)
 	if !ok || offer["amount_cents"] != float64(500) {

--- a/internal/cmd/upsells/upsells_test.go
+++ b/internal/cmd/upsells/upsells_test.go
@@ -553,6 +553,212 @@ func TestDelete_APIError(t *testing.T) {
 	}
 }
 
+func crossSellWithVariantPayload() map[string]any {
+	return map[string]any{
+		"upsell": map[string]any{
+			"id":                        "up1",
+			"name":                      "Companion",
+			"cross_sell":                true,
+			"replace_selected_products": false,
+			"universal":                 false,
+			"text":                      "Add it",
+			"description":               "Great deal",
+			"paused":                    false,
+			"product": map[string]any{
+				"id":            "prod-offered",
+				"name":          "Audiobook",
+				"currency_type": "usd",
+				"variant":       map[string]any{"id": "var-old", "name": "Deluxe"},
+			},
+			"discount":          map[string]any{"type": "percent", "percents": 30},
+			"selected_products": []map[string]any{{"id": "prod-book", "name": "Book"}},
+			"upsell_variants":   []map[string]any{},
+		},
+	}
+}
+
+func versionUpsellPayload() map[string]any {
+	return map[string]any{
+		"upsell": map[string]any{
+			"id": "up1", "name": "Pro upgrade", "cross_sell": false, "paused": false,
+			"product":         map[string]any{"id": "p1", "name": "Course"},
+			"upsell_variants": []map[string]any{{"id": "uv1", "selected_variant": map[string]any{"id": "v1", "name": "Basic"}, "offered_variant": map[string]any{"id": "v2", "name": "Premium"}}},
+		},
+	}
+}
+
+func updatePutBody(t *testing.T, args []string, getPayload map[string]any) map[string]any {
+	t.Helper()
+	var putBody map[string]any
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			testutil.JSON(t, w, getPayload)
+			return
+		}
+		putBody = decodeBody(t, r)
+		testutil.JSON(t, w, crossSellPayload())
+	})
+	cmd := newUpdateCmd()
+	cmd.SetArgs(args)
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	return putBody
+}
+
+func TestUpdate_ProductChangeDropsStaleVariant(t *testing.T) {
+	body := updatePutBody(t, []string{"up1", "--product", "new-prod"}, crossSellWithVariantPayload())
+	if body["product_id"] != "new-prod" {
+		t.Errorf("product_id not applied: %v", body["product_id"])
+	}
+	if _, ok := body["variant_id"]; ok {
+		t.Errorf("stale variant_id should be dropped when product changes, got %v", body["variant_id"])
+	}
+}
+
+func TestUpdate_KeepsVariantWhenProductUnchanged(t *testing.T) {
+	body := updatePutBody(t, []string{"up1", "--name", "X"}, crossSellWithVariantPayload())
+	if body["variant_id"] != "var-old" {
+		t.Errorf("variant_id should be preserved, got %v", body["variant_id"])
+	}
+}
+
+func TestUpdate_ClearSelectedProducts(t *testing.T) {
+	body := updatePutBody(t, []string{"up1", "--selected-product", ""}, crossSellWithVariantPayload())
+	ids, ok := body["product_ids"].([]any)
+	if !ok || len(ids) != 0 {
+		t.Errorf("product_ids should be cleared to empty, got %v", body["product_ids"])
+	}
+}
+
+func TestUpdate_ReplaceSelectedProducts(t *testing.T) {
+	body := updatePutBody(t, []string{"up1", "--selected-product", "new-book"}, crossSellWithVariantPayload())
+	ids, ok := body["product_ids"].([]any)
+	if !ok || len(ids) != 1 || ids[0] != "new-book" {
+		t.Errorf("product_ids should be replaced, got %v", body["product_ids"])
+	}
+}
+
+func TestUpdate_UniversalDropsSelectedProducts(t *testing.T) {
+	body := updatePutBody(t, []string{"up1", "--universal"}, crossSellWithVariantPayload())
+	if body["universal"] != true {
+		t.Errorf("universal should be true, got %v", body["universal"])
+	}
+	if _, ok := body["product_ids"]; ok {
+		t.Errorf("universal cross-sell should not send product_ids, got %v", body["product_ids"])
+	}
+}
+
+func TestUpdate_ReplaceOfferVariants(t *testing.T) {
+	body := updatePutBody(t, []string{"up1", "--offer-variant", "v3:v4"}, versionUpsellPayload())
+	variants, ok := body["upsell_variants"].([]any)
+	if !ok || len(variants) != 1 {
+		t.Fatalf("expected one upsell variant, got %v", body["upsell_variants"])
+	}
+	first := variants[0].(map[string]any)
+	if first["selected_variant_id"] != "v3" || first["offered_variant_id"] != "v4" {
+		t.Errorf("upsell variant not replaced: %v", first)
+	}
+}
+
+func TestUpdate_Plain(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, crossSellPayload())
+	})
+	cmd := testutil.Command(newUpdateCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{"up1", "--name", "Renamed"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if !strings.Contains(out, "up1\tAudiobook") {
+		t.Errorf("plain update row mismatch: %q", out)
+	}
+}
+
+func TestUpdate_DryRunJSON(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			t.Error("PUT should not be sent in dry-run")
+		}
+		testutil.JSON(t, w, crossSellPayload())
+	})
+	cmd := testutil.Command(newUpdateCmd(), testutil.DryRun(true), testutil.JSONOutput())
+	cmd.SetArgs([]string{"up1", "--name", "Renamed"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("dry-run not valid JSON: %v\n%s", err, out)
+	}
+	if payload["method"] != "PUT" || payload["dry_run"] != true {
+		t.Errorf("unexpected dry-run payload: %v", payload)
+	}
+}
+
+func TestCreate_Plain(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{"upsell": map[string]any{"id": "up9", "name": "Add-on"}})
+	})
+	cmd := testutil.Command(newCreateCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{"--name", "Add-on", "--product", "p1"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if !strings.Contains(out, "up9\tAdd-on") {
+		t.Errorf("plain create row mismatch: %q", out)
+	}
+}
+
+func TestCreate_AmountDiscount(t *testing.T) {
+	var body map[string]any
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		body = decodeBody(t, r)
+		testutil.JSON(t, w, crossSellPayload())
+	})
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--name", "X", "--product", "p1", "--cross-sell", "--amount", "5"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	offer, ok := body["offer_code"].(map[string]any)
+	if !ok || offer["amount_cents"] != float64(500) {
+		t.Errorf("offer_code amount_cents mismatch: %v", body["offer_code"])
+	}
+}
+
+func TestCreate_DryRunJSON(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API in dry-run")
+	})
+	cmd := testutil.Command(newCreateCmd(), testutil.DryRun(true), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--name", "X", "--product", "p1"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("dry-run not valid JSON: %v\n%s", err, out)
+	}
+	if payload["method"] != "POST" {
+		t.Errorf("unexpected dry-run method: %v", payload["method"])
+	}
+}
+
+func TestView_Plain(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, crossSellWithVariantPayload())
+	})
+	cmd := testutil.Command(newViewCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{"up1"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if !strings.Contains(out, "cross-sell") || !strings.Contains(out, "30% off") {
+		t.Errorf("plain view mismatch: %q", out)
+	}
+}
+
+func TestView_FullDetail(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, crossSellWithVariantPayload())
+	})
+	cmd := newViewCmd()
+	cmd.SetArgs([]string{"up1"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	for _, want := range []string{"Offered version: Deluxe", "Text: Add it", "Description: Great deal", "30% off", "Book (prod-book)"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("detail view missing %q: %q", want, out)
+		}
+	}
+}
+
 func TestNewUpsellsCmd_RegistersSubcommands(t *testing.T) {
 	cmd := NewUpsellsCmd()
 	for _, args := range [][]string{{"list"}, {"view"}, {"create"}, {"update"}, {"delete"}} {

--- a/internal/cmd/upsells/upsells_test.go
+++ b/internal/cmd/upsells/upsells_test.go
@@ -50,8 +50,6 @@ func crossSellPayload() map[string]any {
 	}
 }
 
-// --- List ---
-
 func TestList_CorrectEndpoint(t *testing.T) {
 	var gotMethod, gotPath string
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
@@ -157,8 +155,6 @@ func TestList_APIError(t *testing.T) {
 	}
 }
 
-// --- View ---
-
 func TestView_RendersCrossSell(t *testing.T) {
 	var gotPath string
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
@@ -226,8 +222,6 @@ func TestView_ArgRequired(t *testing.T) {
 		t.Fatal("expected error without upsell id")
 	}
 }
-
-// --- Create ---
 
 func TestCreate_NameRequired(t *testing.T) {
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
@@ -397,8 +391,6 @@ func TestCreate_DryRun(t *testing.T) {
 	}
 }
 
-// --- Update ---
-
 func TestUpdate_RequiresAtLeastOneField(t *testing.T) {
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
 		t.Error("should not reach API")
@@ -466,8 +458,9 @@ func TestUpdate_RemoveOffer(t *testing.T) {
 	cmd.SetArgs([]string{"up1", "--remove-offer"})
 	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	if _, ok := putBody["offer_code"]; ok {
-		t.Errorf("offer_code should be dropped, got: %v", putBody["offer_code"])
+	offer, ok := putBody["offer_code"].(map[string]any)
+	if !ok || len(offer) != 0 {
+		t.Errorf("offer_code should be an explicit empty object to clear, got: %v", putBody["offer_code"])
 	}
 }
 
@@ -504,8 +497,6 @@ func TestUpdate_DryRun(t *testing.T) {
 		t.Errorf("expected dry-run output, got: %q", out)
 	}
 }
-
-// --- Delete ---
 
 func TestDelete_RequiresConfirmation(t *testing.T) {
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
@@ -609,8 +600,8 @@ func TestUpdate_ProductChangeDropsStaleVariant(t *testing.T) {
 	if body["product_id"] != "new-prod" {
 		t.Errorf("product_id not applied: %v", body["product_id"])
 	}
-	if _, ok := body["variant_id"]; ok {
-		t.Errorf("stale variant_id should be dropped when product changes, got %v", body["variant_id"])
+	if body["variant_id"] != "" {
+		t.Errorf("stale variant_id should be cleared when product changes, got %v", body["variant_id"])
 	}
 }
 
@@ -642,8 +633,25 @@ func TestUpdate_UniversalDropsSelectedProducts(t *testing.T) {
 	if body["universal"] != true {
 		t.Errorf("universal should be true, got %v", body["universal"])
 	}
-	if _, ok := body["product_ids"]; ok {
-		t.Errorf("universal cross-sell should not send product_ids, got %v", body["product_ids"])
+	ids, ok := body["product_ids"].([]any)
+	if !ok || len(ids) != 0 {
+		t.Errorf("universal cross-sell should clear product_ids to empty, got %v", body["product_ids"])
+	}
+}
+
+func TestUpdate_UniversalRespectsExplicitSelectedProduct(t *testing.T) {
+	body := updatePutBody(t, []string{"up1", "--universal", "--selected-product", "keep-me"}, crossSellWithVariantPayload())
+	ids, ok := body["product_ids"].([]any)
+	if !ok || len(ids) != 1 || ids[0] != "keep-me" {
+		t.Errorf("explicit --selected-product should win over universal clearing, got %v", body["product_ids"])
+	}
+}
+
+func TestUpdate_CrossSellClearsUpsellVariants(t *testing.T) {
+	body := updatePutBody(t, []string{"up1", "--cross-sell"}, versionUpsellPayload())
+	variants, ok := body["upsell_variants"].([]any)
+	if !ok || len(variants) != 0 {
+		t.Errorf("converting to a cross-sell should clear upsell_variants, got %v", body["upsell_variants"])
 	}
 }
 
@@ -699,6 +707,20 @@ func TestCreate_Plain(t *testing.T) {
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 	if !strings.Contains(out, "up9\tAdd-on") {
 		t.Errorf("plain create row mismatch: %q", out)
+	}
+}
+
+func TestCreate_UniversalOmitsSelectedProducts(t *testing.T) {
+	var body map[string]any
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		body = decodeBody(t, r)
+		testutil.JSON(t, w, crossSellPayload())
+	})
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--name", "X", "--product", "p1", "--cross-sell", "--universal", "--selected-product", "ignored"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+	if _, ok := body["product_ids"]; ok {
+		t.Errorf("universal create should not send product_ids, got %v", body["product_ids"])
 	}
 }
 

--- a/internal/cmd/upsells/upsells_test.go
+++ b/internal/cmd/upsells/upsells_test.go
@@ -704,6 +704,22 @@ func TestUpdate_ReplaceOfferVariants(t *testing.T) {
 	}
 }
 
+func TestUpdate_ConversionToVersionUpsellClearsCrossSellFields(t *testing.T) {
+	body := updatePutBody(t, []string{"up1", "--cross-sell=false", "--offer-variant", "v1:v2"}, crossSellWithVariantPayload())
+	if body["variant_id"] != "" {
+		t.Errorf("variant_id should be cleared, got %v", body["variant_id"])
+	}
+	if ids, ok := body["product_ids"].([]any); !ok || len(ids) != 0 {
+		t.Errorf("product_ids should be cleared, got %v", body["product_ids"])
+	}
+	if body["universal"] != false {
+		t.Errorf("universal should be false, got %v", body["universal"])
+	}
+	if vs, ok := body["upsell_variants"].([]any); !ok || len(vs) != 1 {
+		t.Errorf("upsell_variants should be set, got %v", body["upsell_variants"])
+	}
+}
+
 func TestUpdate_Plain(t *testing.T) {
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
 		testutil.JSON(t, w, crossSellPayload())

--- a/internal/cmd/upsells/upsells_test.go
+++ b/internal/cmd/upsells/upsells_test.go
@@ -692,6 +692,17 @@ func TestUpdate_CrossSellClearsUpsellVariants(t *testing.T) {
 	}
 }
 
+func TestUpdate_ProductChangeClearsVersionMappings(t *testing.T) {
+	body := updatePutBody(t, []string{"up1", "--product", "new-prod"}, versionUpsellPayload())
+	if body["product_id"] != "new-prod" {
+		t.Errorf("product_id not applied: %v", body["product_id"])
+	}
+	variants, ok := body["upsell_variants"].([]any)
+	if !ok || len(variants) != 0 {
+		t.Errorf("changing the product should clear the old product's version mappings, got %v", body["upsell_variants"])
+	}
+}
+
 func TestUpdate_ReplaceOfferVariants(t *testing.T) {
 	body := updatePutBody(t, []string{"up1", "--offer-variant", "v3:v4"}, versionUpsellPayload())
 	variants, ok := body["upsell_variants"].([]any)

--- a/internal/cmd/upsells/upsells_test.go
+++ b/internal/cmd/upsells/upsells_test.go
@@ -639,11 +639,30 @@ func TestUpdate_UniversalDropsSelectedProducts(t *testing.T) {
 	}
 }
 
-func TestUpdate_UniversalRespectsExplicitSelectedProduct(t *testing.T) {
-	body := updatePutBody(t, []string{"up1", "--universal", "--selected-product", "keep-me"}, crossSellWithVariantPayload())
+func TestUpdate_UniversalAndSelectedProductConflict(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API")
+	})
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{"up1", "--universal", "--selected-product", "x"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--universal and --selected-product cannot be used together") {
+		t.Fatalf("expected conflict error, got: %v", err)
+	}
+}
+
+func TestUpdate_SelectedProductMakesTargeted(t *testing.T) {
+	payload := crossSellWithVariantPayload()
+	payload["upsell"].(map[string]any)["universal"] = true
+	payload["upsell"].(map[string]any)["selected_products"] = []map[string]any{}
+
+	body := updatePutBody(t, []string{"up1", "--selected-product", "prod1"}, payload)
+	if body["universal"] != false {
+		t.Errorf("targeting with --selected-product should set universal false, got %v", body["universal"])
+	}
 	ids, ok := body["product_ids"].([]any)
-	if !ok || len(ids) != 1 || ids[0] != "keep-me" {
-		t.Errorf("explicit --selected-product should win over universal clearing, got %v", body["product_ids"])
+	if !ok || len(ids) != 1 || ids[0] != "prod1" {
+		t.Errorf("product_ids should be the targeted set, got %v", body["product_ids"])
 	}
 }
 
@@ -710,17 +729,27 @@ func TestCreate_Plain(t *testing.T) {
 	}
 }
 
-func TestCreate_UniversalOmitsSelectedProducts(t *testing.T) {
-	var body map[string]any
+func TestCreate_UniversalConflictsSelectedProduct(t *testing.T) {
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
-		body = decodeBody(t, r)
-		testutil.JSON(t, w, crossSellPayload())
+		t.Error("should not reach API")
 	})
 	cmd := newCreateCmd()
-	cmd.SetArgs([]string{"--name", "X", "--product", "p1", "--cross-sell", "--universal", "--selected-product", "ignored"})
-	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
-	if _, ok := body["product_ids"]; ok {
-		t.Errorf("universal create should not send product_ids, got %v", body["product_ids"])
+	cmd.SetArgs([]string{"--name", "X", "--product", "p1", "--cross-sell", "--universal", "--selected-product", "x"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "cannot be combined with --universal") {
+		t.Fatalf("expected universal conflict error, got: %v", err)
+	}
+}
+
+func TestCreate_SelectedProductRequiresCrossSell(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API")
+	})
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--name", "X", "--product", "p1", "--selected-product", "x"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "pass --cross-sell") {
+		t.Fatalf("expected cross-sell requirement error, got: %v", err)
 	}
 }
 

--- a/internal/cmd/upsells/upsells_test.go
+++ b/internal/cmd/upsells/upsells_test.go
@@ -1,0 +1,567 @@
+package upsells
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func decodeBody(t *testing.T, r *http.Request) map[string]any {
+	t.Helper()
+	raw, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if len(raw) == 0 {
+		return map[string]any{}
+	}
+	var body map[string]any
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("decode body %q: %v", string(raw), err)
+	}
+	return body
+}
+
+func crossSellPayload() map[string]any {
+	return map[string]any{
+		"upsell": map[string]any{
+			"id":                        "up1",
+			"name":                      "Audiobook",
+			"cross_sell":                true,
+			"replace_selected_products": false,
+			"universal":                 false,
+			"text":                      "Add the audiobook",
+			"description":               "Listen anywhere",
+			"paused":                    false,
+			"product": map[string]any{
+				"id":            "prod-offered",
+				"name":          "Audiobook",
+				"currency_type": "usd",
+				"variant":       nil,
+			},
+			"discount":          map[string]any{"type": "fixed", "cents": 500},
+			"selected_products": []map[string]any{{"id": "prod-book", "name": "Book"}},
+			"upsell_variants":   []map[string]any{},
+		},
+	}
+}
+
+// --- List ---
+
+func TestList_CorrectEndpoint(t *testing.T) {
+	var gotMethod, gotPath string
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		testutil.JSON(t, w, map[string]any{
+			"upsells": []map[string]any{
+				{"id": "up1", "name": "Upgrade", "cross_sell": false, "paused": false, "product": map[string]any{"id": "p1", "name": "Course"}},
+			},
+		})
+	})
+
+	cmd := newListCmd()
+	cmd.SetArgs([]string{})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != http.MethodGet || gotPath != "/upsells" {
+		t.Errorf("got %s %s, want GET /upsells", gotMethod, gotPath)
+	}
+	if !strings.Contains(out, "Upgrade") {
+		t.Errorf("missing upsell name: %q", out)
+	}
+}
+
+func TestList_Table(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"upsells": []map[string]any{
+				{"id": "up1", "name": "Upgrade", "cross_sell": false, "paused": true, "product": map[string]any{"id": "p1", "name": "Course"}},
+				{"id": "up2", "name": "Audiobook", "cross_sell": true, "paused": false, "product": map[string]any{"id": "p2", "name": "Audiobook"}, "discount": map[string]any{"type": "percent", "percents": 50}},
+			},
+		})
+	})
+
+	cmd := newListCmd()
+	cmd.SetArgs([]string{})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	for _, want := range []string{"upsell", "cross-sell", "50% off", "yes", "no"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("table missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestList_Empty(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{"upsells": []map[string]any{}})
+	})
+
+	cmd := testutil.Command(newListCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "No upsells found") {
+		t.Errorf("expected empty message: %q", out)
+	}
+}
+
+func TestList_JSON(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{"upsells": []map[string]any{{"id": "up1", "name": "Upgrade", "product": map[string]any{"id": "p1", "name": "Course"}}}})
+	})
+
+	cmd := testutil.Command(newListCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v", err)
+	}
+}
+
+func TestList_Plain(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"upsells": []map[string]any{
+				{"id": "up1", "name": "Upgrade", "cross_sell": false, "paused": false, "product": map[string]any{"id": "p1", "name": "Course"}},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newListCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "up1\tUpgrade\tupsell\tCourse\tnone\tno") {
+		t.Errorf("plain row mismatch: %q", out)
+	}
+}
+
+func TestList_APIError(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		testutil.JSON(t, w, map[string]any{"message": "Error"})
+	})
+
+	cmd := newListCmd()
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// --- View ---
+
+func TestView_RendersCrossSell(t *testing.T) {
+	var gotPath string
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		testutil.JSON(t, w, crossSellPayload())
+	})
+
+	cmd := newViewCmd()
+	cmd.SetArgs([]string{"up1"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotPath != "/upsells/up1" {
+		t.Errorf("got path %q", gotPath)
+	}
+	for _, want := range []string{"Audiobook", "cross-sell", "500 cents off", "Book (prod-book)"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("view missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestView_RendersVersionUpgrades(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"upsell": map[string]any{
+				"id": "up1", "name": "Upgrade", "cross_sell": false, "paused": false,
+				"product":         map[string]any{"id": "p1", "name": "Course"},
+				"upsell_variants": []map[string]any{{"id": "uv1", "selected_variant": map[string]any{"id": "v1", "name": "Basic"}, "offered_variant": map[string]any{"id": "v2", "name": "Premium"}}},
+			},
+		})
+	})
+
+	cmd := newViewCmd()
+	cmd.SetArgs([]string{"up1"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "Basic -> Premium") {
+		t.Errorf("missing version upgrade: %q", out)
+	}
+}
+
+func TestView_JSON(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, crossSellPayload())
+	})
+
+	cmd := testutil.Command(newViewCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"up1"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v", err)
+	}
+}
+
+func TestView_ArgRequired(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API")
+	})
+
+	cmd := newViewCmd()
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error without upsell id")
+	}
+}
+
+// --- Create ---
+
+func TestCreate_NameRequired(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API")
+	})
+
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--product", "p1"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--name") {
+		t.Fatalf("expected --name required, got: %v", err)
+	}
+}
+
+func TestCreate_ProductRequired(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API")
+	})
+
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--name", "X"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--product") {
+		t.Fatalf("expected --product required, got: %v", err)
+	}
+}
+
+func TestCreate_VersionUpsell(t *testing.T) {
+	var gotMethod, gotPath string
+	var body map[string]any
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		body = decodeBody(t, r)
+		testutil.JSON(t, w, map[string]any{"upsell": map[string]any{"id": "up1", "name": "Upgrade", "product": map[string]any{"id": "p1", "name": "Course"}}})
+	})
+
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--name", "Upgrade", "--product", "p1", "--offer-variant", "v1:v2"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != http.MethodPost || gotPath != "/upsells" {
+		t.Errorf("got %s %s, want POST /upsells", gotMethod, gotPath)
+	}
+	if body["cross_sell"] != false {
+		t.Errorf("cross_sell should be false, got %v", body["cross_sell"])
+	}
+	variants, ok := body["upsell_variants"].([]any)
+	if !ok || len(variants) != 1 {
+		t.Fatalf("expected one upsell variant, got %v", body["upsell_variants"])
+	}
+	first := variants[0].(map[string]any)
+	if first["selected_variant_id"] != "v1" || first["offered_variant_id"] != "v2" {
+		t.Errorf("variant pair mismatch: %v", first)
+	}
+}
+
+func TestCreate_CrossSellWithDiscountAndSelectedProducts(t *testing.T) {
+	var body map[string]any
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		body = decodeBody(t, r)
+		testutil.JSON(t, w, crossSellPayload())
+	})
+
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--name", "Audiobook", "--product", "prod-offered", "--cross-sell", "--selected-product", "prod-book", "--amount", "5"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if body["cross_sell"] != true {
+		t.Errorf("cross_sell should be true, got %v", body["cross_sell"])
+	}
+	ids, ok := body["product_ids"].([]any)
+	if !ok || len(ids) != 1 || ids[0] != "prod-book" {
+		t.Errorf("product_ids mismatch: %v", body["product_ids"])
+	}
+	offer, ok := body["offer_code"].(map[string]any)
+	if !ok || offer["amount_cents"] != float64(500) {
+		t.Errorf("offer_code amount_cents mismatch: %v", body["offer_code"])
+	}
+}
+
+func TestCreate_PercentOff(t *testing.T) {
+	var body map[string]any
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		body = decodeBody(t, r)
+		testutil.JSON(t, w, crossSellPayload())
+	})
+
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--name", "Audiobook", "--product", "p2", "--cross-sell", "--universal", "--percent-off", "50"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if body["universal"] != true {
+		t.Errorf("universal should be true, got %v", body["universal"])
+	}
+	offer, ok := body["offer_code"].(map[string]any)
+	if !ok || offer["amount_percentage"] != float64(50) {
+		t.Errorf("offer_code amount_percentage mismatch: %v", body["offer_code"])
+	}
+}
+
+func TestCreate_AmountPercentConflict(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API")
+	})
+
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--name", "X", "--product", "p1", "--amount", "5", "--percent-off", "10"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "cannot be used together") {
+		t.Fatalf("expected mutual exclusion error, got: %v", err)
+	}
+}
+
+func TestCreate_PercentOutOfRange(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API")
+	})
+
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--name", "X", "--product", "p1", "--percent-off", "150"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "between 1 and 100") {
+		t.Fatalf("expected percent range error, got: %v", err)
+	}
+}
+
+func TestCreate_OfferVariantBadFormat(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API")
+	})
+
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--name", "X", "--product", "p1", "--offer-variant", "v1"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "offer-variant") {
+		t.Fatalf("expected offer-variant format error, got: %v", err)
+	}
+}
+
+func TestCreate_JSON(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{"upsell": map[string]any{"id": "up1"}})
+	})
+
+	cmd := testutil.Command(newCreateCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--name", "X", "--product", "p1"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v", err)
+	}
+}
+
+func TestCreate_DryRun(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API in dry-run")
+	})
+
+	cmd := testutil.Command(newCreateCmd(), testutil.DryRun(true))
+	cmd.SetArgs([]string{"--name", "X", "--product", "p1", "--cross-sell"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "Dry run") || !strings.Contains(out, "POST /upsells") {
+		t.Errorf("expected dry-run output, got: %q", out)
+	}
+}
+
+// --- Update ---
+
+func TestUpdate_RequiresAtLeastOneField(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API")
+	})
+
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{"up1"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "at least one field to update must be provided") {
+		t.Fatalf("expected no-op update error, got: %v", err)
+	}
+}
+
+func TestUpdate_FetchesThenMerges(t *testing.T) {
+	var putBody map[string]any
+	var sawGet, sawPut bool
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			sawGet = true
+			testutil.JSON(t, w, crossSellPayload())
+		case http.MethodPut:
+			sawPut = true
+			putBody = decodeBody(t, r)
+			testutil.JSON(t, w, crossSellPayload())
+		default:
+			t.Errorf("unexpected method %s", r.Method)
+		}
+	})
+
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{"up1", "--name", "Renamed"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !sawGet || !sawPut {
+		t.Fatalf("expected GET then PUT, got get=%v put=%v", sawGet, sawPut)
+	}
+	if putBody["name"] != "Renamed" {
+		t.Errorf("name override missing: %v", putBody["name"])
+	}
+	if putBody["product_id"] != "prod-offered" {
+		t.Errorf("merged product_id missing: %v", putBody["product_id"])
+	}
+	if putBody["cross_sell"] != true {
+		t.Errorf("merged cross_sell missing: %v", putBody["cross_sell"])
+	}
+	offer, ok := putBody["offer_code"].(map[string]any)
+	if !ok || offer["amount_cents"] != float64(500) {
+		t.Errorf("merged offer_code missing: %v", putBody["offer_code"])
+	}
+}
+
+func TestUpdate_RemoveOffer(t *testing.T) {
+	var putBody map[string]any
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			testutil.JSON(t, w, crossSellPayload())
+			return
+		}
+		putBody = decodeBody(t, r)
+		testutil.JSON(t, w, crossSellPayload())
+	})
+
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{"up1", "--remove-offer"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if _, ok := putBody["offer_code"]; ok {
+		t.Errorf("offer_code should be dropped, got: %v", putBody["offer_code"])
+	}
+}
+
+func TestUpdate_RemoveOfferConflict(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API")
+	})
+
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{"up1", "--remove-offer", "--amount", "5"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--remove-offer cannot be used with") {
+		t.Fatalf("expected remove-offer conflict error, got: %v", err)
+	}
+}
+
+func TestUpdate_DryRun(t *testing.T) {
+	var sawPut bool
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			sawPut = true
+		}
+		testutil.JSON(t, w, crossSellPayload())
+	})
+
+	cmd := testutil.Command(newUpdateCmd(), testutil.DryRun(true))
+	cmd.SetArgs([]string{"up1", "--name", "Renamed"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if sawPut {
+		t.Error("PUT should not be sent in dry-run")
+	}
+	if !strings.Contains(out, "Dry run") || !strings.Contains(out, "PUT /upsells/up1") {
+		t.Errorf("expected dry-run output, got: %q", out)
+	}
+}
+
+// --- Delete ---
+
+func TestDelete_RequiresConfirmation(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API")
+	})
+
+	cmd := testutil.Command(newDeleteCmd(), testutil.NoInput(true))
+	cmd.SetArgs([]string{"up1"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error without confirmation")
+	}
+	if !strings.Contains(err.Error(), "--yes") {
+		t.Errorf("error should mention --yes: %v", err)
+	}
+}
+
+func TestDelete_WithYes(t *testing.T) {
+	var gotMethod, gotPath string
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		testutil.JSON(t, w, map[string]any{"success": true, "message": "The upsell was deleted successfully."})
+	})
+
+	cmd := testutil.Command(newDeleteCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"up1"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != http.MethodDelete || gotPath != "/upsells/up1" {
+		t.Errorf("got %s %s, want DELETE /upsells/up1", gotMethod, gotPath)
+	}
+}
+
+func TestDelete_APIError(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(404)
+		testutil.JSON(t, w, map[string]any{"message": "Not found"})
+	})
+
+	cmd := testutil.Command(newDeleteCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"up1"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error for 404")
+	}
+}
+
+func TestNewUpsellsCmd_RegistersSubcommands(t *testing.T) {
+	cmd := NewUpsellsCmd()
+	for _, args := range [][]string{{"list"}, {"view"}, {"create"}, {"update"}, {"delete"}} {
+		found, _, err := cmd.Find(args)
+		if err != nil {
+			t.Fatalf("Find(%v) failed: %v", args, err)
+		}
+		if found == nil || found.Name() != args[0] {
+			t.Fatalf("Find(%v) returned %v", args, found)
+		}
+	}
+}

--- a/internal/cmd/upsells/upsells_test.go
+++ b/internal/cmd/upsells/upsells_test.go
@@ -641,13 +641,31 @@ func TestUpdate_UniversalDropsSelectedProducts(t *testing.T) {
 
 func TestUpdate_UniversalAndSelectedProductConflict(t *testing.T) {
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
-		t.Error("should not reach API")
+		if r.Method == http.MethodPut {
+			t.Error("should not PUT on a contradictory update")
+		}
+		testutil.JSON(t, w, crossSellPayload())
 	})
 	cmd := newUpdateCmd()
 	cmd.SetArgs([]string{"up1", "--universal", "--selected-product", "x"})
 	err := cmd.Execute()
 	if err == nil || !strings.Contains(err.Error(), "--universal and --selected-product cannot be used together") {
 		t.Fatalf("expected conflict error, got: %v", err)
+	}
+}
+
+func TestUpdate_SelectedProductOnVersionUpsellRejected(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			t.Error("should not PUT on a contradictory update")
+		}
+		testutil.JSON(t, w, versionUpsellPayload())
+	})
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{"up1", "--selected-product", "x"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "pass --cross-sell") {
+		t.Fatalf("expected cross-sell requirement error, got: %v", err)
 	}
 }
 
@@ -736,8 +754,20 @@ func TestCreate_UniversalConflictsSelectedProduct(t *testing.T) {
 	cmd := newCreateCmd()
 	cmd.SetArgs([]string{"--name", "X", "--product", "p1", "--cross-sell", "--universal", "--selected-product", "x"})
 	err := cmd.Execute()
-	if err == nil || !strings.Contains(err.Error(), "cannot be combined with --universal") {
+	if err == nil || !strings.Contains(err.Error(), "cannot be used together") {
 		t.Fatalf("expected universal conflict error, got: %v", err)
+	}
+}
+
+func TestCreate_OfferVariantOnCrossSellRejected(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API")
+	})
+	cmd := newCreateCmd()
+	cmd.SetArgs([]string{"--name", "X", "--product", "p1", "--cross-sell", "--offer-variant", "a:b"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "offer-variant applies to version upsells") {
+		t.Fatalf("expected offer-variant rejection, got: %v", err)
 	}
 }
 

--- a/internal/cmd/upsells/view.go
+++ b/internal/cmd/upsells/view.go
@@ -1,0 +1,102 @@
+package upsells
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+func newViewCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "view <upsell_id>",
+		Short: "View an upsell or cross-sell",
+		Args:  cmdutil.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+
+			return cmdutil.RunRequest(opts, "Fetching upsell...", http.MethodGet, cmdutil.JoinPath("upsells", args[0]), url.Values{}, func(data json.RawMessage) error {
+				var resp upsellResponse
+				if err := json.Unmarshal(data, &resp); err != nil {
+					return fmt.Errorf("could not parse response: %w", err)
+				}
+				return renderUpsellDetail(opts, resp.Upsell)
+			})
+		},
+	}
+}
+
+func renderUpsellDetail(opts cmdutil.Options, u upsell) error {
+	if opts.PlainOutput {
+		return output.PrintPlain(opts.Out(), [][]string{{
+			u.ID,
+			u.Name,
+			upsellType(u),
+			u.Product.Name,
+			formatDiscount(u.Discount),
+			yesNo(u.Paused),
+		}})
+	}
+
+	style := opts.Style()
+	if err := output.Writeln(opts.Out(), style.Bold(u.Name)); err != nil {
+		return err
+	}
+	lines := [][2]string{
+		{"ID", u.ID},
+		{"Type", upsellType(u)},
+		{"Offered product", productLabel(u.Product)},
+	}
+	if u.Product.Variant != nil {
+		lines = append(lines, [2]string{"Offered version", u.Product.Variant.Name})
+	}
+	lines = append(lines,
+		[2]string{"Discount", formatDiscount(u.Discount)},
+		[2]string{"Universal", yesNo(u.Universal)},
+		[2]string{"Replaces selected products", yesNo(u.ReplaceSelectedProducts)},
+		[2]string{"Paused", yesNo(u.Paused)},
+	)
+	if u.Text != "" {
+		lines = append(lines, [2]string{"Text", u.Text})
+	}
+	if u.Description != "" {
+		lines = append(lines, [2]string{"Description", u.Description})
+	}
+	for _, line := range lines {
+		if err := output.Writef(opts.Out(), "%s: %s\n", line[0], line[1]); err != nil {
+			return err
+		}
+	}
+
+	if len(u.SelectedProducts) > 0 {
+		names := make([]string, len(u.SelectedProducts))
+		for i, p := range u.SelectedProducts {
+			names[i] = fmt.Sprintf("%s (%s)", p.Name, p.ID)
+		}
+		if err := output.Writef(opts.Out(), "Selected products: %s\n", strings.Join(names, ", ")); err != nil {
+			return err
+		}
+	}
+
+	if len(u.UpsellVariants) > 0 {
+		if err := output.Writeln(opts.Out(), "Version upgrades:"); err != nil {
+			return err
+		}
+		for _, v := range u.UpsellVariants {
+			if err := output.Writef(opts.Out(), "  %s -> %s\n", v.SelectedVariant.Name, v.OfferedVariant.Name); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func productLabel(p upsellProduct) string {
+	return fmt.Sprintf("%s (%s)", p.Name, p.ID)
+}

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -67,6 +67,7 @@ Most responses are wrapped in `{"success": true, ...}` with resource-specific ke
 - `subscribers list` → `.subscribers[]`, `subscribers view` → `.subscriber`
 - `licenses verify` → `.purchase`
 - `offer-codes list` → `.offer_codes[]`
+- `upsells list` → `.upsells[]`, `upsells view/create/update` → `.upsell`, `upsells delete` → `.message`
 - `variant-categories list` → `.variant_categories[]`
 - `variants list` → `.variants[]`
 - `files upload` / `files complete` → `.file_url`
@@ -485,6 +486,33 @@ gumroad offer-codes delete <code_id> --product <id> --yes --json --no-input
 ```
 
 **Create flags:** `--product` (required), `--name` (required), `--percent-off` OR `--amount`, `--minimum-amount` (minimum order total before the discount applies, e.g. `100.00`), `--max-purchase-count`, `--universal`.
+
+### upsells — Manage upsells and cross-sells
+
+An upsell offers a different version of the product being bought. A cross-sell offers a different product (optionally discounted) to buyers of selected products, or to buyers of every product when universal.
+
+```sh
+# List all upsells and cross-sells
+gumroad upsells list --json --no-input
+
+# Version upsell: offer a higher version of the same product
+gumroad upsells create --name "Pro upgrade" --product <id> --offer-variant <selected_variant_id>:<offered_variant_id> --json --no-input
+
+# Cross-sell to buyers of specific products, with a discount
+gumroad upsells create --name "Audiobook" --product <offered_id> --cross-sell --selected-product <id> --percent-off 50 --json --no-input
+
+# Universal cross-sell (offered to buyers of every product), flat discount
+gumroad upsells create --name "Add-on" --product <offered_id> --cross-sell --universal --amount 5 --json --no-input
+
+# View / update / delete
+gumroad upsells view <upsell_id> --json --no-input
+gumroad upsells update <upsell_id> --paused=false --json --no-input
+gumroad upsells delete <upsell_id> --yes --json --no-input
+```
+
+**Create flags:** `--name` (required), `--product` (required, the offered product), `--cross-sell`, `--text`, `--description`, `--variant` (offered version), `--universal`, `--replace-selected-products`, `--paused`, `--amount` OR `--percent-off`, `--selected-product` (repeatable), `--offer-variant <selected>:<offered>` (repeatable).
+
+**Update** fetches the upsell and changes only the flags you pass; pass `--remove-offer` to drop the discount. `--selected-product` / `--offer-variant` replace the current set.
 
 ### variant-categories — Manage variant categories
 


### PR DESCRIPTION
## What

Adds a `gumroad upsells` command group wrapping the new `/v2/upsells` API: `list`, `view`, `create`, `update`, `delete`. Previously `gumroad upsells` returned "unknown command".

- `create` / `update` send JSON request bodies so nested `upsell_variants` and the `offer_code` round-trip correctly (form-encoding sorts keys and turns the variants array into integer-keyed hashes).
- `update` fetches the upsell first and merges only the flags you pass, so a partial edit doesn't drop the associations the API replaces wholesale. `--remove-offer` clears the discount.
- Supports `--json` / `--jq`, `--plain`, `--quiet`, and `--dry-run` like the other commands. Man page and skill docs included.

## Why

Companion to the Rails API for upsells/cross-sells (`antiwork/gumroad#5551`). Sellers driving their store from the CLI can now automate upsells and cross-sells alongside products, offer codes, and variants.

Part of antiwork/gumroad#5551

---

AI disclosure: implemented with Claude Opus 4.8 via Claude Code.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad-cli/pr/168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784820732&installation_id=134400930&pr_number=168&repository=antiwork%2Fgumroad-cli&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad-cli%2Fpull%2F168&signature=53e54bbe0de75e4058906e96217c4d3ceb83a33f164a7da4dfd8dd3b19ab8aa4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New mutating seller APIs that change checkout upsell/cross-sell configuration; logic is complex but heavily validated and tested, with no auth or payment-path changes.
> 
> **Overview**
> Adds **`gumroad upsells`** (`list`, `view`, `create`, `update`, `delete`) wired to `/upsells`, registered on the root command so the group is no longer unknown.
> 
> **Create** and **update** post JSON bodies (via `PostJSON`/`PutJSON`) so nested `upsell_variants` and `offer_code` serialize correctly. **Update** GETs the current upsell, merges only changed flags into a full PUT payload, and handles type switches (version upsell vs cross-sell), audience rules, and `--remove-offer`. Shared validation covers cross-sell vs upsell flags, discounts, and audience (`--universal` vs `--selected-product`).
> 
> Output modes match other commands (`--json`, `--plain`, `--quiet`, `--dry-run`). **SKILL.md** documents agent usage; a large **upsells_test.go** covers endpoints, payloads, merge behavior, and flag errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e12c2138ec2a85708263ce2a836d3266fb499a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->