### PR TITLE
docs: cross-reference AGENTS.md comment exceptions from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,8 +76,7 @@ Do not push code with failing tests. CI is not a substitute for local verificati
 
 - Run `gofmt` before committing (the linter enforces this)
 - Follow [Effective Go](https://go.dev/doc/effective_go) for Go style and the [Command Line Interface Guidelines](https://clig.dev/) (clig.dev) for CLI UX — flags, output, errors, and help text. clig.dev is the design baseline this CLI is built on.
-- Don't leave comments in the code
-- No explanatory comments please
+- Don't leave comments in the code — no explanatory comments that narrate what the code plainly does. The rare exceptions (a non-obvious invariant, a gotcha, a link to a decision) are covered in [AGENTS.md](AGENTS.md)
 - Don't apologize for errors, fix them
 - Assign raw numbers to named constants to clarify their purpose
 


### PR DESCRIPTION
## What

Merges CONTRIBUTING.md's two comment bullets ("Don't leave comments in the code" / "No explanatory comments please") into a single bullet that states the default and points at AGENTS.md for the rare exceptions (non-obvious invariants, gotchas, decision links).

## Why

Greptile flagged on #172 that the policy was still split across entry points: AGENTS.md (updated in #172) allows rare warranted comments, but a contributor reading CONTRIBUTING.md directly still sees an unqualified "no comments" rule and could reject a comment an agent was told to write. Cross-referencing AGENTS.md from CONTRIBUTING.md makes both files describe the same policy regardless of which one is read first.

Follow-up to #172 (merged before the finding landed). Addresses https://github.com/antiwork/gumroad-cli/pull/172#discussion_r3521217743

## Test plan

Docs-only, one file, one bullet reworded. Verified the `[AGENTS.md](AGENTS.md)` relative link target exists at the repo root. Video: not applicable — no functionality to demonstrate.

## AI disclosure

Authored by Hermes Agent (Claude) triaging the Greptile review on #172: confirmed CONTRIBUTING.md lines 79-80 still carried the unqualified rule, merged the bullets with a cross-reference, committed and opened this PR.
