### PR TITLE
Add workflow email write commands

### DIFF
--- a/internal/cmd/errors.go
+++ b/internal/cmd/errors.go
@@ -13,6 +13,7 @@ import (
 	"github.com/antiwork/gumroad-cli/internal/api"
 	"github.com/antiwork/gumroad-cli/internal/cmd/files"
 	"github.com/antiwork/gumroad-cli/internal/cmd/media"
+	"github.com/antiwork/gumroad-cli/internal/cmd/workflows"
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/config"
 	"github.com/antiwork/gumroad-cli/internal/output"
@@ -51,6 +52,9 @@ type commandRecoveryInfo struct {
 	FileSize       int64                 `json:"file_size,omitempty"`
 	MediaID        string                `json:"media_id,omitempty"`
 	MediaURL       string                `json:"media_url,omitempty"`
+	Action         string                `json:"action,omitempty"`
+	WorkflowID     string                `json:"workflow_id,omitempty"`
+	EmailID        string                `json:"email_id,omitempty"`
 }
 
 type uploadCompletedPart struct {
@@ -146,6 +150,8 @@ func classifyPrimaryCause(err error) commandErrorDetail {
 	var committedMediaOutput *media.CommittedMediaOutputError
 	var completedMediaDelete *media.CompletedMediaDeleteOutputError
 	var unknownMediaDelete *media.UnknownMediaDeleteError
+	var unknownEmailWrite *workflows.UnknownEmailWriteError
+	var completedEmailWrite *workflows.CompletedEmailWriteOutputError
 	var cleanupFailed *upload.CleanupFailedError
 	var rejected *files.CompleteRejectedError
 	switch {
@@ -201,6 +207,30 @@ func classifyPrimaryCause(err error) commandErrorDetail {
 			Recovery: &commandRecoveryInfo{
 				Stage:   "delete",
 				MediaID: unknownMediaDelete.MediaID,
+			},
+		}
+	case errors.As(err, &unknownEmailWrite):
+		return commandErrorDetail{
+			Type:    "mutation_error",
+			Code:    "workflow_email_" + string(unknownEmailWrite.Action) + "_state_unknown",
+			Message: unknownEmailWrite.Error(),
+			Hint:    unknownEmailWrite.RecoveryHint(),
+			Recovery: &commandRecoveryInfo{
+				Action:     string(unknownEmailWrite.Action),
+				WorkflowID: unknownEmailWrite.WorkflowID,
+				EmailID:    unknownEmailWrite.EmailID,
+			},
+		}
+	case errors.As(err, &completedEmailWrite):
+		return commandErrorDetail{
+			Type:    "output_error",
+			Code:    "workflow_email_output_failed",
+			Message: completedEmailWrite.Error(),
+			Hint:    completedEmailWrite.RecoveryHint(),
+			Recovery: &commandRecoveryInfo{
+				Action:     string(completedEmailWrite.Action),
+				WorkflowID: completedEmailWrite.WorkflowID,
+				EmailID:    completedEmailWrite.EmailID,
 			},
 		}
 	// ErrPresignExpired is a sentinel distinct from UnknownStateError: the
@@ -365,8 +395,28 @@ func uploadIncompleteDetail(err error, state *upload.UnknownStateError) commandE
 	}
 }
 
-// printUploadRecovery emits recovery handles for uploads with unknown state.
+// printUploadRecovery emits recovery handles for mutations with uncertain state.
 func printUploadRecovery(w io.Writer, style output.Styler, err error) {
+	var unknownEmail *workflows.UnknownEmailWriteError
+	if errors.As(err, &unknownEmail) {
+		fmt.Fprintln(w, style.Dim("Recovery:"))
+		fmt.Fprintln(w, style.Dim("  action:      "+string(unknownEmail.Action)))
+		fmt.Fprintln(w, style.Dim("  workflow_id: "+unknownEmail.WorkflowID))
+		if unknownEmail.EmailID != "" {
+			fmt.Fprintln(w, style.Dim("  email_id:    "+unknownEmail.EmailID))
+		}
+		return
+	}
+
+	var completedEmail *workflows.CompletedEmailWriteOutputError
+	if errors.As(err, &completedEmail) {
+		fmt.Fprintln(w, style.Dim("Recovery:"))
+		fmt.Fprintln(w, style.Dim("  action:      "+string(completedEmail.Action)))
+		fmt.Fprintln(w, style.Dim("  workflow_id: "+completedEmail.WorkflowID))
+		fmt.Fprintln(w, style.Dim("  email_id:    "+completedEmail.EmailID))
+		return
+	}
+
 	var unknownDelete *media.UnknownMediaDeleteError
 	if errors.As(err, &unknownDelete) {
 		fmt.Fprintln(w, style.Dim("Recovery:"))

--- a/internal/cmd/errors_test.go
+++ b/internal/cmd/errors_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/antiwork/gumroad-cli/internal/api"
 	"github.com/antiwork/gumroad-cli/internal/cmd/files"
 	"github.com/antiwork/gumroad-cli/internal/cmd/media"
+	"github.com/antiwork/gumroad-cli/internal/cmd/workflows"
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/config"
 	"github.com/antiwork/gumroad-cli/internal/output"
@@ -490,6 +491,60 @@ func TestClassifyCommandError_UnknownMediaDelete(t *testing.T) {
 	printUploadRecovery(&buf, output.NewStyler(false), state)
 	if !strings.Contains(buf.String(), state.MediaID) || !strings.Contains(buf.String(), "delete") {
 		t.Fatalf("recovery output = %q", buf.String())
+	}
+}
+
+func TestClassifyCommandError_UnknownWorkflowEmailWrite(t *testing.T) {
+	state := &workflows.UnknownEmailWriteError{
+		Cause:      &api.APIError{StatusCode: 502, Message: "upstream failed"},
+		Action:     workflows.EmailWriteActionUpdate,
+		WorkflowID: "workflow_1",
+		EmailID:    "email_1",
+	}
+	detail := classifyCommandError(state)
+	if detail.Type != "mutation_error" || detail.Code != "workflow_email_update_state_unknown" {
+		t.Fatalf("detail = %+v", detail)
+	}
+	if detail.Recovery == nil || detail.Recovery.Action != "update" || detail.Recovery.WorkflowID != "workflow_1" || detail.Recovery.EmailID != "email_1" {
+		t.Fatalf("recovery = %+v", detail.Recovery)
+	}
+	if !strings.Contains(detail.Hint, "workflows view workflow_1") || !strings.Contains(detail.Hint, "Do not retry") {
+		t.Fatalf("hint = %q", detail.Hint)
+	}
+
+	var buf bytes.Buffer
+	printUploadRecovery(&buf, output.NewStyler(false), state)
+	for _, want := range []string{"action:      update", "workflow_id: workflow_1", "email_id:    email_1"} {
+		if !strings.Contains(buf.String(), want) {
+			t.Fatalf("recovery output missing %q: %q", want, buf.String())
+		}
+	}
+}
+
+func TestClassifyCommandError_CompletedWorkflowEmailOutputFailure(t *testing.T) {
+	state := &workflows.CompletedEmailWriteOutputError{
+		Cause:      errors.New("jq runtime error"),
+		Action:     workflows.EmailWriteActionAdd,
+		WorkflowID: "workflow_1",
+		EmailID:    "email_2",
+	}
+	detail := classifyCommandError(state)
+	if detail.Type != "output_error" || detail.Code != "workflow_email_output_failed" {
+		t.Fatalf("detail = %+v", detail)
+	}
+	if detail.Recovery == nil || detail.Recovery.Action != "add" || detail.Recovery.WorkflowID != "workflow_1" || detail.Recovery.EmailID != "email_2" {
+		t.Fatalf("recovery = %+v", detail.Recovery)
+	}
+	if !strings.Contains(detail.Hint, "Do not retry") {
+		t.Fatalf("hint = %q", detail.Hint)
+	}
+
+	var buf bytes.Buffer
+	printUploadRecovery(&buf, output.NewStyler(false), state)
+	for _, want := range []string{"action:      add", "workflow_id: workflow_1", "email_id:    email_2"} {
+		if !strings.Contains(buf.String(), want) {
+			t.Fatalf("recovery output missing %q: %q", want, buf.String())
+		}
 	}
 }
 

--- a/internal/cmd/workflows/email_write.go
+++ b/internal/cmd/workflows/email_write.go
@@ -1,0 +1,274 @@
+package workflows
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/config"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/antiwork/gumroad-cli/internal/pageutil"
+	"github.com/spf13/cobra"
+)
+
+const (
+	maxWorkflowDelaySeconds int64 = (1 << 31) - 1
+	secondsPerHour                = 60 * 60
+	secondsPerDay                 = 24 * secondsPerHour
+	secondsPerWeek                = 7 * secondsPerDay
+	secondsPerMonth               = 2629746
+)
+
+var workflowDelaySeconds = map[string]int64{
+	"hour":  secondsPerHour,
+	"day":   secondsPerDay,
+	"week":  secondsPerWeek,
+	"month": secondsPerMonth,
+}
+
+type workflowEmailResponse struct {
+	Success bool                `json:"success"`
+	Email   workflowEmailRecord `json:"email"`
+}
+
+type workflowDelayInput struct {
+	Amount int64
+	Unit   string
+}
+
+func newAddEmailCmd() *cobra.Command {
+	var subject, body, delay string
+
+	cmd := &cobra.Command{
+		Use:   "add-email <workflow-id>",
+		Short: "Add an email step to a workflow",
+		Long: `Add one email step from an HTML body file.
+
+This command does not change the workflow publication state. A published
+workflow can schedule eligible past recipients when you add the step. Pass
+--yes to confirm the write.`,
+		Example: `  gumroad workflows add-email <workflow-id> --subject "Week four" --body ./email.html --delay "4 weeks" --yes
+  build-email | gumroad workflows add-email <workflow-id> --subject "Welcome" --body - --delay "0 hours" --yes
+  gumroad workflows add-email <workflow-id> --subject "Check params" --body ./email.html --delay "1 day" --dry-run`,
+		Args: cmdutil.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			if strings.TrimSpace(subject) == "" {
+				return cmdutil.MissingFlagError(c, "--subject")
+			}
+			if body == "" {
+				return cmdutil.MissingFlagError(c, "--body")
+			}
+			if delay == "" {
+				return cmdutil.MissingFlagError(c, "--delay")
+			}
+
+			opts := cmdutil.OptionsFrom(c)
+			if err := output.ValidateJQExpression(opts.JQExpr); err != nil {
+				return err
+			}
+
+			parsedDelay, err := parseWorkflowDelay(delay)
+			if err != nil {
+				return cmdutil.UsageErrorf(c, "--delay: %v", err)
+			}
+
+			input, err := pageutil.ReadHTML(opts.In(), body)
+			if err != nil {
+				return cmdutil.UsageErrorf(c, "--body: %v", err)
+			}
+
+			params := url.Values{}
+			params.Set("subject", subject)
+			params.Set("body", input.HTML)
+			setWorkflowDelayParams(params, parsedDelay)
+
+			ok, err := cmdutil.ConfirmAction(opts, "Add an email step to workflow "+args[0]+"? A published workflow can schedule eligible past recipients.")
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return cmdutil.PrintCancelledAction(opts, "add workflow email", "")
+			}
+
+			return runWorkflowEmailWrite(
+				opts,
+				"Adding workflow email...",
+				http.MethodPost,
+				cmdutil.JoinPath("workflows", args[0], "emails"),
+				params,
+				EmailWriteActionAdd,
+				args[0],
+				"",
+				"Added workflow email:",
+			)
+		},
+	}
+
+	cmd.Flags().StringVar(&subject, "subject", "", "Email subject (required)")
+	cmd.Flags().StringVar(&body, "body", "", "Path to an HTML body file, or - for stdin (required)")
+	cmd.Flags().StringVar(&delay, "delay", "", `Delay such as "4 weeks" (required)`)
+
+	return cmd
+}
+
+func newUpdateEmailCmd() *cobra.Command {
+	var subject, body, delay string
+
+	cmd := &cobra.Command{
+		Use:   "update-email <workflow-id> <email-id>",
+		Short: "Update an email step in a workflow",
+		Long: `Update selected fields on one workflow email step.
+
+Omitted fields stay unchanged. This command does not change the workflow
+publication state. A delay change can reschedule recipients and requires
+confirmation.`,
+		Example: `  gumroad workflows update-email <workflow-id> <email-id> --body ./email.html
+  gumroad workflows update-email <workflow-id> <email-id> --subject "New subject" --delay "2 days" --yes
+  build-email | gumroad workflows update-email <workflow-id> <email-id> --body -
+  gumroad workflows update-email <workflow-id> <email-id> --delay "1 week" --dry-run`,
+		Args: cmdutil.ExactArgs(2),
+		RunE: func(c *cobra.Command, args []string) error {
+			if err := cmdutil.RequireAnyFlagChanged(c, "subject", "body", "delay"); err != nil {
+				return err
+			}
+			if c.Flags().Changed("subject") && strings.TrimSpace(subject) == "" {
+				return cmdutil.UsageErrorf(c, "--subject must be a non-empty string")
+			}
+			if c.Flags().Changed("body") && body == "" {
+				return cmdutil.UsageErrorf(c, "--body must be a file path or - for stdin")
+			}
+
+			opts := cmdutil.OptionsFrom(c)
+			if err := output.ValidateJQExpression(opts.JQExpr); err != nil {
+				return err
+			}
+
+			params := url.Values{}
+			if c.Flags().Changed("subject") {
+				params.Set("subject", subject)
+			}
+			if c.Flags().Changed("delay") {
+				parsedDelay, err := parseWorkflowDelay(delay)
+				if err != nil {
+					return cmdutil.UsageErrorf(c, "--delay: %v", err)
+				}
+				setWorkflowDelayParams(params, parsedDelay)
+			}
+
+			if c.Flags().Changed("body") {
+				input, err := pageutil.ReadHTML(opts.In(), body)
+				if err != nil {
+					return cmdutil.UsageErrorf(c, "--body: %v", err)
+				}
+				params.Set("body", input.HTML)
+			}
+			if c.Flags().Changed("delay") {
+				ok, err := cmdutil.ConfirmAction(opts, "Change the delay for email "+args[1]+"? The change can reschedule recipients.")
+				if err != nil {
+					return err
+				}
+				if !ok {
+					return cmdutil.PrintCancelledAction(opts, "change workflow email delay", args[1])
+				}
+			}
+
+			return runWorkflowEmailWrite(
+				opts,
+				"Updating workflow email...",
+				http.MethodPut,
+				cmdutil.JoinPath("workflows", args[0], "emails", args[1]),
+				params,
+				EmailWriteActionUpdate,
+				args[0],
+				args[1],
+				"Updated workflow email:",
+			)
+		},
+	}
+
+	cmd.Flags().StringVar(&subject, "subject", "", "New email subject")
+	cmd.Flags().StringVar(&body, "body", "", "Path to a new HTML body file, or - for stdin")
+	cmd.Flags().StringVar(&delay, "delay", "", `New delay such as "4 weeks"`)
+
+	return cmd
+}
+
+func parseWorkflowDelay(value string) (workflowDelayInput, error) {
+	parts := strings.Fields(value)
+	if len(parts) != 2 {
+		return workflowDelayInput{}, fmt.Errorf(`must use "<non-negative integer> <hour|day|week|month>"`)
+	}
+
+	amount, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil || amount < 0 {
+		return workflowDelayInput{}, fmt.Errorf("amount must be a non-negative integer")
+	}
+
+	unit := strings.ToLower(parts[1])
+	unit = strings.TrimSuffix(unit, "s")
+	seconds, ok := workflowDelaySeconds[unit]
+	if !ok {
+		return workflowDelayInput{}, fmt.Errorf("unit must be one of: hour, day, week, month")
+	}
+	if amount > maxWorkflowDelaySeconds/seconds {
+		return workflowDelayInput{}, fmt.Errorf("total must not exceed %d seconds", maxWorkflowDelaySeconds)
+	}
+
+	return workflowDelayInput{Amount: amount, Unit: unit}, nil
+}
+
+func setWorkflowDelayParams(params url.Values, delay workflowDelayInput) {
+	params.Set("delay_amount", strconv.FormatInt(delay.Amount, 10))
+	params.Set("delay_unit", delay.Unit)
+}
+
+func runWorkflowEmailWrite(
+	opts cmdutil.Options,
+	spinnerMessage, method, path string,
+	params url.Values,
+	action EmailWriteAction,
+	workflowID, emailID, label string,
+) error {
+	if opts.DryRun {
+		return cmdutil.PrintDryRunRequest(opts, method, path, params)
+	}
+
+	token, err := config.Token()
+	if err != nil {
+		return err
+	}
+	data, err := cmdutil.RunRequestWithTokenData(opts, token, spinnerMessage, method, path, params)
+	if err != nil {
+		return emailWriteRequestError(err, action, workflowID, emailID)
+	}
+	resp, err := cmdutil.DecodeJSON[workflowEmailResponse](data)
+	if err != nil || resp.Email.ID == "" {
+		if err == nil {
+			err = fmt.Errorf("workflow email response did not include email.id")
+		}
+		return newUnknownEmailWriteError(err, action, workflowID, emailID)
+	}
+
+	if err := renderWorkflowEmailWrite(opts, data, resp, label); err != nil {
+		return emailWriteOutputError(err, action, workflowID, resp.Email.ID)
+	}
+	return nil
+}
+
+func renderWorkflowEmailWrite(opts cmdutil.Options, data []byte, resp workflowEmailResponse, label string) error {
+	if opts.UsesJSONOutput() {
+		return cmdutil.PrintJSONResponse(opts, data)
+	}
+	item := resp.Email
+	if opts.PlainOutput {
+		return output.PrintPlain(opts.Out(), [][]string{{item.ID, item.Subject, workflowDelayLabel(item.Delay), item.State}})
+	}
+	if opts.Quiet {
+		return nil
+	}
+	style := opts.Style()
+	return output.Writef(opts.Out(), "%s %s (%s) [%s]\n", style.Bold(label), item.Subject, style.Dim(item.ID), item.State)
+}

--- a/internal/cmd/workflows/email_write_error.go
+++ b/internal/cmd/workflows/email_write_error.go
@@ -1,0 +1,97 @@
+package workflows
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/antiwork/gumroad-cli/internal/api"
+)
+
+type EmailWriteAction string
+
+const (
+	EmailWriteActionAdd    EmailWriteAction = "add"
+	EmailWriteActionUpdate EmailWriteAction = "update"
+)
+
+type UnknownEmailWriteError struct {
+	Cause      error
+	Action     EmailWriteAction
+	WorkflowID string
+	EmailID    string
+}
+
+func (e *UnknownEmailWriteError) Error() string {
+	return fmt.Sprintf("workflow email %s state is unknown for workflow %s: %s", e.Action, e.WorkflowID, e.Cause)
+}
+
+func (e *UnknownEmailWriteError) Unwrap() error {
+	return e.Cause
+}
+
+func (e *UnknownEmailWriteError) RecoveryHint() string {
+	command := fmt.Sprintf("gumroad workflows view %s --json --no-input", e.WorkflowID)
+	if e.EmailID != "" {
+		return fmt.Sprintf("Run `%s` and inspect email ID %s for the requested values. Do not retry automatically because the first request can still finish.", command, e.EmailID)
+	}
+	return fmt.Sprintf("Run `%s` and inspect email IDs and timestamps. A matching step can predate this request, so it does not prove completion. Do not retry automatically. Contact support if the state remains unclear.", command)
+}
+
+type CompletedEmailWriteOutputError struct {
+	Cause      error
+	Action     EmailWriteAction
+	WorkflowID string
+	EmailID    string
+}
+
+func (e *CompletedEmailWriteOutputError) Error() string {
+	return fmt.Sprintf("workflow email %s completed as %s, but output failed: %s", e.Action, e.EmailID, e.Cause)
+}
+
+func (e *CompletedEmailWriteOutputError) Unwrap() error {
+	return e.Cause
+}
+
+func (e *CompletedEmailWriteOutputError) RecoveryHint() string {
+	return fmt.Sprintf("The write completed. Do not retry it. Run `gumroad workflows view %s --json --no-input` and inspect email ID %s.", e.WorkflowID, e.EmailID)
+}
+
+func emailWriteRequestError(err error, action EmailWriteAction, workflowID, emailID string) error {
+	var apiErr *api.APIError
+	if errors.As(err, &apiErr) && isDefinitiveEmailWriteRejection(apiErr.StatusCode) {
+		return err
+	}
+	return newUnknownEmailWriteError(err, action, workflowID, emailID)
+}
+
+func newUnknownEmailWriteError(err error, action EmailWriteAction, workflowID, emailID string) error {
+	return &UnknownEmailWriteError{
+		Cause:      err,
+		Action:     action,
+		WorkflowID: workflowID,
+		EmailID:    emailID,
+	}
+}
+
+func emailWriteOutputError(err error, action EmailWriteAction, workflowID, emailID string) error {
+	return &CompletedEmailWriteOutputError{
+		Cause:      err,
+		Action:     action,
+		WorkflowID: workflowID,
+		EmailID:    emailID,
+	}
+}
+
+// A transient response does not prove whether the server committed the write.
+// The caller must reconcile the workflow before it retries the mutation.
+func isDefinitiveEmailWriteRejection(status int) bool {
+	if status >= http.StatusInternalServerError {
+		return false
+	}
+	switch status {
+	case http.StatusRequestTimeout, http.StatusConflict, http.StatusTooEarly, http.StatusTooManyRequests:
+		return false
+	}
+	return true
+}

--- a/internal/cmd/workflows/email_write_test.go
+++ b/internal/cmd/workflows/email_write_test.go
@@ -1,0 +1,452 @@
+package workflows
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/api"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+	"github.com/spf13/cobra"
+)
+
+const workflowEmailBodyFileMode = 0600
+
+func writeWorkflowEmailBody(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "email.html")
+	if err := os.WriteFile(path, []byte(body), workflowEmailBodyFileMode); err != nil {
+		t.Fatalf("write body: %v", err)
+	}
+	return path
+}
+
+func workflowEmailWriteHandler(t *testing.T, inspect func(*http.Request)) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		if inspect != nil {
+			inspect(r)
+		}
+		testutil.JSON(t, w, map[string]any{"email": workflowEmailPayload("e1", r.PostForm.Get("subject"))})
+	}
+}
+
+func requireWorkflowUsageError(t *testing.T, err error, message string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected usage error")
+	}
+	var usageErr *cmdutil.UsageError
+	if !errors.As(err, &usageErr) {
+		t.Fatalf("got %T, want *cmdutil.UsageError", err)
+	}
+	if !strings.Contains(err.Error(), message) {
+		t.Fatalf("error %q does not contain %q", err, message)
+	}
+}
+
+func TestAddEmail_PostsResolvedBodyAndDelay(t *testing.T) {
+	bodyPath := writeWorkflowEmailBody(t, "<p>Keep going.</p>")
+	var gotMethod, gotPath string
+	var gotForm url.Values
+	testutil.Setup(t, workflowEmailWriteHandler(t, func(r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotForm = r.PostForm
+	}))
+
+	var out bytes.Buffer
+	cmd := testutil.Command(newAddEmailCmd(), testutil.Quiet(false), testutil.Stdout(&out), testutil.Yes(true))
+	cmd.SetArgs([]string{"workflow_1", "--subject", "Week four", "--body", bodyPath, "--delay", "4 weeks"})
+	testutil.MustExecute(t, cmd)
+
+	if gotMethod != http.MethodPost || gotPath != "/workflows/workflow_1/emails" {
+		t.Fatalf("got %s %s, want POST /workflows/workflow_1/emails", gotMethod, gotPath)
+	}
+	if gotForm.Get("subject") != "Week four" || gotForm.Get("body") != "<p>Keep going.</p>" {
+		t.Fatalf("unexpected content params: %#v", gotForm)
+	}
+	if gotForm.Get("delay_amount") != "4" || gotForm.Get("delay_unit") != "week" {
+		t.Fatalf("unexpected delay params: %#v", gotForm)
+	}
+	if !strings.Contains(out.String(), "Added workflow email:") || !strings.Contains(out.String(), "Week four") {
+		t.Fatalf("unexpected output: %q", out.String())
+	}
+}
+
+func TestAddEmail_ReadsBodyFromStdin(t *testing.T) {
+	var gotBody string
+	testutil.Setup(t, workflowEmailWriteHandler(t, func(r *http.Request) {
+		gotBody = r.PostForm.Get("body")
+	}))
+
+	cmd := testutil.Command(newAddEmailCmd(), testutil.Stdin(strings.NewReader("<p>From stdin</p>")), testutil.Yes(true))
+	cmd.SetArgs([]string{"workflow_1", "--subject", "Welcome", "--body", "-", "--delay", "0 hours"})
+	testutil.MustExecute(t, cmd)
+
+	if gotBody != "<p>From stdin</p>" {
+		t.Fatalf("body = %q, want stdin contents", gotBody)
+	}
+}
+
+func TestAddEmail_DryRunShowsResolvedPayloadWithoutRequest(t *testing.T) {
+	bodyPath := writeWorkflowEmailBody(t, "<p>Preview</p>")
+	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
+		t.Fatal("dry run must not call the API")
+	})
+
+	var out bytes.Buffer
+	cmd := testutil.Command(newAddEmailCmd(), testutil.DryRun(true), testutil.JSONOutput(), testutil.Stdout(&out))
+	cmd.SetArgs([]string{"workflow_1", "--subject", "Preview", "--body", bodyPath, "--delay", "1 DAY"})
+	testutil.MustExecute(t, cmd)
+
+	var payload struct {
+		DryRun bool       `json:"dry_run"`
+		Method string     `json:"method"`
+		Path   string     `json:"path"`
+		Params url.Values `json:"params"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("parse dry-run JSON: %v", err)
+	}
+	if !payload.DryRun || payload.Method != http.MethodPost || payload.Path != "/workflows/workflow_1/emails" {
+		t.Fatalf("unexpected dry-run request: %#v", payload)
+	}
+	if payload.Params.Get("body") != "<p>Preview</p>" || payload.Params.Get("delay_unit") != "day" {
+		t.Fatalf("unexpected dry-run params: %#v", payload.Params)
+	}
+}
+
+func TestAddEmail_RequiresEveryFlag(t *testing.T) {
+	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
+		t.Fatal("invalid input must not call the API")
+	})
+
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "subject", args: []string{"workflow_1", "--body", "email.html", "--delay", "1 day"}, want: "missing required flag: --subject"},
+		{name: "body", args: []string{"workflow_1", "--subject", "Welcome", "--delay", "1 day"}, want: "missing required flag: --body"},
+		{name: "delay", args: []string{"workflow_1", "--subject", "Welcome", "--body", "email.html"}, want: "missing required flag: --delay"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := testutil.Command(newAddEmailCmd())
+			cmd.SetArgs(tc.args)
+			requireWorkflowUsageError(t, cmd.Execute(), tc.want)
+		})
+	}
+}
+
+func TestParseWorkflowDelay_AcceptsSupportedUnits(t *testing.T) {
+	tests := []struct {
+		input      string
+		wantAmount int64
+		wantUnit   string
+	}{
+		{input: "0 hours", wantAmount: 0, wantUnit: "hour"},
+		{input: "1 day", wantAmount: 1, wantUnit: "day"},
+		{input: "2 WEEKS", wantAmount: 2, wantUnit: "week"},
+		{input: "3 months", wantAmount: 3, wantUnit: "month"},
+		{input: "816 months", wantAmount: 816, wantUnit: "month"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			delay, err := parseWorkflowDelay(tc.input)
+			if err != nil {
+				t.Fatalf("parse delay: %v", err)
+			}
+			if delay.Amount != tc.wantAmount || delay.Unit != tc.wantUnit {
+				t.Fatalf("delay = %#v, want %d %s", delay, tc.wantAmount, tc.wantUnit)
+			}
+		})
+	}
+}
+
+func TestParseWorkflowDelay_RejectsInvalidValues(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{input: "", want: "must use"},
+		{input: "4", want: "must use"},
+		{input: "four weeks", want: "non-negative integer"},
+		{input: "-1 day", want: "non-negative integer"},
+		{input: "1.5 days", want: "non-negative integer"},
+		{input: "1 year", want: "unit must be one of"},
+		{input: "817 months", want: "must not exceed"},
+		{input: "596524 hours", want: "must not exceed"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			_, err := parseWorkflowDelay(tc.input)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want text %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestUpdateEmail_SendsOnlyTheBody(t *testing.T) {
+	bodyPath := writeWorkflowEmailBody(t, "<p>Updated body</p>")
+	var gotMethod, gotPath string
+	var gotForm url.Values
+	testutil.Setup(t, workflowEmailWriteHandler(t, func(r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotForm = r.PostForm
+	}))
+
+	cmd := testutil.Command(newUpdateEmailCmd(), testutil.NoInput(true))
+	cmd.SetArgs([]string{"workflow_1", "email_1", "--body", bodyPath})
+	testutil.MustExecute(t, cmd)
+
+	if gotMethod != http.MethodPut || gotPath != "/workflows/workflow_1/emails/email_1" {
+		t.Fatalf("got %s %s, want PUT /workflows/workflow_1/emails/email_1", gotMethod, gotPath)
+	}
+	if len(gotForm) != 1 || gotForm.Get("body") != "<p>Updated body</p>" {
+		t.Fatalf("sparse update params = %#v", gotForm)
+	}
+}
+
+func TestUpdateEmail_SendsSubjectAndDelay(t *testing.T) {
+	var gotForm url.Values
+	testutil.Setup(t, workflowEmailWriteHandler(t, func(r *http.Request) {
+		gotForm = r.PostForm
+	}))
+
+	cmd := testutil.Command(newUpdateEmailCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"workflow_1", "email_1", "--subject", "New subject", "--delay", "2 days"})
+	testutil.MustExecute(t, cmd)
+
+	if len(gotForm) != 3 || gotForm.Get("subject") != "New subject" || gotForm.Get("delay_amount") != "2" || gotForm.Get("delay_unit") != "day" {
+		t.Fatalf("update params = %#v", gotForm)
+	}
+}
+
+func TestUpdateEmail_RequiresAChangedField(t *testing.T) {
+	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
+		t.Fatal("empty update must not call the API")
+	})
+
+	cmd := testutil.Command(newUpdateEmailCmd())
+	cmd.SetArgs([]string{"workflow_1", "email_1"})
+	requireWorkflowUsageError(t, cmd.Execute(), "at least one field to update must be provided")
+}
+
+func TestEmailWrites_RequireConfirmationForSchedulingChanges(t *testing.T) {
+	bodyPath := writeWorkflowEmailBody(t, "<p>Body</p>")
+	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
+		t.Fatal("an unconfirmed write must not call the API")
+	})
+
+	tests := []struct {
+		name string
+		cmd  *cobra.Command
+		args []string
+	}{
+		{
+			name: "add",
+			cmd:  newAddEmailCmd(),
+			args: []string{"workflow_1", "--subject", "Welcome", "--body", bodyPath, "--delay", "1 day"},
+		},
+		{
+			name: "delay update",
+			cmd:  newUpdateEmailCmd(),
+			args: []string{"workflow_1", "email_1", "--delay", "2 days"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := testutil.Command(tc.cmd, testutil.NoInput(true))
+			cmd.SetArgs(tc.args)
+			err := cmd.Execute()
+			if !strings.Contains(fmt.Sprint(err), "confirmation required") {
+				t.Fatalf("error = %v, want confirmation requirement", err)
+			}
+		})
+	}
+}
+
+func TestUpdateEmail_RejectsEmptySubjectAndBodyPath(t *testing.T) {
+	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
+		t.Fatal("invalid update must not call the API")
+	})
+
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "subject", args: []string{"workflow_1", "email_1", "--subject", " "}, want: "--subject must be a non-empty string"},
+		{name: "body", args: []string{"workflow_1", "email_1", "--body", ""}, want: "--body must be a file path"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := testutil.Command(newUpdateEmailCmd())
+			cmd.SetArgs(tc.args)
+			requireWorkflowUsageError(t, cmd.Execute(), tc.want)
+		})
+	}
+}
+
+func TestUpdateEmail_JSONPreservesAPIResponse(t *testing.T) {
+	testutil.Setup(t, workflowEmailWriteHandler(t, nil))
+
+	var out bytes.Buffer
+	cmd := testutil.Command(newUpdateEmailCmd(), testutil.JSONOutput(), testutil.Stdout(&out))
+	cmd.SetArgs([]string{"workflow_1", "email_1", "--subject", "Updated"})
+	testutil.MustExecute(t, cmd)
+
+	var payload map[string]any
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("parse JSON response: %v", err)
+	}
+	if payload["success"] != true {
+		t.Fatalf("response = %#v", payload)
+	}
+	email, ok := payload["email"].(map[string]any)
+	if !ok || email["id"] != "e1" || email["subject"] != "Updated" {
+		t.Fatalf("email response = %#v", payload["email"])
+	}
+}
+
+func TestUpdateEmail_PlainOutput(t *testing.T) {
+	testutil.Setup(t, workflowEmailWriteHandler(t, nil))
+
+	var out bytes.Buffer
+	cmd := testutil.Command(newUpdateEmailCmd(), testutil.PlainOutput(), testutil.Stdout(&out))
+	cmd.SetArgs([]string{"workflow_1", "email_1", "--subject", "Updated"})
+	testutil.MustExecute(t, cmd)
+
+	if out.String() != "e1\tUpdated\t4 weeks\tpublished\n" {
+		t.Fatalf("plain output = %q", out.String())
+	}
+}
+
+func TestEmailWrite_InvalidJQFailsBeforeRequest(t *testing.T) {
+	bodyPath := writeWorkflowEmailBody(t, "<p>Body</p>")
+	reached := false
+	testutil.Setup(t, func(http.ResponseWriter, *http.Request) {
+		reached = true
+	})
+
+	cmd := testutil.Command(newAddEmailCmd(), testutil.JQ(".["), testutil.Yes(true))
+	cmd.SetArgs([]string{"workflow_1", "--subject", "Welcome", "--body", bodyPath, "--delay", "1 day"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "invalid jq expression") {
+		t.Fatalf("error = %v, want invalid jq expression", err)
+	}
+	if reached {
+		t.Fatal("invalid jq expression caused a write request")
+	}
+}
+
+func TestEmailWrite_JQRuntimeErrorPreservesCompletedWrite(t *testing.T) {
+	bodyPath := writeWorkflowEmailBody(t, "<p>Body</p>")
+	testutil.Setup(t, workflowEmailWriteHandler(t, nil))
+
+	var out bytes.Buffer
+	cmd := testutil.Command(newAddEmailCmd(), testutil.JQ(".email.id | tonumber"), testutil.Yes(true), testutil.Stdout(&out))
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"workflow_1", "--subject", "Welcome", "--body", bodyPath, "--delay", "1 day"})
+	err := cmd.Execute()
+	var completed *CompletedEmailWriteOutputError
+	if !errors.As(err, &completed) {
+		t.Fatalf("error = %v, want CompletedEmailWriteOutputError", err)
+	}
+	if completed.WorkflowID != "workflow_1" || completed.EmailID != "e1" || completed.Action != EmailWriteActionAdd {
+		t.Fatalf("completed write = %#v", completed)
+	}
+	if !strings.Contains(completed.RecoveryHint(), "Do not retry") {
+		t.Fatalf("hint = %q", completed.RecoveryHint())
+	}
+	if out.Len() != 0 {
+		t.Fatalf("stdout contains partial jq output: %q", out.String())
+	}
+}
+
+func TestEmailWrite_InvalidSuccessResponseHasUnknownState(t *testing.T) {
+	bodyPath := writeWorkflowEmailBody(t, "<p>Body</p>")
+	testutil.Setup(t, func(w http.ResponseWriter, _ *http.Request) {
+		testutil.RawJSON(t, w, `{"success":true,"email":{}}`)
+	})
+
+	cmd := testutil.Command(newAddEmailCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"workflow_1", "--subject", "Welcome", "--body", bodyPath, "--delay", "1 day"})
+	err := cmd.Execute()
+	var unknown *UnknownEmailWriteError
+	if !errors.As(err, &unknown) || unknown.WorkflowID != "workflow_1" || unknown.Action != EmailWriteActionAdd {
+		t.Fatalf("error = %v, want unknown add state", err)
+	}
+}
+
+func TestEmailWrite_TransientFailuresHaveUnknownState(t *testing.T) {
+	bodyPath := writeWorkflowEmailBody(t, "<p>Body</p>")
+	testutil.Setup(t, func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "upstream failure", http.StatusBadGateway)
+	})
+
+	cmd := testutil.Command(newAddEmailCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"workflow_1", "--subject", "Welcome", "--body", bodyPath, "--delay", "1 day"})
+	err := cmd.Execute()
+	var unknown *UnknownEmailWriteError
+	if !errors.As(err, &unknown) {
+		t.Fatalf("error = %v, want UnknownEmailWriteError", err)
+	}
+	if unknown.Action != EmailWriteActionAdd || unknown.WorkflowID != "workflow_1" || unknown.EmailID != "" {
+		t.Fatalf("unknown write = %#v", unknown)
+	}
+	if !strings.Contains(unknown.RecoveryHint(), "Do not retry automatically") {
+		t.Fatalf("hint = %q", unknown.RecoveryHint())
+	}
+}
+
+func TestEmailWrite_DefinitiveRejectionStaysAPIError(t *testing.T) {
+	bodyPath := writeWorkflowEmailBody(t, "<p>Body</p>")
+	testutil.Setup(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		testutil.RawJSON(t, w, `{"success":false,"message":"invalid email"}`)
+	})
+
+	cmd := testutil.Command(newAddEmailCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{"workflow_1", "--subject", "Welcome", "--body", bodyPath, "--delay", "1 day"})
+	err := cmd.Execute()
+	var unknown *UnknownEmailWriteError
+	if errors.As(err, &unknown) {
+		t.Fatalf("definitive rejection became unknown: %v", err)
+	}
+	var apiErr *api.APIError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("error = %v, want 422 APIError", err)
+	}
+}
+
+func TestNewWorkflowsCmd_HelpWarnsAboutScheduling(t *testing.T) {
+	cmd := NewWorkflowsCmd()
+	if !strings.Contains(cmd.Long, "published workflow can schedule recipients") {
+		t.Fatalf("help does not warn about scheduling: %q", cmd.Long)
+	}
+	if !strings.Contains(cmd.Long, "delay change can reschedule recipients") {
+		t.Fatalf("help does not warn about rescheduling: %q", cmd.Long)
+	}
+}

--- a/internal/cmd/workflows/workflows.go
+++ b/internal/cmd/workflows/workflows.go
@@ -53,18 +53,22 @@ type workflowDelay struct {
 func NewWorkflowsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "workflows",
-		Short: "Inspect email workflows",
-		Long: "Inspect Gumroad email workflows.\n\n" +
-			"List workflows and view a workflow's email steps with per-step delay, sent, open, and click stats. " +
-			"Workflows are read-only in the CLI; create and edit them in the Gumroad dashboard.",
+		Short: "Manage email workflows",
+		Long: "Manage Gumroad email workflows.\n\n" +
+			"List workflows and view their email steps. Add a step or update selected step fields without changing the workflow publication state. " +
+			"A new step on a published workflow can schedule recipients. A delay change can reschedule recipients.",
 		Example: `  gumroad workflows list
   gumroad workflows list --json
   gumroad workflows view <id>
-  gumroad workflows view <id> --json --jq '.workflow.emails[] | {subject, click_rate}'`,
+  gumroad workflows view <id> --json --jq '.workflow.emails[] | {subject, click_rate}'
+  gumroad workflows add-email <workflow-id> --subject "Week four" --body ./email.html --delay "4 weeks" --yes
+  gumroad workflows update-email <workflow-id> <email-id> --body ./email.html`,
 	}
 
 	cmd.AddCommand(newListCmd())
 	cmd.AddCommand(newViewCmd())
+	cmd.AddCommand(newAddEmailCmd())
+	cmd.AddCommand(newUpdateEmailCmd())
 
 	return cmd
 }

--- a/internal/cmd/workflows/workflows_test.go
+++ b/internal/cmd/workflows/workflows_test.go
@@ -346,7 +346,9 @@ func TestNewWorkflowsCmd_RegistersSubcommands(t *testing.T) {
 		names = append(names, sub.Name())
 	}
 	joined := strings.Join(names, ",")
-	if !strings.Contains(joined, "list") || !strings.Contains(joined, "view") {
-		t.Errorf("missing subcommands, got: %v", names)
+	for _, name := range []string{"list", "view", "add-email", "update-email"} {
+		if !strings.Contains(joined, name) {
+			t.Errorf("missing %s subcommand, got: %v", name, names)
+		}
 	}
 }

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -3,7 +3,7 @@ name: gumroad
 description: >
   Use the `gumroad` CLI to look up and manage Gumroad data from the terminal.
   Trigger when the user asks about Gumroad products, files, file uploads,
-  attachments, sales, subscribers, licenses, payouts, audience emails, broadcasts, offer codes, webhooks,
+  attachments, sales, subscribers, licenses, payouts, audience emails, email workflows, broadcasts, offer codes, webhooks,
   refund policies,
   or any Gumroad data lookup.
   Also trigger on "check my Gumroad", "look up a sale", "verify a license",
@@ -33,7 +33,7 @@ Always follow these rules:
 - **Always** pass `--no-input` to prevent interactive prompts from blocking.
 - **Always** pass `--json` for programmatic access.
 - Use `--json --jq <expr>` together to extract exactly what you need.
-- For operations that can prompt for confirmation (delete, refund, mutating admin actions, `files abort`, `files complete` replay, product updates that remove files, or `products content set` when omitted page IDs will be deleted), add `--yes` to skip confirmation.
+- For operations that can prompt for confirmation (delete, refund, workflow step adds, workflow delay changes, mutating admin actions, `files abort`, `files complete` replay, product updates that remove files, or `products content set` when omitted page IDs will be deleted), add `--yes` to skip confirmation.
 - Pass `--quiet` to suppress spinners and status messages.
 - Pass `--dry-run` to preview mutating requests without executing them.
 - Use `--page-delay 200ms` with `--all` to avoid rate limits on large datasets.
@@ -46,6 +46,7 @@ Always follow these rules:
 - Product rich content uses `gumroad products content list <id> --json --no-input` to inspect page IDs, `gumroad products content get <id> --json --no-input` to dump the shared `rich_content` page array, and `gumroad products content set <id> content.json --dry-run --json --no-input` to preview a whole-document replacement. Without an explicit path, whole-document `set` reads `./content.json`; `set --page` reads `./page.json`. Use `--page <page_id>` with `get`/`set` to edit one matching page object; `set --page` still sends a merged whole-document PUT. For per-variant content, pass both `--variant <variant_id>` and `--category <cat_id>`. Whole-document `set` deletes existing pages omitted from the JSON.
 - Custom HTML pages can use `data-gumroad-field="name"`, `data-gumroad-field="price"`, `data-gumroad-field="description"`, and `data-gumroad-action="buy"`. To preselect checkout state, add `data-gumroad-option="<variant name>"`, `data-gumroad-quantity="<integer>"`, `data-gumroad-price="<decimal>"`, or `data-gumroad-recurrence="monthly|quarterly|biannually|yearly|every_two_years"`. Production validates these values and falls back to product defaults when invalid. Prefer anchors for buy CTAs so production can add a checkout href; non-anchor buy elements also post to checkout.
 - Audience emails are created as drafts by default. Use `gumroad emails send-preview <id> --json --no-input` and inspect `.preview_url` before `gumroad emails send <id> --yes --json --no-input`. Creating with `--send` publishes and blasts immediately, so use `--dry-run` first and require explicit human approval.
+- Workflow email writes do not change the workflow publication state. Adding a step to a published workflow can schedule eligible past recipients. Changing a delay can reschedule recipients. Use `--dry-run` before each write.
 - If a command fails with a seller auth error, run `gumroad auth status --json --no-input` first. Agents can start seller auth with `gumroad auth login --no-input` and hand the printed approval URL to a human, or use an existing seller token via `GUMROAD_ACCESS_TOKEN` or `gumroad auth login --with-token`.
 - For admin commands in agents/CI, pass `--non-interactive` and set `GUMROAD_ADMIN_TOKEN`; interactive shells can store an admin token with `gumroad auth login --web`.
 
@@ -70,6 +71,7 @@ Most responses are wrapped in `{"success": true, ...}` with resource-specific ke
 - `sales export` → `.status`, `.recipient_email`
 - `sales summary` → `.gross_cents`, `.net_cents`, `.breakdown[]`
 - `emails list` → `.emails[]`, `emails view/create/send` → `.email`, `emails send-preview` → `.preview_url`, `emails delete` → `.message`
+- `workflows list` → `.workflows[]`, `workflows view` → `.workflow`, `workflows add-email/update-email` → `.email`
 - `payouts list` → `.payouts[]`, `payouts view/upcoming` → `.payout`
 - `subscribers list` → `.subscribers[]`, `subscribers view` → `.subscriber`
 - `licenses verify` → `.purchase`
@@ -448,7 +450,7 @@ gumroad emails delete <id> --yes --json --no-input
 
 Use `--dry-run --json --no-input` to inspect create params without calling the API. Passing `--send` blasts the audience immediately; prefer the draft → `send-preview` URL → `send` workflow. `send-preview` emails a copy to the seller. Scheduled emails can only be created in the web UI; the CLI can list and view them (`--state scheduled`) but not create them.
 
-### workflows — Inspect email workflows
+### workflows — Manage email workflows
 
 ```sh
 # List workflows with audience, state, and email step count.
@@ -459,9 +461,23 @@ gumroad workflows view <id> --json --no-input
 
 # Compare steps: pull subject and click rate for every step.
 gumroad workflows view <id> --json --jq '.workflow.emails[] | {subject, click_rate}' --no-input
+
+# Preview and then add one step from an HTML body file.
+gumroad workflows add-email <workflow-id> --subject "Week four" --body ./email.html --delay "4 weeks" --dry-run --json --no-input
+gumroad workflows add-email <workflow-id> --subject "Week four" --body ./email.html --delay "4 weeks" --yes --json --no-input
+
+# Update only the supplied fields on one step.
+gumroad workflows update-email <workflow-id> <email-id> --body ./email.html --dry-run --json --no-input
+gumroad workflows update-email <workflow-id> <email-id> --body ./email.html --json --no-input
 ```
 
-Workflows are read-only in the CLI; create and edit them in the Gumroad dashboard. `view` returns steps ordered by delay, each with `delay` (`amount` + `unit`), `sent_count`, `open_count`, `open_rate`, `click_count`, `click_rate`. Rates are `null` for unsent steps. Plain output for `view` prints one row per email step.
+`add-email` requires `--subject`, `--body`, and `--delay`. `update-email` requires at least one of these flags. `--body` accepts an HTML file path or `-` for stdin. `--delay` accepts a non-negative integer and `hour`, `day`, `week`, or `month`; singular and plural units work.
+
+Neither write command changes the workflow publication state. A new step inherits that state. A published workflow can schedule eligible past recipients when you add a step. A delay change can reschedule recipients. `add-email` and delay updates require `--yes` when you pass `--no-input`. Abandoned cart workflows reject added steps and delay changes. Use the dashboard to create, publish, or unpublish a workflow.
+
+If a write returns `workflow_email_add_state_unknown` or `workflow_email_update_state_unknown`, do not retry it automatically. Run `gumroad workflows view <workflow-id> --json --no-input` and inspect step IDs and timestamps. A matching step does not prove an uncertain add completed. Contact support if the state remains unclear. If the command returns `workflow_email_output_failed`, the write completed. Use `.error.recovery.email_id` to find the saved step. Do not retry it.
+
+`view` returns steps ordered by delay, each with `delay` (`amount` + `unit`), `sent_count`, `open_count`, `open_rate`, `click_count`, and `click_rate`. Rates are `null` for unsent steps. Plain output for `view` prints one row per email step.
 
 ### sales — Manage sales
 


### PR DESCRIPTION
Ref #196

## What

Add `gumroad workflows add-email` and `gumroad workflows update-email` for per-step workflow email writes. The commands support sparse updates, HTML files or stdin, structured output, plain output, and dry-run previews.

Published workflow writes require confirmation when they can schedule or reschedule recipients. Unknown write states return stable recovery data and warn against an automatic retry.

## Why

The CLI only supported read operations after the server write endpoints shipped. These commands provide a safe interface that matches the API contract and clig.dev guidance.

## Before / After

Before: users had to add or update each workflow email in the dashboard.

After: users and scripts can add or update one step through the CLI.

Video: **Gianfranco: add a terminal recording before review.**

## Test Results

`make test-cover` passes. The workflow package has 89.7% coverage.

`make lint` passes.

Autoreview reports no findings at 0.94 confidence.

---

This PR was implemented with AI assistance using GPT-5.6 Sol.