### PR TITLE
docs: add AGENTS.md with comment-style rule — write comments for a reader new to the codebase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+@CONTRIBUTING.md
+
+## Code comments
+
+Write comments for a reader who is new to the codebase but familiar with the goal of the project. Avoid jargon-dense shorthand: explain *why* the code does what it does in plain language, spell out non-obvious context (invariants, gotchas, links to the decision), and don't assume the reader knows internal nicknames, prior incidents, or module history. A good test: someone on day one who knows what the product does should understand the comment without grepping elsewhere.


### PR DESCRIPTION
## What

Adds a code-comment style rule to AGENTS.md so agents (Claude, Codex, etc.) stop writing jargon-dense comments by default.

## Why

Sahil: agent-written comments are too jargony out of the box. The fix is a standing instruction — write comments as if the reader is new to the codebase but familiar with the goal of the project. Plain language, explain the why, no internal shorthand.

## Test plan

Docs-only. Next agent-authored PR in this repo should show the difference in comment style.
