### PR TITLE
Add `gumroad user update` command to edit name and bio

### DIFF
--- a/internal/cmd/user/update.go
+++ b/internal/cmd/user/update.go
@@ -1,0 +1,49 @@
+package user
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+func newUpdateCmd() *cobra.Command {
+	var name, bio string
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update your seller name and bio",
+		Args:  cmdutil.ExactArgs(0),
+		Long: "Update the seller name and bio shown on your profile.\n\n" +
+			"Pass --name and/or --bio. Pass an empty value to clear a field.",
+		Example: `  gumroad user update --name "Jane Doe"
+  gumroad user update --bio "I make great things."
+  gumroad user update --name "Jane Doe" --bio "I make great things."`,
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			if err := cmdutil.RequireAnyFlagChanged(c, "name", "bio"); err != nil {
+				return err
+			}
+
+			params := url.Values{}
+			if c.Flags().Changed("name") {
+				params.Set("name", name)
+			}
+			if c.Flags().Changed("bio") {
+				params.Set("bio", bio)
+			}
+
+			return cmdutil.RunRequestDecoded[userResponse](opts,
+				"Updating user...", http.MethodPut, userPath, params,
+				func(resp userResponse) error {
+					return renderUser(opts, resp.User, "Updated user.")
+				})
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Seller name; pass an empty value to clear it")
+	cmd.Flags().StringVar(&bio, "bio", "", "Seller bio; pass an empty value to clear it")
+
+	return cmd
+}

--- a/internal/cmd/user/update_test.go
+++ b/internal/cmd/user/update_test.go
@@ -1,0 +1,197 @@
+package user
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestUpdate_SendsNameAndBio(t *testing.T) {
+	var gotMethod, gotPath, gotName, gotBio string
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm failed: %v", err)
+		}
+		gotName = r.PostForm.Get("name")
+		gotBio = r.PostForm.Get("bio")
+		testutil.JSON(t, w, map[string]any{
+			"user": map[string]any{
+				"name":        "Jane Doe",
+				"email":       "jane@example.com",
+				"bio":         "I make great things.",
+				"profile_url": "https://gumroad.com/jane",
+			},
+		})
+	})
+
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{"--name", "Jane Doe", "--bio", "I make great things."})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != http.MethodPut || gotPath != userPath {
+		t.Fatalf("got %s %s, want PUT %s", gotMethod, gotPath, userPath)
+	}
+	if gotName != "Jane Doe" {
+		t.Fatalf("name = %q, want Jane Doe", gotName)
+	}
+	if gotBio != "I make great things." {
+		t.Fatalf("bio = %q, want I make great things.", gotBio)
+	}
+	if !strings.Contains(out, "Updated user.") || !strings.Contains(out, "Jane Doe") {
+		t.Fatalf("output missing updated user: %q", out)
+	}
+}
+
+func TestUpdate_OmitsBioWhenFlagNotProvided(t *testing.T) {
+	var gotName string
+	var hasBio bool
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm failed: %v", err)
+		}
+		gotName = r.PostForm.Get("name")
+		_, hasBio = r.PostForm["bio"]
+		testutil.JSON(t, w, map[string]any{
+			"user": map[string]any{"name": "Solo Name", "email": "solo@example.com"},
+		})
+	})
+
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{"--name", "Solo Name"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotName != "Solo Name" {
+		t.Fatalf("name = %q, want Solo Name", gotName)
+	}
+	if hasBio {
+		t.Fatal("bio must be omitted when --bio is not provided")
+	}
+}
+
+func TestUpdate_EmptyBioClearsField(t *testing.T) {
+	var gotValues []string
+	var hasBio bool
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm failed: %v", err)
+		}
+		gotValues, hasBio = r.PostForm["bio"]
+		testutil.JSON(t, w, map[string]any{
+			"user": map[string]any{"name": "Cleared", "email": "cleared@example.com"},
+		})
+	})
+
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{"--bio", ""})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !hasBio {
+		t.Fatal("bio must be sent when --bio is provided")
+	}
+	if len(gotValues) != 1 || gotValues[0] != "" {
+		t.Fatalf("bio values = %#v, want one empty string", gotValues)
+	}
+}
+
+func TestUpdate_RequiresAtLeastOneFlag(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("update without flags must not reach API")
+	})
+
+	cmd := newUpdateCmd()
+	err := cmd.Execute()
+
+	if err == nil || !strings.Contains(err.Error(), "at least one field to update must be provided") {
+		t.Fatalf("expected missing flag error, got: %v", err)
+	}
+}
+
+func TestUpdate_JSON(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"user": map[string]any{"name": "JSON Name", "email": "json@example.com", "bio": "JSON bio"},
+		})
+	})
+
+	cmd := testutil.Command(newUpdateCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--name", "JSON Name"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp userResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if resp.User.Name != "JSON Name" || resp.User.Bio != "JSON bio" {
+		t.Fatalf("unexpected JSON response: %+v", resp.User)
+	}
+}
+
+func TestUpdate_QuietSuppressesHumanOutput(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"user": map[string]any{"name": "Quiet", "email": "quiet@example.com"},
+		})
+	})
+
+	cmd := testutil.Command(newUpdateCmd())
+	cmd.SetArgs([]string{"--name", "Quiet"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if out != "" {
+		t.Fatalf("quiet update should not print human output, got %q", out)
+	}
+}
+
+func TestUpdate_DryRunDoesNotReachAPI(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("dry-run must not reach API")
+	})
+
+	cmd := testutil.Command(newUpdateCmd(), testutil.DryRun(true), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--name", "Dry Run", "--bio", "Preview bio"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	for _, want := range []string{
+		"Dry run: PUT /user",
+		"name: Dry Run",
+		"bio: Preview bio",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("dry-run output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestUpdate_ValidationErrorSurfaces(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.RawJSON(t, w, `{"success":false,"message":"Name cannot contain colons (:) as it causes email delivery problems."}`)
+	})
+
+	cmd := newUpdateCmd()
+	cmd.SetArgs([]string{"--name", "Bad: Name"})
+	err := cmd.Execute()
+
+	if err == nil {
+		t.Fatal("expected API validation error")
+	}
+	if !strings.Contains(err.Error(), "colons") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNewUserCmd_RegistersUpdate(t *testing.T) {
+	cmd := NewUserCmd()
+
+	found, _, err := cmd.Find([]string{"update"})
+	if err != nil {
+		t.Fatalf("Find(update) failed: %v", err)
+	}
+	if found == nil || found.Name() != "update" {
+		t.Fatalf("update subcommand not registered, got %v", found)
+	}
+}

--- a/internal/cmd/user/user.go
+++ b/internal/cmd/user/user.go
@@ -1,12 +1,15 @@
 package user
 
 import (
+	"net/http"
 	"net/url"
 
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
+
+const userPath = "/user"
 
 type profile struct {
 	Name          string `json:"name"`
@@ -21,42 +24,62 @@ type userResponse struct {
 }
 
 func NewUserCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "user",
-		Short: "Show account info",
+		Short: "Show and update account info",
 		Args:  cmdutil.ExactArgs(0),
 		Example: `  gumroad user
   gumroad user --json
-  gumroad user --json --jq '.user.email'`,
+  gumroad user --json --jq '.user.email'
+  gumroad user update --name "Jane Doe" --bio "I make great things."`,
 		RunE: func(c *cobra.Command, args []string) error {
-			opts := cmdutil.OptionsFrom(c)
-			return cmdutil.RunRequestDecoded[userResponse](opts, "Fetching user info...", "GET", "/user", url.Values{}, func(resp userResponse) error {
-				u := resp.User
-				style := opts.Style()
-
-				if opts.PlainOutput {
-					return output.PrintPlain(opts.Out(), [][]string{
-						{u.Name, u.Email, u.ProfileURL},
-					})
-				}
-
-				if err := output.Writeln(opts.Out(), style.Bold(u.Name)); err != nil {
-					return err
-				}
-				if err := output.Writeln(opts.Out(), u.Email); err != nil {
-					return err
-				}
-				if u.Bio != "" {
-					if err := output.Writeln(opts.Out(), style.Dim(u.Bio)); err != nil {
-						return err
-					}
-				}
-				if u.ProfileURL != "" {
-					return output.Writeln(opts.Out(), u.ProfileURL)
-				}
-
-				return nil
-			})
+			return runShow(cmdutil.OptionsFrom(c))
 		},
 	}
+
+	cmd.AddCommand(newUpdateCmd())
+
+	return cmd
+}
+
+func runShow(opts cmdutil.Options) error {
+	return cmdutil.RunRequestDecoded[userResponse](opts, "Fetching user info...", http.MethodGet, userPath, url.Values{}, func(resp userResponse) error {
+		return renderUser(opts, resp.User, "")
+	})
+}
+
+func renderUser(opts cmdutil.Options, u profile, header string) error {
+	style := opts.Style()
+
+	if opts.PlainOutput {
+		return output.PrintPlain(opts.Out(), [][]string{
+			{u.Name, u.Email, u.ProfileURL},
+		})
+	}
+
+	if header != "" {
+		if opts.Quiet {
+			return nil
+		}
+		if err := output.Writeln(opts.Out(), style.Green(header)); err != nil {
+			return err
+		}
+	}
+
+	if err := output.Writeln(opts.Out(), style.Bold(u.Name)); err != nil {
+		return err
+	}
+	if err := output.Writeln(opts.Out(), u.Email); err != nil {
+		return err
+	}
+	if u.Bio != "" {
+		if err := output.Writeln(opts.Out(), style.Dim(u.Bio)); err != nil {
+			return err
+		}
+	}
+	if u.ProfileURL != "" {
+		return output.Writeln(opts.Out(), u.ProfileURL)
+	}
+
+	return nil
 }

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -50,7 +50,7 @@ Always follow these rules:
 
 Most responses are wrapped in `{"success": true, ...}` with resource-specific keys:
 
-- `user` → `.user`
+- `user` → `.user`, `user update` → `.user`
 - `refund-policy view/set` → `.refund_policy`
 - `products list` → `.products[]`
 - `products view` → `.product`
@@ -148,6 +148,10 @@ gumroad auth logout --yes --no-input
 ```sh
 gumroad user --json --no-input
 gumroad user --json --jq '.user.email' --no-input
+
+# Update the seller name and/or bio. Pass an empty value to clear a field.
+gumroad user update --name "Jane Doe" --bio "I make great things." --json --no-input
+gumroad user update --bio "" --json --no-input
 ```
 
 ### refund-policy — Store-wide refund policy


### PR DESCRIPTION
## What

Adds `gumroad user update --name "..." --bio "..."`. The `user` command was read-only; it now keeps its show behavior and gains an `update` subcommand that sends only the flags you pass (an empty value clears a field) to `PUT /v2/user`.

## Why

Companion to the profile-edit API (`antiwork/gumroad#5552`). Sellers can edit their public name and bio from the CLI instead of opening the dashboard.

Part of antiwork/gumroad#5552

---

AI disclosure: implemented with Claude Opus 4.8 via Claude Code

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad-cli/pr/169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784820736&installation_id=134400930&pr_number=169&repository=antiwork%2Fgumroad-cli&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad-cli%2Fpull%2F169&signature=5f6f00d27765a3ef0869459c2a69ce5c2e4aee40e861dc9a4c5ab16482f22107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CLI feature with established cmdutil patterns and broad tests; no auth or payment logic changes.
> 
> **Overview**
> Adds **`gumroad user update`** so sellers can change public **name** and **bio** from the CLI (companion to the profile PUT API). The root **`gumroad user`** command still shows account info; **`update`** is registered as a subcommand with updated help/examples.
> 
> **`update`** requires at least one of **`--name`** or **`--bio`**, sends only flags that were explicitly passed via **`PUT /user`**, and treats an empty flag value as clearing that field. Success reuses a new shared **`renderUser`** helper (also used by show) and prints an **"Updated user."** header when not quiet.
> 
> **`user.go`** is refactored: **`userPath`**, **`runShow`**, and **`renderUser`** centralize GET/PUT display behavior. **`skills/gumroad/SKILL.md`** documents the command and **`.user`** JSON shape. **`update_test.go`** covers request shape, partial updates, clearing, validation, JSON/quiet/dry-run, and subcommand registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 528b86b72c8c460afdb1a65d5707435fa61b7919. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->