### PR TITLE
feat: add --preview-video to products create and update

### DIFF
--- a/internal/cmd/products/create.go
+++ b/internal/cmd/products/create.go
@@ -87,6 +87,7 @@ func newCreateCmd() *cobra.Command {
 	var files, fileNames, fileDescriptions []string
 	var coverImage, thumbnail string
 	var previewImages []string
+	var previewVideos []string
 
 	cmd := &cobra.Command{
 		Use:   "create",
@@ -130,10 +131,10 @@ func newCreateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := validateProductMediaFlagPaths(c, coverImage, previewImages, thumbnail); err != nil {
+			if err := validateProductMediaFlagPaths(c, coverImage, previewImages, previewVideos, thumbnail); err != nil {
 				return err
 			}
-			media, err := describeProductMedia(collectProductMedia(coverImage, previewImages, thumbnail))
+			media, err := describeProductMedia(collectProductMedia(coverImage, previewImages, previewVideos, thumbnail))
 			if err != nil {
 				return err
 			}
@@ -295,6 +296,7 @@ func newCreateCmd() *cobra.Command {
 	cmd.Flags().StringArrayVar(&fileDescriptions, "file-description", nil, "Description for the matching --file upload (repeatable; use an empty string to skip a slot)")
 	cmd.Flags().StringVar(&coverImage, "cover-image", "", "Local JPEG, PNG, or GIF cover image to upload after creating the product")
 	cmd.Flags().StringArrayVar(&previewImages, "preview-image", nil, "Additional local JPEG, PNG, or GIF preview image to upload as a product cover (repeatable)")
+	cmd.Flags().StringArrayVar(&previewVideos, "preview-video", nil, "Local MP4, MOV, M4V, MPEG, WMV, or WebM preview video to upload as a product cover (repeatable)")
 	cmd.Flags().StringVar(&thumbnail, "thumbnail", "", "Local JPEG, PNG, or GIF thumbnail image to upload after creating the product")
 
 	return cmd

--- a/internal/cmd/products/product_media.go
+++ b/internal/cmd/products/product_media.go
@@ -15,8 +15,9 @@ const (
 )
 
 type requestedProductMedia struct {
-	Kind productMediaKind
-	Path string
+	Kind    productMediaKind
+	Path    string
+	IsVideo bool
 }
 
 type plannedProductMedia struct {

--- a/internal/cmd/products/product_media_attach.go
+++ b/internal/cmd/products/product_media_attach.go
@@ -97,9 +97,11 @@ func productMediaAttachPath(productID string, kind productMediaKind) string {
 
 func productMediaRetryCommand(productID string, media plannedProductMedia) string {
 	quotedPath := shellQuote(media.Path)
-	switch media.Kind {
-	case productMediaThumbnail:
+	switch {
+	case media.Kind == productMediaThumbnail:
 		return fmt.Sprintf("gumroad products thumbnail set %s --image %s", productID, quotedPath)
+	case media.IsVideo:
+		return fmt.Sprintf("gumroad products update %s --preview-video %s", productID, quotedPath)
 	default:
 		return fmt.Sprintf("gumroad products covers add %s --image %s", productID, quotedPath)
 	}

--- a/internal/cmd/products/product_media_direct_upload.go
+++ b/internal/cmd/products/product_media_direct_upload.go
@@ -43,7 +43,7 @@ func directUploadProductMedia(opts cmdutil.Options, client *api.Client, media pl
 func putDirectUpload(opts cmdutil.Options, media plannedProductMedia, uploadURL string, headers map[string]string) error {
 	file, err := os.Open(media.Path)
 	if err != nil {
-		return fmt.Errorf("could not open %s image: %w", media.Kind, err)
+		return fmt.Errorf("could not open %s: %w", productMediaNoun(media.requestedProductMedia), err)
 	}
 	defer func() { _ = file.Close() }()
 

--- a/internal/cmd/products/product_media_plan.go
+++ b/internal/cmd/products/product_media_plan.go
@@ -182,15 +182,32 @@ func detectProductVideoContentType(path string, file *os.File) (string, error) {
 		return "", err
 	}
 
-	detected := normalizeVideoContentType(http.DetectContentType(sample[:n]))
+	rawDetected := strings.ToLower(strings.TrimSpace(strings.Split(http.DetectContentType(sample[:n]), ";")[0]))
+	detected := normalizeVideoContentType(rawDetected)
 	if detected != "" {
 		return detected, nil
 	}
-	if fromExtension := videoContentTypeForExtension(strings.ToLower(filepath.Ext(path))); fromExtension != "" {
-		return fromExtension, nil
+	// The extension only decides the content type when sniffing the file's
+	// bytes was inconclusive. If the bytes positively identify something that
+	// is not a video (an image, an archive, ...), a video extension on the
+	// filename must not override that: the server trusts the content type the
+	// CLI declares, so a mislabeled file would become a broken cover.
+	if sniffWasInconclusive(rawDetected) {
+		if fromExtension := videoContentTypeForExtension(strings.ToLower(filepath.Ext(path))); fromExtension != "" {
+			return fromExtension, nil
+		}
 	}
 
 	return "", fmt.Errorf("unsupported preview video type for %s; use an MP4, MOV, M4V, MPEG, WMV, or WebM video", path)
+}
+
+func sniffWasInconclusive(rawDetected string) bool {
+	// http.DetectContentType answers application/octet-stream when it cannot
+	// identify the bytes at all, and it only knows a few video containers, so
+	// an unrecognized video/* answer is also inconclusive. Anything else
+	// (image/*, application/zip, text/plain, ...) is a positive match for a
+	// non-video file and must not be overridden by the filename's extension.
+	return rawDetected == "application/octet-stream" || strings.HasPrefix(rawDetected, "video/")
 }
 
 func normalizeVideoContentType(contentType string) string {

--- a/internal/cmd/products/product_media_plan.go
+++ b/internal/cmd/products/product_media_plan.go
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func collectProductMedia(coverImage string, previewImages []string, thumbnail string) []requestedProductMedia {
+func collectProductMedia(coverImage string, previewImages []string, previewVideos []string, thumbnail string) []requestedProductMedia {
 	var media []requestedProductMedia
 	if coverImage != "" {
 		media = append(media, requestedProductMedia{Kind: productMediaCover, Path: coverImage})
@@ -22,13 +22,16 @@ func collectProductMedia(coverImage string, previewImages []string, thumbnail st
 	for _, path := range previewImages {
 		media = append(media, requestedProductMedia{Kind: productMediaPreview, Path: path})
 	}
+	for _, path := range previewVideos {
+		media = append(media, requestedProductMedia{Kind: productMediaPreview, Path: path, IsVideo: true})
+	}
 	if thumbnail != "" {
 		media = append(media, requestedProductMedia{Kind: productMediaThumbnail, Path: thumbnail})
 	}
 	return media
 }
 
-func validateProductMediaFlagPaths(cmd *cobra.Command, coverImage string, previewImages []string, thumbnail string) error {
+func validateProductMediaFlagPaths(cmd *cobra.Command, coverImage string, previewImages []string, previewVideos []string, thumbnail string) error {
 	if cmd.Flags().Changed("cover-image") && strings.TrimSpace(coverImage) == "" {
 		return cmdutil.UsageErrorf(cmd, "--cover-image cannot be empty")
 	}
@@ -38,6 +41,11 @@ func validateProductMediaFlagPaths(cmd *cobra.Command, coverImage string, previe
 	for _, path := range previewImages {
 		if strings.TrimSpace(path) == "" {
 			return cmdutil.UsageErrorf(cmd, "--preview-image cannot be empty")
+		}
+	}
+	for _, path := range previewVideos {
+		if strings.TrimSpace(path) == "" {
+			return cmdutil.UsageErrorf(cmd, "--preview-video cannot be empty")
 		}
 	}
 	return nil
@@ -56,15 +64,16 @@ func describeProductMedia(media []requestedProductMedia) ([]plannedProductMedia,
 }
 
 func describeSingleProductMedia(media requestedProductMedia) (plannedProductMedia, error) {
+	noun := productMediaNoun(media)
 	file, err := os.Open(media.Path)
 	if err != nil {
-		return plannedProductMedia{}, fmt.Errorf("could not open %s image: %w", media.Kind, err)
+		return plannedProductMedia{}, fmt.Errorf("could not open %s: %w", noun, err)
 	}
 	defer func() { _ = file.Close() }()
 
 	info, err := file.Stat()
 	if err != nil {
-		return plannedProductMedia{}, fmt.Errorf("could not stat %s image: %w", media.Kind, err)
+		return plannedProductMedia{}, fmt.Errorf("could not stat %s: %w", noun, err)
 	}
 	if info.IsDir() {
 		return plannedProductMedia{}, fmt.Errorf("%s is a directory", media.Path)
@@ -75,17 +84,26 @@ func describeSingleProductMedia(media requestedProductMedia) (plannedProductMedi
 	if info.Size() == 0 {
 		return plannedProductMedia{}, fmt.Errorf("%s is empty", media.Path)
 	}
-	if info.Size() > uploadMaxProductMediaFileSize() {
+	if media.IsVideo {
+		if info.Size() > uploadMaxProductVideoFileSize() {
+			return plannedProductMedia{}, fmt.Errorf("%s size %d bytes exceeds maximum of %d bytes (500 MB)", media.Path, info.Size(), uploadMaxProductVideoFileSize())
+		}
+	} else if info.Size() > uploadMaxProductMediaFileSize() {
 		return plannedProductMedia{}, fmt.Errorf("%s size %d bytes exceeds maximum of %d bytes (50 MB)", media.Path, info.Size(), uploadMaxProductMediaFileSize())
 	}
 
-	contentType, err := detectProductImageContentType(media.Path, file)
+	var contentType string
+	if media.IsVideo {
+		contentType, err = detectProductVideoContentType(media.Path, file)
+	} else {
+		contentType, err = detectProductImageContentType(media.Path, file)
+	}
 	if err != nil {
 		return plannedProductMedia{}, err
 	}
 	checksum, err := checksumFileMD5(file)
 	if err != nil {
-		return plannedProductMedia{}, fmt.Errorf("could not checksum %s image: %w", media.Kind, err)
+		return plannedProductMedia{}, fmt.Errorf("could not checksum %s: %w", noun, err)
 	}
 
 	return plannedProductMedia{
@@ -99,6 +117,17 @@ func describeSingleProductMedia(media requestedProductMedia) (plannedProductMedi
 
 func uploadMaxProductMediaFileSize() int64 {
 	return 50 * 1024 * 1024
+}
+
+func uploadMaxProductVideoFileSize() int64 {
+	return 500 * 1024 * 1024
+}
+
+func productMediaNoun(media requestedProductMedia) string {
+	if media.IsVideo {
+		return string(media.Kind) + " video"
+	}
+	return string(media.Kind) + " image"
 }
 
 func detectProductImageContentType(path string, file *os.File) (string, error) {
@@ -138,6 +167,59 @@ func isWebPImage(sample []byte) bool {
 	return len(sample) >= 12 &&
 		string(sample[0:4]) == "RIFF" &&
 		string(sample[8:12]) == "WEBP"
+}
+
+func detectProductVideoContentType(path string, file *os.File) (string, error) {
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return "", err
+	}
+	var sample [512]byte
+	n, err := file.Read(sample[:])
+	if err != nil && err != io.EOF {
+		return "", err
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return "", err
+	}
+
+	detected := normalizeVideoContentType(http.DetectContentType(sample[:n]))
+	if detected != "" {
+		return detected, nil
+	}
+	if fromExtension := videoContentTypeForExtension(strings.ToLower(filepath.Ext(path))); fromExtension != "" {
+		return fromExtension, nil
+	}
+
+	return "", fmt.Errorf("unsupported preview video type for %s; use an MP4, MOV, M4V, MPEG, WMV, or WebM video", path)
+}
+
+func normalizeVideoContentType(contentType string) string {
+	contentType = strings.ToLower(strings.TrimSpace(strings.Split(contentType, ";")[0]))
+	switch contentType {
+	case "video/mp4", "video/quicktime", "video/mpeg", "video/webm", "video/x-m4v", "video/x-ms-wmv":
+		return contentType
+	default:
+		return ""
+	}
+}
+
+func videoContentTypeForExtension(ext string) string {
+	switch ext {
+	case ".mp4":
+		return "video/mp4"
+	case ".mov":
+		return "video/quicktime"
+	case ".m4v":
+		return "video/x-m4v"
+	case ".mpeg", ".mpg":
+		return "video/mpeg"
+	case ".wmv":
+		return "video/x-ms-wmv"
+	case ".webm":
+		return "video/webm"
+	default:
+		return ""
+	}
 }
 
 func normalizeImageContentType(contentType string) string {

--- a/internal/cmd/products/product_media_test.go
+++ b/internal/cmd/products/product_media_test.go
@@ -683,9 +683,12 @@ func TestProductMediaRejectsOversizedImagesClientSide(t *testing.T) {
 }
 
 func TestProductMediaPlanningAndRetryHelpers(t *testing.T) {
-	collected := collectProductMedia("cover.jpg", []string{"preview-a.jpg", "preview-b.jpg"}, "thumb.jpg")
-	if len(collected) != 4 || collected[0].Kind != productMediaCover || collected[3].Kind != productMediaThumbnail {
+	collected := collectProductMedia("cover.jpg", []string{"preview-a.jpg", "preview-b.jpg"}, []string{"demo.mp4"}, "thumb.jpg")
+	if len(collected) != 5 || collected[0].Kind != productMediaCover || collected[4].Kind != productMediaThumbnail {
 		t.Fatalf("unexpected collected media: %+v", collected)
+	}
+	if collected[3].Kind != productMediaPreview || !collected[3].IsVideo {
+		t.Fatalf("unexpected collected video media: %+v", collected[3])
 	}
 
 	cmd := newCreateCmd()
@@ -693,8 +696,11 @@ func TestProductMediaPlanningAndRetryHelpers(t *testing.T) {
 	if err := cmd.ParseFlags([]string{"--preview-image", ""}); err != nil {
 		t.Fatalf("ParseFlags: %v", err)
 	}
-	if err := validateProductMediaFlagPaths(cmd, "", []string{""}, ""); err == nil || !strings.Contains(err.Error(), "--preview-image cannot be empty") {
+	if err := validateProductMediaFlagPaths(cmd, "", []string{""}, nil, ""); err == nil || !strings.Contains(err.Error(), "--preview-image cannot be empty") {
 		t.Fatalf("expected empty preview-image error, got %v", err)
+	}
+	if err := validateProductMediaFlagPaths(cmd, "", nil, []string{""}, ""); err == nil || !strings.Contains(err.Error(), "--preview-video cannot be empty") {
+		t.Fatalf("expected empty preview-video error, got %v", err)
 	}
 
 	if got := productMediaRetryCommand("prod1", plannedProductMedia{requestedProductMedia: requestedProductMedia{Kind: productMediaThumbnail, Path: "thumb one.jpg"}}); got != "gumroad products thumbnail set prod1 --image 'thumb one.jpg'" {
@@ -702,6 +708,9 @@ func TestProductMediaPlanningAndRetryHelpers(t *testing.T) {
 	}
 	if got := productMediaRetryCommand("prod1", plannedProductMedia{requestedProductMedia: requestedProductMedia{Kind: productMediaCover, Path: "cover.jpg"}}); got != "gumroad products covers add prod1 --image cover.jpg" {
 		t.Fatalf("cover retry command = %q", got)
+	}
+	if got := productMediaRetryCommand("prod1", plannedProductMedia{requestedProductMedia: requestedProductMedia{Kind: productMediaPreview, Path: "demo.mp4", IsVideo: true}}); got != "gumroad products update prod1 --preview-video demo.mp4" {
+		t.Fatalf("preview video retry command = %q", got)
 	}
 	wrapped := wrapProductMediaAttachError(fmt.Errorf("upload failed"), "prod1", "product create", false, []plannedProductMedia{
 		{requestedProductMedia: requestedProductMedia{Kind: productMediaCover, Path: "cover.jpg"}},
@@ -1044,4 +1053,175 @@ func testutilClient(t *testing.T) *api.Client {
 		t.Fatalf("Token: %v", err)
 	}
 	return cmdutil.NewAPIClient(testutil.TestOptions(), token)
+}
+
+func mp4FixtureContents() string {
+	return string([]byte{0x00, 0x00, 0x00, 0x18, 'f', 't', 'y', 'p', 'm', 'p', '4', '2', 0x00, 0x00, 0x00, 0x00, 'm', 'p', '4', '2', 'i', 's', 'o', 'm'})
+}
+
+func TestUpdate_WithPreviewVideo_UploadsAndAttachesAsCover(t *testing.T) {
+	srv := newProductMediaServers(t)
+	testutil.Setup(t, srv.dispatch(t))
+
+	videoPath := writeMediaFixture(t, "demo.mp4", mp4FixtureContents())
+	cmd := testutil.Command(newUpdateCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"prod1", "--preview-video", videoPath})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	sequence, forms, puts, signedIDs, productPUTCalls, _ := srv.snapshot()
+	wantSequence := []string{
+		"POST /direct_uploads",
+		"POST /products/prod1/covers",
+	}
+	if !reflect.DeepEqual(sequence, wantSequence) {
+		t.Fatalf("API sequence = %#v, want %#v", sequence, wantSequence)
+	}
+	if productPUTCalls != 0 {
+		t.Fatalf("product PUT calls = %d, want 0", productPUTCalls)
+	}
+	if len(forms) != 1 || forms[0]["filename"] != "demo.mp4" || forms[0]["content_type"] != "video/mp4" {
+		t.Fatalf("direct upload form = %#v", forms)
+	}
+	if len(puts) != 1 || puts[0].Get("Content-Type") != "video/mp4" {
+		t.Fatalf("direct upload PUT headers = %#v", puts)
+	}
+	if !reflect.DeepEqual(signedIDs, []string{"signed-1"}) {
+		t.Fatalf("attached signed IDs = %#v", signedIDs)
+	}
+	var payload struct {
+		Success bool `json:"success"`
+		Product struct {
+			ID string `json:"id"`
+		} `json:"product"`
+		Media []productMediaAttachmentResult `json:"media"`
+	}
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("parse JSON output: %v\n%s", err, out)
+	}
+	if !payload.Success || payload.Product.ID != "prod1" || len(payload.Media) != 1 || payload.Media[0].Kind != "preview" {
+		t.Fatalf("unexpected JSON output: %+v", payload)
+	}
+}
+
+func TestCreate_WithPreviewVideo_CreatesThenUploadsAndAttachesVideo(t *testing.T) {
+	srv := newProductMediaServers(t)
+	testutil.Setup(t, srv.dispatch(t))
+
+	videoPath := writeMediaFixture(t, "demo.mp4", mp4FixtureContents())
+	cmd := testutil.Command(newCreateCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--name", "Art Pack", "--preview-video", videoPath})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	sequence, forms, _, signedIDs, _, _ := srv.snapshot()
+	wantSequence := []string{
+		"POST /products",
+		"POST /direct_uploads",
+		"POST /products/prod-media/covers",
+	}
+	if !reflect.DeepEqual(sequence, wantSequence) {
+		t.Fatalf("API sequence = %#v, want %#v", sequence, wantSequence)
+	}
+	if len(forms) != 1 || forms[0]["content_type"] != "video/mp4" {
+		t.Fatalf("direct upload form = %#v", forms)
+	}
+	if !reflect.DeepEqual(signedIDs, []string{"signed-1"}) {
+		t.Fatalf("attached signed IDs = %#v", signedIDs)
+	}
+}
+
+func TestUpdate_WithPreviewVideoDryRunJSONShowsDirectUploadAndAttachRequests(t *testing.T) {
+	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
+		t.Fatal("dry run must not reach the API")
+	})
+
+	videoPath := writeMediaFixture(t, "demo.mp4", mp4FixtureContents())
+	cmd := testutil.Command(newUpdateCmd(), testutil.DryRun(true), testutil.JSONOutput())
+	cmd.SetArgs([]string{"prod1", "--preview-video", videoPath})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var payload dryRunUpdateBody
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("parse JSON dry-run output: %v\n%s", err, out)
+	}
+	if len(payload.Uploads) != 1 {
+		t.Fatalf("uploads = %d, want 1", len(payload.Uploads))
+	}
+	if payload.Uploads[0].Action != "direct_upload" || payload.Uploads[0].Kind != "preview" || payload.Uploads[0].ContentType != "video/mp4" {
+		t.Fatalf("unexpected upload plan: %+v", payload.Uploads[0])
+	}
+	requests := append([]dryRunCreateRequest{payload.Request}, payload.FollowUpRequests...)
+	if len(requests) != 2 {
+		t.Fatalf("requests = %d, want 2", len(requests))
+	}
+	if requests[0].Path != "/direct_uploads" || requests[1].Path != "/products/prod1/covers" {
+		t.Fatalf("unexpected requests: %+v", requests)
+	}
+	blob, ok := requests[0].Body["blob"].(map[string]any)
+	if !ok || blob["filename"] != "demo.mp4" || blob["content_type"] != "video/mp4" {
+		t.Fatalf("unexpected direct upload body: %+v", requests[0].Body)
+	}
+}
+
+func TestProductMediaRejectsUnsupportedPreviewVideoClientSide(t *testing.T) {
+	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
+		t.Fatal("unsupported video must not reach the API")
+	})
+
+	path := writeMediaFixture(t, "demo.avi", "RIFF\x00\x00\x00\x00AVI LIST")
+	cmd := testutil.Command(newUpdateCmd())
+	cmd.SetArgs([]string{"prod1", "--preview-video", path})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected unsupported video error")
+	}
+	if !strings.Contains(err.Error(), "unsupported preview video type") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDetectProductVideoContentTypeFallsBackToExtension(t *testing.T) {
+	tests := map[string]string{
+		"demo.mov":  "video/quicktime",
+		"demo.m4v":  "video/x-m4v",
+		"demo.mpg":  "video/mpeg",
+		"demo.wmv":  "video/x-ms-wmv",
+		"demo.webm": "video/webm",
+	}
+	for name, want := range tests {
+		path := writeMediaFixture(t, name, "0000000000000000")
+		file, err := os.Open(path)
+		if err != nil {
+			t.Fatalf("open fixture: %v", err)
+		}
+		got, err := detectProductVideoContentType(path, file)
+		_ = file.Close()
+		if err != nil {
+			t.Fatalf("detect %s: %v", name, err)
+		}
+		if got != want {
+			t.Fatalf("content type for %s = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestProductMediaRejectsOversizedVideosClientSide(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "huge.mp4")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create fixture: %v", err)
+	}
+	if err := file.Truncate(uploadMaxProductVideoFileSize() + 1); err != nil {
+		t.Fatalf("truncate fixture: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close fixture: %v", err)
+	}
+
+	_, err = describeSingleProductMedia(requestedProductMedia{Kind: productMediaPreview, Path: path, IsVideo: true})
+	if err == nil {
+		t.Fatal("expected video size validation error")
+	}
+	if !strings.Contains(err.Error(), "500 MB") {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }

--- a/internal/cmd/products/product_media_test.go
+++ b/internal/cmd/products/product_media_test.go
@@ -1188,7 +1188,11 @@ func TestDetectProductVideoContentTypeFallsBackToExtension(t *testing.T) {
 		"demo.webm": "video/webm",
 	}
 	for name, want := range tests {
-		path := writeMediaFixture(t, name, "0000000000000000")
+		// Binary bytes the sniffer cannot identify, so detection has to rely
+		// on the file extension. Real video containers sniff as unknown
+		// binary too, unlike printable text which is positively identified
+		// as text/plain and rejected.
+		path := writeMediaFixture(t, name, "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x0b\x0c\x0e\x0f\x10")
 		file, err := os.Open(path)
 		if err != nil {
 			t.Fatalf("open fixture: %v", err)
@@ -1200,6 +1204,35 @@ func TestDetectProductVideoContentTypeFallsBackToExtension(t *testing.T) {
 		}
 		if got != want {
 			t.Fatalf("content type for %s = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestDetectProductVideoContentTypeRejectsMislabeledNonVideos(t *testing.T) {
+	// Files whose bytes positively identify a non-video type must be rejected
+	// even when the filename carries a video extension: the server trusts the
+	// content type the CLI declares, so letting these through would publish a
+	// broken product cover.
+	pngBytes := "\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"
+	zipBytes := "PK\x03\x04\x14\x00\x00\x00\x08\x00"
+	tests := map[string]string{
+		"png-renamed.mp4":  pngBytes,
+		"zip-renamed.mov":  zipBytes,
+		"text-renamed.mp4": "just some plain text pretending to be a video",
+	}
+	for name, content := range tests {
+		path := writeMediaFixture(t, name, content)
+		file, err := os.Open(path)
+		if err != nil {
+			t.Fatalf("open fixture: %v", err)
+		}
+		got, err := detectProductVideoContentType(path, file)
+		_ = file.Close()
+		if err == nil {
+			t.Fatalf("detect %s = %q, want rejection", name, got)
+		}
+		if !strings.Contains(err.Error(), "unsupported preview video type") {
+			t.Fatalf("unexpected error for %s: %v", name, err)
 		}
 	}
 }

--- a/internal/cmd/products/update.go
+++ b/internal/cmd/products/update.go
@@ -23,6 +23,7 @@ func newUpdateCmd() *cobra.Command {
 	var fileDescriptions []string
 	var coverImage, thumbnail string
 	var previewImages []string
+	var previewVideos []string
 	var customHTML string
 
 	cmd := &cobra.Command{
@@ -34,6 +35,7 @@ func newUpdateCmd() *cobra.Command {
   gumroad products update <id> --tag art --tag digital
   gumroad products update <id> --cover-image ./cover.jpg
   gumroad products update <id> --preview-image ./gallery-1.jpg --preview-image ./gallery-2.jpg
+  gumroad products update <id> --preview-video ./demo.mp4
   gumroad products update <id> --file ./pack.zip
   gumroad products update <id> --custom-html ./landing.html
   gumroad products update <id> --custom-html ''`,
@@ -48,7 +50,7 @@ func newUpdateCmd() *cobra.Command {
 				"pay-what-you-want", "suggested-price", "max-purchase-count",
 				"category", "taxonomy-id", "tag",
 				"file", "file-name", "file-description",
-				"cover-image", "preview-image", "thumbnail",
+				"cover-image", "preview-image", "preview-video", "thumbnail",
 				"custom-html",
 			); err != nil {
 				return err
@@ -67,10 +69,10 @@ func newUpdateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := validateProductMediaFlagPaths(c, coverImage, previewImages, thumbnail); err != nil {
+			if err := validateProductMediaFlagPaths(c, coverImage, previewImages, previewVideos, thumbnail); err != nil {
 				return err
 			}
-			media, err := describeProductMedia(collectProductMedia(coverImage, previewImages, thumbnail))
+			media, err := describeProductMedia(collectProductMedia(coverImage, previewImages, previewVideos, thumbnail))
 			if err != nil {
 				return err
 			}
@@ -277,6 +279,7 @@ func newUpdateCmd() *cobra.Command {
 	cmd.Flags().StringArrayVar(&fileDescriptions, "file-description", nil, "Description for the matching --file (repeatable)")
 	cmd.Flags().StringVar(&coverImage, "cover-image", "", "Local JPEG, PNG, or GIF cover image to upload")
 	cmd.Flags().StringArrayVar(&previewImages, "preview-image", nil, "Additional local JPEG, PNG, or GIF preview image to upload as a product cover (repeatable)")
+	cmd.Flags().StringArrayVar(&previewVideos, "preview-video", nil, "Local MP4, MOV, M4V, MPEG, WMV, or WebM preview video to upload as a product cover (repeatable)")
 	cmd.Flags().StringVar(&thumbnail, "thumbnail", "", "Local JPEG, PNG, or GIF thumbnail image to upload")
 	cmd.Flags().StringVar(&customHTML, "custom-html", "", "Path to an HTML file for the product's custom landing page (empty string clears it)")
 

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -354,7 +354,7 @@ In custom HTML, use Gumroad data attributes for live product values and checkout
 
 Use `products update --file` for shared product Content. It replaces existing rich content file embeds in place when they exist, or creates file embeds when the document has none; pass one `--file` per existing file embed and use `products content get/set` for structural content edits. For products with per-variant Content, use `variants update ... --file` for the specific variant you want to change.
 
-Use `--cover-image` for the primary cover, repeat `--preview-image` for additional gallery/preview images, repeat `--preview-video` for video previews (MP4, MOV, M4V, MPEG, WMV, or WebM), and `--thumbnail` for the card/library thumbnail. These media flags run the required two-step API flow: direct upload first, then attach by signed blob ID. For an existing product, `products thumbnail set --url` asks Gumroad to download and attach a public HTTP(S) image directly.
+Use `--cover-image` for the primary cover, repeat `--preview-image` for additional gallery/preview images, repeat `--preview-video` for video previews (MP4, MOV, M4V, MPEG, WMV, or WebM), and `--thumbnail` for the card/library thumbnail. When multiple media flags are combined, covers attach in a fixed order: cover image first, then preview images (in flag order), then preview videos (in flag order) — images and videos cannot be interleaved in a single command. These media flags run the required two-step API flow: direct upload first, then attach by signed blob ID. For an existing product, `products thumbnail set --url` asks Gumroad to download and attach a public HTTP(S) image directly.
 
 ### files — Upload and recover file attachments
 

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -287,6 +287,7 @@ gumroad products update <id> --category design/ui-and-web/figma --json --no-inpu
 gumroad products update <id> --file ./pack.zip --json --no-input
 gumroad products update <id> --cover-image ./cover.jpg --json --no-input
 gumroad products update <id> --preview-image ./gallery-1.jpg --preview-image ./gallery-2.jpg --json --no-input
+gumroad products update <id> --preview-video ./demo.mp4 --json --no-input
 gumroad products update <id> --thumbnail ./thumb.jpg --json --no-input
 gumroad products page preview <id> ./landing.html --json --no-input
 gumroad products page publish <id> ./landing.html --json --no-input
@@ -347,13 +348,13 @@ In custom HTML, use Gumroad data attributes for live product values and checkout
 
 **Categories:** `products categories [--search <term>]` returns label, path, and numeric ID. Prefer `--category <path>` for product create/update. `--taxonomy-id` remains supported when you already have the numeric ID, but it cannot be combined with `--category`.
 
-**Create flags:** `--name` (required), `--price`, `--type` (digital|course|ebook|membership|bundle|coffee|call|commission), `--currency`, `--pay-what-you-want`, `--suggested-price`, `--description`, `--custom-summary`, `--custom-permalink`, `--custom-receipt`, `--max-purchase-count`, `--category`, `--taxonomy-id`, `--tag` (repeatable), `--file` (repeatable), `--file-name` (repeatable, aligned to `--file`), `--file-description` (repeatable, aligned to `--file`), `--cover-image`, `--preview-image` (repeatable), `--thumbnail`.
+**Create flags:** `--name` (required), `--price`, `--type` (digital|course|ebook|membership|bundle|coffee|call|commission), `--currency`, `--pay-what-you-want`, `--suggested-price`, `--description`, `--custom-summary`, `--custom-permalink`, `--custom-receipt`, `--max-purchase-count`, `--category`, `--taxonomy-id`, `--tag` (repeatable), `--file` (repeatable), `--file-name` (repeatable, aligned to `--file`), `--file-description` (repeatable, aligned to `--file`), `--cover-image`, `--preview-image` (repeatable), `--preview-video` (repeatable), `--thumbnail`.
 
-**Update flags:** `--name`, `--price`, `--currency`, `--description`, `--custom-summary`, `--custom-permalink`, `--custom-receipt`, `--max-purchase-count`, `--category`, `--taxonomy-id`, `--tag` (repeatable), `--custom-html`, `--file` (repeatable), `--file-name`, `--file-description`, `--cover-image`, `--preview-image` (repeatable), `--thumbnail`. Prefer `products page preview/publish/clear/url` for custom HTML page workflows; `products update --custom-html` remains supported as a low-level product update flag.
+**Update flags:** `--name`, `--price`, `--currency`, `--description`, `--custom-summary`, `--custom-permalink`, `--custom-receipt`, `--max-purchase-count`, `--category`, `--taxonomy-id`, `--tag` (repeatable), `--custom-html`, `--file` (repeatable), `--file-name`, `--file-description`, `--cover-image`, `--preview-image` (repeatable), `--preview-video` (repeatable), `--thumbnail`. Prefer `products page preview/publish/clear/url` for custom HTML page workflows; `products update --custom-html` remains supported as a low-level product update flag.
 
 Use `products update --file` for shared product Content. It replaces existing rich content file embeds in place when they exist, or creates file embeds when the document has none; pass one `--file` per existing file embed and use `products content get/set` for structural content edits. For products with per-variant Content, use `variants update ... --file` for the specific variant you want to change.
 
-Use `--cover-image` for the primary cover, repeat `--preview-image` for additional gallery/preview images, and `--thumbnail` for the card/library thumbnail. These media flags run the required two-step API flow: direct upload first, then attach by signed blob ID. For an existing product, `products thumbnail set --url` asks Gumroad to download and attach a public HTTP(S) image directly.
+Use `--cover-image` for the primary cover, repeat `--preview-image` for additional gallery/preview images, repeat `--preview-video` for video previews (MP4, MOV, M4V, MPEG, WMV, or WebM), and `--thumbnail` for the card/library thumbnail. These media flags run the required two-step API flow: direct upload first, then attach by signed blob ID. For an existing product, `products thumbnail set --url` asks Gumroad to download and attach a public HTTP(S) image directly.
 
 ### files — Upload and recover file attachments
 


### PR DESCRIPTION
Adds a repeatable `--preview-video` flag to `gumroad products update` and `gumroad products create`, mirroring the existing `--preview-image` direct-upload → covers-attach pipeline.

Fixes #180

## Scope

- New `--preview-video` StringArray flag on `products update` and `products create`; videos upload through the same two-step flow (POST `/direct_uploads`, then POST `/products/:id/covers` with `signed_blob_id`).
- Video content-type detection: sniffs the file header via `http.DetectContentType`, then falls back to extension. Accepts MP4, MOV, M4V, MPEG/MPG, WMV, and WebM — matching the web editor's `ALLOWED_EXTENSIONS` in `ProductEdit/ProductTab/CoverEditor.tsx` (plus WebM, which the backend's `file.video?` check accepts).
- Unsupported types fail client-side with a plain-English error before any API call.
- Size cap: 500 MB for videos. The app repo has no explicit cover size cap for the web editor's uploader, so this keeps a sensible client-side guard rather than the 50 MB image cap.
- Retry hints for partially-attached media now emit `gumroad products update <id> --preview-video <path>` for video entries.
- Docs: `skills/gumroad/SKILL.md` flag lists and media guidance updated (README does not list per-command flags).

## No backend change needed

`POST /v2/products/:id/covers` already accepts video blobs — `app/controllers/api/v2/covers_controller.rb` attaches by `signed_blob_id`, and `AssetPreview` validates "Cover must be an image (JPEG, PNG, GIF) or a video." with duration/dimension metadata analyzed server-side.

## Dry-run transcript

```
$ gumroad products update prod123 --preview-video ./demo.mp4 --dry-run --no-input
Dry run: direct upload /tmp/demo.mp4
Filename: demo.mp4
Content type: video/mp4
Size: 64.0 KB
Dry run: POST /direct_uploads
{
  "blob": {
    "byte_size": 65560,
    "checksum": "lX32fIraNC6opr0LS/j3UA==",
    "content_type": "video/mp4",
    "filename": "demo.mp4"
  }
}
Dry run: POST /products/prod123/covers
{
  "signed_blob_id": "\u003csigned_blob:preview:0\u003e"
}
```

## Tests

- New coverage: update/create happy paths (direct upload form carries `video/mp4`, PUT `Content-Type` header, attach to `/covers`), dry-run JSON manifest (`kind: preview`, `content_type: video/mp4`, request bodies), unsupported-type rejection (AVI), extension fallback table (mov/m4v/mpg/wmv/webm), empty `--preview-video` usage error, video retry-command hint, and 500 MB size-cap rejection.
- `go test ./...` passes (products package at 85.6% coverage, above the 85% cmd gate); `gofmt -l .` clean; `go vet ./...` clean. The `test/` integration package requires a live `GUMROAD_ACCESS_TOKEN` and is unchanged.
