### PR TITLE
Add currency override for sales partial refunds

### DIFF
--- a/internal/cmd/sales/refund.go
+++ b/internal/cmd/sales/refund.go
@@ -73,6 +73,9 @@ server round trip.`,
 					if currency == "" {
 						return cmdutil.UsageErrorf(c, "--currency cannot be empty")
 					}
+					if !cmdutil.IsSupportedCurrency(currency) {
+						return cmdutil.UsageErrorf(c, "%q is not a currency Gumroad supports", currency)
+					}
 				} else {
 					lookup, err := cmdutil.FetchRequestDecoded[refundSaleLookup](opts, "Looking up sale...", "GET", cmdutil.JoinPath("sales", args[0]), url.Values{})
 					if err != nil {

--- a/internal/cmd/sales/refund.go
+++ b/internal/cmd/sales/refund.go
@@ -28,22 +28,31 @@ func (l refundSaleLookup) currency() string {
 }
 
 func newRefundCmd() *cobra.Command {
-	var amount string
+	var amount, currencyFlag string
 
 	cmd := &cobra.Command{
 		Use:   "refund <id>",
 		Short: "Refund a sale",
 		Long: `Refund a sale in full, or partially with --amount.
 
---amount is given in the sale's own currency, so the sale is looked up first to
-find out what that currency is. Without the lookup a value like 25 could mean
-either $25.00 or ¥25, and sending the wrong one refunds 100 times the intended
-amount on a yen-priced sale.`,
+--amount is given in the sale's own currency, so by default the sale is looked
+up first to find out what that currency is. Without the lookup a value like 25
+could mean either $25.00 or ¥25, and sending the wrong one refunds 100 times
+the intended amount on a yen-priced sale.
+
+The lookup needs the view_sales scope in addition to the scope that authorizes
+the refund itself. A token issued with only refund permission can skip the
+lookup by passing --currency, which is used as-is and trusted without a
+server round trip.`,
 		Example: `  gumroad sales refund A-m3CDDC5dlrSdKZp0RFhA==
-  gumroad sales refund A-m3CDDC5dlrSdKZp0RFhA== --amount 2.00`,
+  gumroad sales refund A-m3CDDC5dlrSdKZp0RFhA== --amount 2.00
+  gumroad sales refund A-m3CDDC5dlrSdKZp0RFhA== --amount 25 --currency jpy`,
 		Args: cmdutil.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
+			if c.Flags().Changed("currency") && !c.Flags().Changed("amount") {
+				return cmdutil.UsageErrorf(c, "--currency requires --amount")
+			}
 
 			var (
 				cents    int
@@ -59,13 +68,20 @@ amount on a yen-priced sale.`,
 					return cmdutil.UsageErrorf(c, "--amount must be greater than 0")
 				}
 
-				lookup, err := cmdutil.FetchRequestDecoded[refundSaleLookup](opts, "Looking up sale...", "GET", cmdutil.JoinPath("sales", args[0]), url.Values{})
-				if err != nil {
-					return err
-				}
-				currency = lookup.currency()
-				if currency == "" {
-					return cmdutil.InvalidInputErrorf("could not determine the currency of sale %s, so --amount cannot be scaled safely; re-run without --amount for a full refund", args[0])
+				if c.Flags().Changed("currency") {
+					currency = strings.TrimSpace(currencyFlag)
+					if currency == "" {
+						return cmdutil.UsageErrorf(c, "--currency cannot be empty")
+					}
+				} else {
+					lookup, err := cmdutil.FetchRequestDecoded[refundSaleLookup](opts, "Looking up sale...", "GET", cmdutil.JoinPath("sales", args[0]), url.Values{})
+					if err != nil {
+						return err
+					}
+					currency = lookup.currency()
+					if currency == "" {
+						return cmdutil.InvalidInputErrorf("could not determine the currency of sale %s, so --amount cannot be scaled safely; re-run without --amount for a full refund, or pass --currency explicitly to skip the lookup", args[0])
+					}
 				}
 
 				parsed, err := cmdutil.ParseMoney("amount", amount, "amount", currency)
@@ -110,6 +126,7 @@ amount on a yen-priced sale.`,
 	}
 
 	cmd.Flags().StringVar(&amount, "amount", "", "Partial refund amount in the sale's currency (e.g. 5, 5.00)")
+	cmd.Flags().StringVar(&currencyFlag, "currency", "", "Sale's currency (e.g. usd, jpy); skips the sale lookup, for tokens without view_sales")
 
 	return cmd
 }

--- a/internal/cmd/sales/sales_test.go
+++ b/internal/cmd/sales/sales_test.go
@@ -1333,6 +1333,45 @@ func TestRefund_PartialLooksUpCurrencyAndScalesUSD(t *testing.T) {
 	}
 }
 
+func TestRefund_CurrencyFlagSkipsLookupAndScalesJPY(t *testing.T) {
+	var gotAmountCents string
+	testutil.Setup(t, salesRefundHandler(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			t.Error("--currency must preserve refund-only tokens by skipping the sale lookup")
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm failed: %v", err)
+			}
+			gotAmountCents = r.PostForm.Get("amount_cents")
+			testutil.JSON(t, w, map[string]any{})
+		}))
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true), testutil.Quiet(false))
+	cmd.SetArgs([]string{"s1", "--amount", "25", "--currency", "jpy"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotAmountCents != "25" {
+		t.Errorf("got amount_cents=%q, want 25 when --currency jpy skips the lookup", gotAmountCents)
+	}
+	if !strings.Contains(out, "Refunded 25 JPY on sale s1.") {
+		t.Errorf("expected the yen amount echoed unscaled and labelled, got %q", out)
+	}
+}
+
+func TestRefund_CurrencyRequiresAmount(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("--currency without --amount is local flag misuse and must not reach the API")
+	})
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"s1", "--currency", "jpy"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--currency requires --amount") {
+		t.Fatalf("expected --currency without --amount to be refused, got %v", err)
+	}
+}
+
 func TestRefund_PartialJSONOutputIsOnlyTheMutationEnvelope(t *testing.T) {
 	testutil.Setup(t, salesRefundHandler(t,
 		saleLookupResponder(t, "usd"),

--- a/internal/cmd/sales/sales_test.go
+++ b/internal/cmd/sales/sales_test.go
@@ -1372,6 +1372,19 @@ func TestRefund_CurrencyRequiresAmount(t *testing.T) {
 	}
 }
 
+func TestRefund_CurrencyRejectsUnsupportedCode(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("a misspelled --currency must be rejected locally, not sent as amount_cents at the wrong scale")
+	})
+
+	cmd := testutil.Command(newRefundCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"s1", "--amount", "25", "--currency", "jpyy"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "is not a currency Gumroad supports") {
+		t.Fatalf("expected an unsupported --currency to be refused, got %v", err)
+	}
+}
+
 func TestRefund_PartialJSONOutputIsOnlyTheMutationEnvelope(t *testing.T) {
 	testutil.Setup(t, salesRefundHandler(t,
 		saleLookupResponder(t, "usd"),

--- a/internal/cmdutil/money.go
+++ b/internal/cmdutil/money.go
@@ -12,10 +12,28 @@ var singleUnitCurrencies = map[string]bool{
 	"jpy": true,
 }
 
+// supportedCurrencies are the ISO codes Gumroad prices and pays out in.
+// Source: config/currencies.json in the Gumroad codebase.
+var supportedCurrencies = map[string]bool{
+	"usd": true, "gbp": true, "eur": true, "jpy": true, "inr": true,
+	"aud": true, "cad": true, "hkd": true, "sgd": true, "twd": true,
+	"nzd": true, "brl": true, "zar": true, "chf": true, "ils": true,
+	"php": true, "krw": true, "pln": true, "czk": true,
+}
+
 // IsSingleUnitCurrency reports whether the given currency code has no
 // minor unit (e.g. JPY where ¥1 = 1 minor unit).
 func IsSingleUnitCurrency(currency string) bool {
 	return singleUnitCurrencies[strings.ToLower(currency)]
+}
+
+// IsSupportedCurrency reports whether the given code is a currency Gumroad
+// prices in. Use this to validate any currency taken as a trusted CLI input
+// rather than read back from the API, where a typo would otherwise scale a
+// refund by the wrong factor silently (e.g. "jpyy" scaling ×100 like a
+// two-decimal currency instead of being rejected).
+func IsSupportedCurrency(currency string) bool {
+	return supportedCurrencies[strings.ToLower(currency)]
 }
 
 // scalingFactor returns the multiplier to convert user-facing amounts to

--- a/internal/cmdutil/money_test.go
+++ b/internal/cmdutil/money_test.go
@@ -164,3 +164,26 @@ func TestIsSingleUnitCurrency(t *testing.T) {
 		})
 	}
 }
+
+func TestIsSupportedCurrency(t *testing.T) {
+	tests := []struct {
+		currency string
+		want     bool
+	}{
+		{"usd", true},
+		{"USD", true},
+		{"jpy", true},
+		{"eur", true},
+		{"jpyy", false},
+		{"xyz", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.currency, func(t *testing.T) {
+			if got := IsSupportedCurrency(tt.currency); got != tt.want {
+				t.Fatalf("IsSupportedCurrency(%q) = %v, want %v", tt.currency, got, tt.want)
+			}
+		})
+	}
+}

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -462,11 +462,15 @@ gumroad sales view <id> --json --no-input
 # --amount is in the sale's OWN currency, so a partial refund fetches the sale
 # first to read that currency. That extra GET is why a yen-priced sale accepts
 # `--amount 25` as ¥25: without it, 25 would be scaled to ¥2500. A full refund
-# sends no amount and makes no lookup.
+# sends no amount and makes no lookup. If a token has refund permission but lacks
+# view_sales, pass --currency explicitly; the CLI then trusts that currency and
+# skips the lookup.
 gumroad sales refund <id> --yes --json --no-input
 gumroad sales refund <id> --amount 5.00 --yes --json --no-input
+gumroad sales refund <id> --amount 25 --currency jpy --yes --json --no-input
 # A sale whose currency cannot be read is refused rather than guessed:
-# re-run without --amount for a full refund.
+# re-run without --amount for a full refund, or pass --currency if you already
+# know the sale's listed currency.
 
 # Resend receipt
 gumroad sales resend-receipt <id> --json --no-input


### PR DESCRIPTION
## What

Follow-up to #193: `gumroad sales refund <id> --amount N` now accepts `--currency <code>` as an explicit currency override.

By default the command still looks up the sale and scales the amount from the sale's own currency. The override is only for tokens that can refund sales but cannot read sales: passing `--currency` skips the `GET /sales/:id` lookup and uses that currency to scale/format the partial refund. `--currency` is checked against Gumroad's supported ISO codes before use, so a typo can't silently scale the amount by the wrong factor.

## Why

Nyoman caught that #193's lookup preserved correct JPY scaling but broke compatibility for tokens that only have the refund scope. The server currently gates `GET /v2/sales/:id` behind `view_sales`, while `PUT /v2/sales/:id/refund` accepts `refund_sales` or `edit_sales`, so a refund-only token would now fail before it reaches the refund endpoint.

This preserves the safer default for normal tokens and gives scoped automation an explicit escape hatch:

- `--amount 25` on JPY still does the lookup and sends `amount_cents=25`
- `--amount 25 --currency jpy` sends `amount_cents=25` without a lookup
- `--currency` without `--amount` is rejected locally because full refunds need no currency
- `--currency jpyy` (or any code Gumroad doesn't support) is rejected locally, before any request — Greptile's review caught that this was previously trusted as-is and would have scaled the amount ×100 like a normal currency instead of erroring

The in-repo `skills/gumroad/SKILL.md` command reference is updated with the new flag and the token-scope caveat.

## Before / after

| token / command | before | after |
| --- | --- | --- |
| token with `view_sales`, `sales refund s1 --amount 25` | lookup sale, send JPY `25` | unchanged |
| token without `view_sales`, `sales refund s1 --amount 25` | lookup fails before refund | unchanged safe default |
| token without `view_sales`, `sales refund s1 --amount 25 --currency jpy` | no override existed | skips lookup, sends JPY `25` |
| `sales refund s1 --currency jpy` | flag did not exist | local usage error |
| `sales refund s1 --amount 25 --currency jpyy` | flag did not exist | local usage error (rejected before this round; previously would have accepted it and sent `amount_cents=2500`) |

## Test Results

Checks run:

- `go build ./...` — pass
- `go test ./internal/cmd/sales/... ./internal/cmdutil/...` — pass, including new `TestIsSupportedCurrency` and `TestRefund_CurrencyRejectsUnsupportedCode`
- `sh -c 'unset $(env | grep ^GUMROAD | cut -d= -f1); make test-cover'` — pass; `internal/cmd/sales` 89.8%, `internal/cmdutil` 92.4%
- `go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run ./internal/...` — clean
- Mutation proof: stubbing `IsSupportedCurrency` to always return `true` made both `TestIsSupportedCurrency` (money.go) and `TestRefund_CurrencyRejectsUnsupportedCode` (sales_test.go) fail, proving the new validation guard is pinned; reverted after confirming red, suite green again.

## QA steps

Executed through the focused command tests against the same mock API harness used by #193:

1. `--amount 25 --currency jpy` never calls the lookup handler.
2. The refund PUT receives `amount_cents=25`.
3. Human output says `Refunded 25 JPY on sale s1.`
4. `--currency jpy` without `--amount` returns `--currency requires --amount` before any API request.
5. `--amount 25 --currency jpyy` returns `"jpyy" is not a currency Gumroad supports` before any API request, fixing Greptile's P1 finding that a mistyped code was previously sent as `amount_cents=2500`.

No new terminal GIF is attached; this is a CLI backend command and the executable evidence above is the QA artifact.

## Status

- [x] Scope — follow-up for Nyoman's #193 compatibility review
- [x] Design — explicit `--currency` override skips only the read lookup, validated against Gumroad's supported currency list
- [x] Build — `35b40ee`, currency validation added in `0da2014`
- [x] QA — focused tests, full coverage gate, pinned linter, mutation proof
- [ ] Ship — draft PR, ready for review
- [ ] Market — n/a
- [ ] Sell — n/a

---

🤖 Written with claude-sonnet-5 via Hermes Agent.
