### PR TITLE
Show buyer_presentment amounts in sales view, list, and CSV output

### DIFF
--- a/internal/cmd/sales/list.go
+++ b/internal/cmd/sales/list.go
@@ -3,6 +3,7 @@ package sales
 import (
 	"bytes"
 	"encoding/csv"
+	"fmt"
 	"io"
 	"net/url"
 	"strconv"
@@ -15,20 +16,35 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type buyerPresentment struct {
+	Currency      string       `json:"currency"`
+	TotalCents    *nullableInt `json:"total_cents"`
+	RefundedCents *nullableInt `json:"refunded_cents"`
+	FxRate        string       `json:"fx_rate"`
+}
+
+func (p *buyerPresentment) formattedTotal() string {
+	if p == nil || p.TotalCents == nil || !p.TotalCents.valid {
+		return ""
+	}
+	return fmt.Sprintf("%.2f %s", float64(p.TotalCents.value)/100, strings.ToUpper(p.Currency))
+}
+
 type saleListItem struct {
-	ID                  string       `json:"id"`
-	Email               string       `json:"email"`
-	ProductName         string       `json:"product_name"`
-	FormattedTotal      string       `json:"formatted_total_price"`
-	CreatedAt           string       `json:"created_at"`
-	Refunded            bool         `json:"refunded"`
-	TotalCents          *nullableInt `json:"total_cents"`
-	Price               *nullableInt `json:"price"`
-	Currency            string       `json:"currency"`
-	CurrencyType        string       `json:"currency_type"`
-	PriceCurrencyType   string       `json:"price_currency_type"`
-	RefundedCents       *nullableInt `json:"refunded_cents"`
-	AmountRefundedCents *nullableInt `json:"amount_refunded_cents"`
+	ID                  string            `json:"id"`
+	Email               string            `json:"email"`
+	ProductName         string            `json:"product_name"`
+	FormattedTotal      string            `json:"formatted_total_price"`
+	CreatedAt           string            `json:"created_at"`
+	Refunded            bool              `json:"refunded"`
+	TotalCents          *nullableInt      `json:"total_cents"`
+	Price               *nullableInt      `json:"price"`
+	Currency            string            `json:"currency"`
+	CurrencyType        string            `json:"currency_type"`
+	PriceCurrencyType   string            `json:"price_currency_type"`
+	RefundedCents       *nullableInt      `json:"refunded_cents"`
+	AmountRefundedCents *nullableInt      `json:"amount_refunded_cents"`
+	BuyerPresentment    *buyerPresentment `json:"buyer_presentment,omitempty"`
 }
 
 type salesListResponse struct {
@@ -242,7 +258,7 @@ func writeSalesPlain(w io.Writer, sales []saleListItem) error {
 	return output.PrintPlain(w, rows)
 }
 
-var salesCSVHeader = []string{"id", "email", "product_name", "total_cents", "currency", "refunded", "refunded_cents", "created_at"}
+var salesCSVHeader = []string{"id", "email", "product_name", "total_cents", "currency", "refunded", "refunded_cents", "created_at", "buyer_currency", "buyer_total_cents", "buyer_refunded_cents", "buyer_fx_rate"}
 
 func writeSalesCSV(w io.Writer, sales []saleListItem) error {
 	cw := csv.NewWriter(w)
@@ -286,11 +302,36 @@ func writeSalesCSVRows(cw *csv.Writer, sales []saleListItem) error {
 			strconv.FormatBool(s.Refunded),
 			formatNullableInt(firstNullableInt(s.RefundedCents, s.AmountRefundedCents)),
 			s.CreatedAt,
+			s.buyerCSVCurrency(),
+			s.buyerCSVCents(func(p *buyerPresentment) *nullableInt { return p.TotalCents }),
+			s.buyerCSVCents(func(p *buyerPresentment) *nullableInt { return p.RefundedCents }),
+			s.buyerCSVFxRate(),
 		}); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func (s saleListItem) buyerCSVCurrency() string {
+	if s.BuyerPresentment == nil {
+		return ""
+	}
+	return s.BuyerPresentment.Currency
+}
+
+func (s saleListItem) buyerCSVCents(field func(*buyerPresentment) *nullableInt) string {
+	if s.BuyerPresentment == nil {
+		return ""
+	}
+	return formatNullableInt(field(s.BuyerPresentment))
+}
+
+func (s saleListItem) buyerCSVFxRate() string {
+	if s.BuyerPresentment == nil {
+		return ""
+	}
+	return s.BuyerPresentment.FxRate
 }
 
 func (s saleListItem) csvCurrency() string {
@@ -325,7 +366,11 @@ func writeSalesTable(w io.Writer, style output.Styler, sales []saleListItem) err
 		if s.Refunded {
 			id = s.ID + " " + style.Red("(refunded)")
 		}
-		tbl.AddRow(id, s.Email, s.ProductName, s.FormattedTotal, s.CreatedAt)
+		total := s.FormattedTotal
+		if buyerTotal := s.BuyerPresentment.formattedTotal(); buyerTotal != "" {
+			total = total + " " + style.Dim("(buyer: "+buyerTotal+")")
+		}
+		tbl.AddRow(id, s.Email, s.ProductName, total, s.CreatedAt)
 	}
 	return tbl.Render(w)
 }

--- a/internal/cmd/sales/list.go
+++ b/internal/cmd/sales/list.go
@@ -324,7 +324,11 @@ func (s saleListItem) buyerCSVCents(field func(*buyerPresentment) *nullableInt) 
 	if s.BuyerPresentment == nil {
 		return ""
 	}
-	return formatNullableInt(field(s.BuyerPresentment))
+	value := field(s.BuyerPresentment)
+	if value == nil || !value.valid {
+		return ""
+	}
+	return strconv.Itoa(int(value.value))
 }
 
 func (s saleListItem) buyerCSVFxRate() string {

--- a/internal/cmd/sales/list.go
+++ b/internal/cmd/sales/list.go
@@ -3,6 +3,7 @@ package sales
 import (
 	"bytes"
 	"encoding/csv"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/url"
@@ -21,13 +22,37 @@ type buyerPresentment struct {
 	TotalCents    *nullableInt `json:"total_cents"`
 	RefundedCents *nullableInt `json:"refunded_cents"`
 	FxRate        string       `json:"fx_rate"`
+
+	// raw keeps the exact API object so JSON output round-trips every field,
+	// not just the ones this struct names (the API also sends price_cents,
+	// tip_cents, tax and shipping amounts).
+	raw json.RawMessage
+}
+
+func (p *buyerPresentment) UnmarshalJSON(data []byte) error {
+	type plain buyerPresentment
+	var decoded plain
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	*p = buyerPresentment(decoded)
+	p.raw = append(json.RawMessage(nil), data...)
+	return nil
+}
+
+func (p buyerPresentment) MarshalJSON() ([]byte, error) {
+	if len(p.raw) > 0 {
+		return p.raw, nil
+	}
+	type plain buyerPresentment
+	return json.Marshal(plain(p))
 }
 
 func (p *buyerPresentment) formattedTotal() string {
 	if p == nil || p.TotalCents == nil || !p.TotalCents.valid {
 		return ""
 	}
-	return fmt.Sprintf("%.2f %s", float64(p.TotalCents.value)/100, strings.ToUpper(p.Currency))
+	return fmt.Sprintf("%s %s", cmdutil.FormatMoney(int(p.TotalCents.value), p.Currency), strings.ToUpper(p.Currency))
 }
 
 type saleListItem struct {

--- a/internal/cmd/sales/sales_test.go
+++ b/internal/cmd/sales/sales_test.go
@@ -110,10 +110,72 @@ func TestList_CSVOutput(t *testing.T) {
 
 	records := readCSVRecords(t, out)
 	want := [][]string{
-		{"id", "email", "product_name", "total_cents", "currency", "refunded", "refunded_cents", "created_at"},
-		{"s1", "a@b.com", "Art, Pack", "1000", "usd", "true", "250", "2024-01-15T10:00:00Z"},
+		{"id", "email", "product_name", "total_cents", "currency", "refunded", "refunded_cents", "created_at", "buyer_currency", "buyer_total_cents", "buyer_refunded_cents", "buyer_fx_rate"},
+		{"s1", "a@b.com", "Art, Pack", "1000", "usd", "true", "250", "2024-01-15T10:00:00Z", "", "", "", ""},
 	}
 	assertCSVRecords(t, records, want)
+}
+
+func TestList_CSVOutputIncludesBuyerPresentment(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"sales": []map[string]any{
+				{
+					"id":           "s1",
+					"email":        "a@b.com",
+					"product_name": "Art",
+					"total_cents":  1500,
+					"currency":     "usd",
+					"created_at":   "2026-07-20T10:00:00Z",
+					"buyer_presentment": map[string]any{
+						"currency":       "cad",
+						"total_cents":    2101,
+						"refunded_cents": 700,
+						"fx_rate":        "1.4005",
+					},
+				},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newListCmd())
+	cmd.SetArgs([]string{"--csv"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	records := readCSVRecords(t, out)
+	want := [][]string{
+		{"id", "email", "product_name", "total_cents", "currency", "refunded", "refunded_cents", "created_at", "buyer_currency", "buyer_total_cents", "buyer_refunded_cents", "buyer_fx_rate"},
+		{"s1", "a@b.com", "Art", "1500", "usd", "false", "0", "2026-07-20T10:00:00Z", "cad", "2101", "700", "1.4005"},
+	}
+	assertCSVRecords(t, records, want)
+}
+
+func TestList_TableShowsBuyerPresentmentTotal(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"sales": []map[string]any{
+				{
+					"id":                    "s1",
+					"email":                 "a@b.com",
+					"product_name":          "Art",
+					"formatted_total_price": "$15",
+					"created_at":            "2026-07-20",
+					"buyer_presentment": map[string]any{
+						"currency":    "cad",
+						"total_cents": 2101,
+						"fx_rate":     "1.4005",
+					},
+				},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newListCmd())
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "(buyer: 21.01 CAD)") {
+		t.Fatalf("table output missing buyer presentment total, got %q", out)
+	}
 }
 
 func TestList_CSVOutputWarnsWhenMorePagesExist(t *testing.T) {
@@ -132,8 +194,8 @@ func TestList_CSVOutputWarnsWhenMorePagesExist(t *testing.T) {
 
 	records := readCSVRecords(t, stdout)
 	want := [][]string{
-		{"id", "email", "product_name", "total_cents", "currency", "refunded", "refunded_cents", "created_at"},
-		{"s1", "a@b.com", "Art", "1000", "usd", "false", "0", "2024-01-15"},
+		{"id", "email", "product_name", "total_cents", "currency", "refunded", "refunded_cents", "created_at", "buyer_currency", "buyer_total_cents", "buyer_refunded_cents", "buyer_fx_rate"},
+		{"s1", "a@b.com", "Art", "1000", "usd", "false", "0", "2024-01-15", "", "", "", ""},
 	}
 	assertCSVRecords(t, records, want)
 	if strings.Contains(stdout, "More results available") {
@@ -206,8 +268,8 @@ func TestList_CSVOutputSkipsNullPrimaryNumericFields(t *testing.T) {
 
 	records := readCSVRecords(t, out)
 	want := [][]string{
-		{"id", "email", "product_name", "total_cents", "currency", "refunded", "refunded_cents", "created_at"},
-		{"s1", "a@b.com", "Art", "1000", "usd", "true", "250", "2024-01-15T10:00:00Z"},
+		{"id", "email", "product_name", "total_cents", "currency", "refunded", "refunded_cents", "created_at", "buyer_currency", "buyer_total_cents", "buyer_refunded_cents", "buyer_fx_rate"},
+		{"s1", "a@b.com", "Art", "1000", "usd", "true", "250", "2024-01-15T10:00:00Z", "", "", "", ""},
 	}
 	assertCSVRecords(t, records, want)
 }
@@ -222,7 +284,7 @@ func TestList_EmptyCSVOutputWritesHeader(t *testing.T) {
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
 
 	records := readCSVRecords(t, out)
-	want := [][]string{{"id", "email", "product_name", "total_cents", "currency", "refunded", "refunded_cents", "created_at"}}
+	want := [][]string{{"id", "email", "product_name", "total_cents", "currency", "refunded", "refunded_cents", "created_at", "buyer_currency", "buyer_total_cents", "buyer_refunded_cents", "buyer_fx_rate"}}
 	assertCSVRecords(t, records, want)
 }
 
@@ -718,9 +780,9 @@ func TestList_AllCSVOutputStreamsAllPages(t *testing.T) {
 
 	records := readCSVRecords(t, out)
 	want := [][]string{
-		{"id", "email", "product_name", "total_cents", "currency", "refunded", "refunded_cents", "created_at"},
-		{"s1", "a@b.com", "Art", "1000", "usd", "false", "0", "2024-01-15"},
-		{"s2", "b@c.com", "Book", "1200", "usd", "true", "1200", "2024-01-16"},
+		{"id", "email", "product_name", "total_cents", "currency", "refunded", "refunded_cents", "created_at", "buyer_currency", "buyer_total_cents", "buyer_refunded_cents", "buyer_fx_rate"},
+		{"s1", "a@b.com", "Art", "1000", "usd", "false", "0", "2024-01-15", "", "", "", ""},
+		{"s2", "b@c.com", "Book", "1200", "usd", "true", "1200", "2024-01-16", "", "", "", ""},
 	}
 	assertCSVRecords(t, records, want)
 	if requests != 2 {
@@ -970,6 +1032,49 @@ func TestView_RefundedStatus(t *testing.T) {
 	out := testutil.CaptureStdout(func() { _ = cmd.RunE(cmd, []string{"s1"}) })
 	if !strings.Contains(out, "refunded") {
 		t.Errorf("output should show refunded status: %q", out)
+	}
+}
+
+func TestView_BuyerPresentment(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"sale": map[string]any{
+				"id": "s1", "email": "a@b.com", "product_name": "Art",
+				"formatted_total_price": "$15", "created_at": "2026-07-20",
+				"buyer_presentment": map[string]any{
+					"currency":       "cad",
+					"total_cents":    2101,
+					"refunded_cents": 0,
+					"fx_rate":        "1.4005",
+				},
+			},
+		})
+	})
+
+	cmd := newViewCmd()
+	out := testutil.CaptureStdout(func() { _ = cmd.RunE(cmd, []string{"s1"}) })
+	if !strings.Contains(out, "Buyer charged: 21.01 CAD") {
+		t.Errorf("output should show buyer-charged amount: %q", out)
+	}
+	if !strings.Contains(out, "FX rate: 1.4005") {
+		t.Errorf("output should show FX rate: %q", out)
+	}
+}
+
+func TestView_NoBuyerPresentmentLinesForCanonicalSale(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"sale": map[string]any{
+				"id": "s1", "email": "a@b.com", "product_name": "Art",
+				"formatted_total_price": "$10", "created_at": "2024-01-15",
+			},
+		})
+	})
+
+	cmd := newViewCmd()
+	out := testutil.CaptureStdout(func() { _ = cmd.RunE(cmd, []string{"s1"}) })
+	if strings.Contains(out, "Buyer charged") || strings.Contains(out, "FX rate") {
+		t.Errorf("canonical sale must not show buyer presentment lines: %q", out)
 	}
 }
 
@@ -1269,8 +1374,8 @@ func TestView_Plain(t *testing.T) {
 		t.Fatalf("RunE failed: %v", execErr)
 	}
 	cols := strings.Split(strings.TrimRight(out, "\n"), "\t")
-	if len(cols) != 7 {
-		t.Fatalf("expected 7 tab-separated columns, got %d: %q", len(cols), out)
+	if len(cols) != 8 {
+		t.Fatalf("expected 8 tab-separated columns, got %d: %q", len(cols), out)
 	}
 	if cols[0] != "s1" || cols[2] != "Art" || cols[3] != "$10" {
 		t.Errorf("plain view data mismatch: %q", cols)
@@ -1298,8 +1403,8 @@ func TestView_PlainWithOrderID(t *testing.T) {
 		t.Fatalf("RunE failed: %v", execErr)
 	}
 	cols := strings.Split(strings.TrimRight(out, "\n"), "\t")
-	if len(cols) != 7 {
-		t.Fatalf("expected 7 tab-separated columns, got %d: %q", len(cols), out)
+	if len(cols) != 8 {
+		t.Fatalf("expected 8 tab-separated columns, got %d: %q", len(cols), out)
 	}
 	if cols[0] != "s1" || cols[2] != "Art" || cols[3] != "$10" {
 		t.Errorf("plain view data mismatch: %q", cols)

--- a/internal/cmd/sales/sales_test.go
+++ b/internal/cmd/sales/sales_test.go
@@ -150,6 +150,53 @@ func TestList_CSVOutputIncludesBuyerPresentment(t *testing.T) {
 	assertCSVRecords(t, records, want)
 }
 
+func TestList_CSVOutputLeavesNullBuyerAmountsEmpty(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"sales": []map[string]any{
+				{
+					"id":           "s1",
+					"email":        "a@b.com",
+					"product_name": "Art",
+					"total_cents":  1500,
+					"currency":     "usd",
+					"created_at":   "2026-07-20T10:00:00Z",
+					"buyer_presentment": map[string]any{
+						"currency":       "cad",
+						"total_cents":    nil,
+						"refunded_cents": nil,
+						"fx_rate":        "1.4005",
+					},
+				},
+				{
+					"id":           "s2",
+					"email":        "c@d.com",
+					"product_name": "Pack",
+					"total_cents":  2000,
+					"currency":     "usd",
+					"created_at":   "2026-07-21T10:00:00Z",
+					"buyer_presentment": map[string]any{
+						"currency": "eur",
+						"fx_rate":  "0.9",
+					},
+				},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newListCmd())
+	cmd.SetArgs([]string{"--csv"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	records := readCSVRecords(t, out)
+	want := [][]string{
+		{"id", "email", "product_name", "total_cents", "currency", "refunded", "refunded_cents", "created_at", "buyer_currency", "buyer_total_cents", "buyer_refunded_cents", "buyer_fx_rate"},
+		{"s1", "a@b.com", "Art", "1500", "usd", "false", "0", "2026-07-20T10:00:00Z", "cad", "", "", "1.4005"},
+		{"s2", "c@d.com", "Pack", "2000", "usd", "false", "0", "2026-07-21T10:00:00Z", "eur", "", "", "0.9"},
+	}
+	assertCSVRecords(t, records, want)
+}
+
 func TestList_TableShowsBuyerPresentmentTotal(t *testing.T) {
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
 		testutil.JSON(t, w, map[string]any{

--- a/internal/cmd/sales/sales_test.go
+++ b/internal/cmd/sales/sales_test.go
@@ -225,6 +225,78 @@ func TestList_TableShowsBuyerPresentmentTotal(t *testing.T) {
 	}
 }
 
+func TestList_TableShowsBuyerPresentmentTotalZeroDecimalCurrency(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"sales": []map[string]any{
+				{
+					"id":                    "s1",
+					"email":                 "a@b.com",
+					"product_name":          "Art",
+					"formatted_total_price": "$15",
+					"created_at":            "2026-07-20",
+					"buyer_presentment": map[string]any{
+						"currency":    "jpy",
+						"total_cents": 2101,
+						"fx_rate":     "140.05",
+					},
+				},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newListCmd())
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "(buyer: 2101 JPY)") {
+		t.Fatalf("JPY has no minor unit so 2101 must render as 2101 JPY, got %q", out)
+	}
+}
+
+func TestList_AllJSONRoundTripsFullBuyerPresentment(t *testing.T) {
+	presentment := map[string]any{
+		"currency":          "cad",
+		"price_cents":       float64(1401),
+		"tip_cents":         float64(280),
+		"seller_tax_cents":  float64(175),
+		"gumroad_tax_cents": float64(0),
+		"shipping_cents":    float64(0),
+		"total_cents":       float64(1856),
+		"fx_rate":           "1.4005",
+		"refunded_cents":    float64(0),
+	}
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"sales": []map[string]any{
+				{
+					"id": "s1", "email": "a@b.com", "product_name": "Art",
+					"formatted_total_price": "$14.01", "created_at": "2026-07-20",
+					"buyer_presentment": presentment,
+				},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newListCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"--all"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp struct {
+		Sales []struct {
+			BuyerPresentment map[string]any `json:"buyer_presentment"`
+		} `json:"sales"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if len(resp.Sales) != 1 {
+		t.Fatalf("got %d sales, want 1", len(resp.Sales))
+	}
+	if !reflect.DeepEqual(resp.Sales[0].BuyerPresentment, presentment) {
+		t.Fatalf("--all --json must round-trip every buyer_presentment field:\ngot  %#v\nwant %#v", resp.Sales[0].BuyerPresentment, presentment)
+	}
+}
+
 func TestList_CSVOutputWarnsWhenMorePagesExist(t *testing.T) {
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
 		testutil.JSON(t, w, map[string]any{
@@ -1421,14 +1493,44 @@ func TestView_Plain(t *testing.T) {
 		t.Fatalf("RunE failed: %v", execErr)
 	}
 	cols := strings.Split(strings.TrimRight(out, "\n"), "\t")
-	if len(cols) != 8 {
-		t.Fatalf("expected 8 tab-separated columns, got %d: %q", len(cols), out)
+	if len(cols) != 7 {
+		t.Fatalf("expected 7 tab-separated columns, got %d: %q", len(cols), out)
 	}
 	if cols[0] != "s1" || cols[2] != "Art" || cols[3] != "$10" {
 		t.Errorf("plain view data mismatch: %q", cols)
 	}
 	if cols[6] != "" {
 		t.Errorf("order_id column should be empty when absent, got %q", cols[6])
+	}
+}
+
+func TestView_PlainWithBuyerPresentmentAppendsColumn(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"sale": map[string]any{
+				"id": "s1", "email": "a@example.com", "product_name": "Art",
+				"formatted_total_price": "$15", "created_at": "2026-07-20",
+				"buyer_presentment": map[string]any{
+					"currency":    "cad",
+					"total_cents": 2101,
+					"fx_rate":     "1.4005",
+				},
+			},
+		})
+	})
+
+	cmd := testutil.Command(newViewCmd(), testutil.PlainOutput())
+	var execErr error
+	out := testutil.CaptureStdout(func() { execErr = cmd.RunE(cmd, []string{"s1"}) })
+	if execErr != nil {
+		t.Fatalf("RunE failed: %v", execErr)
+	}
+	cols := strings.Split(strings.TrimRight(out, "\n"), "\t")
+	if len(cols) != 8 {
+		t.Fatalf("expected 8 tab-separated columns, got %d: %q", len(cols), out)
+	}
+	if cols[7] != "21.01 CAD" {
+		t.Errorf("buyer-charged column mismatch, got %q", cols[7])
 	}
 }
 
@@ -1450,8 +1552,8 @@ func TestView_PlainWithOrderID(t *testing.T) {
 		t.Fatalf("RunE failed: %v", execErr)
 	}
 	cols := strings.Split(strings.TrimRight(out, "\n"), "\t")
-	if len(cols) != 8 {
-		t.Fatalf("expected 8 tab-separated columns, got %d: %q", len(cols), out)
+	if len(cols) != 7 {
+		t.Fatalf("expected 7 tab-separated columns, got %d: %q", len(cols), out)
 	}
 	if cols[0] != "s1" || cols[2] != "Art" || cols[3] != "$10" {
 		t.Errorf("plain view data mismatch: %q", cols)

--- a/internal/cmd/sales/view.go
+++ b/internal/cmd/sales/view.go
@@ -45,9 +45,14 @@ func newViewCmd() *cobra.Command {
 					if s.OrderID > 0 {
 						orderID = fmt.Sprintf("%d", s.OrderID)
 					}
-					return output.PrintPlain(opts.Out(), [][]string{
-						{s.ID, s.Email, s.ProductName, s.FormattedTotal, s.CreatedAt, fmt.Sprintf("refunded=%v", s.Refunded), orderID, buyerTotal},
-					})
+					// Canonical sales keep the pre-existing seven-column schema;
+					// the buyer-charged column is appended only when present so
+					// scripts parsing the original layout keep working.
+					row := []string{s.ID, s.Email, s.ProductName, s.FormattedTotal, s.CreatedAt, fmt.Sprintf("refunded=%v", s.Refunded), orderID}
+					if buyerTotal != "" {
+						row = append(row, buyerTotal)
+					}
+					return output.PrintPlain(opts.Out(), [][]string{row})
 				}
 
 				if err := output.Writef(opts.Out(), "%s  %s\n", style.Bold(s.ProductName), s.FormattedTotal); err != nil {

--- a/internal/cmd/sales/view.go
+++ b/internal/cmd/sales/view.go
@@ -21,14 +21,15 @@ func newViewCmd() *cobra.Command {
 			return cmdutil.RunRequest(opts, "Fetching sale...", "GET", cmdutil.JoinPath("sales", args[0]), url.Values{}, func(data json.RawMessage) error {
 				var resp struct {
 					Sale struct {
-						ID             string      `json:"id"`
-						Email          string      `json:"email"`
-						ProductName    string      `json:"product_name"`
-						FormattedTotal string      `json:"formatted_total_price"`
-						CreatedAt      string      `json:"created_at"`
-						Refunded       bool        `json:"refunded"`
-						Shipped        bool        `json:"shipped"`
-						OrderID        api.JSONInt `json:"order_id"`
+						ID               string            `json:"id"`
+						Email            string            `json:"email"`
+						ProductName      string            `json:"product_name"`
+						FormattedTotal   string            `json:"formatted_total_price"`
+						CreatedAt        string            `json:"created_at"`
+						Refunded         bool              `json:"refunded"`
+						Shipped          bool              `json:"shipped"`
+						OrderID          api.JSONInt       `json:"order_id"`
+						BuyerPresentment *buyerPresentment `json:"buyer_presentment"`
 					} `json:"sale"`
 				}
 				if err := json.Unmarshal(data, &resp); err != nil {
@@ -37,6 +38,7 @@ func newViewCmd() *cobra.Command {
 
 				s := resp.Sale
 				style := opts.Style()
+				buyerTotal := s.BuyerPresentment.formattedTotal()
 
 				if opts.PlainOutput {
 					orderID := ""
@@ -44,7 +46,7 @@ func newViewCmd() *cobra.Command {
 						orderID = fmt.Sprintf("%d", s.OrderID)
 					}
 					return output.PrintPlain(opts.Out(), [][]string{
-						{s.ID, s.Email, s.ProductName, s.FormattedTotal, s.CreatedAt, fmt.Sprintf("refunded=%v", s.Refunded), orderID},
+						{s.ID, s.Email, s.ProductName, s.FormattedTotal, s.CreatedAt, fmt.Sprintf("refunded=%v", s.Refunded), orderID, buyerTotal},
 					})
 				}
 
@@ -61,6 +63,16 @@ func newViewCmd() *cobra.Command {
 				}
 				if err := output.Writef(opts.Out(), "Buyer: %s\n", s.Email); err != nil {
 					return err
+				}
+				if buyerTotal != "" {
+					if err := output.Writef(opts.Out(), "Buyer charged: %s\n", buyerTotal); err != nil {
+						return err
+					}
+					if s.BuyerPresentment.FxRate != "" {
+						if err := output.Writef(opts.Out(), "FX rate: %s\n", s.BuyerPresentment.FxRate); err != nil {
+							return err
+						}
+					}
 				}
 				if err := output.Writef(opts.Out(), "Date: %s\n", s.CreatedAt); err != nil {
 					return err

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -460,6 +460,7 @@ gumroad sales resend-receipt <id> --json --no-input
 ```
 
 **List filters/output:** `--product`, `--order`, `--email`, `--after` (YYYY-MM-DD), `--before` (YYYY-MM-DD), `--all`, `--page-key`, `--csv`.
+**Buyer-currency amounts:** sales charged in the buyer's local currency carry a `buyer_presentment` object in JSON output (`currency`, `price_cents`, `tip_cents`, tax fields, `shipping_cents`, `total_cents`, `fx_rate`, `refunded_cents`); it is omitted for canonical (USD-charged) sales. The list table appends `(buyer: 21.01 CAD)` to TOTAL, `sales list --csv` has four trailing columns (`buyer_currency`, `buyer_total_cents`, `buyer_refunded_cents`, `buyer_fx_rate` — empty for canonical sales), `sales view` prints `Buyer charged:` and `FX rate:` lines, and `sales view --plain` appends one extra column ONLY for presentment sales (canonical sales keep the seven-column schema).
 **Summary filters:** `--from` (YYYY-MM-DD), `--to` (YYYY-MM-DD), `--group-by` (product|day|week|month).
 **Export filters:** `--from`/`--after` (YYYY-MM-DD), `--to`/`--before` (YYYY-MM-DD), `--product`.
 


### PR DESCRIPTION
Surfaces the new Sales API v2 `buyer_presentment` object (antiwork/gumroad#6167) in the CLI so sellers can see what buyers were actually charged when a sale ran in the buyer's local currency.

> **Depends on antiwork/gumroad#6167.** Until that Rails PR deploys, the API omits the field and the CLI renders exactly as today (the struct pointer stays nil).

## Why

Buyer-currency charging is at 100% rollout (antiwork/gumroad#5419): buyers now pay in CAD/EUR/etc while the API's canonical fields stay USD. The CLI deserializes into fixed structs, so the new field was silently dropped — sellers reconciling buyer statements or support inquiries couldn't see the buyer-side amounts at all.

## What

- `sales view <id>`: `Buyer charged: 21.01 CAD` + `FX rate: 1.4005` lines, only when the sale has a presentment record; `--plain` appends one trailing column only for presentment sales (canonical sales keep the existing seven-column schema).
- `sales list`: table TOTAL column appends a dimmed `(buyer: 21.01 CAD)` on presentment sales. Amounts format through `cmdutil.FormatMoney`, so zero-decimal currencies render correctly (`2101 JPY`, not `21.01 JPY`).
- `sales list --csv` (and `--all` streaming): four new trailing columns — `buyer_currency`, `buyer_total_cents`, `buyer_refunded_cents`, `buyer_fx_rate` — empty for canonical sales.
- `--json` output (single-page and `--all`) round-trips the full `buyer_presentment` object exactly as the API sent it: the struct keeps the raw JSON and re-emits it on marshal, so all nine API fields (`price_cents`, `tip_cents`, tax fields, `shipping_cents`, …) survive the `--all` re-encode path.
- Canonical sales are entirely unchanged in styled/plain/JSON output (`buyer_presentment,omitempty` keeps `--json` byte-compatible when absent).
- `skills/gumroad/SKILL.md` documents the new output per CONTRIBUTING's command-behavior-change rule.

## Demo

![demo](https://i.ibb.co/KpgjgrQH/cli-demo.gif)

Demo shows: `sales view` on a presentment sale (buyer-charged + FX lines), the same command on a canonical sale (no new lines), the list table with the dimmed buyer total, and the CSV columns (populated vs empty).

Recorded against a local mock of the v2 API (via `GUMROAD_API_BASE_URL`) returning the exact field shape #6167 serves, since the field isn't deployed yet.

## Test plan

- New: `TestList_CSVOutputIncludesBuyerPresentment`, `TestList_CSVOutputLeavesNullBuyerAmountsEmpty`, `TestList_TableShowsBuyerPresentmentTotal`, `TestList_TableShowsBuyerPresentmentTotalZeroDecimalCurrency`, `TestList_AllJSONRoundTripsFullBuyerPresentment`, `TestView_BuyerPresentment`, `TestView_NoBuyerPresentmentLinesForCanonicalSale`, `TestView_PlainWithBuyerPresentmentAppendsColumn`.
- Updated: CSV header/row expectations (+4 columns); `TestView_Plain` / `TestView_PlainWithOrderID` assert canonical plain output stays at seven columns.
- Full `go test ./...` — **ok** across every package (run with `env -u GUMROAD_ACCESS_TOKEN -u GUMROAD_ADMIN_TOKEN`); sales package coverage 89.8% (gate 85%); `gofmt`, `go vet`, `golangci-lint` clean.

## Test results

![test results](https://i.ibb.co/1G59RLrV/pr190-test-results.png)

---

AI disclosure: Authored by Claude Fable 5 (Hermes agent), on @nyomanjyotisa's request as the CLI follow-up to antiwork/gumroad#6167, with follow-up fixes from the adversarial review on this PR. The agent wrote the code and tests, ran them, built the mock server, and produced the terminal recording.
