### PR TITLE
fix: don't retry device poll when the approved token response fails mid-read

### DIFF
--- a/internal/oauth/flow.go
+++ b/internal/oauth/flow.go
@@ -482,6 +482,14 @@ func pollDeviceTokenOnce(ctx context.Context, cfg FlowConfig, deviceCode string,
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
+		if resp.StatusCode == http.StatusOK {
+			// A 200 means the server approved the login and may have already
+			// consumed the device code while issuing the token. Polling again
+			// with the same code can then fail with expired_token or
+			// invalid_grant even though the user approved, so surface the
+			// failure with a clear next step instead of retrying.
+			return FlowResult{}, currentInterval, fmt.Errorf("connection failed while receiving the approved token; run the login command again: %w", err)
+		}
 		return FlowResult{}, currentInterval, &transientPollError{err: fmt.Errorf("could not read token response: %w", err)}
 	}
 

--- a/internal/oauth/flow_device_retry_test.go
+++ b/internal/oauth/flow_device_retry_test.go
@@ -156,6 +156,57 @@ func TestDeviceFlow_PermanentResponseErrorFailsFast(t *testing.T) {
 	}
 }
 
+func TestDeviceFlow_ApprovedResponseReadErrorFailsFast(t *testing.T) {
+	polls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/oauth/device/code":
+			mustEncode(t, w, DeviceCodeResponse{
+				DeviceCode:      "device-code-123",
+				UserCode:        "GRD-ABCD-1234",
+				VerificationURI: "https://gumroad.com/oauth/device",
+				ExpiresIn:       600,
+				Interval:        1,
+			})
+		case "/oauth/token":
+			polls++
+			// Promise a 200 body, then cut the connection before delivering
+			// it. The server may already have consumed the device code, so
+			// the flow must fail with guidance instead of retrying the poll.
+			w.Header().Set("Content-Length", "512")
+			w.WriteHeader(http.StatusOK)
+			if _, err := w.Write([]byte(`{"access_`)); err != nil {
+				t.Fatalf("write partial body: %v", err)
+			}
+			w.(http.Flusher).Flush()
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				t.Fatal("response writer does not support hijacking")
+			}
+			conn, _, err := hj.Hijack()
+			if err != nil {
+				t.Fatalf("hijack: %v", err)
+			}
+			_ = conn.Close()
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	_, err := DeviceFlowResult(context.Background(), deviceFlowConfig(srv), &strings.Builder{})
+	if err == nil {
+		t.Fatal("expected error when the approved token response cannot be read")
+	}
+	if !strings.Contains(err.Error(), "run the login command again") {
+		t.Fatalf("got error %q, want guidance to run the login command again", err)
+	}
+	if polls != 1 {
+		t.Fatalf("got %d polls, want 1 (read errors on an approved response must not retry)", polls)
+	}
+}
+
 func TestDeviceFlow_DebugLogsPollAttempts(t *testing.T) {
 	var tokenPolls int
 	srv := deviceRetryServer(t, &tokenPolls)


### PR DESCRIPTION
## What

Stops the device poll loop from retrying when the token endpoint returned HTTP 200 but the connection failed while the body was being read. That case now fails immediately with guidance to run the login command again, instead of being wrapped in `transientPollError` and retried.

Follow-up to #176, addressing the Greptile P1 posted after it merged: https://github.com/antiwork/gumroad-cli/pull/176#discussion_r3530159333

## Why

A 200 from the token endpoint means the server approved the login and may have already consumed the device code while issuing the token. If the connection drops mid-body, #176 treated the read error as transient and polled again with the same device code — which can then come back as `expired_token` or `invalid_grant`, failing the login right after the user approved it in the browser.

Read failures on non-200 responses (`authorization_pending`, `slow_down`, etc.) keep the transient classification from #176 — the code hasn't been consumed there, so retrying remains correct. Only the approved-response path changes.

The error message tells the user the one recovery that always works ("run the login command again", which issues a fresh device code) rather than silently burning the remaining authorization window on polls doomed to fail.

## Before/After

Not a user-visible change in the happy path — it alters behavior only in the narrow failure window where the approval response is truncated mid-read. The behavior difference is captured by `TestDeviceFlow_ApprovedResponseReadErrorFailsFast`, which fails on main (the flow retries and completes against a mock that shouldn't be retried) and passes on this branch. I can't record a terminal video from this environment; happy to have a maintainer attach one if required.

## Test plan

- `TestDeviceFlow_ApprovedResponseReadErrorFailsFast` — mock server sends 200 with `Content-Length: 512`, writes a partial body, then hijacks and closes the connection. Asserts exactly 1 poll (no retry) and that the error tells the user to rerun login.
- `TestDeviceFlow_RetriesTransientPollErrors` and the rest of the #176 suite still pass — transport failures and non-200 read failures still retry.
- `go test ./...` green locally; `go vet` and `gofmt` clean.

## Self-review

- The new branch checks `resp.StatusCode` before the existing transient wrap, so the non-200 read-error path is byte-for-byte unchanged.
- An alternative was to retry once and translate a subsequent `expired_token`/`invalid_grant` into a success-ambiguous message, but that adds state to the poll loop for a marginal gain; failing fast with clear guidance is simpler and always recoverable.

---

AI disclosure: Written with Claude (Anthropic), prompted to address the Greptile review finding on #176.
