### PR TITLE
Add --clear-suspension to admin users mark-compliant

### DIFF
--- a/internal/cmd/admin/users/mark_compliant.go
+++ b/internal/cmd/admin/users/mark_compliant.go
@@ -14,12 +14,16 @@ type markCompliantRequest struct {
 	UserID        string `json:"user_id"`
 	ExpectedEmail string `json:"expected_email,omitempty"`
 	Note          string `json:"note,omitempty"`
+	// ClearSuspension has to be sent for a suspended account. The server refuses to lift a
+	// suspension without it, so an automated review can't reverse one by accident.
+	ClearSuspension bool `json:"clear_suspension,omitempty"`
 }
 
 func newMarkCompliantCmd() *cobra.Command {
 	var (
-		targetFlags userMutationFlags
-		note        string
+		targetFlags     userMutationFlags
+		note            string
+		clearSuspension bool
 	)
 
 	cmd := &cobra.Command{
@@ -28,10 +32,15 @@ func newMarkCompliantCmd() *cobra.Command {
 		Long: `Mark a user compliant through the internal admin API.
 
 Identify the user with --user-id. Pass --expected-email as an optional guard
-against acting on an account whose email has changed.`,
+against acting on an account whose email has changed.
+
+If the account is suspended, pass --clear-suspension to also lift the suspension.
+Without it the request is refused, so a review that only looked at its own signals
+cannot silently put a suspended seller's products back on sale.`,
 		Example: `  gumroad admin users mark-compliant --user-id 2245593582708
   gumroad admin users mark-compliant --user-id 2245593582708 --expected-email seller@example.com
-  gumroad admin users mark-compliant --user-id 2245593582708 --note "Cleared after review"`,
+  gumroad admin users mark-compliant --user-id 2245593582708 --note "Cleared after review"
+  gumroad admin users mark-compliant --user-id 2245593582708 --clear-suspension --note "Suspension lifted after appeal"`,
 		Args: cmdutil.ExactArgs(0),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
@@ -42,7 +51,11 @@ against acting on an account whose email has changed.`,
 			}
 
 			identifier := target.Identifier()
-			ok, err := cmdutil.ConfirmAction(opts, "Mark user_id "+identifier+" compliant?")
+			prompt := "Mark user_id " + identifier + " compliant?"
+			if clearSuspension {
+				prompt = "Mark user_id " + identifier + " compliant and lift its suspension?"
+			}
+			ok, err := cmdutil.ConfirmAction(opts, prompt)
 			if err != nil {
 				return err
 			}
@@ -51,9 +64,10 @@ against acting on an account whose email has changed.`,
 			}
 
 			req := markCompliantRequest{
-				UserID:        target.UserID,
-				ExpectedEmail: target.ExpectedEmail,
-				Note:          note,
+				UserID:          target.UserID,
+				ExpectedEmail:   target.ExpectedEmail,
+				Note:            note,
+				ClearSuspension: clearSuspension,
 			}
 			path := "users/mark_compliant"
 
@@ -79,6 +93,7 @@ against acting on an account whose email has changed.`,
 
 	addUserMutationFlags(cmd, &targetFlags)
 	cmd.Flags().StringVar(&note, "note", "", "Optional admin note")
+	cmd.Flags().BoolVar(&clearSuspension, "clear-suspension", false, "Also lift the account's suspension (required when the account is suspended)")
 
 	return cmd
 }
@@ -91,6 +106,9 @@ func markCompliantDryRunParams(req markCompliantRequest) url.Values {
 	}
 	if req.Note != "" {
 		params.Set("note", req.Note)
+	}
+	if req.ClearSuspension {
+		params.Set("clear_suspension", "true")
 	}
 	return params
 }

--- a/internal/cmd/admin/users/mark_compliant_test.go
+++ b/internal/cmd/admin/users/mark_compliant_test.go
@@ -145,6 +145,58 @@ func TestMarkCompliantSendsUserIDExpectedEmailAndNote(t *testing.T) {
 	}
 }
 
+func TestMarkCompliantSendsClearSuspension(t *testing.T) {
+	var body markCompliantRequest
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if err := json.Unmarshal(raw, &body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		testutil.JSON(t, w, map[string]any{
+			"success": true,
+			"status":  "marked_compliant",
+			"message": "User marked compliant",
+		})
+	})
+
+	cmd := testutil.Command(newMarkCompliantCmd(), testutil.Yes(true), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--user-id", "2245593582708", "--clear-suspension"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !body.ClearSuspension {
+		t.Fatalf("expected clear_suspension to be sent, got %#v", body)
+	}
+}
+
+func TestMarkCompliantOmitsClearSuspensionByDefault(t *testing.T) {
+	var raw []byte
+
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		raw, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		testutil.JSON(t, w, map[string]any{
+			"success": true,
+			"status":  "marked_compliant",
+			"message": "User marked compliant",
+		})
+	})
+
+	cmd := testutil.Command(newMarkCompliantCmd(), testutil.Yes(true), testutil.Quiet(false))
+	cmd.SetArgs([]string{"--user-id", "2245593582708"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if strings.Contains(string(raw), "clear_suspension") {
+		t.Fatalf("clear_suspension must be omitted unless asked for, got %q", string(raw))
+	}
+}
+
 func TestMarkCompliantDryRunDoesNotContactEndpoint(t *testing.T) {
 	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
 		t.Error("dry-run must not POST to the mark_compliant endpoint")

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -228,8 +228,15 @@ gumroad admin users related --email seller@example.com --signal ip --signal paym
 gumroad admin users related --username sellerone --signal ip --json --non-interactive --no-input
 gumroad admin users related --email seller@example.com --json --jq '{related_users, truncated, per_signal_limit}' --non-interactive --no-input
 
-# Mutate user compliance and suspension state
+# Mutate user compliance and suspension state.
+# mark-compliant never lifts a suspension unless you ask for it. On a suspended
+# account a plain mark-compliant is refused with a 422: the server assumes a
+# caller that only reviewed the account's finances did not mean to reverse an
+# enforcement decision it never looked at. To intentionally restore a suspended
+# account, pass --clear-suspension, which is the only thing that sends
+# clear_suspension: true.
 gumroad admin users mark-compliant --user-id 2245593582708 --expected-email seller@example.com --note "Cleared after review" --yes --json --non-interactive --no-input
+gumroad admin users mark-compliant --user-id 2245593582708 --expected-email seller@example.com --note "Suspension lifted after appeal review" --clear-suspension --yes --json --non-interactive --no-input
 gumroad admin users suspend --user-id 2245593582708 --expected-email seller@example.com --note "Chargeback risk confirmed" --yes --json --non-interactive --no-input
 gumroad admin users suspend-for-tos-violation --user-id 2245593582708 --expected-email seller@example.com --note "DMCA takedown notice confirmed" --yes --json --non-interactive --no-input
 gumroad admin products flag-for-tos-violation <product-id> --user-id 2245593582708 --expected-email seller@example.com --yes --json --non-interactive --no-input


### PR DESCRIPTION
## What

Adds `--clear-suspension` to `gumroad admin users mark-compliant`. When set, the command sends `clear_suspension: true` in the request body; when not set, the field is omitted entirely. The confirmation prompt also changes to name what is about to happen ("Mark user_id … compliant and lift its suspension?").

## Why

The internal admin API now refuses to move a suspended account to compliant unless the request explicitly asks to lift the suspension (antiwork/gumroad#6448). Without this flag there is no way to clear a suspension from the CLI at all — a plain `mark-compliant` on a suspended account comes back 422.

The default matters as much as the flag. Leaving it off means an automated caller that only meant "this account's finances look fine" gets a rejection instead of silently reversing an enforcement decision it never looked at. That is the failure this exists to prevent: a seller suspended for piracy was un-suspended 106 seconds later by an unrelated first-payout review, and sold for eight more days before anyone noticed.

## Demo

![demo](https://i.ibb.co/V6DsCVs/cli-demo.gif)

The recording shows, against real binaries built from `main` and this branch: the flag absent from `--help` before and present after; a `--dry-run` without the flag sending only `user_id`; the same command with `--clear-suspension` sending `clear_suspension: true`; and the test run.

## Test plan

Two new tests in `mark_compliant_test.go`:

- `TestMarkCompliantSendsClearSuspension` — decodes the request body and asserts the field arrives as `true`.
- `TestMarkCompliantOmitsClearSuspensionByDefault` — asserts the raw body contains no `clear_suspension` key at all when the flag is not passed.

```
go test ./internal/cmd/admin/users/ -cover
ok  github.com/antiwork/gumroad-cli/internal/cmd/admin/users  1.116s  coverage: 86.3% of statements
```

`gofmt` and `go vet` clean.

---

## AI disclosure

Written by Claude Opus 5 (`claude-opus-5`) running as the Gumclaw agent.

Instructions given: fix the mark-compliant race that reverted a piracy suspension, tracked in gumroad-private#1438. The model added the server-side guard in antiwork/gumroad#6448, identified the CLI as the caller needing to opt in, wrote the flag and its tests, recorded the terminal demo, and authored this description.
