### PR TITLE
Add workflows add-email and update-email commands

### DIFF
--- a/internal/cmd/workflows/add_email.go
+++ b/internal/cmd/workflows/add_email.go
@@ -1,0 +1,86 @@
+package workflows
+
+import (
+	"net/url"
+	"strconv"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/pageutil"
+	"github.com/spf13/cobra"
+)
+
+type workflowEmailResponse struct {
+	Success bool                `json:"success"`
+	Email   workflowEmailRecord `json:"email"`
+}
+
+func newAddEmailCmd() *cobra.Command {
+	var subject, body, delay string
+
+	cmd := &cobra.Command{
+		Use:   "add-email <workflow-id>",
+		Short: "Add an email step to a workflow",
+		Long: `Add one email step to an existing workflow from an HTML body file.
+
+The step is appended with the given delay; the workflow's publish state is not
+changed, so adding a step never sends mail by itself. Publishing a workflow
+stays a dashboard action. Abandoned cart workflows do not accept new steps.`,
+		Args: cmdutil.ExactArgs(1),
+		Example: `  gumroad workflows add-email <workflow-id> --subject "Week 4 check-in" --body ./email.html --delay "4 weeks"
+  build-email | gumroad workflows add-email <workflow-id> --subject "From stdin" --body - --delay "1 hour"
+  gumroad workflows add-email <workflow-id> --subject "Check params" --body ./email.html --delay "2 days" --dry-run`,
+		RunE: func(c *cobra.Command, args []string) error {
+			if subject == "" {
+				return cmdutil.MissingFlagError(c, "--subject")
+			}
+			if body == "" {
+				return cmdutil.MissingFlagError(c, "--body")
+			}
+			if delay == "" {
+				return cmdutil.MissingFlagError(c, "--delay")
+			}
+			delayAmount, delayUnit, err := parseDelayFlag(delay)
+			if err != nil {
+				return cmdutil.UsageErrorf(c, "--delay: %v", err)
+			}
+
+			opts := cmdutil.OptionsFrom(c)
+			input, err := pageutil.ReadHTML(opts.In(), body)
+			if err != nil {
+				return cmdutil.UsageErrorf(c, "--body: %v", err)
+			}
+
+			params := url.Values{}
+			params.Set("subject", subject)
+			params.Set("body", input.HTML)
+			params.Set("delay_amount", strconv.Itoa(delayAmount))
+			params.Set("delay_unit", delayUnit)
+
+			path := cmdutil.JoinPath("workflows", args[0], "emails")
+			return cmdutil.RunRequestDecoded[workflowEmailResponse](opts,
+				"Adding email step...", "POST", path, params,
+				func(resp workflowEmailResponse) error {
+					return renderSavedEmail(opts, "Added email step:", resp.Email)
+				})
+		},
+	}
+
+	cmd.Flags().StringVar(&subject, "subject", "", "Email subject (required)")
+	cmd.Flags().StringVar(&body, "body", "", "Path to an HTML body file, or - for stdin (required)")
+	cmd.Flags().StringVar(&delay, "delay", "", `Delay after the trigger, as "<amount> <unit>" with unit hour, day, week, or month (required)`)
+
+	return cmd
+}
+
+func renderSavedEmail(opts cmdutil.Options, label string, item workflowEmailRecord) error {
+	if opts.PlainOutput {
+		return output.PrintPlain(opts.Out(), [][]string{{item.ID, item.Subject, workflowDelayLabel(item.Delay), item.State}})
+	}
+	if opts.Quiet {
+		return nil
+	}
+	style := opts.Style()
+	return output.Writef(opts.Out(), "%s %s (%s) delay %s [%s]\n",
+		style.Bold(label), item.Subject, style.Dim(item.ID), workflowDelayLabel(item.Delay), item.State)
+}

--- a/internal/cmd/workflows/delay.go
+++ b/internal/cmd/workflows/delay.go
@@ -1,0 +1,33 @@
+package workflows
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+var workflowDelayUnits = []string{"hour", "day", "week", "month"}
+
+// parseDelayFlag parses a "<amount> <unit>" delay like "4 weeks" or "1 hour"
+// into the API's delay_amount / delay_unit pair. Units match the server's
+// InstallmentRule vocabulary (hour, day, week, month); a trailing "s" is
+// accepted so natural plurals work.
+func parseDelayFlag(value string) (int, string, error) {
+	fields := strings.Fields(value)
+	if len(fields) != 2 {
+		return 0, "", fmt.Errorf("expected \"<amount> <unit>\" (e.g. \"4 weeks\"), got %q", value)
+	}
+
+	amount, err := strconv.Atoi(fields[0])
+	if err != nil || amount < 0 {
+		return 0, "", fmt.Errorf("amount must be a non-negative integer, got %q", fields[0])
+	}
+
+	unit := strings.ToLower(strings.TrimSuffix(fields[1], "s"))
+	for _, valid := range workflowDelayUnits {
+		if unit == valid {
+			return amount, unit, nil
+		}
+	}
+	return 0, "", fmt.Errorf("unit must be one of: %s (got %q)", strings.Join(workflowDelayUnits, ", "), fields[1])
+}

--- a/internal/cmd/workflows/update_email.go
+++ b/internal/cmd/workflows/update_email.go
@@ -1,0 +1,71 @@
+package workflows
+
+import (
+	"net/url"
+	"strconv"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/pageutil"
+	"github.com/spf13/cobra"
+)
+
+func newUpdateEmailCmd() *cobra.Command {
+	var subject, body, delay string
+
+	cmd := &cobra.Command{
+		Use:   "update-email <workflow-id> <email-id>",
+		Short: "Update an email step in a workflow",
+		Long: `Update one existing email step's subject, body, or delay in place.
+
+Only the flags you pass change; other fields keep their current values. The
+workflow's publish state is not touched. Delay changes are rejected for
+abandoned cart workflows.`,
+		Args: cmdutil.ExactArgs(2),
+		Example: `  gumroad workflows update-email <workflow-id> <email-id> --body ./email.html
+  gumroad workflows update-email <workflow-id> <email-id> --subject "New subject" --delay "2 weeks"
+  gumroad workflows update-email <workflow-id> <email-id> --body ./email.html --dry-run`,
+		RunE: func(c *cobra.Command, args []string) error {
+			if err := cmdutil.RequireAnyFlagChanged(c, "subject", "body", "delay"); err != nil {
+				return err
+			}
+			if c.Flags().Changed("subject") && subject == "" {
+				return cmdutil.UsageErrorf(c, "--subject cannot be empty")
+			}
+
+			params := url.Values{}
+			if c.Flags().Changed("subject") {
+				params.Set("subject", subject)
+			}
+			if c.Flags().Changed("delay") {
+				delayAmount, delayUnit, err := parseDelayFlag(delay)
+				if err != nil {
+					return cmdutil.UsageErrorf(c, "--delay: %v", err)
+				}
+				params.Set("delay_amount", strconv.Itoa(delayAmount))
+				params.Set("delay_unit", delayUnit)
+			}
+
+			opts := cmdutil.OptionsFrom(c)
+			if c.Flags().Changed("body") {
+				input, err := pageutil.ReadHTML(opts.In(), body)
+				if err != nil {
+					return cmdutil.UsageErrorf(c, "--body: %v", err)
+				}
+				params.Set("body", input.HTML)
+			}
+
+			path := cmdutil.JoinPath("workflows", args[0], "emails", args[1])
+			return cmdutil.RunRequestDecoded[workflowEmailResponse](opts,
+				"Updating email step...", "PUT", path, params,
+				func(resp workflowEmailResponse) error {
+					return renderSavedEmail(opts, "Updated email step:", resp.Email)
+				})
+		},
+	}
+
+	cmd.Flags().StringVar(&subject, "subject", "", "New email subject")
+	cmd.Flags().StringVar(&body, "body", "", "Path to an HTML body file, or - for stdin")
+	cmd.Flags().StringVar(&delay, "delay", "", `New delay after the trigger, as "<amount> <unit>" with unit hour, day, week, or month`)
+
+	return cmd
+}

--- a/internal/cmd/workflows/workflows.go
+++ b/internal/cmd/workflows/workflows.go
@@ -53,18 +53,23 @@ type workflowDelay struct {
 func NewWorkflowsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "workflows",
-		Short: "Inspect email workflows",
-		Long: "Inspect Gumroad email workflows.\n\n" +
+		Short: "Inspect and edit email workflows",
+		Long: "Inspect and edit Gumroad email workflows.\n\n" +
 			"List workflows and view a workflow's email steps with per-step delay, sent, open, and click stats. " +
-			"Workflows are read-only in the CLI; create and edit them in the Gumroad dashboard.",
+			"Add or update individual email steps with add-email and update-email; neither changes the workflow's " +
+			"publish state, so they never send mail by themselves. Creating and publishing workflows stays in the Gumroad dashboard.",
 		Example: `  gumroad workflows list
   gumroad workflows list --json
   gumroad workflows view <id>
-  gumroad workflows view <id> --json --jq '.workflow.emails[] | {subject, click_rate}'`,
+  gumroad workflows view <id> --json --jq '.workflow.emails[] | {subject, click_rate}'
+  gumroad workflows add-email <id> --subject "Week 4 check-in" --body ./email.html --delay "4 weeks"
+  gumroad workflows update-email <id> <email-id> --body ./email.html`,
 	}
 
 	cmd.AddCommand(newListCmd())
 	cmd.AddCommand(newViewCmd())
+	cmd.AddCommand(newAddEmailCmd())
+	cmd.AddCommand(newUpdateEmailCmd())
 
 	return cmd
 }

--- a/internal/cmd/workflows/write_email_test.go
+++ b/internal/cmd/workflows/write_email_test.go
@@ -1,0 +1,300 @@
+package workflows
+
+import (
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+func writeWorkflowEmailBody(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "email.html")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write body file: %v", err)
+	}
+	return path
+}
+
+func assertWorkflowUsageError(t *testing.T, err error, want string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected usage error")
+	}
+	var usageErr *cmdutil.UsageError
+	if !errors.As(err, &usageErr) {
+		t.Fatalf("got %T, want *cmdutil.UsageError", err)
+	}
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("error %q does not contain %q", err.Error(), want)
+	}
+}
+
+func savedEmailHandler(t *testing.T, gotMethod *string, gotPath *string, gotForm *map[string]string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if gotMethod != nil {
+			*gotMethod = r.Method
+		}
+		if gotPath != nil {
+			*gotPath = r.URL.Path
+		}
+		if gotForm != nil {
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm failed: %v", err)
+			}
+			form := map[string]string{}
+			for key := range r.PostForm {
+				form[key] = r.PostForm.Get(key)
+			}
+			*gotForm = form
+		}
+		testutil.JSON(t, w, map[string]any{"email": workflowEmailPayload("e9", "Week 4 check-in")})
+	}
+}
+
+func TestParseDelayFlag(t *testing.T) {
+	cases := []struct {
+		in         string
+		wantAmount int
+		wantUnit   string
+		wantErr    string
+	}{
+		{in: "4 weeks", wantAmount: 4, wantUnit: "week"},
+		{in: "1 hour", wantAmount: 1, wantUnit: "hour"},
+		{in: "0 days", wantAmount: 0, wantUnit: "day"},
+		{in: "2 Months", wantAmount: 2, wantUnit: "month"},
+		{in: "4weeks", wantErr: `expected "<amount> <unit>"`},
+		{in: "week 4", wantErr: "amount must be a non-negative integer"},
+		{in: "-1 week", wantErr: "amount must be a non-negative integer"},
+		{in: "3 fortnights", wantErr: "unit must be one of"},
+		{in: "", wantErr: `expected "<amount> <unit>"`},
+	}
+	for _, tc := range cases {
+		amount, unit, err := parseDelayFlag(tc.in)
+		if tc.wantErr != "" {
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("parseDelayFlag(%q) err = %v, want containing %q", tc.in, err, tc.wantErr)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseDelayFlag(%q) unexpected error: %v", tc.in, err)
+			continue
+		}
+		if amount != tc.wantAmount || unit != tc.wantUnit {
+			t.Errorf("parseDelayFlag(%q) = (%d, %q), want (%d, %q)", tc.in, amount, unit, tc.wantAmount, tc.wantUnit)
+		}
+	}
+}
+
+func TestAddEmail_PostsEndpointAndParams(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotForm map[string]string
+	testutil.Setup(t, savedEmailHandler(t, &gotMethod, &gotPath, &gotForm))
+
+	bodyPath := writeWorkflowEmailBody(t, "<p>See you in week four</p>")
+	cmd := testutil.Command(newAddEmailCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"w1", "--subject", "Week 4 check-in", "--body", bodyPath, "--delay", "4 weeks"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != http.MethodPost || gotPath != "/workflows/w1/emails" {
+		t.Fatalf("got %s %s, want POST /workflows/w1/emails", gotMethod, gotPath)
+	}
+	want := map[string]string{
+		"subject":      "Week 4 check-in",
+		"body":         "<p>See you in week four</p>",
+		"delay_amount": "4",
+		"delay_unit":   "week",
+	}
+	for key, wantValue := range want {
+		if gotForm[key] != wantValue {
+			t.Errorf("param %s = %q, want %q", key, gotForm[key], wantValue)
+		}
+	}
+	if !strings.Contains(out, "Added email step:") || !strings.Contains(out, "Week 4 check-in") {
+		t.Errorf("output missing confirmation: %q", out)
+	}
+}
+
+func TestAddEmail_MissingFlagsRejectedBeforeRequest(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("API must not be called when required flags are missing")
+	})
+
+	bodyPath := writeWorkflowEmailBody(t, "<p>Hi</p>")
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "subject", args: []string{"w1", "--body", bodyPath, "--delay", "4 weeks"}, want: "--subject"},
+		{name: "body", args: []string{"w1", "--subject", "Hi", "--delay", "4 weeks"}, want: "--body"},
+		{name: "delay", args: []string{"w1", "--subject", "Hi", "--body", bodyPath}, want: "--delay"},
+		{name: "bad delay", args: []string{"w1", "--subject", "Hi", "--body", bodyPath, "--delay", "4 fortnights"}, want: "unit must be one of"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := testutil.Command(newAddEmailCmd())
+			cmd.SetArgs(tc.args)
+			assertWorkflowUsageError(t, cmd.Execute(), tc.want)
+		})
+	}
+}
+
+func TestAddEmail_DryRunPrintsRequestWithoutCallingAPI(t *testing.T) {
+	called := false
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		t.Fatal("API must not be called during dry-run")
+	})
+
+	bodyPath := writeWorkflowEmailBody(t, "<p>Preview</p>")
+	cmd := testutil.Command(newAddEmailCmd(), testutil.DryRun(true), testutil.Quiet(false))
+	cmd.SetArgs([]string{"w1", "--subject", "Preview", "--body", bodyPath, "--delay", "2 days"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if called {
+		t.Fatal("API was called during dry-run")
+	}
+	for _, want := range []string{"POST", "/workflows/w1/emails", "subject: Preview", "delay_amount: 2", "delay_unit: day"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("dry-run output missing %q in %q", want, out)
+		}
+	}
+}
+
+func TestAddEmail_JSON(t *testing.T) {
+	testutil.Setup(t, savedEmailHandler(t, nil, nil, nil))
+
+	bodyPath := writeWorkflowEmailBody(t, "<p>Hi</p>")
+	cmd := testutil.Command(newAddEmailCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"w1", "--subject", "Week 4 check-in", "--body", bodyPath, "--delay", "4 weeks"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, `"id"`) || !strings.Contains(out, "e9") {
+		t.Errorf("JSON output missing email payload: %q", out)
+	}
+}
+
+func TestUpdateEmail_PutsOnlyChangedFields(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotForm map[string]string
+	testutil.Setup(t, savedEmailHandler(t, &gotMethod, &gotPath, &gotForm))
+
+	cmd := testutil.Command(newUpdateEmailCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"w1", "e9", "--subject", "New subject"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != http.MethodPut || gotPath != "/workflows/w1/emails/e9" {
+		t.Fatalf("got %s %s, want PUT /workflows/w1/emails/e9", gotMethod, gotPath)
+	}
+	if gotForm["subject"] != "New subject" {
+		t.Errorf("subject = %q, want %q", gotForm["subject"], "New subject")
+	}
+	for _, absent := range []string{"body", "delay_amount", "delay_unit"} {
+		if _, ok := gotForm[absent]; ok {
+			t.Errorf("param %s must not be sent when its flag is unset (got %q)", absent, gotForm[absent])
+		}
+	}
+	if !strings.Contains(out, "Updated email step:") {
+		t.Errorf("output missing confirmation: %q", out)
+	}
+}
+
+func TestUpdateEmail_DelaySendsBothDelayParams(t *testing.T) {
+	var gotForm map[string]string
+	testutil.Setup(t, savedEmailHandler(t, nil, nil, &gotForm))
+
+	cmd := testutil.Command(newUpdateEmailCmd())
+	cmd.SetArgs([]string{"w1", "e9", "--delay", "1 hour"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotForm["delay_amount"] != "1" || gotForm["delay_unit"] != "hour" {
+		t.Errorf("delay params = %q/%q, want 1/hour", gotForm["delay_amount"], gotForm["delay_unit"])
+	}
+}
+
+func TestUpdateEmail_BodyFromFile(t *testing.T) {
+	var gotForm map[string]string
+	testutil.Setup(t, savedEmailHandler(t, nil, nil, &gotForm))
+
+	bodyPath := writeWorkflowEmailBody(t, "<p>Revised copy</p>")
+	cmd := testutil.Command(newUpdateEmailCmd())
+	cmd.SetArgs([]string{"w1", "e9", "--body", bodyPath})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotForm["body"] != "<p>Revised copy</p>" {
+		t.Errorf("body = %q, want file contents", gotForm["body"])
+	}
+}
+
+func TestUpdateEmail_NoFlagsRejectedBeforeRequest(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("API must not be called when no update flags are set")
+	})
+
+	cmd := testutil.Command(newUpdateEmailCmd())
+	cmd.SetArgs([]string{"w1", "e9"})
+	assertWorkflowUsageError(t, cmd.Execute(), "at least one field to update")
+}
+
+func TestUpdateEmail_EmptySubjectRejectedBeforeRequest(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("API must not be called with an empty subject")
+	})
+
+	cmd := testutil.Command(newUpdateEmailCmd())
+	cmd.SetArgs([]string{"w1", "e9", "--subject", ""})
+	assertWorkflowUsageError(t, cmd.Execute(), "--subject cannot be empty")
+}
+
+func TestUpdateEmail_MissingBodyFileRejectedBeforeRequest(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("API must not be called when body file is missing")
+	})
+
+	missing := filepath.Join(t.TempDir(), "missing.html")
+	cmd := testutil.Command(newUpdateEmailCmd())
+	cmd.SetArgs([]string{"w1", "e9", "--body", missing})
+	assertWorkflowUsageError(t, cmd.Execute(), "--body: cannot read")
+}
+
+func TestUpdateEmail_DryRunPrintsRequestWithoutCallingAPI(t *testing.T) {
+	called := false
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		t.Fatal("API must not be called during dry-run")
+	})
+
+	cmd := testutil.Command(newUpdateEmailCmd(), testutil.DryRun(true), testutil.Quiet(false))
+	cmd.SetArgs([]string{"w1", "e9", "--subject", "Preview", "--delay", "3 weeks"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if called {
+		t.Fatal("API was called during dry-run")
+	}
+	for _, want := range []string{"PUT", "/workflows/w1/emails/e9", "subject: Preview", "delay_amount: 3", "delay_unit: week"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("dry-run output missing %q in %q", want, out)
+		}
+	}
+}
+
+func TestAddEmail_PlainOutput(t *testing.T) {
+	testutil.Setup(t, savedEmailHandler(t, nil, nil, nil))
+
+	bodyPath := writeWorkflowEmailBody(t, "<p>Hi</p>")
+	cmd := testutil.Command(newAddEmailCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{"w1", "--subject", "Week 4 check-in", "--body", bodyPath, "--delay", "4 weeks"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	line := strings.TrimSpace(out)
+	if !strings.HasPrefix(line, "e9\t") || !strings.Contains(line, "Week 4 check-in") {
+		t.Errorf("plain output missing id/subject columns: %q", out)
+	}
+}

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -70,6 +70,7 @@ Most responses are wrapped in `{"success": true, ...}` with resource-specific ke
 - `sales export` → `.status`, `.recipient_email`
 - `sales summary` → `.gross_cents`, `.net_cents`, `.breakdown[]`
 - `emails list` → `.emails[]`, `emails view/create/send` → `.email`, `emails send-preview` → `.preview_url`, `emails delete` → `.message`
+- `workflows list` → `.workflows[]`, `workflows view` → `.workflow` (with `.workflow.emails[]`), `workflows add-email/update-email` → `.email`
 - `payouts list` → `.payouts[]`, `payouts view/upcoming` → `.payout`
 - `subscribers list` → `.subscribers[]`, `subscribers view` → `.subscriber`
 - `licenses verify` → `.purchase`
@@ -448,7 +449,7 @@ gumroad emails delete <id> --yes --json --no-input
 
 Use `--dry-run --json --no-input` to inspect create params without calling the API. Passing `--send` blasts the audience immediately; prefer the draft → `send-preview` URL → `send` workflow. `send-preview` emails a copy to the seller. Scheduled emails can only be created in the web UI; the CLI can list and view them (`--state scheduled`) but not create them.
 
-### workflows — Inspect email workflows
+### workflows — Inspect and edit email workflows
 
 ```sh
 # List workflows with audience, state, and email step count.
@@ -459,9 +460,18 @@ gumroad workflows view <id> --json --no-input
 
 # Compare steps: pull subject and click rate for every step.
 gumroad workflows view <id> --json --jq '.workflow.emails[] | {subject, click_rate}' --no-input
+
+# Add one email step to an existing workflow. --delay is "<amount> <unit>" with unit hour, day, week, or month.
+gumroad workflows add-email <id> --subject "Week 4 check-in" --body ./email.html --delay "4 weeks" --json --no-input
+
+# Update one existing step in place; pass only the fields to change.
+gumroad workflows update-email <id> <email-id> --body ./email.html --json --no-input
+gumroad workflows update-email <id> <email-id> --subject "New subject" --delay "2 weeks" --json --no-input
 ```
 
-Workflows are read-only in the CLI; create and edit them in the Gumroad dashboard. `view` returns steps ordered by delay, each with `delay` (`amount` + `unit`), `sent_count`, `open_count`, `open_rate`, `click_count`, `click_rate`. Rates are `null` for unsent steps. Plain output for `view` prints one row per email step.
+`view` returns steps ordered by delay, each with `delay` (`amount` + `unit`), `sent_count`, `open_count`, `open_rate`, `click_count`, `click_rate`. Rates are `null` for unsent steps. Plain output for `view` prints one row per email step.
+
+`add-email` and `update-email` respond with the saved step under `.email` (same fields as `view` steps, without analytics). Neither command changes the workflow's publish state, so they never send mail by themselves — a step added to a draft workflow stays unsent until the workflow is published in the dashboard, and on a published workflow the new step schedules like any other. There is deliberately no publish/unpublish flag: the server rejects publish-state parameters on these endpoints, and publishing a workflow stays a dashboard action. Both reject delay edits on abandoned cart workflows (and `add-email` rejects abandoned cart workflows entirely). Creating a new workflow (audience/filter setup) is also dashboard-only.
 
 ### sales — Manage sales
 


### PR DESCRIPTION
Closes #196. CLI half of the write-command split from #192; the server contract shipped in gumroad#7176 (split out of gumroad#7123 per @gianfrancopiana) and is deployed as of `v2026.08.11.5`.

## Status

- [x] Scope — add-email / update-email per #196's confirmed split (no publish flag, per-step edits only)
- [x] Design — wrap gumroad#7176's endpoints directly; `--delay "<amount> <unit>"` parser over the server's InstallmentRule vocabulary
- [x] Build — commands, delay parser, 17 tests, SKILL.md docs
- [x] QA — mock-API end-to-end run (demo GIF below), full test suite + pinned linter green
- [ ] Ship — awaiting review/merge; release cut after merge per repo convention
- [ ] Market — n/a beyond the in-repo SKILL.md agent docs (updated in this PR)
- [ ] Sell — n/a (developer tooling)

## What

Two new subcommands on the existing `workflows` group:

- `gumroad workflows add-email <workflow-id> --subject "..." --body ./email.html --delay "4 weeks"` — appends one email step via `POST /v2/workflows/:id/emails`. All three flags required; `--body` takes a file path or `-` for stdin, same as `emails create`.
- `gumroad workflows update-email <workflow-id> <email-id> [--subject "..."] [--body ./email.html] [--delay "..."]` — edits one step in place via `PUT /v2/workflows/:id/emails/:email_id`. At least one flag required; only the flags you pass are sent, so unset fields keep their current values.

`--delay` parses `"<amount> <unit>"` where the unit is the server's `InstallmentRule` vocabulary (hour, day, week, month; natural plurals accepted) into the API's `delay_amount`/`delay_unit` pair. `--dry-run` prints the resolved request without sending, matching `emails create --dry-run`.

Neither command exposes a publish/send flag — the server rejects any publish-state parameter on these endpoints, so there is no accidental-mail risk and no confirm gate is needed (mirrors the deliberate `emails create` / `emails send` split). `skills/gumroad/SKILL.md` updated: workflows section rewritten for the write commands (including the publish-state semantics an agent needs), response-shapes list gains the `workflows` entries (which were missing entirely since #195).

## Why

`gumroad workflows` was read-only; the only way to add or edit a step in a 30+ email workflow was the dashboard, one email at a time (#192's reported pain). The server-side per-step endpoints exist now, so the CLI can wrap them directly.

## Demo

![demo](https://i.ibb.co/qY4BhzHn/wf-demo.gif)

Demo shows: `workflows view` before; `add-email --dry-run` printing the resolved params without sending; `add-email` appending a step (returned unpublished, workflow publish state untouched); `update-email` changing subject + delay in place; `view` after with the new step and updated row; the no-flags usage error on `update-email`; the invalid delay-unit error. Recorded against a local mock serving gumroad#7176's request/response shapes.

## Test Results

- `make test-cover` — all packages green; `internal/cmd/workflows` at 91.9% (gate 85%).
- `go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run ./internal/...` — clean.
- `gofmt -l internal/` — clean.
- 17 new tests: delay parser table (valid units, plurals, case, zero, negative/garbage rejects), endpoint + form params for both commands, partial-update omits unset params, dry-run makes no API call (both commands), guard-before-request for every missing/invalid flag, JSON and plain output modes.

![tests](https://i.ibb.co/Q7SPY1cD/wf-tests.png)

## QA steps

1. Started the mock API from the demo harness (real gumroad#7176 JSON shapes) and ran every command in the demo against a built binary: add (dry-run + real), partial update (subject-only, delay-only, body-from-file), both error paths.
2. Verified `update-email --subject X` sends only `subject` on the wire (mock echoes received form params) — the in-place-edit contract the issue asked for.
3. Verified `add-email` output reports the step as `[unpublished]` and a following `view` shows the workflow itself still `published` — publish state untouched.

---

This PR was written by an AI agent (Claude Sonnet 5) working autonomously from #196 after @gianfrancopiana confirmed the endpoint split ("This will ship today").
