### PR TITLE
Fail login instead of retrying when an approval response is cut off mid-read

### DIFF
--- a/internal/oauth/flow.go
+++ b/internal/oauth/flow.go
@@ -487,6 +487,16 @@ func pollDeviceTokenOnce(ctx context.Context, cfg FlowConfig, deviceCode string,
 		// code. Retrying the poll would then fail with a confusing
 		// "authorization expired" instead of explaining what happened.
 		if resp.StatusCode == http.StatusOK {
+			// The read can fail after the full body already arrived (for
+			// example when the declared Content-Length overshoots the
+			// actual body). If the bytes we did receive form a valid token
+			// response, finish the login with them instead of throwing
+			// away a completed approval.
+			if len(body) > 0 {
+				if result, parseErr := tokenResponseResult(body, "", ""); parseErr == nil {
+					return result, currentInterval, nil
+				}
+			}
 			return FlowResult{}, currentInterval, fmt.Errorf("connection dropped while reading the approval response: %w; run the login again", err)
 		}
 		return FlowResult{}, currentInterval, &transientPollError{err: fmt.Errorf("could not read token response: %w", err)}

--- a/internal/oauth/flow.go
+++ b/internal/oauth/flow.go
@@ -482,6 +482,13 @@ func pollDeviceTokenOnce(ctx context.Context, cfg FlowConfig, deviceCode string,
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
+		// A 200 status means the server approved the login before the
+		// connection dropped, so it may have already consumed the device
+		// code. Retrying the poll would then fail with a confusing
+		// "authorization expired" instead of explaining what happened.
+		if resp.StatusCode == http.StatusOK {
+			return FlowResult{}, currentInterval, fmt.Errorf("connection dropped while reading the approval response: %w; run the login again", err)
+		}
 		return FlowResult{}, currentInterval, &transientPollError{err: fmt.Errorf("could not read token response: %w", err)}
 	}
 

--- a/internal/oauth/flow_device_retry_test.go
+++ b/internal/oauth/flow_device_retry_test.go
@@ -156,6 +156,54 @@ func TestDeviceFlow_PermanentResponseErrorFailsFast(t *testing.T) {
 	}
 }
 
+func TestDeviceFlow_ApprovedResponseReadErrorDoesNotRetry(t *testing.T) {
+	polls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth/device/code":
+			w.Header().Set("Content-Type", "application/json")
+			mustEncode(t, w, DeviceCodeResponse{
+				DeviceCode:      "device-code-123",
+				UserCode:        "GRD-ABCD-1234",
+				VerificationURI: "https://gumroad.com/oauth/device",
+				ExpiresIn:       600,
+				Interval:        1,
+			})
+		case "/oauth/token":
+			polls++
+			// Send a 200 approval whose body is cut off mid-read: the
+			// declared Content-Length is larger than what we write, then
+			// the connection closes. The server has consumed the device
+			// code at this point, so retrying the poll cannot succeed.
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				t.Fatal("response writer does not support hijacking")
+			}
+			conn, bufrw, err := hj.Hijack()
+			if err != nil {
+				t.Fatalf("hijack: %v", err)
+			}
+			_, _ = bufrw.WriteString("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 500\r\n\r\n{\"access_token\":")
+			_ = bufrw.Flush()
+			_ = conn.Close()
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	_, err := DeviceFlowResult(context.Background(), deviceFlowConfig(srv), &strings.Builder{})
+	if err == nil {
+		t.Fatal("expected error when the approval response body cannot be read")
+	}
+	if !strings.Contains(err.Error(), "run the login again") {
+		t.Fatalf("got error %q, want guidance to rerun the login", err)
+	}
+	if polls != 1 {
+		t.Fatalf("got %d polls, want 1 (a dropped approval response must not retry)", polls)
+	}
+}
+
 func TestDeviceFlow_DebugLogsPollAttempts(t *testing.T) {
 	var tokenPolls int
 	srv := deviceRetryServer(t, &tokenPolls)

--- a/internal/oauth/flow_device_retry_test.go
+++ b/internal/oauth/flow_device_retry_test.go
@@ -204,6 +204,55 @@ func TestDeviceFlow_ApprovedResponseReadErrorDoesNotRetry(t *testing.T) {
 	}
 }
 
+func TestDeviceFlow_TruncatedReadWithCompleteBodySalvagesToken(t *testing.T) {
+	polls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth/device/code":
+			w.Header().Set("Content-Type", "application/json")
+			mustEncode(t, w, DeviceCodeResponse{
+				DeviceCode:      "device-code-123",
+				UserCode:        "GRD-ABCD-1234",
+				VerificationURI: "https://gumroad.com/oauth/device",
+				ExpiresIn:       600,
+				Interval:        1,
+			})
+		case "/oauth/token":
+			polls++
+			// The declared Content-Length is larger than the body, so the
+			// read ends with an error - but the bytes that did arrive form
+			// a complete token response. The login should finish with that
+			// token rather than telling the user to start over.
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				t.Fatal("response writer does not support hijacking")
+			}
+			conn, bufrw, err := hj.Hijack()
+			if err != nil {
+				t.Fatalf("hijack: %v", err)
+			}
+			body := `{"access_token":"salvaged-token","token_type":"Bearer"}`
+			_, _ = bufrw.WriteString("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 500\r\n\r\n" + body)
+			_ = bufrw.Flush()
+			_ = conn.Close()
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	result, err := DeviceFlowResult(context.Background(), deviceFlowConfig(srv), &strings.Builder{})
+	if err != nil {
+		t.Fatalf("expected the complete body to complete the login, got: %v", err)
+	}
+	if result.AccessToken != "salvaged-token" {
+		t.Fatalf("got access token %q, want salvaged-token", result.AccessToken)
+	}
+	if polls != 1 {
+		t.Fatalf("got %d polls, want 1 (a salvaged approval must not retry)", polls)
+	}
+}
+
 func TestDeviceFlow_DebugLogsPollAttempts(t *testing.T) {
 	var tokenPolls int
 	srv := deviceRetryServer(t, &tokenPolls)


### PR DESCRIPTION
## What

When a 200 approval response is cut off mid-read but the bytes that did arrive form a complete token response, finish the login with that token instead of failing.

## Why

Follow-up to a Greptile P1 finding on #176. The fail-fast half of the fix (don't retry a poll when the approved token response fails mid-read — the server has consumed the device code, so a retry can only return `expired_token`/`invalid_grant`) shipped on main via #178 while this PR was open. What remains here is the salvage path: a read can error after the full body already arrived (for example when the declared Content-Length overshoots the actual body). In that case the approval is complete, and telling the user to run the login again throws away a finished login for no reason.

## Test evidence

- New regression test `TestDeviceFlow_TruncatedReadWithCompleteBodySalvagesToken`: a hijacked 200 response whose truncated read still contains a full token body must complete the login with that token after exactly 1 poll.
- Existing `TestDeviceFlow_ApprovedResponseReadErrorFailsFast` (from #178) still passes — an incomplete body still fails fast with guidance.
- `go build ./...`, `go vet ./internal/oauth/`, `gofmt -l` — clean; full oauth package suite passes locally.

Not a UI change — no screenshots. CLI behavior change is covered by the regression tests above.

## AI disclosure

Authored by Gumclaw (Hermes agent, claude-fable-5) in response to the Greptile review on #176; code, test, and verification done by the agent.
