### PR TITLE
Scale sales refund --amount by the sale's own currency

### DIFF
--- a/internal/cmd/sales/refund.go
+++ b/internal/cmd/sales/refund.go
@@ -50,6 +50,15 @@ amount on a yen-priced sale.`,
 				currency string
 			)
 			if c.Flags().Changed("amount") {
+				// Check syntax and sign before the sale lookup, so a malformed
+				// --amount fails locally instead of spending a request and
+				// surfacing an unrelated lookup/auth error.
+				if generic, err := cmdutil.ParseMoney("amount", amount, "amount", ""); err != nil {
+					return cmdutil.UsageErrorf(c, "%s", err.Error())
+				} else if generic <= 0 {
+					return cmdutil.UsageErrorf(c, "--amount must be greater than 0")
+				}
+
 				lookup, err := cmdutil.FetchRequestDecoded[refundSaleLookup](opts, "Looking up sale...", "GET", cmdutil.JoinPath("sales", args[0]), url.Values{})
 				if err != nil {
 					return err
@@ -62,9 +71,6 @@ amount on a yen-priced sale.`,
 				parsed, err := cmdutil.ParseMoney("amount", amount, "amount", currency)
 				if err != nil {
 					return cmdutil.UsageErrorf(c, "%s", err.Error())
-				}
-				if parsed <= 0 {
-					return cmdutil.UsageErrorf(c, "--amount must be greater than 0")
 				}
 				cents = parsed
 			}

--- a/internal/cmd/sales/refund.go
+++ b/internal/cmd/sales/refund.go
@@ -4,10 +4,28 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
+
+type refundSaleLookup struct {
+	Sale struct {
+		Currency          string `json:"currency"`
+		CurrencyType      string `json:"currency_type"`
+		PriceCurrencyType string `json:"price_currency_type"`
+	} `json:"sale"`
+}
+
+func (l refundSaleLookup) currency() string {
+	for _, value := range []string{l.Sale.Currency, l.Sale.CurrencyType, l.Sale.PriceCurrencyType} {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
 
 func newRefundCmd() *cobra.Command {
 	var amount string
@@ -15,14 +33,33 @@ func newRefundCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "refund <id>",
 		Short: "Refund a sale",
-		Args:  cmdutil.ExactArgs(1),
+		Long: `Refund a sale in full, or partially with --amount.
+
+--amount is given in the sale's own currency, so the sale is looked up first to
+find out what that currency is. Without the lookup a value like 25 could mean
+either $25.00 or ¥25, and sending the wrong one refunds 100 times the intended
+amount on a yen-priced sale.`,
+		Example: `  gumroad sales refund A-m3CDDC5dlrSdKZp0RFhA==
+  gumroad sales refund A-m3CDDC5dlrSdKZp0RFhA== --amount 2.00`,
+		Args: cmdutil.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
 
-			var cents int
-			hasAmount := c.Flags().Changed("amount")
-			if hasAmount {
-				parsed, err := cmdutil.ParseMoney("amount", amount, "amount", "")
+			var (
+				cents    int
+				currency string
+			)
+			if c.Flags().Changed("amount") {
+				lookup, err := cmdutil.FetchRequestDecoded[refundSaleLookup](opts, "Looking up sale...", "GET", cmdutil.JoinPath("sales", args[0]), url.Values{})
+				if err != nil {
+					return err
+				}
+				currency = lookup.currency()
+				if currency == "" {
+					return cmdutil.InvalidInputErrorf("could not determine the currency of sale %s, so --amount cannot be scaled safely; re-run without --amount for a full refund", args[0])
+				}
+
+				parsed, err := cmdutil.ParseMoney("amount", amount, "amount", currency)
 				if err != nil {
 					return cmdutil.UsageErrorf(c, "%s", err.Error())
 				}
@@ -33,7 +70,10 @@ func newRefundCmd() *cobra.Command {
 			}
 
 			isPartial := cents > 0
-			amountDesc := cmdutil.FormatMoney(cents, "")
+			amountDesc := ""
+			if isPartial {
+				amountDesc = fmt.Sprintf("%s %s", cmdutil.FormatMoney(cents, currency), strings.ToUpper(currency))
+			}
 
 			msg := "Refund sale " + args[0] + "?"
 			if isPartial {
@@ -63,7 +103,7 @@ func newRefundCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&amount, "amount", "", "Partial refund amount (e.g. 5, 5.00)")
+	cmd.Flags().StringVar(&amount, "amount", "", "Partial refund amount in the sale's currency (e.g. 5, 5.00)")
 
 	return cmd
 }

--- a/internal/cmd/sales/sales_test.go
+++ b/internal/cmd/sales/sales_test.go
@@ -1211,15 +1211,17 @@ func TestView_RawFixture(t *testing.T) {
 
 // salesRefundHandler routes the sale lookup and the refund PUT to separate
 // handlers so a test can assert the lookup fired before the money moved.
+// Routed on method rather than the "/refund" path suffix, so a sale id that
+// happens to end in "refund" still reaches the lookup handler on its GET.
 func salesRefundHandler(t *testing.T, lookup, refund http.HandlerFunc) http.HandlerFunc {
 	t.Helper()
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasSuffix(r.URL.Path, "/refund") {
-			refund(w, r)
+		if r.Method == http.MethodGet {
+			lookup(w, r)
 			return
 		}
-		lookup(w, r)
+		refund(w, r)
 	}
 }
 
@@ -1329,6 +1331,34 @@ func TestRefund_PartialLooksUpCurrencyAndScalesUSD(t *testing.T) {
 	if !strings.Contains(out, "Refunded 5.00 USD on sale s1.") {
 		t.Errorf("expected partial refund message naming the currency, got %q", out)
 	}
+}
+
+func TestRefund_PartialJSONOutputIsOnlyTheMutationEnvelope(t *testing.T) {
+	testutil.Setup(t, salesRefundHandler(t,
+		saleLookupResponder(t, "usd"),
+		func(w http.ResponseWriter, r *http.Request) {
+			testutil.JSON(t, w, map[string]any{"sale": map[string]any{"id": "s1"}})
+		}))
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true), testutil.JSONOutput())
+	cmd.SetArgs([]string{"s1", "--amount", "5.00"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("expected exactly one JSON mutation envelope, got %q: %v", out, err)
+	}
+	if payload["success"] != true {
+		t.Errorf("expected success: true, got %v", payload["success"])
+	}
+	if msg, _ := payload["message"].(string); msg != "Refunded 5.00 USD on sale s1." {
+		t.Errorf("got message %q, want the labelled refund message", msg)
+	}
+	if _, ok := payload["result"].(map[string]any); !ok {
+		t.Errorf("expected a result object carrying the refund response, got %#v", payload["result"])
+	}
+	// json.Unmarshal above already rejects trailing data, so a leaked second
+	// JSON value (e.g. the sale lookup's own body) would have failed there.
 }
 
 // A JPY sale is the case the ×100 default got wrong: yen has no minor unit, so

--- a/internal/cmd/sales/sales_test.go
+++ b/internal/cmd/sales/sales_test.go
@@ -1209,6 +1209,33 @@ func TestView_RawFixture(t *testing.T) {
 	}
 }
 
+// salesRefundHandler routes the sale lookup and the refund PUT to separate
+// handlers so a test can assert the lookup fired before the money moved.
+func salesRefundHandler(t *testing.T, lookup, refund http.HandlerFunc) http.HandlerFunc {
+	t.Helper()
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/refund") {
+			refund(w, r)
+			return
+		}
+		lookup(w, r)
+	}
+}
+
+func saleLookupResponder(t *testing.T, currency string) http.HandlerFunc {
+	t.Helper()
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("sale lookup must be a GET, got %s", r.Method)
+		}
+		testutil.JSON(t, w, map[string]any{
+			"sale": map[string]any{"id": "s1", "currency": currency},
+		})
+	}
+}
+
 func TestRefund_RequiresConfirmation(t *testing.T) {
 	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
 		t.Error("should not reach API without confirmation")
@@ -1223,9 +1250,11 @@ func TestRefund_RequiresConfirmation(t *testing.T) {
 }
 
 func TestRefund_DryRunSkipsConfirmationAndNetwork(t *testing.T) {
-	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
-		t.Error("dry-run should not reach API")
-	})
+	testutil.Setup(t, salesRefundHandler(t,
+		saleLookupResponder(t, "usd"),
+		func(w http.ResponseWriter, r *http.Request) {
+			t.Error("dry-run should not reach the refund API")
+		}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.DryRun(true), testutil.NoInput(true))
 	cmd.SetArgs([]string{"s1", "--amount", "5.00"})
@@ -1238,19 +1267,23 @@ func TestRefund_DryRunSkipsConfirmationAndNetwork(t *testing.T) {
 	}
 }
 
-func TestRefund_FullRefund(t *testing.T) {
+func TestRefund_FullRefundSkipsLookup(t *testing.T) {
 	var gotMethod, gotPath string
-	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
-		gotMethod = r.Method
-		gotPath = r.URL.Path
-		if err := r.ParseForm(); err != nil {
-			t.Fatalf("ParseForm failed: %v", err)
-		}
-		if r.PostForm.Get("amount_cents") != "" {
-			t.Error("full refund should not send amount_cents")
-		}
-		testutil.JSON(t, w, map[string]any{})
-	})
+	testutil.Setup(t, salesRefundHandler(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			t.Error("a full refund needs no currency, so it must not spend a lookup request")
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			gotMethod = r.Method
+			gotPath = r.URL.Path
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm failed: %v", err)
+			}
+			if r.PostForm.Get("amount_cents") != "" {
+				t.Error("full refund should not send amount_cents")
+			}
+			testutil.JSON(t, w, map[string]any{})
+		}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true), testutil.Quiet(false))
 	cmd.SetArgs([]string{"s1"})
@@ -1263,31 +1296,154 @@ func TestRefund_FullRefund(t *testing.T) {
 	}
 }
 
-func TestRefund_Partial(t *testing.T) {
-	var gotAmountCents string
-	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
-		if err := r.ParseForm(); err != nil {
-			t.Fatalf("ParseForm failed: %v", err)
-		}
-		gotAmountCents = r.PostForm.Get("amount_cents")
-		testutil.JSON(t, w, map[string]any{})
-	})
+func TestRefund_PartialLooksUpCurrencyAndScalesUSD(t *testing.T) {
+	var lookupHits int
+	var lookupPath, gotAmountCents string
+	testutil.Setup(t, salesRefundHandler(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			lookupHits++
+			lookupPath = r.URL.Path
+			saleLookupResponder(t, "usd")(w, r)
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm failed: %v", err)
+			}
+			gotAmountCents = r.PostForm.Get("amount_cents")
+			testutil.JSON(t, w, map[string]any{})
+		}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true), testutil.Quiet(false))
 	cmd.SetArgs([]string{"s1", "--amount", "5.00"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
-	if gotAmountCents != "500" {
-		t.Errorf("got amount_cents=%q, want 500", gotAmountCents)
+
+	if lookupHits != 1 {
+		t.Fatalf("expected exactly one sale lookup, got %d", lookupHits)
 	}
-	if !strings.Contains(out, "Refunded 5.00 on sale s1.") {
-		t.Errorf("expected partial refund message, got %q", out)
+	if lookupPath != "/sales/s1" {
+		t.Errorf("got lookup path %q, want /sales/s1", lookupPath)
+	}
+	if gotAmountCents != "500" {
+		t.Errorf("got amount_cents=%q, want 500 for $5.00 USD", gotAmountCents)
+	}
+	if !strings.Contains(out, "Refunded 5.00 USD on sale s1.") {
+		t.Errorf("expected partial refund message naming the currency, got %q", out)
+	}
+}
+
+// A JPY sale is the case the ×100 default got wrong: yen has no minor unit, so
+// --amount 25 must stay 25 on the wire instead of becoming ¥2500.
+func TestRefund_PartialUsesSaleCurrencyForJPY(t *testing.T) {
+	var gotAmountCents string
+	testutil.Setup(t, salesRefundHandler(t,
+		saleLookupResponder(t, "jpy"),
+		func(w http.ResponseWriter, r *http.Request) {
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm failed: %v", err)
+			}
+			gotAmountCents = r.PostForm.Get("amount_cents")
+			testutil.JSON(t, w, map[string]any{})
+		}))
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true), testutil.Quiet(false))
+	cmd.SetArgs([]string{"s1", "--amount", "25"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotAmountCents != "25" {
+		t.Errorf("got amount_cents=%q, want 25 for ¥25 (JPY has no minor unit)", gotAmountCents)
+	}
+	if !strings.Contains(out, "Refunded 25 JPY on sale s1.") {
+		t.Errorf("expected the yen amount echoed unscaled and labelled, got %q", out)
+	}
+}
+
+func TestRefund_FallsBackToLegacyCurrencyFields(t *testing.T) {
+	var gotAmountCents string
+	testutil.Setup(t, salesRefundHandler(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			testutil.JSON(t, w, map[string]any{
+				"sale": map[string]any{"id": "s1", "price_currency_type": "jpy"},
+			})
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm failed: %v", err)
+			}
+			gotAmountCents = r.PostForm.Get("amount_cents")
+			testutil.JSON(t, w, map[string]any{})
+		}))
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true), testutil.Quiet(false))
+	cmd.SetArgs([]string{"s1", "--amount", "25"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotAmountCents != "25" {
+		t.Errorf("got amount_cents=%q, want 25 — a server without the `currency` field still exposes price_currency_type", gotAmountCents)
+	}
+}
+
+func TestRefund_RefusesAmountWhenCurrencyUnknown(t *testing.T) {
+	testutil.Setup(t, salesRefundHandler(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			testutil.JSON(t, w, map[string]any{
+				"sale": map[string]any{"id": "s1"},
+			})
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			t.Error("refund PUT must not fire when the currency cannot be determined")
+		}))
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"s1", "--amount", "25"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected a refusal when the sale exposes no currency")
+	}
+	if !strings.Contains(err.Error(), "could not determine the currency") {
+		t.Errorf("expected the currency-unknown guard, got: %v", err)
+	}
+	var invalidInputErr *cmdutil.InvalidInputError
+	if !errors.As(err, &invalidInputErr) {
+		t.Errorf("guard must be a *cmdutil.InvalidInputError so --json classifies it as invalid input, got %T", err)
+	}
+}
+
+func TestRefund_RefusesAmountWhenCurrencyIsBlank(t *testing.T) {
+	testutil.Setup(t, salesRefundHandler(t,
+		saleLookupResponder(t, "   "),
+		func(w http.ResponseWriter, r *http.Request) {
+			t.Error("refund PUT must not fire when the currency is blank")
+		}))
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"s1", "--amount", "25"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "could not determine the currency") {
+		t.Fatalf("expected the currency-unknown guard for a whitespace-only currency, got: %v", err)
+	}
+}
+
+func TestRefund_RejectsDecimalAmountForJPY(t *testing.T) {
+	testutil.Setup(t, salesRefundHandler(t,
+		saleLookupResponder(t, "jpy"),
+		func(w http.ResponseWriter, r *http.Request) {
+			t.Error("should not reach the refund API for a fractional yen amount")
+		}))
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"s1", "--amount", "5.00"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "JPY") {
+		t.Fatalf("expected the JPY decimal rejection, got: %v", err)
 	}
 }
 
 func TestRefund_AmountInvalidInput(t *testing.T) {
-	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
-		t.Error("should not reach API")
-	})
+	testutil.Setup(t, salesRefundHandler(t,
+		saleLookupResponder(t, "usd"),
+		func(w http.ResponseWriter, r *http.Request) {
+			t.Error("should not reach the refund API")
+		}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
 	cmd.SetArgs([]string{"s1", "--amount", "abc"})
@@ -1302,22 +1458,26 @@ func TestRefund_AmountInvalidInput(t *testing.T) {
 }
 
 func TestRefund_AmountWholeNumberMessage(t *testing.T) {
-	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
-		testutil.JSON(t, w, map[string]any{})
-	})
+	testutil.Setup(t, salesRefundHandler(t,
+		saleLookupResponder(t, "usd"),
+		func(w http.ResponseWriter, r *http.Request) {
+			testutil.JSON(t, w, map[string]any{})
+		}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true), testutil.Quiet(false))
 	cmd.SetArgs([]string{"s1", "--amount", "5"})
 	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
-	if !strings.Contains(out, "Refunded 5.00 on sale s1.") {
+	if !strings.Contains(out, "Refunded 5.00 USD on sale s1.") {
 		t.Errorf("expected normalized refund message, got %q", out)
 	}
 }
 
 func TestRefund_AmountNoInputShowsNormalized(t *testing.T) {
-	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
-		t.Error("should not reach API without confirmation")
-	})
+	testutil.Setup(t, salesRefundHandler(t,
+		saleLookupResponder(t, "usd"),
+		func(w http.ResponseWriter, r *http.Request) {
+			t.Error("should not reach the refund API without confirmation")
+		}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.NoInput(true))
 	cmd.SetArgs([]string{"s1", "--amount", "5"})
@@ -1325,16 +1485,17 @@ func TestRefund_AmountNoInputShowsNormalized(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error without confirmation")
 	}
-	// The error message should mention --yes (confirmation required), not raw "5"
 	if !strings.Contains(err.Error(), "--yes") {
 		t.Fatalf("expected confirmation error mentioning --yes, got: %v", err)
 	}
 }
 
 func TestRefund_AmountZeroRejected(t *testing.T) {
-	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
-		t.Error("should not reach API")
-	})
+	testutil.Setup(t, salesRefundHandler(t,
+		saleLookupResponder(t, "usd"),
+		func(w http.ResponseWriter, r *http.Request) {
+			t.Error("should not reach the refund API")
+		}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
 	cmd.SetArgs([]string{"s1", "--amount", "0"})
@@ -1345,9 +1506,11 @@ func TestRefund_AmountZeroRejected(t *testing.T) {
 }
 
 func TestRefund_InvalidPartialAmount(t *testing.T) {
-	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
-		t.Error("should not reach API with invalid amount")
-	})
+	testutil.Setup(t, salesRefundHandler(t,
+		saleLookupResponder(t, "usd"),
+		func(w http.ResponseWriter, r *http.Request) {
+			t.Error("should not reach the refund API with an invalid amount")
+		}))
 
 	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
 	cmd.SetArgs([]string{"s1", "--amount", "-1"})

--- a/internal/cmd/sales/sales_test.go
+++ b/internal/cmd/sales/sales_test.go
@@ -1457,6 +1457,23 @@ func TestRefund_AmountInvalidInput(t *testing.T) {
 	}
 }
 
+func TestRefund_MalformedAmountSkipsLookup(t *testing.T) {
+	testutil.Setup(t, salesRefundHandler(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			t.Error("malformed --amount must be rejected before the sale lookup")
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			t.Error("should not reach the refund API")
+		}))
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"s1", "--amount", "abc"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "not a valid amount") {
+		t.Fatalf("expected validation error, got: %v", err)
+	}
+}
+
 func TestRefund_AmountWholeNumberMessage(t *testing.T) {
 	testutil.Setup(t, salesRefundHandler(t,
 		saleLookupResponder(t, "usd"),

--- a/internal/cmdutil/read.go
+++ b/internal/cmdutil/read.go
@@ -103,8 +103,15 @@ func RunRequestDecoded[T any](opts Options, spinnerMessage, method, path string,
 // response without rendering it. Use it when one command chains requests and
 // only needs the data from the first (e.g. reading a resource's currency before
 // it can interpret a user-supplied amount).
+//
+// Unlike the other Run*/RunRequest* helpers, a mutating method has nothing
+// sensible to print under --dry-run (there is no response to decode), so this
+// refuses outright rather than silently making the real request.
 func FetchRequestDecoded[T any](opts Options, spinnerMessage, method, path string, params url.Values) (T, error) {
 	var zero T
+	if opts.DryRun && method != http.MethodGet {
+		return zero, fmt.Errorf("cannot dry-run a chained %s request to %s: FetchRequestDecoded has no response to preview", method, path)
+	}
 	data, err := runAuthenticatedData(opts, spinnerMessage, requestRunner(method, path, params))
 	if err != nil {
 		return zero, err

--- a/internal/cmdutil/read.go
+++ b/internal/cmdutil/read.go
@@ -99,6 +99,19 @@ func RunRequestDecoded[T any](opts Options, spinnerMessage, method, path string,
 	return RunDecoded[T](opts, spinnerMessage, requestRunner(method, path, params), render)
 }
 
+// FetchRequestDecoded executes an authenticated API request and decodes the
+// response without rendering it. Use it when one command chains requests and
+// only needs the data from the first (e.g. reading a resource's currency before
+// it can interpret a user-supplied amount).
+func FetchRequestDecoded[T any](opts Options, spinnerMessage, method, path string, params url.Values) (T, error) {
+	var zero T
+	data, err := runAuthenticatedData(opts, spinnerMessage, requestRunner(method, path, params))
+	if err != nil {
+		return zero, err
+	}
+	return DecodeJSON[T](data)
+}
+
 // RunRequestWithSuccess executes a mutating API request and prints a success
 // message in human mode. The id identifies the affected resource in JSON output.
 func RunRequestWithSuccess(opts Options, spinnerMessage, method, path string, params url.Values, id, successMessage string) error {

--- a/internal/cmdutil/read_test.go
+++ b/internal/cmdutil/read_test.go
@@ -199,6 +199,33 @@ func TestFetchRequestDecoded_PropagatesRequestErrors(t *testing.T) {
 	}
 }
 
+func TestFetchRequestDecoded_RefusesDryRunForMutatingMethods(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("a dry run must not make a real PUT/POST/DELETE request")
+	})
+
+	_, err := cmdutil.FetchRequestDecoded[map[string]any](testutil.TestOptions(testutil.DryRun(true)), "Refunding...", "PUT", "/sales/s1/refund", url.Values{})
+	if err == nil {
+		t.Fatal("expected a refusal: there is no response to preview for a chained mutating request")
+	}
+}
+
+func TestFetchRequestDecoded_DryRunStillAllowsGET(t *testing.T) {
+	var reached bool
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		testutil.JSON(t, w, map[string]any{"sale": map[string]any{"id": "s1"}})
+	})
+
+	_, err := cmdutil.FetchRequestDecoded[map[string]any](testutil.TestOptions(testutil.DryRun(true)), "Fetching sale...", "GET", "/sales/s1", url.Values{})
+	if err != nil {
+		t.Fatalf("GET lookups must still run under --dry-run so a chained mutating dry run can preview correctly, got: %v", err)
+	}
+	if !reached {
+		t.Fatal("expected the GET to reach the server")
+	}
+}
+
 func TestDecodeJSON_WrapsParseErrors(t *testing.T) {
 	type payload struct {
 		User struct {

--- a/internal/cmdutil/read_test.go
+++ b/internal/cmdutil/read_test.go
@@ -153,6 +153,52 @@ func TestRunRequestDecoded_RendersTypedResponse(t *testing.T) {
 	}
 }
 
+func TestFetchRequestDecoded_ReturnsDataWithoutRendering(t *testing.T) {
+	type userResponse struct {
+		User struct {
+			Email string `json:"email"`
+		} `json:"user"`
+	}
+
+	var gotPath string
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		testutil.JSON(t, w, map[string]any{
+			"user": map[string]any{"email": "fetched@example.com"},
+		})
+	})
+
+	// JSON output mode must not print the intermediate response: a chained
+	// command still owes its own output after this call.
+	out := testutil.CaptureStdout(func() {
+		resp, err := cmdutil.FetchRequestDecoded[userResponse](testutil.TestOptions(testutil.JSONOutput()), "Fetching user...", "GET", "/user", url.Values{})
+		if err != nil {
+			t.Fatalf("FetchRequestDecoded failed: %v", err)
+		}
+		if resp.User.Email != "fetched@example.com" {
+			t.Fatalf("got email %q, want fetched@example.com", resp.User.Email)
+		}
+	})
+	if gotPath != "/user" {
+		t.Fatalf("got path %q, want /user", gotPath)
+	}
+	if strings.TrimSpace(out) != "" {
+		t.Fatalf("expected no rendered output, got %q", out)
+	}
+}
+
+func TestFetchRequestDecoded_PropagatesRequestErrors(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		testutil.RawJSON(t, w, `{"success":false,"message":"The sale was not found."}`)
+	})
+
+	_, err := cmdutil.FetchRequestDecoded[map[string]any](testutil.TestOptions(), "Fetching sale...", "GET", "/sales/missing", url.Values{})
+	if err == nil {
+		t.Fatal("expected the lookup failure to propagate so the caller does not proceed on zero data")
+	}
+}
+
 func TestDecodeJSON_WrapsParseErrors(t *testing.T) {
 	type payload struct {
 		User struct {

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -66,7 +66,7 @@ Most responses are wrapped in `{"success": true, ...}` with resource-specific ke
 - `products content set` → mutation envelope with `.result`
 - `sales list` → `.sales[]`
 - `sales buyers` → `.buyers[]` (`email`, `name`, `purchase_count`, `last_purchase_date`, `utm_source`, `utm_medium`, `utm_campaign`, `utm_term`, `utm_content`)
-- `sales view` → `.sale`
+- `sales view` → `.sale` (includes `.currency`, the ISO code the sale is priced in — the same currency a refund amount is read in)
 - `sales export` → `.status`, `.recipient_email`
 - `sales summary` → `.gross_cents`, `.net_cents`, `.breakdown[]`
 - `emails list` → `.emails[]`, `emails view/create/send` → `.email`, `emails send-preview` → `.preview_url`, `emails delete` → `.message`
@@ -459,8 +459,14 @@ gumroad sales export --product <id> --json --no-input
 gumroad sales view <id> --json --no-input
 
 # Refund (destructive — needs --yes)
+# --amount is in the sale's OWN currency, so a partial refund fetches the sale
+# first to read that currency. That extra GET is why a yen-priced sale accepts
+# `--amount 25` as ¥25: without it, 25 would be scaled to ¥2500. A full refund
+# sends no amount and makes no lookup.
 gumroad sales refund <id> --yes --json --no-input
 gumroad sales refund <id> --amount 5.00 --yes --json --no-input
+# A sale whose currency cannot be read is refused rather than guessed:
+# re-run without --amount for a full refund.
 
 # Resend receipt
 gumroad sales resend-receipt <id> --json --no-input


### PR DESCRIPTION
## What

`gumroad sales refund <id> --amount N` scaled `N` by a hardcoded ×100. It now looks the sale up first, reads the currency it is priced in, and scales by that currency's actual minor unit — refusing the partial refund rather than guessing when the currency cannot be determined.

Client half of gumroad-private#1782. Server half: antiwork/gumroad#6936.

## Why

`internal/cmd/sales/refund.go` called `cmdutil.ParseMoney("amount", amount, "amount", "")` — the fourth argument is the currency, and it was the empty string. `scalingFactor("")` returns `100`, so every amount was multiplied by 100 regardless of the sale.

JPY is the one currency Gumroad lists in where that is wrong: yen has no minor unit (`"single_unit": true` in `config/currencies.json`, and `unit_scaling_factor` returns `1` server-side). So on a JPY-listed sale:

- seller types `--amount 25`, meaning ¥25
- the CLI sends `amount_cents=2500`
- the server reads 2500 as **¥2500** and refunds it

The refundable-balance guard only rejects amounts *above* the balance, so this fails loudly on a cheap product and succeeds silently on an expensive one — a ¥25 partial refund on a ¥3,000 sale refunds ¥2,500 and prints a success message. The confirmation prompt did not help either: it formatted the amount with the same empty currency, so it said `Refund 25.00` while the wire carried ¥2500.

Sibling commands already thread currency here. `list.go` and `summary.go` format amounts currency-aware with a `currency` → `currency_type` → `price_currency_type` fallback chain, and `admin purchases refund` already does the lookup-then-scale dance this PR ports over. `sales refund` was the outlier, and the only one of them that moves money.

## Before / after

For a sale on a JPY-listed product, `--amount 25`:

| | before | after |
| --- | --- | --- |
| confirmation prompt | `Refund 25.00 on sale s1?` | `Refund 25 JPY on sale s1?` |
| `amount_cents` on the wire | `2500` | `25` |
| refund executed | ¥2500 | ¥25 |
| success message | `Refunded 25.00 on sale s1.` | `Refunded 25 JPY on sale s1.` |

For every non-JPY sale the wire value is unchanged (`--amount 5.00` → `500`); only the echoed text gains a currency label (`Refunded 5.00 USD on sale s1.`).

Three deliberate design points:

1. **Full refunds make no lookup.** A full refund sends no amount, so it needs no currency, and spending a request on one would be a regression in the common path. There is a test asserting the lookup handler is never reached.
2. **Unknown currency refuses rather than falls back.** Falling back to ×100 is what caused the bug; a warning would be printed after the prompt already showed the wrong number. The error names the escape hatch (`re-run without --amount for a full refund`). It is an `InvalidInputError`, not a `UsageError`, so it does not dump the full help block for a runtime condition — and `--json` still classifies it as invalid input.
3. **The currency read keeps the existing fallback chain** (`currency` → `currency_type` → `price_currency_type`) so the CLI works against a server that predates the `currency` field.

**One deliberate behaviour change beyond the fix:** `--dry-run --amount N` now performs the sale lookup, so it needs the network and a real sale. Previously a dry run against a nonexistent sale happily printed `amount_cents: 2500`; it now reports `The sale was not found.` and exits 1. That is the point — a dry run exists to show the amount that *would* be sent, and it cannot do that without the currency. The lookup is a GET, so nothing is mutated, and a full-refund dry run still makes no request at all.

A new `cmdutil.FetchRequestDecoded` provides the fetch-without-rendering step; `RunRequestDecoded` cannot be used, because its JSON fast-path would print the intermediate sale lookup and skip the render callback entirely. It is the v2-API counterpart of the existing `admincmd.FetchGetDecoded`.

## Test Results

Checks run:

- `make test-cover` — all packages pass their gates; `internal/cmd/sales` **89.8%** (gate 85%), `internal/cmdutil` **92.3%** (gate 90%)
- `go test ./internal/cmd/sales/... ./internal/cmdutil/...` — pass
- `go build ./...`, `go vet ./internal/...` — clean
- `gofmt -l internal/` — no output
- `golangci-lint run --timeout 10m ./internal/...` (v1.64.8, the version CI pins) — clean

Nine refund tests, six of them new: JPY scaling, USD scaling with a lookup-count assertion, legacy-field fallback, currency-unknown refusal, blank-currency refusal, and full-refund-skips-lookup. Two new `cmdutil` tests cover the helper, including that it prints nothing in JSON mode and that a failed lookup propagates instead of returning zero data.

Mutation proof — three mutants, each killed by a **different** set of examples, so no example is redundant:

| mutant | result |
| --- | --- |
| restore `ParseMoney(..., "")` (the original bug) | RED — `PartialUsesSaleCurrencyForJPY`, `FallsBackToLegacyCurrencyFields`, `RejectsDecimalAmountForJPY` |
| delete the currency-unknown guard | RED — `RefusesAmountWhenCurrencyUnknown`, `RefusesAmountWhenCurrencyIsBlank` |
| replace `c.Flags().Changed("amount")` with `true` (always look up) | RED — `RequiresConfirmation`, `FullRefundSkipsLookup` |

## QA steps

Recorded against a local mock API serving the real v2 shapes, running the **old binary built from `origin/main`** and the new one against the same server, so the before/after is one session rather than two claims:

![demo](https://i.ibb.co/qM14Htj0/gp1782-demo.gif)

The mock logs every `amount_cents` it receives, and the last frame prints that log — which is the part a diff cannot show:

```
amount_cents=2500                 (sale jpy_sale_1, listed in jpy)   <- old binary, --amount 25
amount_cents=25                   (sale jpy_sale_1, listed in jpy)   <- new binary, --amount 25
amount_cents=500                  (sale usd_sale_1, listed in usd)   <- new binary, --amount 5.00
amount_cents=<none: full refund>  (sale jpy_sale_1, listed in jpy)   <- new binary, no --amount
```

Steps executed in the recording, in order:

1. `GET /sales/jpy_sale_1` showing `"currency": "jpy"`
2. old binary, `--amount 25` → prints `Refunded 25.00`, sends **2500** (the bug)
3. new binary, `--amount 25` → prints `Refunded 25 JPY`, sends **25**
4. new binary, `--amount 5.00` on a USD sale → sends 500, wire value unchanged
5. new binary, `--amount 5.50` on the JPY sale → rejected, no request
6. sale with no currency, `--amount 25` → refused, **exit code 1**, no refund request
7. the same refusal under `--json` → `"code": "invalid_input"`
8. full refund, no `--amount` → succeeds and makes no lookup request

Separately verified outside the recording (dry-run paths, which the mock also proves send no `PUT`):

| command | before | after |
| --- | --- | --- |
| `--amount 25 --dry-run` on the JPY sale | `amount_cents: 2500` | `amount_cents: 25` |
| `--amount 25 --dry-run` on a nonexistent sale | printed a plan with `2500` | `The sale was not found.`, exit 1 |
| `--dry-run` with no `--amount` | no request | no request |

## Documentation

`skills/gumroad/SKILL.md` updated in the same commit, as CONTRIBUTING requires for a behaviour change: the `sales refund` block now explains why a partial refund costs an extra GET and what the refusal means, and the response-keys list notes that `sales view` carries `.currency`.

## Deploy ordering

Merging this before antiwork/gumroad#6936 is safe: without the server field the CLI reads `currency_type` / `price_currency_type`, and if a server sends neither it refuses `--amount` instead of mis-scaling it. A CLI *release* should follow the server deploy so the primary field is present.

## Review round

An adversarial pass found no P1s. Two fixes landed after the recording above (so its wire-log evidence still holds — neither changes what goes on the wire):

- A sibling autonomous pass (Greptile finding, commit `ae40c85`) moved the `--amount` syntax/sign check before the sale lookup, so a malformed amount fails locally instead of spending an authenticated request.
- `FetchRequestDecoded` had no `--dry-run` guard on mutating methods — today's only caller passes GET, so it was latent, but a future PUT/POST/DELETE caller would have made a real request under `--dry-run`. It now refuses; GET still runs under dry-run, which is why `sales refund --amount --dry-run` correctly shows the scaled preview.
- The `salesRefundHandler` test double routed on a `/refund` path suffix, which a sale id literally ending in "refund" would have defeated; it now routes on HTTP method.
- Added a `--json` test pinning that a partial refund prints exactly one mutation envelope, not the lookup's body plus the refund's.

## Status

- [x] Scope — client half of gumroad-private#1782, option 1 from the issue as directed by @nyomanjyotisa
- [x] Design — lookup-then-scale, mirroring `admin purchases refund`; refuse on unknown currency
- [x] Build — `19d06b8`
- [x] QA — terminal recording attached; wire values verified against a mock server; review fixes re-tested (all gates green)
- [ ] Ship — not merged
- [ ] Market — n/a
- [ ] Sell — n/a

---

🤖 Written with claude-opus-5 via Hermes Agent.
