### PR TITLE
fix: append file embeds on variants update --file

### DIFF
--- a/internal/cmd/variants/file_updates.go
+++ b/internal/cmd/variants/file_updates.go
@@ -158,9 +158,9 @@ func runVariantUpdateWithFiles(
 	if err != nil {
 		return err
 	}
-	richContent, err := richcontent.RollFileEmbeds(variantState.RichContent, nil, fileRefs)
+	richContent, err := richcontent.AppendFileEmbeds(variantState.RichContent, nil, fileRefs)
 	if err != nil {
-		return cmdutil.InvalidInputErrorf("%s; pass one --file per existing file embed, or use products content get/set for structural content changes", err.Error())
+		return err
 	}
 
 	productPath := cmdutil.JoinPath("products", productID)

--- a/internal/cmd/variants/update.go
+++ b/internal/cmd/variants/update.go
@@ -85,7 +85,7 @@ func newUpdateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&description, "description", "", "New description")
 	cmd.Flags().StringVar(&priceDifference, "price-difference", "", "New price difference (e.g. 5.00, -1.50)")
 	cmd.Flags().IntVar(&maxPurchaseCount, "max-purchase-count", 0, "New max purchase count")
-	cmd.Flags().StringArrayVar(&files, "file", nil, "Roll a local file into this variant's content file embeds (repeatable)")
+	cmd.Flags().StringArrayVar(&files, "file", nil, "Add a local file to this variant's content without replacing existing embeds (repeatable)")
 	cmd.Flags().StringArrayVar(&fileNames, "file-name", nil, "Display name for the matching --file (repeatable)")
 	cmd.Flags().StringArrayVar(&fileDescriptions, "file-description", nil, "Description for the matching --file (repeatable)")
 

--- a/internal/cmd/variants/variants_test.go
+++ b/internal/cmd/variants/variants_test.go
@@ -965,7 +965,7 @@ func TestUpdate_MaxPurchaseCountZero(t *testing.T) {
 	}
 }
 
-func TestUpdate_FileRollsVariantRichContent(t *testing.T) {
+func TestUpdate_FileAppendsToVariantRichContent(t *testing.T) {
 	srv := newVariantFileAttachServers(t)
 	testutil.Setup(t, srv.dispatch(t))
 
@@ -1009,8 +1009,59 @@ func TestUpdate_FileRollsVariantRichContent(t *testing.T) {
 	}
 
 	richContentPages := variantUpdateJSONRichContent(t, srv.variantJSON)
-	if ids := richcontent.FileEmbedIDs(richContentPages); !reflect.DeepEqual(ids, []string{newFileID}) {
-		t.Fatalf("variant rich_content fileEmbed ids = %#v, want new upload only", ids)
+	if richContentPages[0]["id"] != "page_1" {
+		t.Fatalf("rich_content page id = %#v, want page_1", richContentPages[0]["id"])
+	}
+	if ids := richcontent.FileEmbedIDs(richContentPages); !reflect.DeepEqual(ids, []string{"file_existing", newFileID}) {
+		t.Fatalf("variant rich_content fileEmbed ids = %#v, want existing embed plus new upload", ids)
+	}
+}
+
+func TestUpdate_FileAppendsWhenEmbedCountDiffers(t *testing.T) {
+	srv := newVariantFileAttachServers(t)
+	srv.variantRichContent = []map[string]any{{
+		"id":    "page_1",
+		"title": "Existing page",
+		"description": map[string]any{
+			"type": "doc",
+			"content": []any{
+				map[string]any{"type": "fileEmbed", "attrs": map[string]any{"id": "file_a", "uid": "uid-a"}},
+				map[string]any{"type": "fileEmbed", "attrs": map[string]any{"id": "file_b", "uid": "uid-b"}},
+				map[string]any{"type": "paragraph"},
+			},
+		},
+	}}
+	testutil.Setup(t, srv.dispatch(t))
+
+	path := writeVariantUploadFixture(t, "license bytes")
+	cmd := testutil.Command(newUpdateCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{
+		"v1",
+		"--product", "p1",
+		"--category", "vc1",
+		"--file", path,
+	})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if srv.s3Calls.Load() != 1 {
+		t.Fatalf("S3 calls = %d, want 1", srv.s3Calls.Load())
+	}
+	if srv.variantPutCalls.Load() != 1 {
+		t.Fatalf("variant PUT calls = %d, want 1", srv.variantPutCalls.Load())
+	}
+
+	files := variantUpdateJSONFiles(t, srv.productJSON)
+	if len(files) != 2 {
+		t.Fatalf("files payload len = %d, want 2", len(files))
+	}
+	newFileID, ok := files[1]["external_id"].(string)
+	if !ok || !strings.HasPrefix(newFileID, "cli-upload-") {
+		t.Fatalf("files[1].external_id = %#v, want generated id", files[1]["external_id"])
+	}
+
+	richContentPages := variantUpdateJSONRichContent(t, srv.variantJSON)
+	if ids := richcontent.FileEmbedIDs(richContentPages); !reflect.DeepEqual(ids, []string{"file_a", "file_b", newFileID}) {
+		t.Fatalf("variant rich_content fileEmbed ids = %#v, want existing embeds plus new upload", ids)
 	}
 }
 
@@ -1132,8 +1183,8 @@ func TestUpdate_FileDryRunJSONShowsProductAndVariantRequests(t *testing.T) {
 		t.Fatalf("variant description = %#v, want Updated variant", payload.VariantRequest.Body["description"])
 	}
 	richContentPages := variantUpdateJSONRichContent(t, payload.VariantRequest.Body)
-	if ids := richcontent.FileEmbedIDs(richContentPages); len(ids) != 1 || !strings.HasPrefix(ids[0], "cli-upload-") {
-		t.Fatalf("dry-run variant rich_content fileEmbed ids = %#v, want one generated upload id", ids)
+	if ids := richcontent.FileEmbedIDs(richContentPages); len(ids) != 2 || ids[0] != "file_existing" || !strings.HasPrefix(ids[1], "cli-upload-") {
+		t.Fatalf("dry-run variant rich_content fileEmbed ids = %#v, want existing embed plus one generated upload id", ids)
 	}
 	if srv.s3Calls.Load() != 0 {
 		t.Fatalf("S3 calls = %d, want 0", srv.s3Calls.Load())

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -665,7 +665,7 @@ gumroad variants delete <var_id> --product <id> --category <cat_id> --yes --json
 
 **All subcommands require** `--product` and `--category`.
 
-**Update flags:** `--name`, `--description`, `--price-difference`, `--max-purchase-count`, `--file` (repeatable), `--file-name`, `--file-description`. Use `variants update --file` only for products with per-variant Content; for shared Content, add files at the product level with `products update --file`.
+**Update flags:** `--name`, `--description`, `--price-difference`, `--max-purchase-count`, `--file` (repeatable), `--file-name`, `--file-description`. Use `variants update --file` only for products with per-variant Content. It appends each new file embed to the variant's existing page and leaves prior embeds intact. For shared Content, add files at the product level with `products update --file`.
 
 ### custom-fields — Manage custom fields
 


### PR DESCRIPTION
## What

`variants update --file` now appends new file embeds to the variant's rich content instead of rolling the existing embeds in place. This mirrors the `products update --file` fix from #206 and uses the same `richcontent.AppendFileEmbeds` helper.

- The variant file-attach path calls `richcontent.AppendFileEmbeds` instead of `richcontent.RollFileEmbeds`. Existing embeds stay intact, and new files append to the page that already holds embeds.
- The `--file` help text and the variants section of `skills/gumroad/SKILL.md` now describe append semantics.
- The count-mismatch error path is gone. `AppendFileEmbeds` cannot return it, so adding one file to a variant with two embeds now works instead of failing.

## Why

The variant path had the exact bug #205 reported for products. When the `--file` count matched the embed count, the command replaced the embed ids in place. The previous files stayed attached to the product but lost their embed, which made them undeliverable to buyers — with exit 0 and no warning. PR #206 fixed the product path only; this PR gives the variant path the same semantics, so both commands behave the same way.

Root cause: the roll helper was written for a "replace this file with a new version" flow, but `--file` reads as "add this file". The append helper matches the intent, and #206 already established it as the correct default.

## Before/After

**Before** — a variant page embeds `FILE_A`; `variants update --file fileB` leaves the variant embedding **`FILE_B` only**, while `FILE_A` stays attached with no embed. With two existing embeds and one `--file`, the command errors with `rich_content has 2 file embeds; got 1 replacement files`.

**After** — the same command yields embeds `[FILE_A, FILE_B]`, and the two-embed case appends instead of erroring.

## Test Results

Rewritten tests fail under the old roll behavior (verified by temporarily restoring the `RollFileEmbeds` call):

- `TestUpdate_FileAppendsToVariantRichContent` — asserts the existing embed survives and the new one appends.
- `TestUpdate_FileAppendsWhenEmbedCountDiffers` — two embeds, one `--file`; errored before, appends now.
- `TestUpdate_FileDryRunJSONShowsProductAndVariantRequests` — dry-run body shows both the preserved and the generated embed.

```
$ make test-cover
OK: github.com/antiwork/gumroad-cli/internal/cmd/variants 87.0%
(all packages pass their coverage gates)

$ make lint
golangci-lint run (clean)
```

---

**AI disclosure:** Written by Claude Fable 5 (Claude Code). Prompts: (1) switch `variants update --file` from `richcontent.RollFileEmbeds` to `richcontent.AppendFileEmbeds`, mirroring #206, update the `--file` help text and the variants section of `skills/gumroad/SKILL.md`, and rewrite the tests so they fail if the roll behavior returns; (2) run an autoreview with Claude Fable 5 at high effort and publish a draft PR once clean. The autoreview confirmed the patch and flagged only the stale branch base, which the rebase onto `origin/main` resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
