### PR TITLE
feat: require --reason on admin purchases refund

### DIFF
--- a/internal/cmd/admin/purchases/refund.go
+++ b/internal/cmd/admin/purchases/refund.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/antiwork/gumroad-cli/internal/adminapi"
 	"github.com/antiwork/gumroad-cli/internal/admincmd"
@@ -20,6 +21,7 @@ type refundRequest struct {
 	AmountCents        int    `json:"amount_cents,omitempty"`
 	Force              bool   `json:"force,omitempty"`
 	CancelSubscription bool   `json:"cancel_subscription,omitempty"`
+	Reason             string `json:"reason,omitempty"`
 }
 
 type refundResponse struct {
@@ -35,6 +37,7 @@ func newRefundCmd() *cobra.Command {
 		amount             string
 		force              bool
 		cancelSubscription bool
+		reason             string
 	)
 
 	cmd := &cobra.Command{
@@ -45,17 +48,24 @@ func newRefundCmd() *cobra.Command {
 The buyer email is required as a sanity check against the purchase. Without --amount,
 the entire purchase is refunded. --force bypasses the refund-policy timeframe and
 fine-print guards (the active-chargeback guard still applies). --cancel-subscription
-cancels the linked subscription after a successful refund.`,
-		Example: `  gumroad admin purchases refund 12345 --email buyer@example.com
-  gumroad admin purchases refund 12345 --email buyer@example.com --amount 5.00
-  gumroad admin purchases refund 12345 --email buyer@example.com --force
-  gumroad admin purchases refund 12345 --email buyer@example.com --cancel-subscription`,
+cancels the linked subscription after a successful refund.
+
+A reason is required. It is stored on the refund and shown to the creator in the
+"A sale has been refunded" email so they know why Gumroad refunded the sale on
+their behalf.`,
+		Example: `  gumroad admin purchases refund 12345 --email buyer@example.com --reason "Buyer reported being charged twice"
+  gumroad admin purchases refund 12345 --email buyer@example.com --amount 5.00 --reason "Partial refund agreed with buyer"
+  gumroad admin purchases refund 12345 --email buyer@example.com --force --reason "Product not delivered"
+  gumroad admin purchases refund 12345 --email buyer@example.com --cancel-subscription --reason "Buyer requested cancellation and refund"`,
 		Args: cmdutil.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
 
 			if email == "" {
 				return cmdutil.MissingFlagError(c, "--email")
+			}
+			if strings.TrimSpace(reason) == "" {
+				return cmdutil.MissingFlagError(c, "--reason")
 			}
 
 			refundPath := cmdutil.JoinPath("purchases", args[0], "refund")
@@ -125,6 +135,7 @@ cancels the linked subscription after a successful refund.`,
 				AmountCents:        cents,
 				Force:              force,
 				CancelSubscription: cancelSubscription,
+				Reason:             strings.TrimSpace(reason),
 			}
 
 			if opts.DryRun {
@@ -152,6 +163,7 @@ cancels the linked subscription after a successful refund.`,
 	cmd.Flags().StringVar(&amount, "amount", "", "Partial refund amount in displayed currency (e.g. 5, 5.00); omit for full refund")
 	cmd.Flags().BoolVar(&force, "force", false, "Bypass refund-policy timeframe and fine-print guards")
 	cmd.Flags().BoolVar(&cancelSubscription, "cancel-subscription", false, "Cancel the linked subscription after the refund succeeds")
+	cmd.Flags().StringVar(&reason, "reason", "", "Why the sale is being refunded; shown to the creator in the refund notification email (required)")
 
 	return cmd
 }
@@ -191,6 +203,9 @@ func refundDryRunParams(req refundRequest) url.Values {
 	}
 	if req.CancelSubscription {
 		params.Set("cancel_subscription", "true")
+	}
+	if req.Reason != "" {
+		params.Set("reason", req.Reason)
 	}
 	return params
 }

--- a/internal/cmd/admin/purchases/refund_test.go
+++ b/internal/cmd/admin/purchases/refund_test.go
@@ -55,7 +55,7 @@ func purchaseLookupResponderWithRefundable(currency string, refundableCents int)
 
 func TestRefund_RequiresEmail(t *testing.T) {
 	cmd := newRefundCmd()
-	cmd.SetArgs([]string{"123"})
+	cmd.SetArgs([]string{"123", "--reason", "Buyer reported being charged twice"})
 
 	err := cmd.Execute()
 	if err == nil {
@@ -66,13 +66,47 @@ func TestRefund_RequiresEmail(t *testing.T) {
 	}
 }
 
+func TestRefund_RequiresReason(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API without a reason")
+	})
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected missing reason error")
+	}
+	if !strings.Contains(err.Error(), "missing required flag: --reason") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRefund_RejectsWhitespaceOnlyReason(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API with a blank reason")
+	})
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--reason", "   "})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected missing reason error")
+	}
+	if !strings.Contains(err.Error(), "missing required flag: --reason") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestRefund_RequiresConfirmation(t *testing.T) {
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
 		t.Error("should not reach API without confirmation")
 	})
 
 	cmd := testutil.Command(newRefundCmd(), testutil.NoInput(true))
-	cmd.SetArgs([]string{"123", "--email", "buyer@example.com"})
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--reason", "Buyer reported being charged twice"})
 
 	err := cmd.Execute()
 	if err == nil {
@@ -116,7 +150,7 @@ func TestRefund_FullSendsEmailAndOmitsAmountCents(t *testing.T) {
 	}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true), testutil.Quiet(false))
-	cmd.SetArgs([]string{"123", "--email", "buyer@example.com"})
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--reason", "Buyer reported being charged twice"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
 	if gotMethod != "POST" || gotPath != "/internal/admin/purchases/123/refund" {
@@ -130,6 +164,9 @@ func TestRefund_FullSendsEmailAndOmitsAmountCents(t *testing.T) {
 	}
 	if body.Email != "buyer@example.com" {
 		t.Fatalf("got email %q, want buyer@example.com", body.Email)
+	}
+	if body.Reason != "Buyer reported being charged twice" {
+		t.Fatalf("got reason %q, want the provided reason forwarded in the body", body.Reason)
 	}
 	if _, present := bodyKeys["amount_cents"]; present {
 		t.Errorf("amount_cents must be omitted on full refund, got body keys: %v", bodyKeys)
@@ -171,7 +208,7 @@ func TestRefund_PartialLooksUpPurchaseAndConvertsUSD(t *testing.T) {
 		}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true), testutil.Quiet(false))
-	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "5.00"})
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "5.00", "--reason", "Partial refund agreed with buyer"})
 	testutil.MustExecute(t, cmd)
 
 	if lookupHits != 1 {
@@ -202,7 +239,7 @@ func TestRefund_PartialUsesPurchaseCurrencyForJPY(t *testing.T) {
 		}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true), testutil.Quiet(false))
-	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "500"})
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "500", "--reason", "Partial refund agreed with buyer"})
 	testutil.MustExecute(t, cmd)
 
 	if body.AmountCents != 500 {
@@ -222,7 +259,7 @@ func TestRefund_RejectsMissingCurrencyTypeFromLookup(t *testing.T) {
 		}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
-	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "500"})
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "500", "--reason", "Partial refund agreed with buyer"})
 
 	err := cmd.Execute()
 	if err == nil {
@@ -256,7 +293,7 @@ func TestRefund_RejectsEmptyCurrencyTypeFromLookup(t *testing.T) {
 		}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
-	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "500"})
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "500", "--reason", "Partial refund agreed with buyer"})
 
 	err := cmd.Execute()
 	if err == nil || !strings.Contains(err.Error(), "could not determine purchase currency") {
@@ -276,7 +313,7 @@ func TestRefund_RejectsDecimalAmountForJPY(t *testing.T) {
 		}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
-	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "5.00"})
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "5.00", "--reason", "Partial refund agreed with buyer"})
 
 	err := cmd.Execute()
 	if err == nil || !strings.Contains(err.Error(), "JPY") {
@@ -292,7 +329,7 @@ func TestRefund_RejectsInvalidAmount(t *testing.T) {
 		}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
-	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "abc"})
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "abc", "--reason", "Partial refund agreed with buyer"})
 
 	err := cmd.Execute()
 	if err == nil || !strings.Contains(err.Error(), "not a valid amount") {
@@ -308,7 +345,7 @@ func TestRefund_RejectsZeroAmount(t *testing.T) {
 		}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
-	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "0"})
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "0", "--reason", "Partial refund agreed with buyer"})
 
 	err := cmd.Execute()
 	if err == nil || !strings.Contains(err.Error(), "--amount must be greater than 0") {
@@ -331,7 +368,7 @@ func TestRefund_ForwardsForceAndCancelSubscription(t *testing.T) {
 	}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true), testutil.Quiet(false))
-	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--force", "--cancel-subscription"})
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--force", "--cancel-subscription", "--reason", "Product not delivered"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
 	if !body.Force {
@@ -356,7 +393,7 @@ func TestRefund_ShowsSubscriptionCancelError(t *testing.T) {
 	}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true), testutil.Quiet(false))
-	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--cancel-subscription"})
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--cancel-subscription", "--reason", "Buyer requested cancellation"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
 	if !strings.Contains(out, "Subscription cancel failed: stripe blew up") {
@@ -370,7 +407,7 @@ func TestRefund_DryRunDoesNotContactRefundEndpoint(t *testing.T) {
 	}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.DryRun(true), testutil.NoInput(true))
-	cmd.SetArgs([]string{"123", "--email", "buyer@example.com"})
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--reason", "Buyer reported being charged twice"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
 	if !strings.Contains(out, "POST") || !strings.Contains(out, "/internal/admin/purchases/123/refund") {
@@ -378,6 +415,32 @@ func TestRefund_DryRunDoesNotContactRefundEndpoint(t *testing.T) {
 	}
 	if !strings.Contains(out, "email: buyer@example.com") {
 		t.Errorf("expected dry-run preview to include email, got: %q", out)
+	}
+	if !strings.Contains(out, "reason: Buyer reported being charged twice") {
+		t.Errorf("expected dry-run preview to include the reason, got: %q", out)
+	}
+}
+
+func TestRefund_TrimsReasonBeforeSending(t *testing.T) {
+	var body refundRequest
+
+	testutil.SetupAdmin(t, adminRefundHandler(t, nil, func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		testutil.JSON(t, w, map[string]any{
+			"message":                "Successfully refunded purchase number 123",
+			"purchase":               map[string]any{"id": "123"},
+			"subscription_cancelled": false,
+		})
+	}))
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--reason", "  Buyer reported being charged twice  "})
+	testutil.MustExecute(t, cmd)
+
+	if body.Reason != "Buyer reported being charged twice" {
+		t.Errorf("got reason %q, want it trimmed of surrounding whitespace", body.Reason)
 	}
 }
 
@@ -394,7 +457,7 @@ func TestRefund_DryRunWithPartialAmountLooksUpButDoesNotRefund(t *testing.T) {
 		}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.DryRun(true), testutil.NoInput(true))
-	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "500"})
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "500", "--reason", "Partial refund agreed with buyer"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
 	if lookupHits != 1 {
@@ -411,7 +474,7 @@ func TestRefund_CancelledByPromptDeclineNotReached(t *testing.T) {
 	}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.NoInput(true))
-	cmd.SetArgs([]string{"123", "--email", "buyer@example.com"})
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--reason", "Buyer reported being charged twice"})
 
 	if err := cmd.Execute(); err == nil {
 		t.Fatal("expected confirmation error")
@@ -428,7 +491,7 @@ func TestRefund_JSONPreservesResponse(t *testing.T) {
 	}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true), testutil.JSONOutput())
-	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--cancel-subscription"})
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--cancel-subscription", "--reason", "Buyer requested cancellation"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
 	var resp struct {
@@ -455,7 +518,7 @@ func TestRefund_PlainOutput(t *testing.T) {
 	}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true), testutil.PlainOutput())
-	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--cancel-subscription"})
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--cancel-subscription", "--reason", "Buyer requested cancellation"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
 	want := "true\tSuccessfully refunded purchase number 123\t123\tcancelled\t"
@@ -472,7 +535,7 @@ func TestRefund_RejectsAmountAboveRefundableBalance(t *testing.T) {
 		}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
-	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "10.00"})
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "10.00", "--reason", "Partial refund agreed with buyer"})
 
 	err := cmd.Execute()
 	if err == nil || !strings.Contains(err.Error(), "exceeds the refundable balance") {
@@ -496,7 +559,7 @@ func TestRefund_AcceptsAmountAtRefundableBalance(t *testing.T) {
 		}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
-	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "5.00"})
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "5.00", "--reason", "Partial refund agreed with buyer"})
 	testutil.MustExecute(t, cmd)
 
 	if body.AmountCents != 500 {
@@ -514,7 +577,7 @@ func TestRefund_PurchaseHasNoChargeSurfacesMessage(t *testing.T) {
 	}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
-	cmd.SetArgs([]string{"123", "--email", "buyer@example.com"})
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--reason", "Buyer reported being charged twice"})
 
 	err := cmd.Execute()
 	if err == nil {
@@ -538,7 +601,7 @@ func TestRefund_JSONIncludesVerifyStateHint(t *testing.T) {
 	}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true), testutil.JSONOutput())
-	cmd.SetArgs([]string{"123", "--email", "buyer@example.com"})
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--reason", "Buyer reported being charged twice"})
 
 	err := cmd.Execute()
 	if err == nil {
@@ -567,7 +630,7 @@ func TestRefund_MalformedSuccessResponseIsNotWrappedAsRequestFailed(t *testing.T
 	}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
-	cmd.SetArgs([]string{"123", "--email", "buyer@example.com"})
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--reason", "Buyer reported being charged twice"})
 
 	err := cmd.Execute()
 	if err == nil {
@@ -599,7 +662,7 @@ func TestRefund_FullyRefundedPurchaseDefersToServer(t *testing.T) {
 		}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
-	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "5.00"})
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "5.00", "--reason", "Partial refund agreed with buyer"})
 
 	err := cmd.Execute()
 	if err == nil {
@@ -625,7 +688,7 @@ func TestRefund_APIErrorSurfacesMessage(t *testing.T) {
 		}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
-	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "50.00"})
+	cmd.SetArgs([]string{"123", "--email", "buyer@example.com", "--amount", "50.00", "--reason", "Partial refund agreed with buyer"})
 
 	err := cmd.Execute()
 	if err == nil {

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -243,6 +243,11 @@ gumroad admin users refund-balance --user-id 2245593582708 --expected-email sell
 gumroad admin purchases view <purchase-id> --with-clusters --json --non-interactive --no-input
 gumroad admin purchases search --email buyer@example.com --json --jq '{purchases, has_more, limit}' --non-interactive --no-input
 gumroad admin purchases lookup --stripe-fingerprint fp_abc --limit 25 --json --non-interactive --no-input
+
+# Refund a purchase. --reason is required: it is stored on the refund and shown to the
+# creator in the "A sale has been refunded" notification email.
+gumroad admin purchases refund <purchase-id> --email buyer@example.com --reason "Buyer reported being charged twice" --yes --json --non-interactive --no-input
+gumroad admin purchases refund <purchase-id> --email buyer@example.com --amount 5.00 --reason "Partial refund agreed with buyer" --yes --json --non-interactive --no-input
 gumroad admin products list --email seller@example.com --page 2 --per-page 25 --json --non-interactive --no-input
 gumroad admin products view <product-id> --with-fraud-context --json --non-interactive --no-input
 


### PR DESCRIPTION
## What

`gumroad admin purchases refund` now takes a **required** `--reason` flag and sends it to the internal admin refund endpoint as the `reason` param:

- `--reason` is validated up front (missing or whitespace-only → `missing required flag: --reason`, no API call made), trimmed, and forwarded in the POST body as `reason`
- `--dry-run` previews include the reason
- help text and examples updated; `skills/gumroad/SKILL.md` documents the new invocation shape

## Why

antiwork/gumroad#5800 makes support/admin refunds email the creator ("A sale has been refunded"), with an optional reason rendered in the email ("Reason: Buyer reported being charged twice"). The internal admin refund API accepts a `reason` param, but the CLI didn't send one — so every refund issued through the CLI (the main path for agent/support tooling) would notify the creator with no explanation, which is exactly the confusing message that PR set out to eliminate.

The flag is **required** client-side per the direction on that PR ("Make it a requirement for admin/agent Refunds"). The server treats the reason as optional (a missing reason never blocks a refund), so enforcing it at the CLI keeps other callers unaffected while guaranteeing every CLI-issued refund carries a reason.

Depends on antiwork/gumroad#5800 — until that merges and deploys, the server ignores the `reason` param (harmless: the refund still processes, the email just has no reason line).

## Before/After

Before:

```
$ gumroad admin purchases refund 12345 --email buyer@example.com --dry-run --no-input
Dry run: POST /internal/admin/purchases/12345/refund
email: buyer@example.com
```

After:

```
$ gumroad admin purchases refund 12345 --email buyer@example.com --no-input
Error: missing required flag: --reason

$ gumroad admin purchases refund 12345 --email buyer@example.com --reason "Buyer reported being charged twice" --dry-run --no-input
Dry run: POST /internal/admin/purchases/12345/refund
email: buyer@example.com
reason: Buyer reported being charged twice
```

Terminal recording (before on `main`, then the new required-flag error, whitespace rejection, dry-run preview with reason, and the test run):

![refund --reason demo](https://i.ibb.co/dwHD1ybw/refund-demo.gif)

## Test Results

```
$ gofmt -l internal/cmd/admin/purchases/   # clean
$ go vet ./internal/cmd/admin/purchases/   # clean
$ go test ./internal/cmd/admin/purchases/ -cover
ok  github.com/antiwork/gumroad-cli/internal/cmd/admin/purchases  1.072s  coverage: 88.1% of statements
$ go test ./...                            # full suite green
```

New tests: `--reason` required, whitespace-only rejected before any API call, reason forwarded in the request body, reason trimmed, dry-run preview includes it. All existing refund tests updated to pass a reason.

Note: local `make lint` is blocked by the golangci-lint v1-config/v2-binary mismatch; substituted `gofmt` + `go vet` locally and CI runs the pinned linter.

---

AI disclosure: Written by Claude (claude-fable-5) running as Gumclaw, prompted by @slavingia's comment on antiwork/gumroad#5800: "Ensure gumroad admin CLI supports this too".

