### PR TITLE
Add product-level refund policy flags to products create/update

### DIFF
--- a/internal/cmd/products/create.go
+++ b/internal/cmd/products/create.go
@@ -88,6 +88,7 @@ func newCreateCmd() *cobra.Command {
 	var coverImage, thumbnail string
 	var previewImages []string
 	var previewVideos []string
+	var refundPeriod, refundFinePrint string
 
 	cmd := &cobra.Command{
 		Use:   "create",
@@ -97,7 +98,8 @@ func newCreateCmd() *cobra.Command {
   gumroad products create --name "Art Pack" --cover-image ./cover.jpg --thumbnail ./thumb.jpg
   gumroad products create --name "Figma Kit" --category design/ui-and-web/figma
   gumroad products create --name "Newsletter" --type membership --subscription-duration monthly
-  gumroad products create --name "E-Book" --type ebook --price 5 --tag art --tag digital`,
+  gumroad products create --name "E-Book" --type ebook --price 5 --tag art --tag digital
+  gumroad products create --name "Art Pack" --price 10 --refund-period none --refund-fine-print "No refunds once downloaded."`,
 		Args: cmdutil.ExactArgs(0),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
@@ -124,6 +126,9 @@ func newCreateCmd() *cobra.Command {
 				return err
 			}
 			if err := validateProductCategoryFlags(c); err != nil {
+				return err
+			}
+			if err := validateProductRefundPolicyFlags(c, refundPeriod); err != nil {
 				return err
 			}
 
@@ -190,6 +195,7 @@ func newCreateCmd() *cobra.Command {
 			for _, t := range tags {
 				params.Add("tags[]", t)
 			}
+			setProductRefundPolicyParams(c, params, refundPeriod, refundFinePrint)
 
 			if len(plannedUploads) > 0 || len(media) > 0 {
 				fileRefs, err := newRichContentFileRefs(len(plannedUploads))
@@ -298,6 +304,7 @@ func newCreateCmd() *cobra.Command {
 	cmd.Flags().StringArrayVar(&previewImages, "preview-image", nil, "Additional local JPEG, PNG, or GIF preview image to upload as a product cover (repeatable)")
 	cmd.Flags().StringArrayVar(&previewVideos, "preview-video", nil, "Local MP4, MOV, M4V, MPEG, WMV, or WebM preview video to upload as a product cover (repeatable)")
 	cmd.Flags().StringVar(&thumbnail, "thumbnail", "", "Local JPEG, PNG, or GIF thumbnail image to upload after creating the product")
+	registerProductRefundPolicyFlags(cmd, &refundPeriod, &refundFinePrint)
 
 	return cmd
 }

--- a/internal/cmd/products/refund_policy_flags.go
+++ b/internal/cmd/products/refund_policy_flags.go
@@ -1,0 +1,54 @@
+package products
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+// Allowed values for --refund-period on products create/update. "inherit"
+// disables the product-level override so the account default applies again;
+// the numeric values match the account-level refund-policy periods.
+var allowedProductRefundPeriods = []string{"inherit", "none", "7", "14", "30", "183"}
+
+func registerProductRefundPolicyFlags(cmd *cobra.Command, refundPeriod, refundFinePrint *string) {
+	cmd.Flags().StringVar(refundPeriod, "refund-period", "", "Product-level refund period: inherit, none, 7, 14, 30, or 183 (inherit returns to the account default)")
+	cmd.Flags().StringVar(refundFinePrint, "refund-fine-print", "", "Fine print for the product-level refund policy (empty string clears it)")
+	_ = cmd.RegisterFlagCompletionFunc("refund-period", productRefundPeriodCompletion)
+}
+
+func productRefundPeriodCompletion(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return allowedProductRefundPeriods, cobra.ShellCompDirectiveNoFileComp
+}
+
+func validateProductRefundPolicyFlags(c *cobra.Command, refundPeriod string) error {
+	flags := c.Flags()
+	if flags.Changed("refund-period") {
+		valid := false
+		for _, allowed := range allowedProductRefundPeriods {
+			if refundPeriod == allowed {
+				valid = true
+				break
+			}
+		}
+		if !valid {
+			return cmdutil.UsageErrorf(c, "--refund-period must be one of: %s", strings.Join(allowedProductRefundPeriods, ", "))
+		}
+		if refundPeriod == "inherit" && flags.Changed("refund-fine-print") {
+			return cmdutil.UsageErrorf(c, "--refund-fine-print cannot be combined with --refund-period inherit; the account-level policy's fine print applies")
+		}
+	}
+	return nil
+}
+
+func setProductRefundPolicyParams(c *cobra.Command, params url.Values, refundPeriod, refundFinePrint string) {
+	flags := c.Flags()
+	if flags.Changed("refund-period") {
+		params.Set("refund_period", refundPeriod)
+	}
+	if flags.Changed("refund-fine-print") {
+		params.Set("refund_fine_print", refundFinePrint)
+	}
+}

--- a/internal/cmd/products/refund_policy_flags_test.go
+++ b/internal/cmd/products/refund_policy_flags_test.go
@@ -1,0 +1,207 @@
+package products
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func TestUpdate_RefundPeriodAndFinePrint(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotForm url.Values
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		_ = r.ParseForm()
+		gotForm = r.PostForm
+		testutil.JSON(t, w, map[string]any{})
+	})
+
+	cmd := testutil.Command(newUpdateCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"prod1", "--refund-period", "none", "--refund-fine-print", "No refunds once downloaded."})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != "PUT" {
+		t.Errorf("got method %q, want PUT", gotMethod)
+	}
+	if gotPath != "/products/prod1" {
+		t.Errorf("got path %q, want /products/prod1", gotPath)
+	}
+	if got := gotForm.Get("refund_period"); got != "none" {
+		t.Errorf("got refund_period=%q, want %q", got, "none")
+	}
+	if got := gotForm.Get("refund_fine_print"); got != "No refunds once downloaded." {
+		t.Errorf("got refund_fine_print=%q, want fine print", got)
+	}
+	if !strings.Contains(out, "updated") {
+		t.Errorf("expected updated message, got: %q", out)
+	}
+}
+
+func TestUpdate_RefundPeriodInherit(t *testing.T) {
+	var gotForm url.Values
+	var hasFinePrint bool
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotForm = r.PostForm
+		_, hasFinePrint = r.PostForm["refund_fine_print"]
+		testutil.JSON(t, w, map[string]any{})
+	})
+
+	cmd := testutil.Command(newUpdateCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"prod1", "--refund-period", "inherit"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if got := gotForm.Get("refund_period"); got != "inherit" {
+		t.Errorf("got refund_period=%q, want inherit", got)
+	}
+	if hasFinePrint {
+		t.Errorf("refund_fine_print should not be sent when the flag is unset")
+	}
+}
+
+func TestUpdate_RefundFinePrintEmptyClears(t *testing.T) {
+	var gotForm url.Values
+	var hasFinePrint bool
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotForm = r.PostForm
+		_, hasFinePrint = r.PostForm["refund_fine_print"]
+		testutil.JSON(t, w, map[string]any{})
+	})
+
+	cmd := testutil.Command(newUpdateCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"prod1", "--refund-period", "30", "--refund-fine-print", ""})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !hasFinePrint {
+		t.Fatalf("refund_fine_print should be sent (present but empty) to clear the fine print")
+	}
+	if got := gotForm.Get("refund_fine_print"); got != "" {
+		t.Errorf("got refund_fine_print=%q, want empty string", got)
+	}
+}
+
+func TestUpdate_InvalidRefundPeriod(t *testing.T) {
+	reached := false
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		testutil.JSON(t, w, map[string]any{})
+	})
+
+	cmd := testutil.Command(newUpdateCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"prod1", "--refund-period", "45"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error for invalid refund period")
+	}
+	if !strings.Contains(err.Error(), "--refund-period must be one of: inherit, none, 7, 14, 30, 183") {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if reached {
+		t.Errorf("API should not be reached on invalid --refund-period")
+	}
+}
+
+func TestUpdate_RefundFinePrintWithInheritRejected(t *testing.T) {
+	reached := false
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		testutil.JSON(t, w, map[string]any{})
+	})
+
+	cmd := testutil.Command(newUpdateCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"prod1", "--refund-period", "inherit", "--refund-fine-print", "Nope."})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error for --refund-fine-print with inherit")
+	}
+	if !strings.Contains(err.Error(), "cannot be combined with --refund-period inherit") {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if reached {
+		t.Errorf("API should not be reached when flags conflict")
+	}
+}
+
+func TestUpdate_RefundPeriodAloneSatisfiesRequireAnyFlag(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{})
+	})
+
+	cmd := testutil.Command(newUpdateCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"prod1", "--refund-period", "7"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+}
+
+func TestCreate_RefundPolicyFlags(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotForm url.Values
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		_ = r.ParseForm()
+		gotForm = r.PostForm
+		testutil.JSON(t, w, map[string]any{
+			"product": map[string]any{"id": "p1", "name": "Art Pack", "formatted_price": "$10"},
+		})
+	})
+
+	cmd := testutil.Command(newCreateCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--name", "Art Pack", "--price", "10", "--refund-period", "none", "--refund-fine-print", "All sales final."})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != "POST" || gotPath != "/products" {
+		t.Errorf("got %s %s, want POST /products", gotMethod, gotPath)
+	}
+	if got := gotForm.Get("refund_period"); got != "none" {
+		t.Errorf("got refund_period=%q, want none", got)
+	}
+	if got := gotForm.Get("refund_fine_print"); got != "All sales final." {
+		t.Errorf("got refund_fine_print=%q, want fine print", got)
+	}
+}
+
+func TestCreate_InvalidRefundPeriod(t *testing.T) {
+	reached := false
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		testutil.JSON(t, w, map[string]any{})
+	})
+
+	cmd := testutil.Command(newCreateCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--name", "Art Pack", "--refund-period", "forever"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error for invalid refund period")
+	}
+	if !strings.Contains(err.Error(), "--refund-period must be one of: inherit, none, 7, 14, 30, 183") {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if reached {
+		t.Errorf("API should not be reached on invalid --refund-period")
+	}
+}
+
+func TestCreate_RefundPolicyOmittedWhenFlagsUnset(t *testing.T) {
+	var hasPeriod, hasFinePrint bool
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		_, hasPeriod = r.PostForm["refund_period"]
+		_, hasFinePrint = r.PostForm["refund_fine_print"]
+		testutil.JSON(t, w, map[string]any{
+			"product": map[string]any{"id": "p1", "name": "Art Pack", "formatted_price": "$10"},
+		})
+	})
+
+	cmd := testutil.Command(newCreateCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--name", "Art Pack", "--price", "10"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if hasPeriod || hasFinePrint {
+		t.Errorf("refund policy params should not be sent when flags are unset (period=%v finePrint=%v)", hasPeriod, hasFinePrint)
+	}
+}

--- a/internal/cmd/products/update.go
+++ b/internal/cmd/products/update.go
@@ -25,6 +25,7 @@ func newUpdateCmd() *cobra.Command {
 	var previewImages []string
 	var previewVideos []string
 	var customHTML string
+	var refundPeriod, refundFinePrint string
 
 	cmd := &cobra.Command{
 		Use:   "update <product_id>",
@@ -38,7 +39,9 @@ func newUpdateCmd() *cobra.Command {
   gumroad products update <id> --preview-video ./demo.mp4
   gumroad products update <id> --file ./pack.zip
   gumroad products update <id> --custom-html ./landing.html
-  gumroad products update <id> --custom-html ''`,
+  gumroad products update <id> --custom-html ''
+  gumroad products update <id> --refund-period none --refund-fine-print "No refunds once downloaded."
+  gumroad products update <id> --refund-period inherit`,
 		Args: cmdutil.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
@@ -52,7 +55,12 @@ func newUpdateCmd() *cobra.Command {
 				"file", "file-name", "file-description",
 				"cover-image", "preview-image", "preview-video", "thumbnail",
 				"custom-html",
+				"refund-period", "refund-fine-print",
 			); err != nil {
+				return err
+			}
+
+			if err := validateProductRefundPolicyFlags(c, refundPeriod); err != nil {
 				return err
 			}
 
@@ -137,6 +145,7 @@ func newUpdateCmd() *cobra.Command {
 			for _, t := range tags {
 				params.Add("tags[]", t)
 			}
+			setProductRefundPolicyParams(c, params, refundPeriod, refundFinePrint)
 
 			path := cmdutil.JoinPath("products", args[0])
 			productFieldsChanged := productUpdateFieldFlagsChanged(c)
@@ -282,6 +291,7 @@ func newUpdateCmd() *cobra.Command {
 	cmd.Flags().StringArrayVar(&previewVideos, "preview-video", nil, "Local MP4, MOV, M4V, MPEG, WMV, or WebM preview video to upload as a product cover (repeatable)")
 	cmd.Flags().StringVar(&thumbnail, "thumbnail", "", "Local JPEG, PNG, or GIF thumbnail image to upload")
 	cmd.Flags().StringVar(&customHTML, "custom-html", "", "Path to an HTML file for the product's custom landing page (empty string clears it)")
+	registerProductRefundPolicyFlags(cmd, &refundPeriod, &refundFinePrint)
 
 	return cmd
 }
@@ -292,6 +302,7 @@ func productUpdateFieldFlagsChanged(cmd *cobra.Command) bool {
 		"custom-permalink", "custom-summary", "custom-receipt",
 		"pay-what-you-want", "suggested-price", "max-purchase-count",
 		"category", "taxonomy-id", "tag", "custom-html",
+		"refund-period", "refund-fine-print",
 	} {
 		if cmd.Flags().Changed(flag) {
 			return true

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -87,6 +87,7 @@ Most responses are wrapped in `{"success": true, ...}` with resource-specific ke
 - `products page preview` → `.custom_html`, `.sanitization_report`
 - `products page publish` / `products page clear` → `.product.custom_html`, `.product.landing_url`, `.previous_custom_html`, `.sanitization_report`
 - `products update --custom-html` → `.product.custom_html`, `.product.landing_url`, `.previous_custom_html`, `.sanitization_report`
+- `products create/update --refund-period/--refund-fine-print` and `products view` → `.product.refund_policy` (`.refund_period` is `inherit` or `none/7/14/30/183`, plus `.title`, `.fine_print`, `.inherited`)
 - Not every `products` write verb is flat: `create`, `update`, `unpublish`, and `delete` return top-level fields, but `covers add`, `thumbnail set`, and `content set` still wrap their payload in the `{success, …, result}` envelope — read those under `.result`
 - `webhooks list` → `.resource_subscriptions[]`
 - `admin users info` → `.user` (includes `.user.stripe` Stripe Connect state — `connected`, and when connected `stripe_connect_account_id`, `stripe_dashboard_url`, and a `verification` block of flags/counts or an `error` subfield when the live Stripe lookup failed — and `.user.admin_links` impersonate/user/purchases/stripe-dashboard URLs)
@@ -300,6 +301,12 @@ gumroad products update <id> --cover-image ./cover.jpg --json --no-input
 gumroad products update <id> --preview-image ./gallery-1.jpg --preview-image ./gallery-2.jpg --json --no-input
 gumroad products update <id> --preview-video ./demo.mp4 --json --no-input
 gumroad products update <id> --thumbnail ./thumb.jpg --json --no-input
+
+# Product-level refund policy override (only when the account-level policy is off).
+# Allowed periods: inherit, none, 7, 14, 30, 183. "inherit" returns to the account default.
+gumroad products update <id> --refund-period none --refund-fine-print "No refunds once downloaded." --json --no-input
+gumroad products update <id> --refund-period inherit --json --no-input
+gumroad products create --name "Art Pack" --price 10 --refund-period none --json --no-input
 gumroad products page preview <id> ./landing.html --json --no-input
 gumroad products page publish <id> ./landing.html --json --no-input
 gumroad products page publish <id> - --json --no-input < landing.html


### PR DESCRIPTION
## What

Adds product-level refund policy flags to `products create` and `products update`:

- `--refund-period <inherit|none|7|14|30|183>` — sets the product-level refund period; `inherit` disables the product override and returns the product to the account default.
- `--refund-fine-print <text>` — optional fine print for the product-level policy; an empty string clears it.

Both flags flow through the standard form-data field path, so they appear in `--dry-run` bodies and `--json` output like every other product field. Shell completion is registered for `--refund-period`. Invalid periods and the `--refund-fine-print` + `--refund-period inherit` combination are rejected client-side before any API request.

## Why

`gumroad refund-policy` only manages the store-wide policy through `/refund_policy`. Gumroad's product settings also allow sellers to enable a per-product override with a refund period and optional fine print, but automated product creation still required a manual dashboard step for each product needing a different policy — easy to miss in batch workflows, and a product can end up showing a 30-day guarantee even when its description says no refunds.

Backend support lands in antiwork/gumroad#6001 (`refund_period` / `refund_fine_print` params on `POST/PUT /v2/products`, plus a `refund_policy` object in the product JSON). **Deploy ordering:** this PR is safe to merge before the backend deploys — until then the API ignores unknown params and the product simply keeps its existing policy; the flags become effective once #6001 ships. Product-level policies only apply to sellers whose account-level refund policy is off; the API returns a clear error otherwise, which the CLI surfaces as-is.

Closes #188.

## Before / After

![demo](https://i.ibb.co/fzh0Rmvz/demo.gif)

Demo shows: before (flag doesn't exist on main), setting a no-refunds policy with fine print, returning to the account default with `inherit`, create with `--refund-period` in JSON dry-run output, and both client-side validation errors.

## Test results

- 9 new tests in `internal/cmd/products/refund_policy_flags_test.go`: params sent on update/create, fine-print empty-clears (present-but-empty assertion), params omitted when flags unset, `inherit` round-trip, invalid-period and fine-print-with-inherit rejections asserting the mock API is never reached, and `--refund-period` alone satisfying the at-least-one-flag gate.
- `make test-cover` green across all packages; `internal/cmd/products` at **85.9%** (gate: 85%).
- `golangci-lint v1.64.8` (CI-pinned version, via `go run`) clean on `./internal/...`; `gofmt -l` clean.

## QA steps

1. `gumroad products update <id> --refund-period none --refund-fine-print "No refunds once downloaded." --dry-run --json --no-input` → body contains `refund_period` and `refund_fine_print`.
2. `gumroad products update <id> --refund-period inherit --dry-run --no-input` → body contains `refund_period: inherit`, no fine print key.
3. `gumroad products update <id> --refund-period 45 --dry-run --no-input` → usage error listing allowed values, no request sent.
4. Against a seller with the account-level policy disabled (once antiwork/gumroad#6001 deploys): run without `--dry-run` and confirm the response's `product.refund_policy` reflects the change and the product page shows the policy.

---

## AI disclosure

Authored by Claude Fable 5 (Hermes agent), triggered by the assignment of issue #188. The agent implemented the paired backend change (antiwork/gumroad#6001), wired the flags through create/update, wrote and ran the tests, lint, and the terminal recording.
