### PR TITLE
Add `gumroad user page` commands for the profile landing page

### DIFF
--- a/internal/cmd/user/page.go
+++ b/internal/cmd/user/page.go
@@ -1,0 +1,39 @@
+package user
+
+import (
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/pageutil"
+	"github.com/spf13/cobra"
+)
+
+func newPageCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "page",
+		Short: "Manage your profile landing page",
+		Example: `  gumroad user page preview ./landing.html
+  gumroad user page publish ./landing.html
+  gumroad user page publish - < landing.html
+  gumroad user page clear --yes
+  gumroad user page url`,
+	}
+
+	cmd.AddCommand(newPagePreviewCmd())
+	cmd.AddCommand(newPagePublishCmd())
+	cmd.AddCommand(newPageClearCmd())
+	cmd.AddCommand(newPageURLCmd())
+	return cmd
+}
+
+func profilePageHTMLArgs(cmd *cobra.Command, args []string) error {
+	if len(args) > 1 {
+		return cmdutil.UsageErrorf(cmd, "unexpected argument: %s", args[1])
+	}
+	return nil
+}
+
+func profilePageHTMLPath(args []string) string {
+	if len(args) > 0 {
+		return args[0]
+	}
+	return pageutil.DefaultHTMLPath
+}

--- a/internal/cmd/user/page_clear.go
+++ b/internal/cmd/user/page_clear.go
@@ -1,0 +1,47 @@
+package user
+
+import (
+	"net/http"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/pageutil"
+	"github.com/spf13/cobra"
+)
+
+func newPageClearCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "clear",
+		Short: "Clear your profile landing page",
+		Args:  cmdutil.ExactArgs(0),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			ok, err := cmdutil.ConfirmAction(opts, "Clear your profile landing page?")
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return cmdutil.PrintCancelledAction(opts, "clear profile landing page", "")
+			}
+
+			target := pageutil.ProfileTarget()
+			err = cmdutil.RunRequestDecoded[pageutil.ProfileUpdateResponse](
+				opts,
+				"Clearing page...",
+				http.MethodPut,
+				target.Path,
+				pageutil.ClearParams(),
+				func(resp pageutil.ProfileUpdateResponse) error {
+					return pageutil.RenderSanitizationResult(opts, pageutil.RenderResult{
+						Action:       "Cleared page",
+						BeforeHTML:   pageutil.ProfilePreviousHTML(resp),
+						AfterHTML:    resp.CustomHTML,
+						LandingURL:   resp.ProfileURL,
+						Report:       resp.SanitizationReport,
+						ClearMessage: "Page cleared.",
+					})
+				},
+			)
+			return pageutil.TranslateRateLimitError(err, pageutil.ProfileClearRateLimitMessage)
+		},
+	}
+}

--- a/internal/cmd/user/page_clear_test.go
+++ b/internal/cmd/user/page_clear_test.go
@@ -1,0 +1,77 @@
+package user
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestUserPageClearConfirmsAndSendsEmptyCustomHTML(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotForm url.Values
+	var hasCustomHTML bool
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		_ = r.ParseForm()
+		gotForm = r.PostForm
+		_, hasCustomHTML = r.PostForm["custom_html"]
+		previous := "<h1>Old</h1>"
+		testutil.JSON(t, w, map[string]any{
+			"custom_html":          "",
+			"previous_custom_html": previous,
+			"profile_url":          "https://jane.gumroad.com",
+			"sanitization_report":  emptyReport(),
+		})
+	})
+
+	cmd := testutil.Command(newPageClearCmd(), testutil.Yes(true), testutil.Quiet(false), testutil.NoColor(true))
+	cmd.SetArgs([]string{})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != http.MethodPut {
+		t.Errorf("got method %q, want PUT", gotMethod)
+	}
+	if gotPath != "/user/custom_html" {
+		t.Errorf("got path %q, want /user/custom_html", gotPath)
+	}
+	if !hasCustomHTML {
+		t.Fatalf("custom_html should be sent to clear")
+	}
+	if got := gotForm.Get("custom_html"); got != "" {
+		t.Fatalf("got custom_html=%q, want empty", got)
+	}
+	if !strings.Contains(out, "Page cleared.") {
+		t.Fatalf("output missing clear message: %q", out)
+	}
+}
+
+func TestUserPageClearNoInputRequiresYesBeforeAPI(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("clear without confirmation should not call API")
+	})
+
+	cmd := testutil.Command(newPageClearCmd(), testutil.NoInput(true), testutil.Quiet(false), testutil.NoColor(true))
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "Use --yes to skip confirmation") {
+		t.Fatalf("expected confirmation error, got %v", err)
+	}
+}
+
+func TestUserPageClearRateLimitMessage(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		testutil.RawJSON(t, w, `{"success":false,"message":"Rate limited"}`)
+	})
+
+	cmd := testutil.Command(newPageClearCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "Wait a moment before trying again") {
+		t.Fatalf("expected clear-specific rate limit message, got %v", err)
+	}
+}

--- a/internal/cmd/user/page_preview.go
+++ b/internal/cmd/user/page_preview.go
@@ -1,0 +1,43 @@
+package user
+
+import (
+	"net/http"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/pageutil"
+	"github.com/spf13/cobra"
+)
+
+func newPagePreviewCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "preview [path]",
+		Short: "Preview server sanitization for your profile landing page",
+		Args:  profilePageHTMLArgs,
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			input, err := pageutil.ReadHTML(opts.In(), profilePageHTMLPath(args))
+			if err != nil {
+				return cmdutil.UsageErrorf(c, "%s", err)
+			}
+
+			target := pageutil.ProfileTarget()
+			err = cmdutil.RunRequestDecoded[pageutil.PreviewResponse](
+				opts,
+				"Previewing page...",
+				http.MethodPost,
+				target.PreviewPath,
+				pageutil.HTMLParams(input.HTML),
+				func(resp pageutil.PreviewResponse) error {
+					return pageutil.RenderSanitizationResult(opts, pageutil.RenderResult{
+						Action:     "Previewed page",
+						Source:     input.Source,
+						BeforeHTML: input.HTML,
+						AfterHTML:  resp.CustomHTML,
+						Report:     resp.SanitizationReport,
+					})
+				},
+			)
+			return pageutil.TranslateRateLimitError(err, pageutil.ProfilePreviewRateLimitMessage)
+		},
+	}
+}

--- a/internal/cmd/user/page_preview_test.go
+++ b/internal/cmd/user/page_preview_test.go
@@ -1,0 +1,149 @@
+package user
+
+import (
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestUserPagePreviewPostsHTMLToPreviewEndpoint(t *testing.T) {
+	htmlPath := writeProfilePageHTML(t, "<script src=\"https://evil.test/x.js\"></script><h1>Hi</h1>")
+
+	var gotMethod, gotPath string
+	var gotForm url.Values
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		_ = r.ParseForm()
+		gotForm = r.PostForm
+		testutil.JSON(t, w, map[string]any{
+			"custom_html": "<h1>Hi</h1>",
+			"sanitization_report": map[string]any{
+				"removed_tags": []map[string]any{{
+					"tag":    "script",
+					"attrs":  map[string]string{"src": "https://evil.test/x.js"},
+					"reason": "script src host not allowed",
+				}},
+				"removed_attributes": []any{},
+				"total_removed":      1,
+				"truncated":          false,
+			},
+		})
+	})
+
+	cmd := testutil.Command(newPagePreviewCmd(), testutil.Quiet(false), testutil.NoColor(true))
+	cmd.SetArgs([]string{htmlPath})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("got method %q, want POST", gotMethod)
+	}
+	if gotPath != "/user/preview_custom_html" {
+		t.Errorf("got path %q, want /user/preview_custom_html", gotPath)
+	}
+	if got := gotForm.Get("custom_html"); got != "<script src=\"https://evil.test/x.js\"></script><h1>Hi</h1>" {
+		t.Errorf("got custom_html=%q", got)
+	}
+	if !strings.Contains(out, "Previewed page") || !strings.Contains(out, "Sanitization removed 1 item") {
+		t.Fatalf("output missing preview summary: %q", out)
+	}
+	if !strings.Contains(out, "script src host not allowed") {
+		t.Fatalf("output missing report reason: %q", out)
+	}
+}
+
+func TestUserPagePreviewDefaultsToLandingHTML(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "landing.html"), []byte("<h1>Hi</h1>"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	t.Chdir(dir)
+
+	var gotForm url.Values
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotForm = r.PostForm
+		testutil.JSON(t, w, map[string]any{
+			"custom_html":         "<h1>Hi</h1>",
+			"sanitization_report": emptyReport(),
+		})
+	})
+
+	cmd := testutil.Command(newPagePreviewCmd(), testutil.Quiet(false), testutil.NoColor(true))
+	cmd.SetArgs([]string{})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if got := gotForm.Get("custom_html"); got != "<h1>Hi</h1>" {
+		t.Errorf("got custom_html=%q from default ./landing.html", got)
+	}
+}
+
+func TestUserPagePreviewDryRunDoesNotCallAPI(t *testing.T) {
+	htmlPath := writeProfilePageHTML(t, "<h1>Hi</h1>")
+
+	var calls atomic.Int32
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		t.Errorf("preview --dry-run should not call API")
+	})
+
+	cmd := testutil.Command(newPagePreviewCmd(), testutil.DryRun(true), testutil.Quiet(false), testutil.NoColor(true))
+	cmd.SetArgs([]string{htmlPath})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if calls.Load() != 0 {
+		t.Fatalf("API was called %d times", calls.Load())
+	}
+	if !strings.Contains(out, "Dry run: POST /user/preview_custom_html") {
+		t.Fatalf("dry-run output missing preview request: %q", out)
+	}
+}
+
+func TestUserPagePreviewRateLimitMessage(t *testing.T) {
+	htmlPath := writeProfilePageHTML(t, "<h1>Hi</h1>")
+
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		testutil.RawJSON(t, w, `{"success":false,"message":"Rate limited"}`)
+	})
+
+	cmd := testutil.Command(newPagePreviewCmd())
+	cmd.SetArgs([]string{htmlPath})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "60 previews/min") {
+		t.Fatalf("expected preview-specific rate limit message, got %v", err)
+	}
+}
+
+func TestUserPagePreviewRejectsExtraArg(t *testing.T) {
+	cmd := testutil.Command(newPagePreviewCmd())
+	cmd.SetArgs([]string{"./landing.html", "unexpected"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "unexpected argument") {
+		t.Fatalf("expected usage error for extra arg, got %v", err)
+	}
+}
+
+func writeProfilePageHTML(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "landing.html")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+func emptyReport() map[string]any {
+	return map[string]any{
+		"removed_tags":       []any{},
+		"removed_attributes": []any{},
+		"total_removed":      0,
+		"truncated":          false,
+	}
+}

--- a/internal/cmd/user/page_publish.go
+++ b/internal/cmd/user/page_publish.go
@@ -1,0 +1,44 @@
+package user
+
+import (
+	"net/http"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/pageutil"
+	"github.com/spf13/cobra"
+)
+
+func newPagePublishCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "publish [path]",
+		Short: "Publish custom HTML for your profile landing page",
+		Args:  profilePageHTMLArgs,
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			input, err := pageutil.ReadHTML(opts.In(), profilePageHTMLPath(args))
+			if err != nil {
+				return cmdutil.UsageErrorf(c, "%s", err)
+			}
+
+			target := pageutil.ProfileTarget()
+			err = cmdutil.RunRequestDecoded[pageutil.ProfileUpdateResponse](
+				opts,
+				"Publishing page...",
+				http.MethodPut,
+				target.Path,
+				pageutil.HTMLParams(input.HTML),
+				func(resp pageutil.ProfileUpdateResponse) error {
+					return pageutil.RenderSanitizationResult(opts, pageutil.RenderResult{
+						Action:     "Published page",
+						Source:     input.Source,
+						BeforeHTML: input.HTML,
+						AfterHTML:  resp.CustomHTML,
+						LandingURL: resp.ProfileURL,
+						Report:     resp.SanitizationReport,
+					})
+				},
+			)
+			return pageutil.TranslateRateLimitError(err, pageutil.ProfilePublishRateLimitMessage)
+		},
+	}
+}

--- a/internal/cmd/user/page_publish_test.go
+++ b/internal/cmd/user/page_publish_test.go
@@ -1,0 +1,137 @@
+package user
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestUserPagePublishPutsHTMLAndPrintsProfileURL(t *testing.T) {
+	htmlPath := writeProfilePageHTML(t, "<h1>Welcome</h1>")
+
+	var gotMethod, gotPath string
+	var gotForm url.Values
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		_ = r.ParseForm()
+		gotForm = r.PostForm
+		testutil.JSON(t, w, map[string]any{
+			"custom_html":          "<h1>Welcome</h1>",
+			"previous_custom_html": nil,
+			"profile_url":          "https://jane.gumroad.com",
+			"sanitization_report":  emptyReport(),
+		})
+	})
+
+	cmd := testutil.Command(newPagePublishCmd(), testutil.Quiet(false), testutil.NoColor(true))
+	cmd.SetArgs([]string{htmlPath})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != http.MethodPut {
+		t.Errorf("got method %q, want PUT", gotMethod)
+	}
+	if gotPath != "/user/custom_html" {
+		t.Errorf("got path %q, want /user/custom_html", gotPath)
+	}
+	if got := gotForm.Get("custom_html"); got != "<h1>Welcome</h1>" {
+		t.Errorf("got custom_html=%q", got)
+	}
+	if !strings.Contains(out, "Published page") || !strings.Contains(out, "Live at https://jane.gumroad.com") {
+		t.Fatalf("output missing publish summary: %q", out)
+	}
+}
+
+func TestUserPagePublishReadsStdin(t *testing.T) {
+	var gotForm url.Values
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotForm = r.PostForm
+		testutil.JSON(t, w, map[string]any{
+			"custom_html":          "<h1>From stdin</h1>",
+			"previous_custom_html": nil,
+			"profile_url":          "https://jane.gumroad.com",
+			"sanitization_report":  emptyReport(),
+		})
+	})
+
+	cmd := testutil.Command(newPagePublishCmd(),
+		testutil.Quiet(false), testutil.NoColor(true),
+		testutil.Stdin(strings.NewReader("<h1>From stdin</h1>")))
+	cmd.SetArgs([]string{"-"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if got := gotForm.Get("custom_html"); got != "<h1>From stdin</h1>" {
+		t.Errorf("got custom_html=%q from stdin", got)
+	}
+}
+
+func TestUserPagePublishJSONPrintsRawResponse(t *testing.T) {
+	htmlPath := writeProfilePageHTML(t, "<h1>Welcome</h1>")
+
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"custom_html":          "<h1>Welcome</h1>",
+			"previous_custom_html": nil,
+			"profile_url":          "https://jane.gumroad.com",
+			"sanitization_report":  emptyReport(),
+		})
+	})
+
+	cmd := testutil.Command(newPagePublishCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{htmlPath})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+	if resp["profile_url"] != "https://jane.gumroad.com" {
+		t.Fatalf("JSON output missing profile_url: %s", out)
+	}
+}
+
+func TestUserPagePublishDryRunDoesNotCallAPI(t *testing.T) {
+	htmlPath := writeProfilePageHTML(t, "<h1>Welcome</h1>")
+
+	var calls atomic.Int32
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		t.Errorf("publish --dry-run should not call API")
+	})
+
+	cmd := testutil.Command(newPagePublishCmd(), testutil.DryRun(true), testutil.Quiet(false), testutil.NoColor(true))
+	cmd.SetArgs([]string{htmlPath})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if calls.Load() != 0 {
+		t.Fatalf("API was called %d times", calls.Load())
+	}
+	if !strings.Contains(out, "Dry run: PUT /user/custom_html") {
+		t.Fatalf("dry-run output missing publish request: %q", out)
+	}
+}
+
+func TestUserPagePublishRateLimitMessage(t *testing.T) {
+	htmlPath := writeProfilePageHTML(t, "<h1>Welcome</h1>")
+
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		testutil.RawJSON(t, w, `{"success":false,"message":"Rate limited"}`)
+	})
+
+	cmd := testutil.Command(newPagePublishCmd())
+	cmd.SetArgs([]string{htmlPath})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "30 PUTs/min") {
+		t.Fatalf("expected publish-specific rate limit message, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "user page preview") {
+		t.Fatalf("publish rate limit should point at user page preview, got %v", err)
+	}
+}

--- a/internal/cmd/user/page_url.go
+++ b/internal/cmd/user/page_url.go
@@ -1,0 +1,44 @@
+package user
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/pageutil"
+	"github.com/spf13/cobra"
+)
+
+func newPageURLCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "url",
+		Short: "Print your profile landing page URLs",
+		Args:  cmdutil.ExactArgs(0),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			target := pageutil.ProfileTarget()
+			return cmdutil.RunRequestDecoded[pageutil.ProfileShowResponse](
+				opts,
+				"Fetching page URL...",
+				http.MethodGet,
+				target.Path,
+				url.Values{},
+				func(resp pageutil.ProfileShowResponse) error {
+					if resp.ProfileURL == "" {
+						return fmt.Errorf("user response did not include profile_url")
+					}
+					embedURL := pageutil.ProfileEmbedURL(resp.ProfileURL)
+					if opts.PlainOutput {
+						return output.PrintPlain(opts.Out(), [][]string{{resp.ProfileURL, embedURL}})
+					}
+					if err := output.Writeln(opts.Out(), resp.ProfileURL); err != nil {
+						return err
+					}
+					return output.Writeln(opts.Out(), embedURL)
+				},
+			)
+		},
+	}
+}

--- a/internal/cmd/user/page_url_test.go
+++ b/internal/cmd/user/page_url_test.go
@@ -1,0 +1,83 @@
+package user
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestUserPageURLPrintsProfileAndEmbedURLs(t *testing.T) {
+	var gotMethod, gotPath string
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		testutil.JSON(t, w, map[string]any{
+			"custom_html":      "<h1>Hi</h1>",
+			"has_landing_page": true,
+			"profile_url":      "https://jane.gumroad.com",
+		})
+	})
+
+	cmd := testutil.Command(newPageURLCmd())
+	cmd.SetArgs([]string{})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != http.MethodGet {
+		t.Errorf("got method %q, want GET", gotMethod)
+	}
+	if gotPath != "/user/custom_html" {
+		t.Errorf("got path %q, want /user/custom_html", gotPath)
+	}
+	if !strings.Contains(out, "https://jane.gumroad.com") {
+		t.Fatalf("output missing profile URL: %q", out)
+	}
+	if !strings.Contains(out, "https://jane.gumroad.com/landing/embed") {
+		t.Fatalf("output missing embed URL: %q", out)
+	}
+}
+
+func TestUserPageURLPlainPrintsBothColumns(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"has_landing_page": true,
+			"profile_url":      "https://jane.gumroad.com",
+		})
+	})
+
+	cmd := testutil.Command(newPageURLCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "https://jane.gumroad.com\thttps://jane.gumroad.com/landing/embed") {
+		t.Fatalf("plain output should be tab-separated URLs: %q", out)
+	}
+}
+
+func TestUserPageURLErrorsWhenProfileURLMissing(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"has_landing_page": false,
+			"profile_url":      "",
+		})
+	})
+
+	cmd := testutil.Command(newPageURLCmd())
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "did not include profile_url") {
+		t.Fatalf("expected missing profile_url error, got %v", err)
+	}
+}
+
+func TestUserCommandIncludesPageNamespace(t *testing.T) {
+	cmd := NewUserCmd()
+	found, _, err := cmd.Find([]string{"page", "publish"})
+	if err != nil {
+		t.Fatalf("Find returned error: %v", err)
+	}
+	if found == nil || found.Name() != "publish" {
+		t.Fatalf("expected user page publish command, got %#v", found)
+	}
+}

--- a/internal/cmd/user/user.go
+++ b/internal/cmd/user/user.go
@@ -31,13 +31,15 @@ func NewUserCmd() *cobra.Command {
 		Example: `  gumroad user
   gumroad user --json
   gumroad user --json --jq '.user.email'
-  gumroad user update --name "Jane Doe" --bio "I make great things."`,
+  gumroad user update --name "Jane Doe" --bio "I make great things."
+  gumroad user page publish ./landing.html`,
 		RunE: func(c *cobra.Command, args []string) error {
 			return runShow(cmdutil.OptionsFrom(c))
 		},
 	}
 
 	cmd.AddCommand(newUpdateCmd())
+	cmd.AddCommand(newPageCmd())
 
 	return cmd
 }

--- a/internal/pageutil/api.go
+++ b/internal/pageutil/api.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/antiwork/gumroad-cli/internal/api"
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
@@ -13,6 +14,10 @@ const (
 	PublishRateLimitMessage = "Hit Gumroad's rate limit (30 PUTs/min). Use `gumroad products page preview` to iterate without burning your publish budget."
 	PreviewRateLimitMessage = "Hit Gumroad's rate limit (60 previews/min). Wait a moment before previewing again."
 	ClearRateLimitMessage   = "Hit Gumroad's rate limit (30 PUTs/min). Wait a moment before trying again."
+
+	ProfilePublishRateLimitMessage = "Hit Gumroad's rate limit (30 PUTs/min). Use `gumroad user page preview` to iterate without burning your publish budget."
+	ProfilePreviewRateLimitMessage = "Hit Gumroad's rate limit (60 previews/min). Wait a moment before previewing again."
+	ProfileClearRateLimitMessage   = "Hit Gumroad's rate limit (30 PUTs/min). Wait a moment before trying again."
 )
 
 type Target struct {
@@ -75,6 +80,46 @@ func ShareURL(product PageProduct) string {
 		return product.LandingURL
 	}
 	return product.PermalinkURL
+}
+
+// ProfileTarget points at the seller's own profile landing page. Unlike a
+// product there is no id — the API derives the seller from the access token.
+func ProfileTarget() Target {
+	return Target{
+		Path:        cmdutil.JoinPath("user", "custom_html"),
+		PreviewPath: cmdutil.JoinPath("user", "preview_custom_html"),
+	}
+}
+
+type ProfileUpdateResponse struct {
+	Success            bool               `json:"success"`
+	CustomHTML         string             `json:"custom_html"`
+	PreviousCustomHTML *string            `json:"previous_custom_html"`
+	ProfileURL         string             `json:"profile_url"`
+	SanitizationReport SanitizationReport `json:"sanitization_report"`
+}
+
+type ProfileShowResponse struct {
+	Success        bool   `json:"success"`
+	CustomHTML     string `json:"custom_html"`
+	HasLandingPage bool   `json:"has_landing_page"`
+	ProfileURL     string `json:"profile_url"`
+}
+
+func ProfilePreviousHTML(resp ProfileUpdateResponse) string {
+	if resp.PreviousCustomHTML == nil {
+		return ""
+	}
+	return *resp.PreviousCustomHTML
+}
+
+// ProfileEmbedURL is where the sandboxed custom HTML renders inside the public
+// profile — the profile URL with the landing/embed suffix the backend serves.
+func ProfileEmbedURL(profileURL string) string {
+	if profileURL == "" {
+		return ""
+	}
+	return strings.TrimSuffix(profileURL, "/") + "/landing/embed"
 }
 
 func HTMLParams(html string) url.Values {

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -11,6 +11,7 @@ description: >
   "refund a sale", "create a product", "upload a file", "attach a file to a product",
   "add a cover image", "set a product thumbnail", "get product content", "set product content", "upload product media",
   "publish a product landing page", "publish custom HTML", "clear custom HTML",
+  "customize my profile page", "publish a profile landing page", "set profile custom HTML",
   "attach a file to a variant", "finish a failed upload", "abort an upload", "manage webhooks",
   "draft an email", "preview a broadcast", "send an audience email", "list drafts",
   "set refund policy", "check my refund policy", "check my earnings", "see my revenue", "who subscribed", "manage my store",
@@ -40,6 +41,7 @@ Always follow these rules:
 - Products are created as drafts — use `gumroad products publish <id>` to make them live.
 - Product cover and thumbnail uploads support JPEG, PNG, and GIF. WebP is not supported by the API and the CLI rejects it before upload.
 - Product custom HTML landing pages use `gumroad products page preview <id> ./landing.html` to run the backend sanitizer without writing, `gumroad products page publish <id> ./landing.html` to store the page, `gumroad products page clear <id> --yes` to remove it, and `gumroad products page url <id>` to print the live URL. `--dry-run` only previews the CLI request body; it does not call the backend sanitizer. Inspect `.sanitization_report` in `preview` and `publish` JSON output for server-side changes.
+- Profile custom HTML landing pages mirror the product commands without a product id and without checkout: `gumroad user page preview ./landing.html`, `gumroad user page publish ./landing.html` (read from stdin with `-`), `gumroad user page clear --yes`, and `gumroad user page url` (prints the public profile URL and its `/landing/embed` URL). A profile has no buy button, so omit `data-gumroad-action="buy"` and the checkout data attributes; link to products instead.
 - Product rich content uses `gumroad products content list <id> --json --no-input` to inspect page IDs, `gumroad products content get <id> --json --no-input` to dump the shared `rich_content` page array, and `gumroad products content set <id> content.json --dry-run --json --no-input` to preview a whole-document replacement. Without an explicit path, whole-document `set` reads `./content.json`; `set --page` reads `./page.json`. Use `--page <page_id>` with `get`/`set` to edit one matching page object; `set --page` still sends a merged whole-document PUT. For per-variant content, pass both `--variant <variant_id>` and `--category <cat_id>`. Whole-document `set` deletes existing pages omitted from the JSON.
 - Custom HTML pages can use `data-gumroad-field="name"`, `data-gumroad-field="price"`, `data-gumroad-field="description"`, and `data-gumroad-action="buy"`. To preselect checkout state, add `data-gumroad-option="<variant name>"`, `data-gumroad-quantity="<integer>"`, `data-gumroad-price="<decimal>"`, or `data-gumroad-recurrence="monthly|quarterly|biannually|yearly|every_two_years"`. Production validates these values and falls back to product defaults when invalid. Prefer anchors for buy CTAs so production can add a checkout href; non-anchor buy elements also post to checkout.
 - Audience emails are created as drafts by default. Use `gumroad emails send-preview <id> --json --no-input` and inspect `.preview_url` before `gumroad emails send <id> --yes --json --no-input`. Creating with `--send` publishes and blasts immediately, so use `--dry-run` first and require explicit human approval.
@@ -51,6 +53,9 @@ Always follow these rules:
 Most responses are wrapped in `{"success": true, ...}` with resource-specific keys:
 
 - `user` → `.user`, `user update` → `.user`
+- `user page preview` → `.custom_html`, `.sanitization_report`
+- `user page publish` / `user page clear` → `.custom_html`, `.previous_custom_html`, `.profile_url`, `.sanitization_report`
+- `user page url` → `.profile_url`, `.has_landing_page`
 - `refund-policy view/set` → `.refund_policy`
 - `products list` → `.products[]`
 - `products view` → `.product`
@@ -153,6 +158,14 @@ gumroad user --json --jq '.user.email' --no-input
 # Update the seller name and/or bio. Pass an empty value to clear a field.
 gumroad user update --name "Jane Doe" --bio "I make great things." --json --no-input
 gumroad user update --bio "" --json --no-input
+
+# Custom HTML profile landing page (authored by your agent; no checkout flags).
+gumroad user page preview ./landing.html --json --no-input
+gumroad user page publish ./landing.html --json --no-input
+gumroad user page publish - --json --no-input < landing.html
+gumroad user page clear --yes --json --no-input
+gumroad user page url --no-input
+gumroad user page url --json --jq '.profile_url' --no-input
 ```
 
 ### refund-policy — Store-wide refund policy


### PR DESCRIPTION
## What

Adds the `gumroad user page` command group so a seller can author their **profile** custom HTML landing page from the CLI, mirroring the existing `gumroad products page` group:

| Command | Method + endpoint | Notes |
|---|---|---|
| `gumroad user page preview [path]` | `POST /user/preview_custom_html` | Dry-run sanitize; prints the `sanitization_report` without writing. |
| `gumroad user page publish [path]` | `PUT /user/custom_html` | Stores the page; reads stdin with `-`. Prints "Live at \<profile_url\>". |
| `gumroad user page clear` | `PUT /user/custom_html` (empty body) | Confirms first (`--yes` to skip). |
| `gumroad user page url` | `GET /user/custom_html` | Prints the public profile URL and its `/landing/embed` URL. |

`[path]` defaults to `./landing.html`. All global flags (`--json`, `--jq`, `--dry-run`, `--plain`, `--quiet`, `--no-input`) work as for `products page`.

## Why

This is the CLI half of profile custom HTML. The backend API it targets is added in **antiwork/gumroad#5569** (`GET`/`PUT /v2/user/custom_html`, `POST /v2/user/preview_custom_html`, scoped to `view_profile`/`edit_profile`). That PR returns `profile_url` from the page endpoints specifically so `publish` can echo where the page is live and `url` can resolve it from the same endpoint — exactly how `products page` uses `landing_url`.

**Naming:** the issue that spawned this called it `gumroad profile page`, but the CLI has no `profile` group — the `user` group already holds profile operations (`user update` edits the profile name/bio), and the API path is `/v2/user/...`. So this lands as `gumroad user page`, mirroring `products page` (`<noun> page`) and keeping one group per entity. Easy to alias later if maintainers prefer `profile`.

**Profile ≠ product:** a profile has no native buy button, so these commands carry **no checkout flags**, and the rate-limit hints point back at `user page preview` (not the product command).

## DRY

The sanitization render, HTML IO (file/stdin), report formatting, `HTMLParams`/`ClearParams`, and rate-limit translation already live in `internal/pageutil` and are reused unchanged. Only the profile-specific bits are new: `ProfileTarget()`, `ProfileUpdateResponse`/`ProfileShowResponse`, `ProfileEmbedURL`, `ProfilePreviousHTML`, and three profile rate-limit message constants.

## Test Results

`make test-cover` — new `internal/cmd/user` package at **92.5%** (gate 85%); full suite green (46 packages).

```
internal/cmd/user        92.5%   (preview/publish/clear/url: request shape, paths,
internal/pageutil        ...      stdin input, dry-run, JSON passthrough, plain output,
                                  rate-limit messages, confirmation gating, registration)
```

`gofmt`, `go vet`, `staticcheck`, and `golangci-lint` (v1.64.8, the CI-pinned version) all clean. Man pages regenerate via `make man` (the `man/` dir is gitignored). Docs added to `skills/gumroad/SKILL.md`.

## Dependency

Requires antiwork/gumroad#5569 (the profile custom_html API) to be deployed; without it the endpoints 404 / return "no access to custom HTML pages".

---

🤖 AI disclosure: implemented with Claude Opus 4.8 (1M context) via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New CLI surface with tests and shared `pageutil` patterns; behavior depends on the backend profile custom HTML API being deployed.
> 
> **Overview**
> Adds **`gumroad user page`** under the existing `user` command so sellers can manage **profile** custom HTML from the CLI, parallel to `gumroad products page` but without a product id.
> 
> **`preview`**, **`publish`**, and **`clear`** reuse `pageutil` for HTML input (file, `./landing.html` default, or stdin via `-`), sanitization output, and form params. They call **`POST /user/preview_custom_html`** and **`PUT /user/custom_html`**. **`clear`** is confirmation-gated (`--yes`). **`url`** **`GET`s** the same resource and prints **`profile_url`** plus a derived **`/landing/embed`** URL (with **`--plain`** tab output).
> 
> `internal/pageutil` gains **`ProfileTarget`**, profile response types, **`ProfileEmbedURL`**, and profile-specific rate-limit hint strings. **`skills/gumroad/SKILL.md`** documents the new commands and JSON shapes. Broad HTTP/integration tests cover dry-run, JSON, rate limits, and command registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63ee7fe8348dc6244fca16aa9b22f4027cdcc055. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad-cli/pr/170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784924154&installation_id=134400930&pr_number=170&repository=antiwork%2Fgumroad-cli&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad-cli%2Fpull%2F170&signature=05f4674897b2378eec2f3529c3892ad0af1dda4e91e4c6cb0344b3bf1cc42116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->