### PR TITLE
Retry transient device poll errors and add --debug logging to auth login

### DIFF
--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -118,6 +118,9 @@ func defaultIsTerminal(r interface{}) bool {
 
 func oauthLogin(opts cmdutil.Options, webFlag bool) (loginCredentials, error) {
 	cfg := oauth.DefaultFlowConfig()
+	if opts.DebugEnabled() {
+		cfg.DebugWriter = opts.Err()
+	}
 
 	if webFlag {
 		result, err := tryBrowserFlow(opts, cfg)

--- a/internal/oauth/flow.go
+++ b/internal/oauth/flow.go
@@ -56,6 +56,19 @@ type FlowConfig struct {
 	Timeout       time.Duration
 	HTTPClient    *http.Client // optional; defaults to http.DefaultClient
 	Sleep         func(context.Context, time.Duration) error
+	DebugWriter   io.Writer // optional; when set, poll attempts and outcomes are logged
+}
+
+// devicePollRequestTimeout caps how long a single device token poll can hang.
+// Without it, a dead reused connection stalls a poll for the full flow timeout
+// (2 minutes) with no feedback before the next attempt.
+const devicePollRequestTimeout = 30 * time.Second
+
+func (cfg FlowConfig) debugf(format string, args ...any) {
+	if cfg.DebugWriter == nil {
+		return
+	}
+	fmt.Fprintf(cfg.DebugWriter, "DEBUG "+format+"\n", args...)
 }
 
 // DefaultFlowConfigFunc returns a FlowConfig using the built-in constants.
@@ -289,6 +302,7 @@ func DeviceFlowResult(ctx context.Context, cfg FlowConfig, out io.Writer) (FlowR
 	if err != nil {
 		return FlowResult{}, err
 	}
+	cfg.debugf("device code request url=%s expires_in=%d interval=%d", cfg.DeviceCodeURL, deviceCode.ExpiresIn, deviceCode.Interval)
 	if deviceCode.DeviceCode == "" {
 		return FlowResult{}, fmt.Errorf("device code response did not contain a device code")
 	}
@@ -364,6 +378,7 @@ func pollDeviceToken(ctx context.Context, cfg FlowConfig, deviceCode DeviceCodeR
 	}
 	expiresAt := time.Now().Add(time.Duration(deviceCode.ExpiresIn) * time.Second)
 
+	poll := 0
 	for {
 		remaining := time.Until(expiresAt)
 		if remaining <= 0 {
@@ -377,14 +392,32 @@ func pollDeviceToken(ctx context.Context, cfg FlowConfig, deviceCode DeviceCodeR
 			return FlowResult{}, fmt.Errorf("authorization cancelled: %w", err)
 		}
 
+		poll++
 		result, nextInterval, err := pollDeviceTokenOnce(ctx, cfg, deviceCode.DeviceCode, interval)
 		if err == nil {
+			cfg.debugf("device poll attempt=%d outcome=approved", poll)
 			return result, nil
 		}
 		var oauthErr *oauthDevicePollError
 		if !errors.As(err, &oauthErr) {
-			return FlowResult{}, err
+			var transient *transientPollError
+			if !errors.As(err, &transient) {
+				// A completed response we could not use (invalid JSON,
+				// missing access token, unexpected HTTP status) is a
+				// permanent contract failure; retrying would hide it.
+				return FlowResult{}, err
+			}
+			// The request itself failed in transport (connection reset,
+			// DNS blip, hung request). The authorization window is still
+			// open server-side, so keep polling until it expires instead
+			// of aborting the whole login.
+			if ctx.Err() != nil {
+				return FlowResult{}, fmt.Errorf("authorization cancelled: %w", err)
+			}
+			cfg.debugf("device poll attempt=%d outcome=transient_error retrying err=%q", poll, err)
+			continue
 		}
+		cfg.debugf("device poll attempt=%d outcome=%s", poll, oauthErr.Code)
 		switch oauthErr.Code {
 		case "authorization_pending":
 			continue
@@ -413,6 +446,18 @@ func (e *oauthDevicePollError) Error() string {
 	return e.Code + ": " + e.Description
 }
 
+// transientPollError marks a poll failure that happened in transport (the
+// request never completed) rather than in the server's response. Only these
+// are safe to retry: a response-level error (bad JSON, missing token) is a
+// permanent contract failure and retrying would hide it until expiry.
+type transientPollError struct {
+	err error
+}
+
+func (e *transientPollError) Error() string { return e.err.Error() }
+
+func (e *transientPollError) Unwrap() error { return e.err }
+
 func pollDeviceTokenOnce(ctx context.Context, cfg FlowConfig, deviceCode string, currentInterval time.Duration) (FlowResult, time.Duration, error) {
 	data := url.Values{
 		"grant_type":  {DeviceGrantType},
@@ -420,7 +465,7 @@ func pollDeviceTokenOnce(ctx context.Context, cfg FlowConfig, deviceCode string,
 		"device_code": {deviceCode},
 	}
 
-	requestCtx, cancel := requestContext(ctx, cfg)
+	requestCtx, cancel := devicePollContext(ctx, cfg)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(requestCtx, "POST", cfg.TokenURL, strings.NewReader(data.Encode()))
@@ -431,13 +476,13 @@ func pollDeviceTokenOnce(ctx context.Context, cfg FlowConfig, deviceCode string,
 
 	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
-		return FlowResult{}, currentInterval, fmt.Errorf("token exchange failed: %w", err)
+		return FlowResult{}, currentInterval, &transientPollError{err: fmt.Errorf("token exchange failed: %w", err)}
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
-		return FlowResult{}, currentInterval, fmt.Errorf("could not read token response: %w", err)
+		return FlowResult{}, currentInterval, &transientPollError{err: fmt.Errorf("could not read token response: %w", err)}
 	}
 
 	if resp.StatusCode == http.StatusOK {
@@ -463,6 +508,18 @@ func requestContext(ctx context.Context, cfg FlowConfig) (context.Context, conte
 		return ctx, func() {}
 	}
 	return context.WithTimeout(ctx, cfg.Timeout)
+}
+
+// devicePollContext bounds a single device token poll. Polls are cheap and
+// repeated, so a poll hung on a dead reused connection should fail fast and
+// let the loop retry on a fresh attempt rather than stall for the full flow
+// timeout.
+func devicePollContext(ctx context.Context, cfg FlowConfig) (context.Context, context.CancelFunc) {
+	timeout := devicePollRequestTimeout
+	if cfg.Timeout > 0 && cfg.Timeout < timeout {
+		timeout = cfg.Timeout
+	}
+	return context.WithTimeout(ctx, timeout)
 }
 
 func generateState() (string, error) {

--- a/internal/oauth/flow_device_retry_test.go
+++ b/internal/oauth/flow_device_retry_test.go
@@ -1,0 +1,196 @@
+package oauth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// deviceRetryServer simulates the field failure from a TLS-intercepting
+// middlebox: the first poll returns authorization_pending, the second poll's
+// connection is reset mid-flight, and the third poll succeeds (the user
+// approved in the browser while the CLI was polling).
+func deviceRetryServer(t *testing.T, tokenPolls *int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/oauth/device/code":
+			mustEncode(t, w, DeviceCodeResponse{
+				DeviceCode:      "device-code-123",
+				UserCode:        "GRD-ABCD-1234",
+				VerificationURI: "https://gumroad.com/oauth/device",
+				ExpiresIn:       600,
+				Interval:        1,
+			})
+		case "/oauth/token":
+			*tokenPolls++
+			switch *tokenPolls {
+			case 1:
+				w.WriteHeader(http.StatusBadRequest)
+				mustEncode(t, w, oauthErrorResponse{Error: "authorization_pending", ErrorDescription: "Authorization is pending"})
+			case 2:
+				hj, ok := w.(http.Hijacker)
+				if !ok {
+					t.Fatal("response writer does not support hijacking")
+				}
+				conn, _, err := hj.Hijack()
+				if err != nil {
+					t.Fatalf("hijack: %v", err)
+				}
+				_ = conn.Close()
+			default:
+				mustEncode(t, w, TokenResponse{AccessToken: "device-access-token", TokenType: "Bearer"})
+			}
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+}
+
+func TestDeviceFlow_RetriesTransientPollErrors(t *testing.T) {
+	var tokenPolls int
+	srv := deviceRetryServer(t, &tokenPolls)
+	defer srv.Close()
+
+	result, err := DeviceFlowResult(context.Background(), deviceFlowConfig(srv), &strings.Builder{})
+	if err != nil {
+		t.Fatalf("DeviceFlowResult should survive a transient poll error, got: %v", err)
+	}
+	if result.AccessToken != "device-access-token" {
+		t.Fatalf("got access token %q, want device-access-token", result.AccessToken)
+	}
+	if tokenPolls != 3 {
+		t.Fatalf("got %d token polls, want 3 (pending, transient failure, success)", tokenPolls)
+	}
+}
+
+func TestDeviceFlow_TransientRetryStopsOnContextCancel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/oauth/device/code":
+			mustEncode(t, w, DeviceCodeResponse{
+				DeviceCode:      "device-code-123",
+				UserCode:        "GRD-ABCD-1234",
+				VerificationURI: "https://gumroad.com/oauth/device",
+				ExpiresIn:       600,
+				Interval:        1,
+			})
+		case "/oauth/token":
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				t.Fatal("response writer does not support hijacking")
+			}
+			conn, _, err := hj.Hijack()
+			if err != nil {
+				t.Fatalf("hijack: %v", err)
+			}
+			_ = conn.Close()
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	polls := 0
+	cfg := deviceFlowConfig(srv)
+	cfg.Sleep = func(context.Context, time.Duration) error {
+		polls++
+		if polls > 2 {
+			cancel()
+		}
+		return nil
+	}
+
+	_, err := DeviceFlowResult(ctx, cfg, &strings.Builder{})
+	if err == nil {
+		t.Fatal("expected error after context cancellation")
+	}
+	if !strings.Contains(err.Error(), "authorization cancelled") {
+		t.Fatalf("got error %q, want authorization cancelled", err)
+	}
+}
+
+func TestDeviceFlow_PermanentResponseErrorFailsFast(t *testing.T) {
+	polls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/oauth/device/code":
+			mustEncode(t, w, DeviceCodeResponse{
+				DeviceCode:      "device-code-123",
+				UserCode:        "GRD-ABCD-1234",
+				VerificationURI: "https://gumroad.com/oauth/device",
+				ExpiresIn:       600,
+				Interval:        1,
+			})
+		case "/oauth/token":
+			polls++
+			// A 200 with a body missing the access token is a broken
+			// server contract, not a transient failure.
+			mustEncode(t, w, TokenResponse{TokenType: "Bearer"})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	_, err := DeviceFlowResult(context.Background(), deviceFlowConfig(srv), &strings.Builder{})
+	if err == nil {
+		t.Fatal("expected error for token response without access token")
+	}
+	if !strings.Contains(err.Error(), "did not contain an access token") {
+		t.Fatalf("got error %q, want missing access token error", err)
+	}
+	if polls != 1 {
+		t.Fatalf("got %d polls, want 1 (permanent response errors must not retry)", polls)
+	}
+}
+
+func TestDeviceFlow_DebugLogsPollAttempts(t *testing.T) {
+	var tokenPolls int
+	srv := deviceRetryServer(t, &tokenPolls)
+	defer srv.Close()
+
+	var debug strings.Builder
+	cfg := deviceFlowConfig(srv)
+	cfg.DebugWriter = &debug
+
+	if _, err := DeviceFlowResult(context.Background(), cfg, &strings.Builder{}); err != nil {
+		t.Fatalf("DeviceFlowResult: %v", err)
+	}
+
+	for _, want := range []string{
+		"device code request",
+		"attempt=1 outcome=authorization_pending",
+		"attempt=2 outcome=transient_error retrying",
+		"attempt=3 outcome=approved",
+	} {
+		if !strings.Contains(debug.String(), want) {
+			t.Fatalf("debug output missing %q:\n%s", want, debug.String())
+		}
+	}
+}
+
+func TestDeviceFlow_NoDebugWriterProducesNoDebugOutput(t *testing.T) {
+	var tokenPolls int
+	srv := deviceRetryServer(t, &tokenPolls)
+	defer srv.Close()
+
+	var out strings.Builder
+	if _, err := DeviceFlowResult(context.Background(), deviceFlowConfig(srv), &out); err != nil {
+		t.Fatalf("DeviceFlowResult: %v", err)
+	}
+	if strings.Contains(out.String(), "DEBUG") {
+		t.Fatalf("user-facing output should not contain debug lines:\n%s", out.String())
+	}
+}


### PR DESCRIPTION
## What

Makes the device flow poll loop survive transient network failures, adds `--debug` logging to `auth login`, and bounds each poll with a 30-second per-request timeout.

- `pollDeviceToken` now distinguishes transport failures (connection reset, DNS blip, hung request — wrapped in a new `transientPollError`) from response-level failures. Transport failures retry until the device code expires; response-level failures (invalid JSON, missing access token, unexpected HTTP status) still fail immediately so real contract errors aren't hidden.
- Each poll runs under a 30-second request context (`devicePollContext`) instead of the 2-minute flow timeout, so a dead reused connection fails fast and re-dials on the next attempt rather than hanging with no feedback.
- `FlowConfig` gains an optional `DebugWriter`; `auth login --debug` now logs the device code request and every poll outcome (`authorization_pending` / `slow_down` / `transient_error retrying` / `approved`) to stderr. Previously `--debug` printed nothing during the entire login flow.

## Why

Fixes #175. A Windows/Git Bash user's `gumroad auth login` froze on `Waiting for approval...` even though their browser approval succeeded. Server-side rows showed the pattern clearly: every attempt reached `status: approved`, but the CLI's polling stopped after 1–3 polls (`last_polled_at` frozen seconds after `created_at`) and never resumed, so no row was ever consumed.

The root cause is that `pollDeviceToken` treated any non-OAuth-protocol error as fatal. A single dropped poll — typical behind TLS-intercepting proxies/VPNs/AV middleboxes — killed a 10-minute authorization window the server was still happily serving. The API client (`internal/api/client.go`) already retries transient errors with backoff; the oauth package had no retry at all. And with zero debug instrumentation in `internal/oauth`, the user's `--debug` attempt produced literally nothing to self-diagnose with.

The failure was reproduced locally before fixing: a mock OAuth server that returns `authorization_pending`, then resets the connection mid-poll, then serves the token. Against the previous code the login dies at poll 2 with `token exchange failed: Post "...": EOF` — matching the field evidence. With this change the same sequence completes login on poll 3.

## Test plan

- `TestDeviceFlow_RetriesTransientPollErrors` — connection reset mid-flight no longer aborts; login completes on the next poll (fails on the previous code, passes now)
- `TestDeviceFlow_PermanentResponseErrorFailsFast` — a 200 with no access token fails after exactly 1 poll (retry scope stays narrow)
- `TestDeviceFlow_TransientRetryStopsOnContextCancel` — cancellation still exits the retry loop immediately
- `TestDeviceFlow_DebugLogsPollAttempts` / `TestDeviceFlow_NoDebugWriterProducesNoDebugOutput` — debug lines appear on stderr only when `--debug` is set
- Full suite: `make test-cover` green locally (all package gates pass); `go vet` clean; `gofmt` clean
- `GOOS=windows GOARCH=amd64 go build ./...` compiles; the CI `cross-platform` matrix runs the new tests on `windows-latest`
- golangci-lint not run locally (local v2 binary vs repo v1 config — known mismatch); gofmt + go vet substituted, CI runs the pinned linter

## Self-review

- The retry deliberately has no attempt cap: the bound is the device code's `expires_at`, which the server controls (10 minutes). A cap would reintroduce the bug for long-lived middlebox flakiness; the OAuth device grant is designed to be polled for the full window.
- `slow_down` handling, `access_denied`, and `expired_token` behavior are unchanged.
- `requestContext` (the 2-minute bound) still applies to the initial device code request and the browser/headless flows; only the repeated poll uses the shorter bound.

I can't record a terminal video from this environment — the before/after behavior is captured by `TestDeviceFlow_RetriesTransientPollErrors` (which fails on main and passes on this branch). Happy to have a maintainer attach a recording if required.

---

AI disclosure: Written with Claude (Anthropic), prompted to reproduce and fix #175 (retry transient device poll errors, add `--debug` logging, bound hung polls).
