### PR TITLE
fix: require the HTML path argument on pages push

### DIFF
--- a/internal/cmd/pages/pages_test.go
+++ b/internal/cmd/pages/pages_test.go
@@ -291,6 +291,19 @@ func TestPush_MissingSlug(t *testing.T) {
 	}
 }
 
+func TestPush_MissingPathIsUsageError(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API")
+	})
+
+	cmd := testutil.Command(newPushCmd(), testutil.Quiet(false), testutil.NoColor(true))
+	cmd.SetArgs([]string{"about"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "missing HTML path") {
+		t.Fatalf("expected missing-path error, got: %v", err)
+	}
+}
+
 func TestPush_MissingFileIsUsageError(t *testing.T) {
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
 		t.Error("should not reach API")

--- a/internal/cmd/pages/push.go
+++ b/internal/cmd/pages/push.go
@@ -10,7 +10,7 @@ import (
 
 func newPushCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "push <slug> [path]",
+		Use:   "push <slug> <path>",
 		Short: "Publish custom HTML to a storefront page",
 		Long:  "Publish custom HTML to a storefront page, replacing whatever the page had before.\n\nUse the slug \"profile\" to replace your profile landing page (your store's home page) — that goes through the profile endpoints, same as `gumroad user page publish`.",
 		Args:  pushArgs,
@@ -20,11 +20,7 @@ func newPushCmd() *cobra.Command {
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
 			slug := args[0]
-			path := ""
-			if len(args) > 1 {
-				path = args[1]
-			}
-			input, err := pageutil.ReadHTML(opts.In(), path)
+			input, err := pageutil.ReadHTML(opts.In(), args[1])
 			if err != nil {
 				return cmdutil.UsageErrorf(c, "%s", err)
 			}
@@ -72,6 +68,9 @@ func newPushCmd() *cobra.Command {
 func pushArgs(cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return cmdutil.UsageErrorf(cmd, "missing page slug")
+	}
+	if len(args) < 2 {
+		return cmdutil.UsageErrorf(cmd, "missing HTML path (use - for stdin)")
 	}
 	if len(args) > 2 {
 		return cmdutil.UsageErrorf(cmd, "unexpected argument: %s", args[2])


### PR DESCRIPTION
## What

Follow-up to #182, addressing Greptile's P1 review on that PR: `gumroad pages push <slug>` now requires the HTML path argument. Omitting it is a usage error (`missing HTML path (use - for stdin)`) raised before any token lookup or API call.

## Why

`push` reused the shared `pageutil.ReadHTML` pipeline, which defaults an empty path to `./landing.html` — the right behavior for the profile-landing commands it was built for, but wrong for slugged pages: `gumroad pages push about` with a stray `landing.html` in the working directory would silently publish that file's contents to the `about` page. There is no sensible default file for an arbitrary slug, so the path is now mandatory. `-` for stdin and explicit paths behave exactly as before.

`pages create [path]` keeps its optional path — it only reads a file when one is explicitly given, so it never had this fallback.

## Before/After

Before: missing path silently reads `./landing.html`. After: usage error, no API call.

![demo](https://i.ibb.co/dwRDb5Y0/demo-pages.gif)

## Test plan

- New `TestPush_MissingPathIsUsageError` asserts the usage error and that the API is never reached
- `go test ./...` — full suite green
- `internal/cmd/pages` coverage 86.7% (gate: 85%)
- `gofmt -l` clean, `go vet` clean (local golangci-lint is v2 and can't read the repo's v1 config — CI runs the pinned linter)

## Self-review

- The fix is in `pushArgs` (arg-count validation) plus dropping the empty-path fallback in `RunE`, so cobra's usage text (`push <slug> <path>`) and the error path stay consistent.
- `TestPush_MissingFileIsUsageError` and the stdin test pin that explicit-path and `-` behavior are unchanged.

---

AI disclosure: authored by claude-fable-5 (Hermes agent) — triaged the Greptile finding, wrote the fix and test, ran the full suite and coverage gates locally, recorded the terminal demo with asciinema + agg.
