### PR TITLE
Add admin users refund-all-for-fraud command

### DIFF
--- a/internal/cmd/admin/users/refund_all_for_fraud.go
+++ b/internal/cmd/admin/users/refund_all_for_fraud.go
@@ -1,7 +1,7 @@
 package users
 
 import (
-	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -9,54 +9,59 @@ import (
 
 	"github.com/antiwork/gumroad-cli/internal/adminapi"
 	"github.com/antiwork/gumroad-cli/internal/admincmd"
+	"github.com/antiwork/gumroad-cli/internal/api"
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
-const refundAllForFraudConfirmationMessage = "Refund ALL successful purchases of user_id %s for fraud and block every buyer? This refunds every remaining sale, cancels linked subscriptions, and cannot be undone."
+const refundAllForFraudConfirmationMessage = "Queue fraud refunds for %d purchase(s) of user_id %s%s? This refunds every remaining sale, cancels linked subscriptions, and cannot be undone once queued."
 
 type refundAllForFraudRequest struct {
-	UserID        string `json:"user_id"`
-	ExpectedEmail string `json:"expected_email,omitempty"`
-	Force         bool   `json:"force,omitempty"`
-}
-
-type refundAllForFraudFailure struct {
-	PurchaseExternalIDNumeric int64  `json:"purchase_external_id_numeric"`
-	Error                     string `json:"error"`
+	UserID                string `json:"user_id"`
+	ExpectedEmail         string `json:"expected_email"`
+	ExpectedPurchaseCount int    `json:"expected_purchase_count"`
+	BlockBuyers           bool   `json:"block_buyers,omitempty"`
 }
 
 type refundAllForFraudResponse struct {
-	Success       bool                       `json:"success"`
-	UserID        string                     `json:"user_id"`
-	Message       string                     `json:"message"`
-	RefundedCount int                        `json:"refunded_count"`
-	SkippedCount  int                        `json:"skipped_count"`
-	Failed        []refundAllForFraudFailure `json:"failed"`
+	Success           bool   `json:"success"`
+	UserID            string `json:"user_id"`
+	Status            string `json:"status"`
+	Message           string `json:"message"`
+	PurchasesToRefund int    `json:"purchases_to_refund"`
+	BlockBuyers       bool   `json:"block_buyers"`
 }
 
 func newRefundAllForFraudCmd() *cobra.Command {
 	var (
-		targetFlags userMutationFlags
-		force       bool
+		targetFlags   userMutationFlags
+		expectedCount int
+		blockBuyers   bool
 	)
 
 	cmd := &cobra.Command{
 		Use:   "refund-all-for-fraud",
-		Short: "Refund every successful purchase of a fraudulent seller",
-		Long: `Refund all successful, non-refunded, non-charged-back purchases of a seller as
-fraud in one call, blocking each buyer and cancelling linked subscriptions.
+		Short: "Queue fraud refunds for every remaining purchase of a suspended seller",
+		Long: `Queue refunds for all successful, non-refunded purchases of a suspended seller
+as fraud. The server validates and enqueues a background job; refunds are
+processed asynchronously with per-purchase retries. Completion is recorded as a
+comment on the seller account and in the admin audit log.
 
-The seller must already be suspended or flagged; pass --force to override that
-guard for a seller in good standing. Already-refunded purchases are skipped, so
-re-running the command after a partial failure only retries what is left.
+By default buyers are NOT blocked (seller-fraud case: the buyers are victims).
+Pass --block-buyers only when the buyers themselves are fraudulent (self-purchase
+or card-testing ring); that variant also blocks each buyer's email, card
+fingerprint, browser, and IP platform-wide.
+
+--expected-email and --expected-count are required stale-state guards: the server
+responds 409 if either does not match the current account state. The seller must
+already be suspended; suspend first with 'gumroad admin users suspend'.
 
 Requires the bulk endpoint POST /internal/admin/users/refund_all_for_fraud on
 the Gumroad API.`,
-		Example: `  gumroad admin users refund-all-for-fraud --user-id 2245593582708 --dry-run
-  gumroad admin users refund-all-for-fraud --user-id 2245593582708 --yes
-  gumroad admin users refund-all-for-fraud --user-id 2245593582708 --force --yes`,
+		Example: `  gumroad admin users refund-all-for-fraud --user-id 2245593582708 --expected-email seller@example.com --expected-count 18 --dry-run
+  gumroad admin users refund-all-for-fraud --user-id 2245593582708 --expected-email seller@example.com --expected-count 18 --yes
+  gumroad admin users refund-all-for-fraud --user-id 2245593582708 --expected-email seller@example.com --expected-count 18 --block-buyers --yes`,
 		Args: cmdutil.ExactArgs(0),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
@@ -65,11 +70,21 @@ the Gumroad API.`,
 			if err != nil {
 				return err
 			}
+			if target.ExpectedEmail == "" {
+				return cmdutil.MissingFlagError(c, "--expected-email")
+			}
+			if !c.Flags().Changed("expected-count") {
+				return cmdutil.MissingFlagError(c, "--expected-count")
+			}
+			if expectedCount < 0 {
+				return cmdutil.UsageErrorf(c, "--expected-count must be a non-negative integer")
+			}
 
 			req := refundAllForFraudRequest{
-				UserID:        target.UserID,
-				ExpectedEmail: target.ExpectedEmail,
-				Force:         force,
+				UserID:                target.UserID,
+				ExpectedEmail:         target.ExpectedEmail,
+				ExpectedPurchaseCount: expectedCount,
+				BlockBuyers:           blockBuyers,
 			}
 			path := "users/refund_all_for_fraud"
 
@@ -77,7 +92,11 @@ the Gumroad API.`,
 				return cmdutil.PrintDryRunRequest(opts, http.MethodPost, adminapi.AdminPath(path), refundAllForFraudDryRunParams(req))
 			}
 
-			ok, err := cmdutil.ConfirmAction(opts, fmt.Sprintf(refundAllForFraudConfirmationMessage, target.UserID))
+			blockingNote := ""
+			if blockBuyers {
+				blockingNote = ", blocking every buyer platform-wide"
+			}
+			ok, err := cmdutil.ConfirmAction(opts, fmt.Sprintf(refundAllForFraudConfirmationMessage, expectedCount, target.UserID, blockingNote))
 			if err != nil {
 				return err
 			}
@@ -85,81 +104,64 @@ the Gumroad API.`,
 				return cmdutil.PrintCancelledAction(opts, "refund all purchases of user_id "+target.UserID+" for fraud", target.UserID)
 			}
 
-			data, err := admincmd.FetchPostJSON(opts, "Refunding all purchases for fraud...", path, req)
+			data, err := admincmd.FetchPostJSON(opts, "Queueing bulk fraud refund...", path, req)
 			if err != nil {
-				return err
+				return refundAllForFraudConflictError(err)
 			}
 			if opts.UsesJSONOutput() {
-				if err := cmdutil.PrintJSONResponse(opts, data); err != nil {
-					return err
-				}
-				return refundAllForFraudExitError(data)
+				return cmdutil.PrintJSONResponse(opts, data)
 			}
 
 			decoded, err := cmdutil.DecodeJSON[refundAllForFraudResponse](data)
 			if err != nil {
 				return err
 			}
-			if err := renderRefundAllForFraud(opts, fallback(decoded.UserID, target.UserID), decoded); err != nil {
-				return err
-			}
-			if len(decoded.Failed) > 0 {
-				return fmt.Errorf("%d purchase(s) failed to refund; re-run the command to retry only the remaining purchases", len(decoded.Failed))
-			}
-			return nil
+			return renderRefundAllForFraud(opts, fallback(decoded.UserID, target.UserID), decoded)
 		},
 	}
 
 	addUserMutationFlags(cmd, &targetFlags)
-	cmd.Flags().BoolVar(&force, "force", false, "Refund even when the seller is not suspended or flagged")
+	cmd.Flags().IntVar(&expectedCount, "expected-count", 0, "Expected number of refundable purchases (required; the server rejects a mismatch)")
+	cmd.Flags().BoolVar(&blockBuyers, "block-buyers", false, "Also block every buyer platform-wide (only for buyer-fraud cases like card-testing rings)")
 
 	return cmd
 }
 
-// In JSON output mode the raw response is printed as-is, but the process must
-// still exit non-zero when any purchase failed so scripts can detect partial
-// failures without parsing the payload.
-func refundAllForFraudExitError(data json.RawMessage) error {
-	decoded, err := cmdutil.DecodeJSON[refundAllForFraudResponse](data)
-	if err != nil {
-		return nil //nolint:nilerr // Output already printed; an unparseable body should not fail the command.
+func refundAllForFraudConflictError(err error) error {
+	var apiErr *api.APIError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusConflict {
+		return err
 	}
-	if len(decoded.Failed) > 0 {
-		return fmt.Errorf("%d purchase(s) failed to refund; re-run the command to retry only the remaining purchases", len(decoded.Failed))
-	}
-	return nil
+	return fmt.Errorf("%s — re-check the account with 'gumroad admin users info' and retry with current values; a 409 also means a bulk refund run may already be queued", apiErr.Message)
 }
 
 func refundAllForFraudDryRunParams(req refundAllForFraudRequest) url.Values {
 	params := url.Values{}
 	params.Set("user_id", req.UserID)
-	if req.ExpectedEmail != "" {
-		params.Set("expected_email", req.ExpectedEmail)
-	}
-	if req.Force {
-		params.Set("force", "true")
+	params.Set("expected_email", req.ExpectedEmail)
+	params.Set("expected_purchase_count", strconv.Itoa(req.ExpectedPurchaseCount))
+	if req.BlockBuyers {
+		params.Set("block_buyers", "true")
 	}
 	return params
 }
 
 func renderRefundAllForFraud(opts cmdutil.Options, userID string, resp refundAllForFraudResponse) error {
-	summary := fmt.Sprintf("Refunded %d, skipped %d already-refunded, %d failed", resp.RefundedCount, resp.SkippedCount, len(resp.Failed))
+	blocking := "buyers will not be blocked"
+	if resp.BlockBuyers {
+		blocking = "buyers will be blocked"
+	}
+	summary := fmt.Sprintf("Queued fraud refunds for %d purchase(s); %s", resp.PurchasesToRefund, blocking)
 
 	if opts.PlainOutput {
-		rows := [][]string{{
-			// The API always reports success once the batch runs; whether
-			// every purchase actually refunded is what callers care about.
-			strconv.FormatBool(len(resp.Failed) == 0),
-			summary,
+		return output.PrintPlain(opts.Out(), [][]string{{
+			strconv.FormatBool(resp.Success),
+			fallback(resp.Message, resp.Status),
 			userID,
-			strconv.Itoa(resp.RefundedCount),
-			strconv.Itoa(resp.SkippedCount),
-			strconv.Itoa(len(resp.Failed)),
-		}}
-		for _, failure := range resp.Failed {
-			rows = append(rows, []string{"failed", strconv.FormatInt(failure.PurchaseExternalIDNumeric, 10), failure.Error})
-		}
-		return output.PrintPlain(opts.Out(), rows)
+			resp.Status,
+			strconv.Itoa(resp.PurchasesToRefund),
+			strconv.FormatBool(resp.BlockBuyers),
+		}})
 	}
 
 	if opts.Quiet {
@@ -167,33 +169,16 @@ func renderRefundAllForFraud(opts cmdutil.Options, userID string, resp refundAll
 	}
 
 	style := opts.Style()
-	headline := "Refunded all remaining purchases for fraud and blocked the buyers"
-	if len(resp.Failed) > 0 {
-		headline = "Bulk fraud refund finished with failures"
-	}
-	styledHeadline := style.Green(headline)
-	if len(resp.Failed) > 0 {
-		styledHeadline = style.Red(headline)
-	}
-	if err := output.Writeln(opts.Out(), styledHeadline); err != nil {
+	if err := output.Writeln(opts.Out(), style.Green(summary)); err != nil {
 		return err
 	}
 	if err := output.Writef(opts.Out(), "User ID: %s\n", userID); err != nil {
 		return err
 	}
-	if err := output.Writef(opts.Out(), "%s\n", summary); err != nil {
-		return err
+	if resp.Status != "" {
+		if err := output.Writef(opts.Out(), "Status: %s\n", resp.Status); err != nil {
+			return err
+		}
 	}
-	if len(resp.Failed) == 0 {
-		return nil
-	}
-
-	if err := output.Writeln(opts.Out(), ""); err != nil {
-		return err
-	}
-	tbl := output.NewStyledTable(style, "PURCHASE ID", "ERROR")
-	for _, failure := range resp.Failed {
-		tbl.AddRow(strconv.FormatInt(failure.PurchaseExternalIDNumeric, 10), failure.Error)
-	}
-	return tbl.Render(opts.Out())
+	return output.Writeln(opts.Out(), "Refunds run in the background with per-purchase retries; check the seller's comments and the admin audit log for completion.")
 }

--- a/internal/cmd/admin/users/refund_all_for_fraud.go
+++ b/internal/cmd/admin/users/refund_all_for_fraud.go
@@ -1,0 +1,199 @@
+package users
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/antiwork/gumroad-cli/internal/adminapi"
+	"github.com/antiwork/gumroad-cli/internal/admincmd"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+const refundAllForFraudConfirmationMessage = "Refund ALL successful purchases of user_id %s for fraud and block every buyer? This refunds every remaining sale, cancels linked subscriptions, and cannot be undone."
+
+type refundAllForFraudRequest struct {
+	UserID        string `json:"user_id"`
+	ExpectedEmail string `json:"expected_email,omitempty"`
+	Force         bool   `json:"force,omitempty"`
+}
+
+type refundAllForFraudFailure struct {
+	PurchaseExternalIDNumeric int64  `json:"purchase_external_id_numeric"`
+	Error                     string `json:"error"`
+}
+
+type refundAllForFraudResponse struct {
+	Success       bool                       `json:"success"`
+	UserID        string                     `json:"user_id"`
+	Message       string                     `json:"message"`
+	RefundedCount int                        `json:"refunded_count"`
+	SkippedCount  int                        `json:"skipped_count"`
+	Failed        []refundAllForFraudFailure `json:"failed"`
+}
+
+func newRefundAllForFraudCmd() *cobra.Command {
+	var (
+		targetFlags userMutationFlags
+		force       bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "refund-all-for-fraud",
+		Short: "Refund every successful purchase of a fraudulent seller",
+		Long: `Refund all successful, non-refunded, non-charged-back purchases of a seller as
+fraud in one call, blocking each buyer and cancelling linked subscriptions.
+
+The seller must already be suspended or flagged; pass --force to override that
+guard for a seller in good standing. Already-refunded purchases are skipped, so
+re-running the command after a partial failure only retries what is left.
+
+Requires the bulk endpoint POST /internal/admin/users/refund_all_for_fraud on
+the Gumroad API.`,
+		Example: `  gumroad admin users refund-all-for-fraud --user-id 2245593582708 --dry-run
+  gumroad admin users refund-all-for-fraud --user-id 2245593582708 --yes
+  gumroad admin users refund-all-for-fraud --user-id 2245593582708 --force --yes`,
+		Args: cmdutil.ExactArgs(0),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+
+			target, err := resolveUserMutationTarget(c, targetFlags)
+			if err != nil {
+				return err
+			}
+
+			req := refundAllForFraudRequest{
+				UserID:        target.UserID,
+				ExpectedEmail: target.ExpectedEmail,
+				Force:         force,
+			}
+			path := "users/refund_all_for_fraud"
+
+			if opts.DryRun {
+				return cmdutil.PrintDryRunRequest(opts, http.MethodPost, adminapi.AdminPath(path), refundAllForFraudDryRunParams(req))
+			}
+
+			ok, err := cmdutil.ConfirmAction(opts, fmt.Sprintf(refundAllForFraudConfirmationMessage, target.UserID))
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return cmdutil.PrintCancelledAction(opts, "refund all purchases of user_id "+target.UserID+" for fraud", target.UserID)
+			}
+
+			data, err := admincmd.FetchPostJSON(opts, "Refunding all purchases for fraud...", path, req)
+			if err != nil {
+				return err
+			}
+			if opts.UsesJSONOutput() {
+				if err := cmdutil.PrintJSONResponse(opts, data); err != nil {
+					return err
+				}
+				return refundAllForFraudExitError(data)
+			}
+
+			decoded, err := cmdutil.DecodeJSON[refundAllForFraudResponse](data)
+			if err != nil {
+				return err
+			}
+			if err := renderRefundAllForFraud(opts, fallback(decoded.UserID, target.UserID), decoded); err != nil {
+				return err
+			}
+			if len(decoded.Failed) > 0 {
+				return fmt.Errorf("%d purchase(s) failed to refund; re-run the command to retry only the remaining purchases", len(decoded.Failed))
+			}
+			return nil
+		},
+	}
+
+	addUserMutationFlags(cmd, &targetFlags)
+	cmd.Flags().BoolVar(&force, "force", false, "Refund even when the seller is not suspended or flagged")
+
+	return cmd
+}
+
+// In JSON output mode the raw response is printed as-is, but the process must
+// still exit non-zero when any purchase failed so scripts can detect partial
+// failures without parsing the payload.
+func refundAllForFraudExitError(data json.RawMessage) error {
+	decoded, err := cmdutil.DecodeJSON[refundAllForFraudResponse](data)
+	if err != nil {
+		return nil //nolint:nilerr // Output already printed; an unparseable body should not fail the command.
+	}
+	if len(decoded.Failed) > 0 {
+		return fmt.Errorf("%d purchase(s) failed to refund; re-run the command to retry only the remaining purchases", len(decoded.Failed))
+	}
+	return nil
+}
+
+func refundAllForFraudDryRunParams(req refundAllForFraudRequest) url.Values {
+	params := url.Values{}
+	params.Set("user_id", req.UserID)
+	if req.ExpectedEmail != "" {
+		params.Set("expected_email", req.ExpectedEmail)
+	}
+	if req.Force {
+		params.Set("force", "true")
+	}
+	return params
+}
+
+func renderRefundAllForFraud(opts cmdutil.Options, userID string, resp refundAllForFraudResponse) error {
+	summary := fmt.Sprintf("Refunded %d, skipped %d already-refunded, %d failed", resp.RefundedCount, resp.SkippedCount, len(resp.Failed))
+
+	if opts.PlainOutput {
+		rows := [][]string{{
+			// The API always reports success once the batch runs; whether
+			// every purchase actually refunded is what callers care about.
+			strconv.FormatBool(len(resp.Failed) == 0),
+			summary,
+			userID,
+			strconv.Itoa(resp.RefundedCount),
+			strconv.Itoa(resp.SkippedCount),
+			strconv.Itoa(len(resp.Failed)),
+		}}
+		for _, failure := range resp.Failed {
+			rows = append(rows, []string{"failed", strconv.FormatInt(failure.PurchaseExternalIDNumeric, 10), failure.Error})
+		}
+		return output.PrintPlain(opts.Out(), rows)
+	}
+
+	if opts.Quiet {
+		return nil
+	}
+
+	style := opts.Style()
+	headline := "Refunded all remaining purchases for fraud and blocked the buyers"
+	if len(resp.Failed) > 0 {
+		headline = "Bulk fraud refund finished with failures"
+	}
+	styledHeadline := style.Green(headline)
+	if len(resp.Failed) > 0 {
+		styledHeadline = style.Red(headline)
+	}
+	if err := output.Writeln(opts.Out(), styledHeadline); err != nil {
+		return err
+	}
+	if err := output.Writef(opts.Out(), "User ID: %s\n", userID); err != nil {
+		return err
+	}
+	if err := output.Writef(opts.Out(), "%s\n", summary); err != nil {
+		return err
+	}
+	if len(resp.Failed) == 0 {
+		return nil
+	}
+
+	if err := output.Writeln(opts.Out(), ""); err != nil {
+		return err
+	}
+	tbl := output.NewStyledTable(style, "PURCHASE ID", "ERROR")
+	for _, failure := range resp.Failed {
+		tbl.AddRow(strconv.FormatInt(failure.PurchaseExternalIDNumeric, 10), failure.Error)
+	}
+	return tbl.Render(opts.Out())
+}

--- a/internal/cmd/admin/users/refund_all_for_fraud_test.go
+++ b/internal/cmd/admin/users/refund_all_for_fraud_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestRefundAllForFraudRequiresUserID(t *testing.T) {
 	cmd := newRefundAllForFraudCmd()
-	cmd.SetArgs([]string{})
+	cmd.SetArgs([]string{"--expected-email", "seller@example.com", "--expected-count", "3"})
 
 	err := cmd.Execute()
 	if err == nil {
@@ -23,13 +23,64 @@ func TestRefundAllForFraudRequiresUserID(t *testing.T) {
 	}
 }
 
+func TestRefundAllForFraudRequiresExpectedEmail(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API without --expected-email")
+	})
+
+	cmd := testutil.Command(newRefundAllForFraudCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--expected-count", "3"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected missing --expected-email error")
+	}
+	if !strings.Contains(err.Error(), "missing required flag: --expected-email") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRefundAllForFraudRequiresExpectedCount(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API without --expected-count")
+	})
+
+	cmd := testutil.Command(newRefundAllForFraudCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--expected-email", "seller@example.com"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected missing --expected-count error")
+	}
+	if !strings.Contains(err.Error(), "missing required flag: --expected-count") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRefundAllForFraudRejectsNegativeExpectedCount(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API with a negative --expected-count")
+	})
+
+	cmd := testutil.Command(newRefundAllForFraudCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--expected-email", "seller@example.com", "--expected-count", "-1"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected negative --expected-count error")
+	}
+	if !strings.Contains(err.Error(), "--expected-count must be a non-negative integer") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestRefundAllForFraudRequiresConfirmation(t *testing.T) {
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
 		t.Error("should not reach API without confirmation")
 	})
 
 	cmd := testutil.Command(newRefundAllForFraudCmd(), testutil.NoInput(true))
-	cmd.SetArgs([]string{"--user-id", "2245593582708"})
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--expected-email", "seller@example.com", "--expected-count", "3"})
 
 	err := cmd.Execute()
 	if err == nil {
@@ -40,7 +91,7 @@ func TestRefundAllForFraudRequiresConfirmation(t *testing.T) {
 	}
 }
 
-func TestRefundAllForFraudSendsRequestAndRendersSummary(t *testing.T) {
+func TestRefundAllForFraudSendsRequestAndRendersQueuedSummary(t *testing.T) {
 	var gotMethod, gotPath, gotAuth string
 	var body refundAllForFraudRequest
 
@@ -55,20 +106,21 @@ func TestRefundAllForFraudSendsRequestAndRendersSummary(t *testing.T) {
 		if err := json.Unmarshal(raw, &body); err != nil {
 			t.Fatalf("decode body: %v", err)
 		}
-		if strings.Contains(string(raw), `"force"`) {
-			t.Errorf("force must be omitted when the flag is not passed, got %q", raw)
+		if strings.Contains(string(raw), `"block_buyers"`) {
+			t.Errorf("block_buyers must be omitted when the flag is not passed, got %q", raw)
 		}
 		testutil.JSON(t, w, map[string]any{
-			"success":        true,
-			"user_id":        "2245593582708",
-			"refunded_count": 17,
-			"skipped_count":  1,
-			"failed":         []any{},
+			"success":             true,
+			"user_id":             "2245593582708",
+			"status":              "queued",
+			"message":             "Refund all for fraud queued",
+			"purchases_to_refund": 18,
+			"block_buyers":        false,
 		})
 	})
 
 	cmd := testutil.Command(newRefundAllForFraudCmd(), testutil.Yes(true), testutil.Quiet(false))
-	cmd.SetArgs([]string{"--user-id", "2245593582708"})
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--expected-email", "seller@example.com", "--expected-count", "18"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
 	if gotMethod != "POST" || gotPath != "/internal/admin/users/refund_all_for_fraud" {
@@ -77,17 +129,22 @@ func TestRefundAllForFraudSendsRequestAndRendersSummary(t *testing.T) {
 	if gotAuth != "Bearer admin-token" {
 		t.Fatalf("got auth %q, want Bearer admin-token", gotAuth)
 	}
-	if body.UserID != "2245593582708" || body.Force {
+	if body.UserID != "2245593582708" || body.ExpectedEmail != "seller@example.com" || body.ExpectedPurchaseCount != 18 || body.BlockBuyers {
 		t.Fatalf("unexpected request body: %#v", body)
 	}
-	for _, want := range []string{"User ID: 2245593582708", "Refunded 17, skipped 1 already-refunded, 0 failed"} {
+	for _, want := range []string{
+		"Queued fraud refunds for 18 purchase(s); buyers will not be blocked",
+		"User ID: 2245593582708",
+		"Status: queued",
+		"check the seller's comments and the admin audit log",
+	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("output missing %q: %q", want, out)
 		}
 	}
 }
 
-func TestRefundAllForFraudForwardsForceAndExpectedEmail(t *testing.T) {
+func TestRefundAllForFraudForwardsBlockBuyers(t *testing.T) {
 	var body refundAllForFraudRequest
 
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
@@ -95,106 +152,77 @@ func TestRefundAllForFraudForwardsForceAndExpectedEmail(t *testing.T) {
 			t.Fatalf("decode body: %v", err)
 		}
 		testutil.JSON(t, w, map[string]any{
-			"success":        true,
-			"user_id":        "2245593582708",
-			"refunded_count": 0,
-			"skipped_count":  0,
-			"failed":         []any{},
+			"success":             true,
+			"user_id":             "2245593582708",
+			"status":              "queued",
+			"message":             "Refund all for fraud queued",
+			"purchases_to_refund": 4,
+			"block_buyers":        true,
 		})
 	})
 
-	cmd := testutil.Command(newRefundAllForFraudCmd(), testutil.Yes(true))
-	cmd.SetArgs([]string{"--user-id", "2245593582708", "--expected-email", "seller@example.com", "--force"})
-	testutil.MustExecute(t, cmd)
+	cmd := testutil.Command(newRefundAllForFraudCmd(), testutil.Yes(true), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--expected-email", "seller@example.com", "--expected-count", "4", "--block-buyers"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	if body.UserID != "2245593582708" || body.ExpectedEmail != "seller@example.com" || !body.Force {
+	if body.UserID != "2245593582708" || !body.BlockBuyers || body.ExpectedPurchaseCount != 4 {
 		t.Fatalf("unexpected request body: %#v", body)
+	}
+	if !strings.Contains(out, "buyers will be blocked") {
+		t.Fatalf("output should note buyer blocking: %q", out)
 	}
 }
 
-func TestRefundAllForFraudPartialFailureRendersTableAndExitsNonZero(t *testing.T) {
+func TestRefundAllForFraudConflictExplainsStaleStateAndDuplicateRun(t *testing.T) {
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
 		testutil.RawJSON(t, w, `{
-			"success": true,
+			"success": false,
 			"user_id": "2245593582708",
-			"refunded_count": 16,
-			"skipped_count": 1,
-			"failed": [
-				{"purchase_external_id_numeric": 12345, "error": "Stripe is unavailable"},
-				{"purchase_external_id_numeric": 67890, "error": "Refund amount cannot be greater than the purchase price."}
-			]
+			"message": "Expected purchase count does not match the current number of refundable purchases",
+			"current": {"purchases_to_refund": 17}
 		}`)
 	})
 
-	cmd := testutil.Command(newRefundAllForFraudCmd(), testutil.Yes(true), testutil.Quiet(false))
-	cmd.SetArgs([]string{"--user-id", "2245593582708"})
+	cmd := testutil.Command(newRefundAllForFraudCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--expected-email", "seller@example.com", "--expected-count", "18"})
 
-	var execErr error
-	out := testutil.CaptureStdout(func() { execErr = cmd.Execute() })
-
-	if execErr == nil {
-		t.Fatal("expected non-nil error when some purchases failed")
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error on 409 conflict")
 	}
-	if !strings.Contains(execErr.Error(), "2 purchase(s) failed to refund") {
-		t.Fatalf("unexpected error: %v", execErr)
-	}
-	for _, want := range []string{"Refunded 16, skipped 1 already-refunded, 2 failed", "12345", "Stripe is unavailable", "67890"} {
-		if !strings.Contains(out, want) {
-			t.Fatalf("output missing %q: %q", want, out)
+	for _, want := range []string{
+		"Expected purchase count does not match",
+		"gumroad admin users info",
+		"already be queued",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("conflict error missing %q: %v", want, err)
 		}
 	}
 }
 
-func TestRefundAllForFraudJSONPreservesResponseAndExitsNonZeroOnFailures(t *testing.T) {
+func TestRefundAllForFraudJSONPreservesQueuedResponse(t *testing.T) {
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
 		testutil.RawJSON(t, w, `{
 			"success": true,
 			"user_id": "2245593582708",
-			"refunded_count": 0,
-			"skipped_count": 0,
-			"failed": [{"purchase_external_id_numeric": 12345, "error": "Stripe is unavailable"}]
+			"status": "queued",
+			"message": "Refund all for fraud queued",
+			"purchases_to_refund": 3,
+			"block_buyers": false
 		}`)
 	})
 
 	cmd := testutil.Command(newRefundAllForFraudCmd(), testutil.Yes(true), testutil.JSONOutput())
-	cmd.SetArgs([]string{"--user-id", "2245593582708"})
-
-	var execErr error
-	out := testutil.CaptureStdout(func() { execErr = cmd.Execute() })
-
-	if execErr == nil {
-		t.Fatal("expected non-nil error when some purchases failed in JSON mode")
-	}
-
-	var resp refundAllForFraudResponse
-	if err := json.Unmarshal([]byte(out), &resp); err != nil {
-		t.Fatalf("not valid JSON: %v\n%s", err, out)
-	}
-	if !resp.Success || len(resp.Failed) != 1 || resp.Failed[0].PurchaseExternalIDNumeric != 12345 {
-		t.Fatalf("unexpected JSON payload: %s", out)
-	}
-}
-
-func TestRefundAllForFraudJSONSuccessExitsZero(t *testing.T) {
-	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
-		testutil.JSON(t, w, map[string]any{
-			"success":        true,
-			"user_id":        "2245593582708",
-			"refunded_count": 3,
-			"skipped_count":  0,
-			"failed":         []any{},
-		})
-	})
-
-	cmd := testutil.Command(newRefundAllForFraudCmd(), testutil.Yes(true), testutil.JSONOutput())
-	cmd.SetArgs([]string{"--user-id", "2245593582708"})
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--expected-email", "seller@example.com", "--expected-count", "3"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
 	var resp refundAllForFraudResponse
 	if err := json.Unmarshal([]byte(out), &resp); err != nil {
 		t.Fatalf("not valid JSON: %v\n%s", err, out)
 	}
-	if !resp.Success || resp.RefundedCount != 3 {
+	if !resp.Success || resp.Status != "queued" || resp.PurchasesToRefund != 3 || resp.BlockBuyers {
 		t.Fatalf("unexpected JSON payload: %s", out)
 	}
 }
@@ -205,45 +233,37 @@ func TestRefundAllForFraudDryRunDoesNotContactEndpoint(t *testing.T) {
 	})
 
 	cmd := testutil.Command(newRefundAllForFraudCmd(), testutil.DryRun(true), testutil.NoInput(true))
-	cmd.SetArgs([]string{"--user-id", "2245593582708", "--force"})
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--expected-email", "seller@example.com", "--expected-count", "18", "--block-buyers"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
 	if !strings.Contains(out, "POST") || !strings.Contains(out, "/internal/admin/users/refund_all_for_fraud") {
 		t.Errorf("expected dry-run preview to mention POST and the refund_all_for_fraud path, got: %q", out)
 	}
-	if !strings.Contains(out, "user_id: 2245593582708") || !strings.Contains(out, "force: true") {
-		t.Errorf("expected dry-run preview to include user_id and force, got: %q", out)
+	for _, want := range []string{"user_id: 2245593582708", "expected_email: seller@example.com", "expected_purchase_count: 18", "block_buyers: true"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected dry-run preview to include %q, got: %q", want, out)
+		}
 	}
 }
 
-func TestRefundAllForFraudPlainOutputIncludesFailureRows(t *testing.T) {
+func TestRefundAllForFraudPlainOutputPrintsQueuedRow(t *testing.T) {
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
 		testutil.RawJSON(t, w, `{
 			"success": true,
 			"user_id": "2245593582708",
-			"refunded_count": 1,
-			"skipped_count": 0,
-			"failed": [{"purchase_external_id_numeric": 12345, "error": "Stripe is unavailable"}]
+			"status": "queued",
+			"message": "Refund all for fraud queued",
+			"purchases_to_refund": 2,
+			"block_buyers": true
 		}`)
 	})
 
 	cmd := testutil.Command(newRefundAllForFraudCmd(), testutil.Yes(true), testutil.PlainOutput())
-	cmd.SetArgs([]string{"--user-id", "2245593582708"})
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--expected-email", "seller@example.com", "--expected-count", "2", "--block-buyers"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
-	var execErr error
-	out := testutil.CaptureStdout(func() { execErr = cmd.Execute() })
-
-	if execErr == nil {
-		t.Fatal("expected non-nil error when some purchases failed in plain mode")
-	}
-	lines := strings.Split(strings.TrimSpace(out), "\n")
-	if len(lines) != 2 {
-		t.Fatalf("expected summary row plus one failure row, got %d lines: %q", len(lines), out)
-	}
-	if !strings.HasPrefix(lines[0], "false\t") || !strings.Contains(lines[0], "2245593582708") {
-		t.Fatalf("unexpected summary row: %q", lines[0])
-	}
-	if lines[1] != "failed\t12345\tStripe is unavailable" {
-		t.Fatalf("unexpected failure row: %q", lines[1])
+	line := strings.TrimSpace(out)
+	if line != "true\tRefund all for fraud queued\t2245593582708\tqueued\t2\ttrue" {
+		t.Fatalf("unexpected plain row: %q", line)
 	}
 }

--- a/internal/cmd/admin/users/refund_all_for_fraud_test.go
+++ b/internal/cmd/admin/users/refund_all_for_fraud_test.go
@@ -1,0 +1,249 @@
+package users
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestRefundAllForFraudRequiresUserID(t *testing.T) {
+	cmd := newRefundAllForFraudCmd()
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected missing identifier error")
+	}
+	if !strings.Contains(err.Error(), "missing required flag: --user-id") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRefundAllForFraudRequiresConfirmation(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach API without confirmation")
+	})
+
+	cmd := testutil.Command(newRefundAllForFraudCmd(), testutil.NoInput(true))
+	cmd.SetArgs([]string{"--user-id", "2245593582708"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error without --yes and --no-input")
+	}
+	if !strings.Contains(err.Error(), "--yes") {
+		t.Errorf("error should mention --yes: %v", err)
+	}
+}
+
+func TestRefundAllForFraudSendsRequestAndRendersSummary(t *testing.T) {
+	var gotMethod, gotPath, gotAuth string
+	var body refundAllForFraudRequest
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if err := json.Unmarshal(raw, &body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if strings.Contains(string(raw), `"force"`) {
+			t.Errorf("force must be omitted when the flag is not passed, got %q", raw)
+		}
+		testutil.JSON(t, w, map[string]any{
+			"success":        true,
+			"user_id":        "2245593582708",
+			"refunded_count": 17,
+			"skipped_count":  1,
+			"failed":         []any{},
+		})
+	})
+
+	cmd := testutil.Command(newRefundAllForFraudCmd(), testutil.Yes(true), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--user-id", "2245593582708"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != "POST" || gotPath != "/internal/admin/users/refund_all_for_fraud" {
+		t.Fatalf("got %s %s, want POST /internal/admin/users/refund_all_for_fraud", gotMethod, gotPath)
+	}
+	if gotAuth != "Bearer admin-token" {
+		t.Fatalf("got auth %q, want Bearer admin-token", gotAuth)
+	}
+	if body.UserID != "2245593582708" || body.Force {
+		t.Fatalf("unexpected request body: %#v", body)
+	}
+	for _, want := range []string{"User ID: 2245593582708", "Refunded 17, skipped 1 already-refunded, 0 failed"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestRefundAllForFraudForwardsForceAndExpectedEmail(t *testing.T) {
+	var body refundAllForFraudRequest
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		testutil.JSON(t, w, map[string]any{
+			"success":        true,
+			"user_id":        "2245593582708",
+			"refunded_count": 0,
+			"skipped_count":  0,
+			"failed":         []any{},
+		})
+	})
+
+	cmd := testutil.Command(newRefundAllForFraudCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--expected-email", "seller@example.com", "--force"})
+	testutil.MustExecute(t, cmd)
+
+	if body.UserID != "2245593582708" || body.ExpectedEmail != "seller@example.com" || !body.Force {
+		t.Fatalf("unexpected request body: %#v", body)
+	}
+}
+
+func TestRefundAllForFraudPartialFailureRendersTableAndExitsNonZero(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.RawJSON(t, w, `{
+			"success": true,
+			"user_id": "2245593582708",
+			"refunded_count": 16,
+			"skipped_count": 1,
+			"failed": [
+				{"purchase_external_id_numeric": 12345, "error": "Stripe is unavailable"},
+				{"purchase_external_id_numeric": 67890, "error": "Refund amount cannot be greater than the purchase price."}
+			]
+		}`)
+	})
+
+	cmd := testutil.Command(newRefundAllForFraudCmd(), testutil.Yes(true), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--user-id", "2245593582708"})
+
+	var execErr error
+	out := testutil.CaptureStdout(func() { execErr = cmd.Execute() })
+
+	if execErr == nil {
+		t.Fatal("expected non-nil error when some purchases failed")
+	}
+	if !strings.Contains(execErr.Error(), "2 purchase(s) failed to refund") {
+		t.Fatalf("unexpected error: %v", execErr)
+	}
+	for _, want := range []string{"Refunded 16, skipped 1 already-refunded, 2 failed", "12345", "Stripe is unavailable", "67890"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestRefundAllForFraudJSONPreservesResponseAndExitsNonZeroOnFailures(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.RawJSON(t, w, `{
+			"success": true,
+			"user_id": "2245593582708",
+			"refunded_count": 0,
+			"skipped_count": 0,
+			"failed": [{"purchase_external_id_numeric": 12345, "error": "Stripe is unavailable"}]
+		}`)
+	})
+
+	cmd := testutil.Command(newRefundAllForFraudCmd(), testutil.Yes(true), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--user-id", "2245593582708"})
+
+	var execErr error
+	out := testutil.CaptureStdout(func() { execErr = cmd.Execute() })
+
+	if execErr == nil {
+		t.Fatal("expected non-nil error when some purchases failed in JSON mode")
+	}
+
+	var resp refundAllForFraudResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if !resp.Success || len(resp.Failed) != 1 || resp.Failed[0].PurchaseExternalIDNumeric != 12345 {
+		t.Fatalf("unexpected JSON payload: %s", out)
+	}
+}
+
+func TestRefundAllForFraudJSONSuccessExitsZero(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"success":        true,
+			"user_id":        "2245593582708",
+			"refunded_count": 3,
+			"skipped_count":  0,
+			"failed":         []any{},
+		})
+	})
+
+	cmd := testutil.Command(newRefundAllForFraudCmd(), testutil.Yes(true), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--user-id", "2245593582708"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp refundAllForFraudResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if !resp.Success || resp.RefundedCount != 3 {
+		t.Fatalf("unexpected JSON payload: %s", out)
+	}
+}
+
+func TestRefundAllForFraudDryRunDoesNotContactEndpoint(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("dry-run must not POST to the refund_all_for_fraud endpoint")
+	})
+
+	cmd := testutil.Command(newRefundAllForFraudCmd(), testutil.DryRun(true), testutil.NoInput(true))
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--force"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "POST") || !strings.Contains(out, "/internal/admin/users/refund_all_for_fraud") {
+		t.Errorf("expected dry-run preview to mention POST and the refund_all_for_fraud path, got: %q", out)
+	}
+	if !strings.Contains(out, "user_id: 2245593582708") || !strings.Contains(out, "force: true") {
+		t.Errorf("expected dry-run preview to include user_id and force, got: %q", out)
+	}
+}
+
+func TestRefundAllForFraudPlainOutputIncludesFailureRows(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.RawJSON(t, w, `{
+			"success": true,
+			"user_id": "2245593582708",
+			"refunded_count": 1,
+			"skipped_count": 0,
+			"failed": [{"purchase_external_id_numeric": 12345, "error": "Stripe is unavailable"}]
+		}`)
+	})
+
+	cmd := testutil.Command(newRefundAllForFraudCmd(), testutil.Yes(true), testutil.PlainOutput())
+	cmd.SetArgs([]string{"--user-id", "2245593582708"})
+
+	var execErr error
+	out := testutil.CaptureStdout(func() { execErr = cmd.Execute() })
+
+	if execErr == nil {
+		t.Fatal("expected non-nil error when some purchases failed in plain mode")
+	}
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected summary row plus one failure row, got %d lines: %q", len(lines), out)
+	}
+	if !strings.HasPrefix(lines[0], "false\t") || !strings.Contains(lines[0], "2245593582708") {
+		t.Fatalf("unexpected summary row: %q", lines[0])
+	}
+	if lines[1] != "failed\t12345\tStripe is unavailable" {
+		t.Fatalf("unexpected failure row: %q", lines[1])
+	}
+}

--- a/internal/cmd/admin/users/users.go
+++ b/internal/cmd/admin/users/users.go
@@ -30,6 +30,7 @@ func NewUsersCmd() *cobra.Command {
   gumroad admin users suspend --user-id 2245593582708 --note "Chargeback risk confirmed"
   gumroad admin users suspend-for-tos-violation --user-id 2245593582708 --note "DMCA takedown notice confirmed"
   gumroad admin users refund-balance --user-id 2245593582708 --expected-email user@example.com --dry-run
+  gumroad admin users refund-all-for-fraud --user-id 2245593582708 --yes
   gumroad admin users reset-password --user-id 2245593582708
   gumroad admin users update-email --user-id 2245593582708 --new-email new@example.com
   gumroad admin users two-factor disable --user-id 2245593582708`,
@@ -51,6 +52,7 @@ func NewUsersCmd() *cobra.Command {
 	cmd.AddCommand(newSuspendCmd())
 	cmd.AddCommand(newSuspendForTOSViolationCmd())
 	cmd.AddCommand(newRefundBalanceCmd())
+	cmd.AddCommand(newRefundAllForFraudCmd())
 	cmd.AddCommand(newResetPasswordCmd())
 	cmd.AddCommand(newUpdateEmailCmd())
 	cmd.AddCommand(newTwoFactorCmd())

--- a/internal/cmd/admin/users/users.go
+++ b/internal/cmd/admin/users/users.go
@@ -30,7 +30,7 @@ func NewUsersCmd() *cobra.Command {
   gumroad admin users suspend --user-id 2245593582708 --note "Chargeback risk confirmed"
   gumroad admin users suspend-for-tos-violation --user-id 2245593582708 --note "DMCA takedown notice confirmed"
   gumroad admin users refund-balance --user-id 2245593582708 --expected-email user@example.com --dry-run
-  gumroad admin users refund-all-for-fraud --user-id 2245593582708 --yes
+  gumroad admin users refund-all-for-fraud --user-id 2245593582708 --expected-email user@example.com --expected-count 18 --yes
   gumroad admin users reset-password --user-id 2245593582708
   gumroad admin users update-email --user-id 2245593582708 --new-email new@example.com
   gumroad admin users two-factor disable --user-id 2245593582708`,

--- a/internal/cmd/admin/users/users_test.go
+++ b/internal/cmd/admin/users/users_test.go
@@ -193,6 +193,7 @@ func TestNewUsersCmdWiresSubcommands(t *testing.T) {
 		"suspend",
 		"suspend-for-tos-violation",
 		"refund-balance",
+		"refund-all-for-fraud",
 		"reset-password",
 		"update-email",
 		"two-factor",

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -104,6 +104,7 @@ Most responses are wrapped in `{"success": true, ...}` with resource-specific ke
 - `admin payouts list` → `.recent_payouts[]`, `.pagination.next`. Each payout carries `stripe_transfer_id` (a `po_…` payout or `py_…` destination payment, or null), `bank_account` (null for PayPal and debit-card payouts; otherwise `bank_number` routing/BIC, `account_holder_full_name`, `account_type`, `currency`), and `trace_id` (currently always null).
 - `admin payouts scheduled create` → `.message`, `.user_id`, `.scheduled_payout`
 - `admin users refund-balance` → `.status`, `.message`, `.user_id`, `.count`, `.total_amount_cents`, `.currency`
+- `admin users refund-all-for-fraud` → `.success`, `.user_id`, `.refunded_count`, `.skipped_count`, `.failed[]` (each failure: `.purchase_external_id_numeric`, `.error`)
 - `admin purchases view` → `.purchase`
 - `admin purchases search` → `.purchases[]`, `.has_more`, `.limit`
 - `admin purchases lookup` → `.purchases[]`
@@ -240,6 +241,12 @@ gumroad admin payouts list --user-id 2245593582708 --limit 25 --json --jq '.rece
 # Refund-balance dry-run still calls the preview GET, but skips the guarded POST.
 gumroad admin users refund-balance --user-id 2245593582708 --expected-email seller@example.com --dry-run --json --non-interactive --no-input
 gumroad admin users refund-balance --user-id 2245593582708 --expected-email seller@example.com --yes --json --non-interactive --no-input
+
+# Refund every remaining successful purchase of a fraudulent seller in one call.
+# The seller must already be suspended or flagged; --force overrides that guard.
+# Exits non-zero if any purchase failed; re-running retries only what is left.
+gumroad admin users refund-all-for-fraud --user-id 2245593582708 --yes --json --non-interactive --no-input
+gumroad admin users refund-all-for-fraud --user-id 2245593582708 --force --yes --json --non-interactive --no-input
 
 # Inspect purchase and product fraud context
 gumroad admin purchases view <purchase-id> --with-clusters --json --non-interactive --no-input

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -104,7 +104,7 @@ Most responses are wrapped in `{"success": true, ...}` with resource-specific ke
 - `admin payouts list` → `.recent_payouts[]`, `.pagination.next`. Each payout carries `stripe_transfer_id` (a `po_…` payout or `py_…` destination payment, or null), `bank_account` (null for PayPal and debit-card payouts; otherwise `bank_number` routing/BIC, `account_holder_full_name`, `account_type`, `currency`), and `trace_id` (currently always null).
 - `admin payouts scheduled create` → `.message`, `.user_id`, `.scheduled_payout`
 - `admin users refund-balance` → `.status`, `.message`, `.user_id`, `.count`, `.total_amount_cents`, `.currency`
-- `admin users refund-all-for-fraud` → `.success`, `.user_id`, `.refunded_count`, `.skipped_count`, `.failed[]` (each failure: `.purchase_external_id_numeric`, `.error`)
+- `admin users refund-all-for-fraud` → `.success`, `.user_id`, `.status` (`queued`), `.message`, `.purchases_to_refund`, `.block_buyers`
 - `admin purchases view` → `.purchase`
 - `admin purchases search` → `.purchases[]`, `.has_more`, `.limit`
 - `admin purchases lookup` → `.purchases[]`
@@ -242,11 +242,13 @@ gumroad admin payouts list --user-id 2245593582708 --limit 25 --json --jq '.rece
 gumroad admin users refund-balance --user-id 2245593582708 --expected-email seller@example.com --dry-run --json --non-interactive --no-input
 gumroad admin users refund-balance --user-id 2245593582708 --expected-email seller@example.com --yes --json --non-interactive --no-input
 
-# Refund every remaining successful purchase of a fraudulent seller in one call.
-# The seller must already be suspended or flagged; --force overrides that guard.
-# Exits non-zero if any purchase failed; re-running retries only what is left.
-gumroad admin users refund-all-for-fraud --user-id 2245593582708 --yes --json --non-interactive --no-input
-gumroad admin users refund-all-for-fraud --user-id 2245593582708 --force --yes --json --non-interactive --no-input
+# Queue fraud refunds for every remaining successful purchase of a suspended seller.
+# Requires --expected-email and --expected-count (409 on mismatch or if a run is
+# already queued). Buyers are NOT blocked by default; add --block-buyers only for
+# buyer-fraud cases (self-purchase / card-testing rings). Refunds run in a
+# background job; completion is recorded on the seller's comments and audit log.
+gumroad admin users refund-all-for-fraud --user-id 2245593582708 --expected-email seller@example.com --expected-count 18 --yes --json --non-interactive --no-input
+gumroad admin users refund-all-for-fraud --user-id 2245593582708 --expected-email seller@example.com --expected-count 18 --block-buyers --yes --json --non-interactive --no-input
 
 # Inspect purchase and product fraud context
 gumroad admin purchases view <purchase-id> --with-clusters --json --non-interactive --no-input


### PR DESCRIPTION
Adds `gumroad admin users refund-all-for-fraud`, a bulk companion to `admin purchases refund-for-fraud`, so a fraud seller's entire sales history can be refunded in one command instead of one call (plus a purchase-id lookup) per purchase.

> **Depends on antiwork/gumroad#5958.** This command calls the new `POST /internal/admin/users/refund_all_for_fraud` endpoint and will return a 404 error until that Rails PR deploys.

## Why

A recent fraud case required refunding all 18 purchases of a suspended seller. With only the per-purchase command available, that meant 17 `admin purchases search --email` round-trips to resolve purchase ids, then 18 individual `refund-for-fraud` calls, then a manual verification pass. One seller-level command removes all of that.

## What

```
gumroad admin users refund-all-for-fraud --user-id <id> --expected-email <email> --expected-count <n> [--block-buyers] --yes
```

The server endpoint was restructured (per the [security review on the Rails PR](https://github.com/antiwork/gumroad/pull/5958#issuecomment-5010358000)) into **validate-and-enqueue**; this command matches the new contract:

- **Required stale-state guards:** `--expected-email` and `--expected-count` are mandatory and fail fast client-side. The server compares both against the current account state and returns **409** on any mismatch — or when a bulk refund run is already queued (Sidekiq uniqueness lock). The CLI rewrites 409s with guidance to re-check via `admin users info` and retry with current values.
- **Buyer blocking is opt-in:** by default the endpoint refunds for fraud **without** blocking buyers (seller-fraud case — the buyers are victims). Pass `--block-buyers` only for buyer-fraud cases (self-purchase / card-testing rings); that variant also platform-blocks each buyer's email, card fingerprint, browser, and IP. The confirmation prompt calls out the blocking decision.
- **`--force` is gone:** the seller must already be suspended; suspend first with `gumroad admin users suspend`.
- **Queued response handling:** on 200 the server responds `{status: "queued", purchases_to_refund, block_buyers}`; the command prints the queued summary and notes that refunds run in the background with per-purchase retries — completion is recorded on the seller's comments and in the admin audit log.
- Confirmation prompt consistent with the other destructive admin commands; `--yes` skips it, `--dry-run` previews the guarded POST without sending it.

## Progress

- [x] Subcommand updated to the async contract: required `--expected-email`/`--expected-count` (client-side fail-fast), opt-in `--block-buyers`, no `--force`
- [x] Queued-response rendering (human, plain, JSON) with pointer to seller comments / audit log for completion
- [x] 409 conflict handling with actionable retry guidance (stale state or duplicate run)
- [x] Go tests with mock server: required-flag failures, negative count, request shape incl. `block_buyers` omitted-by-default, confirmation guard, dry-run never contacts the endpoint, 409 messaging, JSON passthrough, plain output row
- [x] Coverage gate: `internal/cmd/admin/users` at 86.4% (gate 85%); full `make test-cover` green
- [x] golangci-lint v1.64.8 (CI-pinned) clean
- [x] `skills/gumroad/SKILL.md` updated (command usage + JSON response shape)

## Test results

```
make test-cover      # all packages green; admin/users 86.4% (gate 85%)
go test ./...        # ok
golangci-lint (v1.64.8) run ./...   # clean
```


## Demo

![demo](https://i.ibb.co/d0vqmhL5/demo-187.gif)

Terminal recording (real binary built from this branch): required-flag fail-fast without `--expected-email`/`--expected-count`, negative-count rejection, `--dry-run` previewing the request without contacting the endpoint, the destructive confirmation guard aborting on decline (no `--force` exists), and the package test run passing at 86.4% coverage. The queue-and-execute path itself is exercised against the mock server in the Go tests rather than recorded, since a live demo would enqueue real refunds.
