### PR TITLE
Document Windows binary install in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,23 @@ CLI for the [Gumroad API](https://app.gumroad.com/api). Designed for humans and 
 brew install antiwork/cli/gumroad
 ```
 
+On Windows, download [`gumroad-cli_windows_amd64.zip`](https://github.com/antiwork/gumroad-cli/releases/latest/download/gumroad-cli_windows_amd64.zip) or [`gumroad-cli_windows_arm64.zip`](https://github.com/antiwork/gumroad-cli/releases/latest/download/gumroad-cli_windows_arm64.zip), unzip it, and put `gumroad.exe` on your PATH. In PowerShell:
+
+```powershell
+Invoke-WebRequest https://github.com/antiwork/gumroad-cli/releases/latest/download/gumroad-cli_windows_amd64.zip -OutFile gumroad-cli.zip
+Expand-Archive .\gumroad-cli.zip -DestinationPath "$env:LOCALAPPDATA\gumroad"
+$env:Path = "$env:LOCALAPPDATA\gumroad;$env:Path"
+[Environment]::SetEnvironmentVariable("Path", "$env:LOCALAPPDATA\gumroad;" + [Environment]::GetEnvironmentVariable("Path", "User"), "User")
+gumroad auth login
+```
+
+Use Windows Terminal or PowerShell. Quote paths that contain spaces (`& "$env:LOCALAPPDATA\gumroad\gumroad.exe"`). If SmartScreen blocks `gumroad.exe`, choose More info → Run anyway. Homebrew and the curl installer do not apply to stock PowerShell.
+
 <details>
 <summary>Other installation methods</summary>
 
 ```sh
-# Shell script
+# Shell script (macOS, Linux, and Windows Git Bash / MSYS2)
 curl -fsSL https://gumroad.com/install-cli.sh | bash
 
 # Go


### PR DESCRIPTION
Document Windows binary install in the README.

Closes #209.

## What

Adds a first-class Windows install path to `README.md`: direct links to the published `gumroad-cli_windows_amd64.zip` / `gumroad-cli_windows_arm64.zip` assets, PowerShell commands that download, unzip, and put `gumroad.exe` on the user PATH, plus notes for Windows Terminal, quoting paths with spaces, and SmartScreen. Also labels the existing curl installer as Git Bash / MSYS2-capable so it is not mistaken for a stock PowerShell path.

## Why

Windows binaries already ship on every release. The Install section only documented Homebrew, curl-to-bash, `go install`, and `make install`, so a Windows creator had to hunt release assets and guess at setup. The ask is a straight "download this binary and run it" section, not WSL or a Go toolchain.

## Before / after

- Before: Install section never mentioned Windows. Verified against `origin/main` and against live release `v0.20260814.0`, which publishes both Windows zips with `gumroad.exe` at the archive root.
- After: Windows download links and a copy-pasteable PowerShell block sit next to the Homebrew one-liner.

![demo](https://i.ibb.co/M5shnGW6/gcli209-demo.gif)

Demo shows: main README Install section with no Windows mention; new README Windows download + PowerShell PATH block; live `latest/download` URLs 302 to `v0.20260814.0` zips; both zips list `gumroad.exe`.

## Checklist

- [x] Scope — README install docs only. No binary, installer, or signing change.
- [x] Design — document the already-published zip; do not send Windows users through WSL or `go install`.
- [x] Build — `8120e3e75c7360d3b06f560cc695e2bf21c247e3` on `docs/windows-install-readme`
- [x] QA — download URLs return 200 after redirect; both zips contain `gumroad.exe`; demo recording of before/after + probes
- [ ] Shipped — not merged
- [x] Market — n/a, docs for an existing artifact
- [x] Sell — n/a

## Test Results

Docs-only diff (`README.md` +13/−1). No Go tests added or required.

Probed this session:

- `GET .../latest/download/gumroad-cli_windows_amd64.zip` → 302 → 302 → 200 `application/octet-stream` 5,597,345 bytes; `unzip -l` shows `gumroad.exe` (13,888,000 bytes) among 189 files
- `GET .../latest/download/gumroad-cli_windows_arm64.zip` → 302 → 302 → 200 `application/octet-stream` 5,002,398 bytes; `unzip -l` shows `gumroad.exe` (12,613,632 bytes) among 189 files
- `git show HEAD:README.md` contains both zip links and `gumroad.exe`

![tests](https://i.ibb.co/8DkM4HhW/gcli209-tests.png)

## QA steps

1. Open the README Install section on this branch.
2. Confirm both Windows zip links are present and resolve (302 to the current release, then 200).
3. Confirm the PowerShell block writes `gumroad.exe` onto `%LOCALAPPDATA%\gumroad` and prepends that folder to the user PATH.
4. Confirm Homebrew / curl / `go install` / `make install` remain documented, with curl labeled for Git Bash / MSYS2.

Premerge review: exempt (docs-only README change)

---

AI disclosure: Grok 4.6. Prompt/instructions: handle GitHub issues event for antiwork/gumroad-cli#209 (add Windows install guidance to the README for already-published Windows binaries).
