### PR TITLE
Add read-only workflows commands (list, view)

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -28,6 +28,7 @@ import (
 	"github.com/antiwork/gumroad-cli/internal/cmd/user"
 	"github.com/antiwork/gumroad-cli/internal/cmd/variants"
 	"github.com/antiwork/gumroad-cli/internal/cmd/webhooks"
+	"github.com/antiwork/gumroad-cli/internal/cmd/workflows"
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/antiwork/gumroad-cli/internal/updatecheck"
@@ -128,6 +129,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(offercodes.NewOfferCodesCmd())
 	cmd.AddCommand(upsells.NewUpsellsCmd())
 	cmd.AddCommand(emails.NewEmailsCmd())
+	cmd.AddCommand(workflows.NewWorkflowsCmd())
 	cmd.AddCommand(categories.NewCategoriesCmd())
 	cmd.AddCommand(variants.NewVariantsCmd())
 	cmd.AddCommand(customfields.NewCustomFieldsCmd())

--- a/internal/cmd/workflows/list.go
+++ b/internal/cmd/workflows/list.go
@@ -1,0 +1,73 @@
+package workflows
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+type workflowListResponse struct {
+	Success   bool             `json:"success"`
+	Workflows []workflowRecord `json:"workflows"`
+}
+
+func newListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List email workflows",
+		Long:  "List email workflows with audience, state, and email step count.",
+		Args:  cmdutil.ExactArgs(0),
+		Example: `  gumroad workflows list
+  gumroad workflows list --json --jq '.workflows[] | {id, name, emails_count}'
+  gumroad workflows list --plain`,
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			return cmdutil.RunRequestDecoded[workflowListResponse](opts, "Fetching workflows...", "GET", cmdutil.JoinPath("workflows"), url.Values{}, func(resp workflowListResponse) error {
+				return renderWorkflowList(opts, resp)
+			})
+		},
+	}
+}
+
+func renderWorkflowList(opts cmdutil.Options, resp workflowListResponse) error {
+	if len(resp.Workflows) == 0 {
+		return cmdutil.PrintInfo(opts, "No workflows found.")
+	}
+
+	if opts.PlainOutput {
+		var rows [][]string
+		for _, item := range resp.Workflows {
+			rows = append(rows, []string{
+				item.ID,
+				item.Name,
+				workflowAudienceLabel(item.AudienceType),
+				item.State,
+				fmt.Sprintf("%d", item.EmailsCount),
+				item.ProductID,
+				item.PublishedAt,
+			})
+		}
+		return output.PrintPlain(opts.Out(), rows)
+	}
+
+	style := opts.Style()
+	return output.WithPager(opts.Out(), opts.Err(), func(w io.Writer) error {
+		tbl := output.NewStyledTable(style, "ID", "NAME", "AUDIENCE", "STATE", "EMAILS", "PRODUCT", "PUBLISHED AT")
+		for _, item := range resp.Workflows {
+			tbl.AddRow(
+				item.ID,
+				item.Name,
+				workflowAudienceLabel(item.AudienceType),
+				item.State,
+				fmt.Sprintf("%d", item.EmailsCount),
+				item.ProductID,
+				item.PublishedAt,
+			)
+		}
+		return tbl.Render(w)
+	})
+}

--- a/internal/cmd/workflows/view.go
+++ b/internal/cmd/workflows/view.go
@@ -34,6 +34,10 @@ func newViewCmd() *cobra.Command {
 	}
 }
 
+// Steps render in response order. The server orders them by
+// delayed_delivery_time, a seconds value the API does not expose;
+// a client-side sort on the displayed delay units could only
+// approximate that order, so do not re-sort here.
 func renderWorkflowView(opts cmdutil.Options, item workflowRecord) error {
 	if opts.PlainOutput {
 		var rows [][]string

--- a/internal/cmd/workflows/view.go
+++ b/internal/cmd/workflows/view.go
@@ -1,0 +1,112 @@
+package workflows
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+type workflowViewResponse struct {
+	Success  bool           `json:"success"`
+	Workflow workflowRecord `json:"workflow"`
+}
+
+func newViewCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "view <id>",
+		Short: "View a workflow and its email steps",
+		Long: "View a workflow and its email steps, with per-step delay, sent, open, and click stats.\n\n" +
+			"Plain output prints one row per email step: id, subject, delay, state, sent, opens, open rate, clicks, click rate.",
+		Args: cmdutil.ExactArgs(1),
+		Example: `  gumroad workflows view <id>
+  gumroad workflows view <id> --json
+  gumroad workflows view <id> --plain`,
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			return cmdutil.RunRequestDecoded[workflowViewResponse](opts, "Fetching workflow...", "GET", cmdutil.JoinPath("workflows", args[0]), url.Values{}, func(resp workflowViewResponse) error {
+				return renderWorkflowView(opts, resp.Workflow)
+			})
+		},
+	}
+}
+
+func renderWorkflowView(opts cmdutil.Options, item workflowRecord) error {
+	if opts.PlainOutput {
+		var rows [][]string
+		for _, email := range item.Emails {
+			rows = append(rows, []string{
+				email.ID,
+				email.Subject,
+				workflowDelayLabel(email.Delay),
+				email.State,
+				fmt.Sprintf("%d", email.SentCount),
+				fmt.Sprintf("%d", email.OpenCount),
+				workflowRateLabel(email.OpenRate),
+				fmt.Sprintf("%d", email.ClickCount),
+				workflowRateLabel(email.ClickRate),
+			})
+		}
+		return output.PrintPlain(opts.Out(), rows)
+	}
+
+	if opts.Quiet {
+		return nil
+	}
+
+	style := opts.Style()
+	return output.WithPager(opts.Out(), opts.Err(), func(w io.Writer) error {
+		if err := output.Writeln(w, style.Bold(item.Name)); err != nil {
+			return err
+		}
+		lines := [][2]string{
+			{"ID", item.ID},
+			{"Audience", workflowAudienceLabel(item.AudienceType)},
+			{"State", item.State},
+		}
+		if item.Trigger != "" {
+			lines = append(lines, [2]string{"Trigger", item.Trigger})
+		}
+		if item.ProductID != "" {
+			lines = append(lines, [2]string{"Product ID", item.ProductID})
+		}
+		if item.VariantID != "" {
+			lines = append(lines, [2]string{"Variant ID", item.VariantID})
+		}
+		lines = append(lines, [2]string{"Send to past customers", workflowBool(item.SendToPastCustomers)})
+		if item.PublishedAt != "" {
+			lines = append(lines, [2]string{"Published at", item.PublishedAt})
+		}
+		for _, line := range lines {
+			if err := output.Writef(w, "%s: %s\n", line[0], line[1]); err != nil {
+				return err
+			}
+		}
+
+		if len(item.Emails) == 0 {
+			return output.Writeln(w, "No emails in this workflow.")
+		}
+
+		if err := output.Writeln(w, ""); err != nil {
+			return err
+		}
+		tbl := output.NewStyledTable(style, "ID", "SUBJECT", "DELAY", "STATE", "SENT", "OPENS", "OPEN %", "CLICKS", "CLICK %")
+		for _, email := range item.Emails {
+			tbl.AddRow(
+				email.ID,
+				email.Subject,
+				workflowDelayLabel(email.Delay),
+				email.State,
+				fmt.Sprintf("%d", email.SentCount),
+				fmt.Sprintf("%d", email.OpenCount),
+				workflowRateLabel(email.OpenRate),
+				fmt.Sprintf("%d", email.ClickCount),
+				workflowRateLabel(email.ClickRate),
+			)
+		}
+		return tbl.Render(w)
+	})
+}

--- a/internal/cmd/workflows/workflows.go
+++ b/internal/cmd/workflows/workflows.go
@@ -1,0 +1,108 @@
+package workflows
+
+import (
+	"fmt"
+
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/spf13/cobra"
+)
+
+const (
+	workflowAudienceAll       = "all"
+	workflowAudienceCustomers = "customers"
+	workflowAudienceFollowers = "followers"
+
+	workflowAPIAudienceAll       = "audience"
+	workflowAPIAudienceCustomers = "seller"
+	workflowAPIAudienceFollowers = "follower"
+)
+
+type workflowRecord struct {
+	ID                  string                `json:"id"`
+	Name                string                `json:"name"`
+	AudienceType        string                `json:"audience_type"`
+	Trigger             string                `json:"trigger"`
+	ProductID           string                `json:"product_id"`
+	VariantID           string                `json:"variant_id"`
+	State               string                `json:"state"`
+	PublishedAt         string                `json:"published_at"`
+	FirstPublishedAt    string                `json:"first_published_at"`
+	SendToPastCustomers bool                  `json:"send_to_past_customers"`
+	EmailsCount         api.JSONInt           `json:"emails_count"`
+	Emails              []workflowEmailRecord `json:"emails"`
+}
+
+type workflowEmailRecord struct {
+	ID         string        `json:"id"`
+	Subject    string        `json:"subject"`
+	State      string        `json:"state"`
+	SendEmails bool          `json:"send_emails"`
+	Delay      workflowDelay `json:"delay"`
+	SentCount  api.JSONInt   `json:"sent_count"`
+	OpenCount  api.JSONInt   `json:"open_count"`
+	OpenRate   *float64      `json:"open_rate"`
+	ClickCount api.JSONInt   `json:"click_count"`
+	ClickRate  *float64      `json:"click_rate"`
+}
+
+type workflowDelay struct {
+	Amount api.JSONInt `json:"amount"`
+	Unit   string      `json:"unit"`
+}
+
+func NewWorkflowsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "workflows",
+		Short: "Inspect email workflows",
+		Long: "Inspect Gumroad email workflows.\n\n" +
+			"List workflows and view a workflow's email steps with per-step delay, sent, open, and click stats. " +
+			"Workflows are read-only in the CLI; create and edit them in the Gumroad dashboard.",
+		Example: `  gumroad workflows list
+  gumroad workflows list --json
+  gumroad workflows view <id>
+  gumroad workflows view <id> --json --jq '.workflow.emails[] | {subject, click_rate}'`,
+	}
+
+	cmd.AddCommand(newListCmd())
+	cmd.AddCommand(newViewCmd())
+
+	return cmd
+}
+
+func workflowAudienceLabel(audienceType string) string {
+	switch audienceType {
+	case workflowAPIAudienceAll:
+		return workflowAudienceAll
+	case workflowAPIAudienceCustomers:
+		return workflowAudienceCustomers
+	case workflowAPIAudienceFollowers:
+		return workflowAudienceFollowers
+	default:
+		return audienceType
+	}
+}
+
+func workflowBool(value bool) string {
+	if value {
+		return "yes"
+	}
+	return "no"
+}
+
+func workflowDelayLabel(delay workflowDelay) string {
+	if delay.Unit == "" {
+		return ""
+	}
+	unit := delay.Unit
+	if delay.Amount != 1 {
+		unit += "s"
+	}
+	return fmt.Sprintf("%d %s", delay.Amount, unit)
+}
+
+func workflowRateLabel(rate *float64) string {
+	if rate == nil {
+		return ""
+	}
+	return fmt.Sprintf("%.1f%%", *rate)
+}

--- a/internal/cmd/workflows/workflows_test.go
+++ b/internal/cmd/workflows/workflows_test.go
@@ -1,0 +1,352 @@
+package workflows
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+const (
+	workflowTestEmailsCount = 2
+	workflowTestSentCount   = 120
+	workflowTestOpenCount   = 48
+	workflowTestOpenRate    = 40.0
+	workflowTestClickCount  = 6
+	workflowTestClickRate   = 5.0
+	workflowTestDelayWeeks  = 4
+)
+
+func workflowPayload(id, name string) map[string]any {
+	return map[string]any{
+		"id":                     id,
+		"name":                   name,
+		"audience_type":          "seller",
+		"trigger":                nil,
+		"product_id":             "p1",
+		"variant_id":             nil,
+		"state":                  "published",
+		"published_at":           "2026-06-17T10:00:00Z",
+		"first_published_at":     "2026-06-17T10:00:00Z",
+		"send_to_past_customers": false,
+		"emails_count":           workflowTestEmailsCount,
+		"created_at":             "2026-06-17T09:00:00Z",
+		"updated_at":             "2026-06-17T09:30:00Z",
+	}
+}
+
+func workflowEmailPayload(id, subject string) map[string]any {
+	return map[string]any{
+		"id":            id,
+		"subject":       subject,
+		"message":       "<p>Hello</p>",
+		"audience_type": "seller",
+		"product_id":    "p1",
+		"state":         "published",
+		"published_at":  "2026-06-17T10:00:00Z",
+		"send_emails":   true,
+		"delay":         map[string]any{"amount": workflowTestDelayWeeks, "unit": "week"},
+		"sent_count":    workflowTestSentCount,
+		"open_count":    workflowTestOpenCount,
+		"open_rate":     workflowTestOpenRate,
+		"click_count":   workflowTestClickCount,
+		"click_rate":    workflowTestClickRate,
+		"created_at":    "2026-06-17T09:00:00Z",
+		"updated_at":    "2026-06-17T09:30:00Z",
+	}
+}
+
+func workflowListHandler(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{
+			"workflows": []map[string]any{
+				workflowPayload("w1", "Onboarding"),
+				workflowPayload("w2", "Masterminds"),
+			},
+		})
+	}
+}
+
+func workflowViewHandler(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		payload := workflowPayload("w1", "Onboarding")
+		payload["emails"] = []map[string]any{
+			workflowEmailPayload("e1", "Welcome"),
+			workflowEmailPayload("e2", "Week four check-in"),
+		}
+		testutil.JSON(t, w, map[string]any{"workflow": payload})
+	}
+}
+
+func TestList_CorrectEndpoint(t *testing.T) {
+	var gotPath string
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		workflowListHandler(t)(w, r)
+	})
+
+	cmd := newListCmd()
+	cmd.SetArgs([]string{})
+	out := testutil.CaptureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+
+	if gotPath != "/workflows" {
+		t.Errorf("got path %q", gotPath)
+	}
+	if !strings.Contains(out, "Onboarding") || !strings.Contains(out, "Masterminds") {
+		t.Errorf("output missing workflow names: %q", out)
+	}
+}
+
+func TestList_TableShowsAudienceAndEmailsCount(t *testing.T) {
+	testutil.Setup(t, workflowListHandler(t))
+
+	cmd := newListCmd()
+	cmd.SetArgs([]string{})
+	out := testutil.CaptureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "customers") {
+		t.Errorf("output missing mapped audience label: %q", out)
+	}
+	if !strings.Contains(out, "2") {
+		t.Errorf("output missing emails count: %q", out)
+	}
+}
+
+func TestList_JSON(t *testing.T) {
+	testutil.Setup(t, workflowListHandler(t))
+
+	cmd := testutil.Command(newListCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{})
+	out := testutil.CaptureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v", err)
+	}
+	items := resp["workflows"].([]any)
+	if len(items) != 2 {
+		t.Errorf("got %d workflows, want 2", len(items))
+	}
+}
+
+func TestList_Plain(t *testing.T) {
+	testutil.Setup(t, workflowListHandler(t))
+
+	cmd := testutil.Command(newListCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{})
+	out := testutil.CaptureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("got %d plain rows, want 2: %q", len(lines), out)
+	}
+	if !strings.HasPrefix(lines[0], "w1\t") {
+		t.Errorf("first row missing id column: %q", lines[0])
+	}
+}
+
+func TestList_Empty(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.JSON(t, w, map[string]any{"workflows": []map[string]any{}})
+	})
+
+	cmd := newListCmd()
+	cmd.SetArgs([]string{})
+	out := testutil.CaptureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "No workflows found.") {
+		t.Errorf("output missing empty message: %q", out)
+	}
+}
+
+func TestView_CorrectEndpoint(t *testing.T) {
+	var gotPath string
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		workflowViewHandler(t)(w, r)
+	})
+
+	cmd := newViewCmd()
+	cmd.SetArgs([]string{"w1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	if gotPath != "/workflows/w1" {
+		t.Errorf("got path %q", gotPath)
+	}
+}
+
+func TestView_TableShowsStepStats(t *testing.T) {
+	testutil.Setup(t, workflowViewHandler(t))
+
+	cmd := newViewCmd()
+	cmd.SetArgs([]string{"w1"})
+	out := testutil.CaptureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+
+	for _, want := range []string{"Onboarding", "Welcome", "4 weeks", "120", "48", "40.0%", "6", "5.0%"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestView_NullRatesRenderAsEmptyFields(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		email := workflowEmailPayload("e1", "Unsent step")
+		email["state"] = "draft"
+		email["sent_count"] = 0
+		email["open_count"] = 0
+		email["open_rate"] = nil
+		email["click_count"] = 0
+		email["click_rate"] = nil
+		payload := workflowPayload("w1", "Onboarding")
+		payload["emails"] = []map[string]any{email}
+		testutil.JSON(t, w, map[string]any{"workflow": payload})
+	})
+
+	cmd := testutil.Command(newViewCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{"w1"})
+	out := testutil.CaptureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+
+	row := strings.TrimRight(out, "\n")
+	columns := strings.Split(row, "\t")
+	if len(columns) != 9 {
+		t.Fatalf("got %d plain columns, want 9: %q", len(columns), row)
+	}
+	if columns[6] != "" || columns[8] != "" {
+		t.Errorf("null rates not rendered as empty fields: %q", row)
+	}
+}
+
+func TestView_PlainPrintsOneRowPerEmail(t *testing.T) {
+	testutil.Setup(t, workflowViewHandler(t))
+
+	cmd := testutil.Command(newViewCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{"w1"})
+	out := testutil.CaptureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("got %d plain rows, want 2: %q", len(lines), out)
+	}
+	if !strings.HasPrefix(lines[0], "e1\t") || !strings.HasPrefix(lines[1], "e2\t") {
+		t.Errorf("plain rows missing email ids: %q", out)
+	}
+}
+
+func TestView_NoEmails(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		payload := workflowPayload("w1", "Onboarding")
+		payload["emails"] = []map[string]any{}
+		testutil.JSON(t, w, map[string]any{"workflow": payload})
+	})
+
+	cmd := newViewCmd()
+	cmd.SetArgs([]string{"w1"})
+	out := testutil.CaptureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "No emails in this workflow.") {
+		t.Errorf("output missing empty emails message: %q", out)
+	}
+}
+
+func TestView_JSON(t *testing.T) {
+	testutil.Setup(t, workflowViewHandler(t))
+
+	cmd := testutil.Command(newViewCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"w1"})
+	out := testutil.CaptureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v", err)
+	}
+	workflow := resp["workflow"].(map[string]any)
+	emails := workflow["emails"].([]any)
+	if len(emails) != 2 {
+		t.Errorf("got %d emails, want 2", len(emails))
+	}
+}
+
+func TestView_MemberCancellationTriggerShown(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		payload := workflowPayload("w1", "Winback")
+		payload["trigger"] = "member_cancellation"
+		payload["emails"] = []map[string]any{workflowEmailPayload("e1", "Come back")}
+		testutil.JSON(t, w, map[string]any{"workflow": payload})
+	})
+
+	cmd := newViewCmd()
+	cmd.SetArgs([]string{"w1"})
+	out := testutil.CaptureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "Trigger: member_cancellation") {
+		t.Errorf("output missing trigger line: %q", out)
+	}
+}
+
+func TestWorkflowDelayLabel_SingularUnit(t *testing.T) {
+	label := workflowDelayLabel(workflowDelay{Amount: 1, Unit: "hour"})
+	if label != "1 hour" {
+		t.Errorf("got %q, want %q", label, "1 hour")
+	}
+}
+
+func TestNewWorkflowsCmd_RegistersSubcommands(t *testing.T) {
+	cmd := NewWorkflowsCmd()
+	var names []string
+	for _, sub := range cmd.Commands() {
+		names = append(names, sub.Name())
+	}
+	joined := strings.Join(names, ",")
+	if !strings.Contains(joined, "list") || !strings.Contains(joined, "view") {
+		t.Errorf("missing subcommands, got: %v", names)
+	}
+}

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -423,6 +423,21 @@ gumroad emails delete <id> --yes --json --no-input
 
 Use `--dry-run --json --no-input` to inspect create params without calling the API. Passing `--send` blasts the audience immediately; prefer the draft → `send-preview` URL → `send` workflow. `send-preview` emails a copy to the seller. Scheduled emails can only be created in the web UI; the CLI can list and view them (`--state scheduled`) but not create them.
 
+### workflows — Inspect email workflows
+
+```sh
+# List workflows with audience, state, and email step count.
+gumroad workflows list --json --no-input
+
+# View one workflow's email steps with per-step delay, sent, open, and click stats.
+gumroad workflows view <id> --json --no-input
+
+# Compare steps: pull subject and click rate for every step.
+gumroad workflows view <id> --json --jq '.workflow.emails[] | {subject, click_rate}' --no-input
+```
+
+Workflows are read-only in the CLI; create and edit them in the Gumroad dashboard. `view` returns steps ordered by delay, each with `delay` (`amount` + `unit`), `sent_count`, `open_count`, `open_rate`, `click_count`, `click_rate`. Rates are `null` for unsent steps. Plain output for `view` prints one row per email step.
+
 ### sales — Manage sales
 
 ```sh


### PR DESCRIPTION
Ref #192

## What

Adds a read-only `workflows` command group:

- `gumroad workflows list` — each workflow with audience, state, email step count, product, and publish date.
- `gumroad workflows view <id>` — the workflow plus its email steps, with per-step delay, sent, opens, open rate, clicks, and click rate. Plain output prints one tab-separated row per step; `--json`/`--jq` expose the full response for export and diffing.

Both commands consume the `GET /v2/workflows` endpoints added in antiwork/gumroad#7036. The skill doc (`skills/gumroad/SKILL.md`) gains a `workflows` section with agent-ready examples.

## Why

Workflows were the one seller surface the CLI could not see. The v2 API excluded workflow installments on purpose, so the reported blocker in #192 — comparing 30+ steps means scrolling one web page, with no export and no diffing — had no CLI answer. The issue also asked for write commands (`create`, `add-email`, `update-email`); those are deliberately out of scope here. The server edit path replaces a workflow's full installment list in one request and carries publish semantics, where a wrong call mails past customers. Write support needs its own design pass, so this PR ships the read contract that covers the reported pain first.

Two small pattern notes for review:

- `view` renders its steps table inside the pager. No other `view` command pages, but the target case is a 30+ step table, and short output still prints directly.
- `view --plain` prints one row per email step instead of one row per record. The per-step rows are the export use case; workflow-level fields stay reachable via `--json`.

## Before/After

_Demo video below runs against a local mock API server with sample data (the new endpoints are not on production data in this recording). "Before" is the binary built from `main`._

https://github.com/user-attachments/assets/b808a75c-3be6-4078-887a-60f742ac1a01

## Test Results

`make test-cover` passes all gates (new package at 86.5%, cmd gate 85%) and `make lint` is clean:

```
OK: github.com/antiwork/gumroad-cli/internal/cmd/workflows 86.5%
OK: github.com/antiwork/gumroad-cli/internal/cmdutil 92.4%
OK: github.com/antiwork/gumroad-cli/internal/config 92.0%
OK: github.com/antiwork/gumroad-cli/internal/output 90.9%
golangci-lint run  (no findings)
```

---

This PR was implemented with AI assistance using Claude Fable 5.
