### PR TITLE
Append file embeds on products update --file

### DIFF
--- a/internal/cmd/products/rich_content.go
+++ b/internal/cmd/products/rich_content.go
@@ -1,9 +1,7 @@
 package products
 
 import (
-	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/richcontent"
-	"github.com/spf13/cobra"
 )
 
 const defaultFileRichContentTitle = richcontent.DefaultFileTitle
@@ -19,7 +17,6 @@ func buildFileRichContent(fileRefs []richContentFileRef) []map[string]any {
 }
 
 func buildProductUpdateRichContent(
-	cmd *cobra.Command,
 	existingRichContent []map[string]any,
 	existingFiles []existingProductFile,
 	fileRefs []richContentFileRef,
@@ -28,15 +25,11 @@ func buildProductUpdateRichContent(
 		return nil, false, nil
 	}
 
-	richContent, err := rollFileEmbeds(existingRichContent, existingFiles, fileRefs)
+	richContent, err := richcontent.AppendFileEmbeds(existingRichContent, preservedProductFileIDs(existingFiles), fileRefs)
 	if err != nil {
-		return nil, false, cmdutil.UsageErrorf(cmd, "%s; pass one --file per existing file embed, or use products content get/set for structural content changes", err.Error())
+		return nil, false, err
 	}
 	return richContent, true, nil
-}
-
-func rollFileEmbeds(richContent []map[string]any, preserved []existingProductFile, fileRefs []richContentFileRef) ([]map[string]any, error) {
-	return richcontent.RollFileEmbeds(richContent, preservedProductFileIDs(preserved), fileRefs)
 }
 
 func preservedProductFileIDs(files []existingProductFile) []string {

--- a/internal/cmd/products/update.go
+++ b/internal/cmd/products/update.go
@@ -229,7 +229,7 @@ func newUpdateCmd() *cobra.Command {
 					args[0], args[0])
 			}
 
-			richContent, includeRichContent, err := buildProductUpdateRichContent(c, existingState.RichContent, existingState.Files, fileRefs)
+			richContent, includeRichContent, err := buildProductUpdateRichContent(existingState.RichContent, existingState.Files, fileRefs)
 			if err != nil {
 				return err
 			}
@@ -283,7 +283,7 @@ func newUpdateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&category, "category", "", "New product category path (for example: design/ui-and-web/figma)")
 	cmd.Flags().StringVar(&taxonomyID, "taxonomy-id", "", "New numeric taxonomy/category ID")
 	cmd.Flags().StringArrayVar(&tags, "tag", nil, "Tag (repeatable, replaces all existing tags)")
-	cmd.Flags().StringArrayVar(&files, "file", nil, "Roll a local file into rich content file embeds (repeatable)")
+	cmd.Flags().StringArrayVar(&files, "file", nil, "Add a local file to product content without replacing existing embeds (repeatable)")
 	cmd.Flags().StringArrayVar(&fileNames, "file-name", nil, "Display name for the matching --file (repeatable)")
 	cmd.Flags().StringArrayVar(&fileDescriptions, "file-description", nil, "Description for the matching --file (repeatable)")
 	cmd.Flags().StringVar(&coverImage, "cover-image", "", "Local JPEG, PNG, or GIF cover image to upload")

--- a/internal/cmd/products/update_files_test.go
+++ b/internal/cmd/products/update_files_test.go
@@ -515,7 +515,7 @@ func TestUpdate_FileUploadUsesExternalIDForNewFiles(t *testing.T) {
 	}
 }
 
-func TestUpdate_FileRollsExistingRichContentEmbed(t *testing.T) {
+func TestUpdate_FileAppendsToExistingRichContentEmbed(t *testing.T) {
 	srv := newProductUpdateFileServers(t)
 	srv.existingFiles = []existingProductFile{
 		{ID: "file_old", Name: "Old Pack.zip"},
@@ -574,12 +574,15 @@ func TestUpdate_FileRollsExistingRichContentEmbed(t *testing.T) {
 	if got := richContent[0]["id"]; got != "page_1" {
 		t.Fatalf("rich_content page id = %#v, want page_1", got)
 	}
-	if got := firstRichContentFileEmbedID(t, richContent[0]); got != newFileID {
-		t.Fatalf("fileEmbed id = %q, want new file id %q", got, newFileID)
+	if got := firstRichContentFileEmbedID(t, richContent[0]); got != "file_old" {
+		t.Fatalf("first fileEmbed id = %q, want file_old", got)
+	}
+	if ids := fileEmbedIDs(richContent); !reflect.DeepEqual(ids, []string{"file_old", newFileID}) {
+		t.Fatalf("rich_content fileEmbed ids = %#v, want existing embed plus new upload", ids)
 	}
 }
 
-func TestUpdate_FileRollsBeforeTrailingParagraph(t *testing.T) {
+func TestUpdate_FileAppendsBeforeTrailingParagraph(t *testing.T) {
 	srv := newProductUpdateFileServers(t)
 	srv.existingFiles = []existingProductFile{
 		{ID: "file_old", Name: "Old Pack.zip"},
@@ -611,15 +614,15 @@ func TestUpdate_FileRollsBeforeTrailingParagraph(t *testing.T) {
 		t.Fatalf("files payload len = %d, want 2", len(files))
 	}
 	newFileID := productUpdateNewUploadExternalID(t, files[1], "files[1]")
-	if ids := richContentFileEmbedIDsFromBody(t, srv.putJSON); !reflect.DeepEqual(ids, []string{newFileID}) {
-		t.Fatalf("rich_content fileEmbed ids = %#v, want new upload only", ids)
+	if ids := richContentFileEmbedIDsFromBody(t, srv.putJSON); !reflect.DeepEqual(ids, []string{"file_old", newFileID}) {
+		t.Fatalf("rich_content fileEmbed ids = %#v, want existing embed plus new upload", ids)
 	}
-	if types := firstRichContentNodeTypesFromBody(t, srv.putJSON); !reflect.DeepEqual(types, []string{"fileEmbed", "paragraph"}) {
-		t.Fatalf("rich_content node types = %#v, want file embed then one trailing paragraph", types)
+	if types := firstRichContentNodeTypesFromBody(t, srv.putJSON); !reflect.DeepEqual(types, []string{"fileEmbed", "fileEmbed", "paragraph"}) {
+		t.Fatalf("rich_content node types = %#v, want existing embed, new embed, then trailing paragraph", types)
 	}
 }
 
-func TestUpdate_FileRollsOnPageWithExistingEmbed(t *testing.T) {
+func TestUpdate_FileAppendsOnPageWithExistingEmbed(t *testing.T) {
 	srv := newProductUpdateFileServers(t)
 	srv.existingFiles = []existingProductFile{
 		{ID: "file_old", Name: "Old Pack.zip"},
@@ -672,18 +675,18 @@ func TestUpdate_FileRollsOnPageWithExistingEmbed(t *testing.T) {
 	if ids := fileEmbedIDs([]map[string]any{richContent[0]}); len(ids) != 0 {
 		t.Fatalf("page 1 fileEmbed ids = %#v, want none", ids)
 	}
-	if ids := fileEmbedIDs([]map[string]any{richContent[1]}); !reflect.DeepEqual(ids, []string{newFileID}) {
-		t.Fatalf("page 2 fileEmbed ids = %#v, want new upload only", ids)
+	if ids := fileEmbedIDs([]map[string]any{richContent[1]}); !reflect.DeepEqual(ids, []string{"file_old", newFileID}) {
+		t.Fatalf("page 2 fileEmbed ids = %#v, want existing embed plus new upload", ids)
 	}
 	if types := richContentNodeTypes(t, richContent[0]); !reflect.DeepEqual(types, []string{"paragraph", "paragraph"}) {
 		t.Fatalf("page 1 node types = %#v, want unchanged paragraphs", types)
 	}
-	if types := richContentNodeTypes(t, richContent[1]); !reflect.DeepEqual(types, []string{"fileEmbed", "paragraph"}) {
-		t.Fatalf("page 2 node types = %#v, want file embed then one trailing paragraph", types)
+	if types := richContentNodeTypes(t, richContent[1]); !reflect.DeepEqual(types, []string{"fileEmbed", "fileEmbed", "paragraph"}) {
+		t.Fatalf("page 2 node types = %#v, want existing embed, new embed, then trailing paragraph", types)
 	}
 }
 
-func TestUpdate_FileRollsMultipleEmbedsInsideExistingFileEmbedGroup(t *testing.T) {
+func TestUpdate_FileAppendsInsideExistingFileEmbedGroup(t *testing.T) {
 	srv := newProductUpdateFileServers(t)
 	srv.existingFiles = []existingProductFile{
 		{ID: "file_a", Name: "Old A.zip"},
@@ -737,8 +740,8 @@ func TestUpdate_FileRollsMultipleEmbedsInsideExistingFileEmbedGroup(t *testing.T
 		t.Fatalf("first rich_content node = %#v, want fileEmbedGroup", content[0])
 	}
 	groupIDs := fileEmbedIDs([]map[string]any{{"description": group}})
-	if !reflect.DeepEqual(groupIDs, []string{firstNewFileID, secondNewFileID}) {
-		t.Fatalf("fileEmbedGroup ids = %#v, want new upload ids", groupIDs)
+	if !reflect.DeepEqual(groupIDs, []string{"file_a", "file_b", firstNewFileID, secondNewFileID}) {
+		t.Fatalf("fileEmbedGroup ids = %#v, want existing embeds plus new upload ids", groupIDs)
 	}
 }
 
@@ -779,16 +782,16 @@ func TestUpdate_FilePreservesAuthoredTrailingParagraph(t *testing.T) {
 		t.Fatalf("files payload len = %d, want 2", len(files))
 	}
 	newFileID := productUpdateNewUploadExternalID(t, files[1], "files[1]")
-	if ids := richContentFileEmbedIDsFromBody(t, srv.putJSON); !reflect.DeepEqual(ids, []string{newFileID}) {
-		t.Fatalf("rich_content fileEmbed ids = %#v, want new upload only", ids)
+	if ids := richContentFileEmbedIDsFromBody(t, srv.putJSON); !reflect.DeepEqual(ids, []string{"file_old", newFileID}) {
+		t.Fatalf("rich_content fileEmbed ids = %#v, want existing embed plus new upload", ids)
 	}
 
 	richContent := productUpdateJSONRichContent(t, srv.putJSON)
-	if types := richContentNodeTypes(t, richContent[0]); !reflect.DeepEqual(types, []string{"fileEmbed", "paragraph"}) {
-		t.Fatalf("rich_content node types = %#v, want file embed then authored paragraph", types)
+	if types := richContentNodeTypes(t, richContent[0]); !reflect.DeepEqual(types, []string{"fileEmbed", "fileEmbed", "paragraph"}) {
+		t.Fatalf("rich_content node types = %#v, want existing embed, new embed, then authored paragraph", types)
 	}
 	content := richContentPageContent(t, richContent[0])
-	paragraph := content[1].(map[string]any)
+	paragraph := content[2].(map[string]any)
 	textNodes, ok := paragraph["content"].([]any)
 	if !ok || len(textNodes) != 1 {
 		t.Fatalf("trailing paragraph content = %#v, want one text node", paragraph["content"])
@@ -799,7 +802,7 @@ func TestUpdate_FilePreservesAuthoredTrailingParagraph(t *testing.T) {
 	}
 }
 
-func TestUpdate_FileAmbiguousEmbeddedReplacementErrorsBeforeUpload(t *testing.T) {
+func TestUpdate_FileAppendsWhenEmbedCountDiffers(t *testing.T) {
 	srv := newProductUpdateFileServers(t)
 	srv.existingFiles = []existingProductFile{
 		{ID: "file_a", Name: "Old A.zip"},
@@ -824,18 +827,21 @@ func TestUpdate_FileAmbiguousEmbeddedReplacementErrorsBeforeUpload(t *testing.T)
 		"prod1",
 		"--file", path,
 	})
-	err := cmd.Execute()
-	if err == nil {
-		t.Fatal("expected ambiguous rich_content replacement error")
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if srv.s3Calls.Load() != 1 {
+		t.Fatalf("S3 calls = %d, want 1", srv.s3Calls.Load())
 	}
-	if !strings.Contains(err.Error(), "rich_content has 2 file embeds") || !strings.Contains(err.Error(), "pass one --file per existing file embed") {
-		t.Fatalf("expected rich_content count error, got %v", err)
+	if srv.putCalls.Load() != 1 {
+		t.Fatalf("PUT calls = %d, want 1", srv.putCalls.Load())
 	}
-	if srv.s3Calls.Load() != 0 {
-		t.Fatalf("unexpected S3 calls: %d", srv.s3Calls.Load())
+	files := productUpdateJSONFiles(t, srv.putJSON)
+	if len(files) != 3 {
+		t.Fatalf("files payload len = %d, want 3", len(files))
 	}
-	if srv.putCalls.Load() != 0 {
-		t.Fatalf("unexpected PUT calls: %d", srv.putCalls.Load())
+	newFileID := productUpdateNewUploadExternalID(t, files[2], "files[2]")
+	if ids := richContentFileEmbedIDsFromBody(t, srv.putJSON); !reflect.DeepEqual(ids, []string{"file_a", "file_b", newFileID}) {
+		t.Fatalf("rich_content fileEmbed ids = %#v, want existing embeds plus new upload", ids)
 	}
 }
 
@@ -927,8 +933,8 @@ func TestUpdate_FileDryRunPrefetchesButDoesNotUploadOrPut(t *testing.T) {
 	}
 	newFileID := productUpdateNewUploadExternalID(t, files[2], "files[2]")
 	richContent := productUpdateJSONRichContent(t, payload.Request.Body)
-	if ids := fileEmbedIDs(richContent); !reflect.DeepEqual(ids, []string{newFileID}) {
-		t.Fatalf("dry-run fileEmbed ids = %#v, want new upload only", ids)
+	if ids := fileEmbedIDs(richContent); !reflect.DeepEqual(ids, []string{"file_a", newFileID}) {
+		t.Fatalf("dry-run fileEmbed ids = %#v, want existing embed plus new upload", ids)
 	}
 }
 

--- a/internal/richcontent/files_test.go
+++ b/internal/richcontent/files_test.go
@@ -6,6 +6,31 @@ import (
 	"testing"
 )
 
+func TestAppendFileEmbedsKeepsExistingAndAddsNew(t *testing.T) {
+	richContent := []map[string]any{{
+		"id":    "page_1",
+		"title": "Existing page",
+		"description": map[string]any{
+			"type": "doc",
+			"content": []any{
+				map[string]any{"type": "fileEmbed", "attrs": map[string]any{"id": "file_old", "uid": "old-uid"}},
+				map[string]any{"type": "paragraph"},
+			},
+		},
+	}}
+
+	next, err := AppendFileEmbeds(richContent, []string{"file_old"}, []FileRef{{FileID: "file_new", EmbedUID: "new-uid"}})
+	if err != nil {
+		t.Fatalf("AppendFileEmbeds failed: %v", err)
+	}
+	if ids := FileEmbedIDs(next); !reflect.DeepEqual(ids, []string{"file_old", "file_new"}) {
+		t.Fatalf("file embed ids = %#v, want existing plus new", ids)
+	}
+	if next[0]["id"] != "page_1" {
+		t.Fatalf("page id = %#v, want page_1", next[0]["id"])
+	}
+}
+
 func TestRollFileEmbedsReplacesOnlyCountedEmbeds(t *testing.T) {
 	richContent := []map[string]any{{
 		"description": map[string]any{

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -388,7 +388,7 @@ In custom HTML, use Gumroad data attributes for live product values and checkout
 
 **Update flags:** `--name`, `--price`, `--currency`, `--description`, `--custom-summary`, `--custom-permalink`, `--custom-receipt`, `--max-purchase-count`, `--category`, `--taxonomy-id`, `--tag` (repeatable), `--custom-html`, `--file` (repeatable), `--file-name`, `--file-description`, `--cover-image`, `--preview-image` (repeatable), `--preview-video` (repeatable), `--thumbnail`. Prefer `products page preview/publish/clear/url` for custom HTML page workflows; `products update --custom-html` remains supported as a low-level product update flag.
 
-Use `products update --file` for shared product Content. It replaces existing rich content file embeds in place when they exist, or creates file embeds when the document has none; pass one `--file` per existing file embed and use `products content get/set` for structural content edits. For products with per-variant Content, use `variants update ... --file` for the specific variant you want to change.
+Use `products update --file` for shared product Content. It appends each new file embed to the existing page and leaves prior embeds intact. Use `products content get/set` for structural content edits. For products with per-variant Content, use `variants update ... --file` for the specific variant you want to change.
 
 Use `--cover-image` for the primary cover, repeat `--preview-image` for additional gallery/preview images, repeat `--preview-video` for video previews (MP4, MOV, M4V, MPEG, WMV, or WebM), and `--thumbnail` for the card/library thumbnail. When multiple media flags are combined, covers attach in a fixed order: cover image first, then preview images (in flag order), then preview videos (in flag order) — images and videos cannot be interleaved in a single command. These media flags run the required two-step API flow: direct upload first, then attach by signed blob ID. For an existing product, `products thumbnail set --url` asks Gumroad to download and attach a public HTTP(S) image directly.
 
@@ -665,7 +665,7 @@ gumroad variants delete <var_id> --product <id> --category <cat_id> --yes --json
 
 **All subcommands require** `--product` and `--category`.
 
-**Update flags:** `--name`, `--description`, `--price-difference`, `--max-purchase-count`, `--file` (repeatable), `--file-name`, `--file-description`. Use `variants update --file` only for products with per-variant Content; for shared Content, roll files at the product level with `products update --file`.
+**Update flags:** `--name`, `--description`, `--price-difference`, `--max-purchase-count`, `--file` (repeatable), `--file-name`, `--file-description`. Use `variants update --file` only for products with per-variant Content; for shared Content, add files at the product level with `products update --file`.
 
 ### custom-fields — Manage custom fields
 


### PR DESCRIPTION
# Append new `--file` embeds instead of replacing the page

Closes https://github.com/antiwork/gumroad-cli/issues/205

## What

`products update --file` appends each new file embed to the existing content page. Previously attached file embeds stay on the page.

## Why

`--file` kept every existing file on the product (`removed: []`) but rebuilt `rich_content` as a 1:1 embed roll. When the new-file count matched the existing embed count — the usual "add one more file" case — the previous embeds disappeared. The files stayed attached and undeliverable, and dry-run looked safe.

## Before / after

- Before: create with file A, then `update --file B` left page 1 embedding only B.
- After: the same command leaves page 1 embedding A, then B.

![dry-run before/after](https://i.ibb.co/SX0DJyc4/gcli205.gif)

Recorded against a local mock API. Main dry-run embeds only the new `cli-upload-…` id; this branch keeps `FILE_A` and appends the new id. `removed` stays `[]` on both sides.

## Checklist

- [x] Scope — product-level `products update --file` only. `variants update --file` still rolls in place.
- [x] Design — call `AppendFileEmbeds` instead of `RollFileEmbeds`. Rejected keeping the 1:1 roll: it contradicts file preservation and the `--file` add semantics on create.
- [x] Build — `f67e7c8807b117337f1ff760182108505d82ad12` on `fix/products-update-append-file-embeds`
- [x] QA — mock dry-run walkthrough above
- [ ] Shipped
- [x] Market — n/a, CLI behavior fix
- [x] Sell — n/a

## Test Results

Ran at `f67e7c8807b117337f1ff760182108505d82ad12`:

- `go test ./internal/cmd/products/ ./internal/richcontent/ -count=1` — ok
- `make test-cover` — all packages ok; products 86.0% (gate 85%)
- `go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run ./internal/cmd/products/ ./internal/richcontent/` — clean
- mutation: restore `RollFileEmbeds` in `buildProductUpdateRichContent` — `go test ./internal/cmd/products/` red; restored
- GitHub CI at `f67e7c8807b117337f1ff760182108505d82ad12`: Analyze, quality, and Cross-platform verification (macOS/Linux/Windows) all pass
- Premerge review: clean @ f67e7c8807b117337f1ff760182108505d82ad12

## QA steps

1. Point the CLI at a product whose Page 1 already embeds one file.
2. `gumroad products update <id> --file ./new.txt --dry-run --json --no-input --quiet`
3. Confirm `request.body.rich_content` still contains the original fileEmbed id and adds the new `cli-upload-…` embed.
4. Confirm `removed` stays `[]` and `files` still lists both ids.

No hosted preview app applies; this is a CLI request-body change.

---

AI disclosure: grok-4.6. Prompt/instructions: GitHub webhook for antiwork/gumroad-cli#205 (`products update --file` silently orphans existing file embeds). Follow autonomous-product-dev: claim, build the reported expected behavior (append embeds), open a draft PR.