### PR TITLE
docs: reconcile AGENTS.md comment rule with CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,4 +2,4 @@
 
 ## Code comments
 
-Write comments for a reader who is new to the codebase but familiar with the goal of the project. Avoid jargon-dense shorthand: explain *why* the code does what it does in plain language, spell out non-obvious context (invariants, gotchas, links to the decision), and don't assume the reader knows internal nicknames, prior incidents, or module history. A good test: someone on day one who knows what the product does should understand the comment without grepping elsewhere.
+Comments are rare by default — CONTRIBUTING.md's "no explanatory comments" rule means don't narrate what the code plainly does. But when a comment is genuinely warranted (a non-obvious invariant, a gotcha, a link to the decision behind the code), write it for a reader who is new to the codebase but familiar with the goal of the project. Avoid jargon-dense shorthand: explain *why* the code does what it does in plain language, and don't assume the reader knows internal nicknames, prior incidents, or module history. A good test: someone on day one who knows what the product does should understand the comment without grepping elsewhere.


### PR DESCRIPTION
## What

Rewords the AGENTS.md code-comment rule so it no longer conflicts with CONTRIBUTING.md's "no explanatory comments" guideline. The rule now says: comments stay rare by default per CONTRIBUTING.md, and the plain-language, reader-new-to-the-codebase style applies to the few comments that are genuinely warranted (invariants, gotchas, decision links).

## Why

Greptile flagged on #171 that an agent reading AGENTS.md gets two conflicting instructions: CONTRIBUTING.md says "don't leave comments in the code / no explanatory comments," while AGENTS.md told the same reader to explain why the code does what it does. Depending on which instruction wins, agent-authored changes either violate CONTRIBUTING.md or ignore the style rule. This resolves the conflict explicitly instead of leaving priority ambiguous.

Follow-up to #171 (merged before the finding could be addressed on its branch). Addresses https://github.com/antiwork/gumroad-cli/pull/171#discussion_r3521147543

## Test plan

Docs-only, one file, no code paths. Video: not applicable — no functionality to demonstrate; the diff is a single reworded paragraph in AGENTS.md.

## AI disclosure

Authored by Hermes Agent (Claude) triaging the Greptile review on #171: verified the conflict against CONTRIBUTING.md lines 79-80, reworded the rule, committed and opened this PR.
