### PR TITLE
docs: reconcile AGENTS.md comment rule with CONTRIBUTING's no-comments default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,4 +2,6 @@
 
 ## Code comments
 
-Write comments for a reader who is new to the codebase but familiar with the goal of the project. Avoid jargon-dense shorthand: explain *why* the code does what it does in plain language, spell out non-obvious context (invariants, gotchas, links to the decision), and don't assume the reader knows internal nicknames, prior incidents, or module history. A good test: someone on day one who knows what the product does should understand the comment without grepping elsewhere.
+The default is still no comments — CONTRIBUTING.md's "no explanatory comments" rule stands, and code should explain itself through clear naming and structure. This section is about the exceptions: the rare comment that is genuinely needed because the code alone can't carry the context (a surprising invariant, a workaround for an external bug, a non-obvious decision).
+
+When you do write one of those comments, write it for a reader who is new to the codebase but familiar with the goal of the project. Avoid jargon-dense shorthand: explain *why* the code does what it does in plain language, spell out non-obvious context (invariants, gotchas, links to the decision), and don't assume the reader knows internal nicknames, prior incidents, or module history. A good test: someone on day one who knows what the product does should understand the comment without grepping elsewhere.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,8 +76,7 @@ Do not push code with failing tests. CI is not a substitute for local verificati
 
 - Run `gofmt` before committing (the linter enforces this)
 - Follow [Effective Go](https://go.dev/doc/effective_go) for Go style and the [Command Line Interface Guidelines](https://clig.dev/) (clig.dev) for CLI UX — flags, output, errors, and help text. clig.dev is the design baseline this CLI is built on.
-- Don't leave comments in the code
-- No explanatory comments please
+- No explanatory comments — code should explain itself through clear naming and structure. The rare exception is a comment the code alone can't carry (a surprising invariant, a workaround for an external bug, a link to a non-obvious decision); write those in plain language per the style rule in [AGENTS.md](AGENTS.md)
 - Don't apologize for errors, fix them
 - Assign raw numbers to named constants to clarify their purpose
 


### PR DESCRIPTION
## What

Makes the comment-style rule in AGENTS.md explicitly defer to CONTRIBUTING.md's "no explanatory comments" default, and merges CONTRIBUTING.md's two comment bullets into one rule that names the same rare exception and links back to AGENTS.md for how to write it. The plain-language guidance now applies only to the rare comment that is genuinely needed (surprising invariants, external-bug workarounds, non-obvious decisions).

## Why

AGENTS.md includes CONTRIBUTING.md, which says not to leave comments in the code. The comment-style section added in #171 told agents to explain code in plain language — two rules pulling in opposite directions, so agent behavior could diverge depending on which one it weighted. Greptile flagged this on #171 after merge. This keeps both intents: comment-free code stays the default, and when a comment is warranted it's written for a reader new to the codebase.

## Before/After

Not applicable — docs-only change to an agent instruction file; no code, commands, or output affected.

## Test Results

Not applicable — no code changes; `make test`/`make lint` untouched surface.

---

AI disclosure: Written by Claude (Hermes Agent) in response to Greptile's post-merge review of #171. Prompt: address the flagged conflict between AGENTS.md's comment guidance and CONTRIBUTING.md's no-explanatory-comments rule.

