### PR TITLE
Resolve variant file embeds to created product file ids

### DIFF
--- a/internal/cmd/variants/file_id_replacements_test.go
+++ b/internal/cmd/variants/file_id_replacements_test.go
@@ -38,3 +38,14 @@ func TestFileIDReplacementsRequiresMatchingCount(t *testing.T) {
 		t.Fatalf("replacements = %#v", got)
 	}
 }
+
+func TestCompleteFileIDMappingsRequiresEveryRef(t *testing.T) {
+	refs := []richcontent.FileRef{{FileID: "cli-upload-1"}, {FileID: "cli-upload-2"}}
+	if got := completeFileIDMappings(refs, map[string]string{"cli-upload-1": "file_a"}); got != nil {
+		t.Fatalf("partial mappings = %#v, want nil", got)
+	}
+	got := completeFileIDMappings(refs, map[string]string{"cli-upload-1": "file_a", "cli-upload-2": "file_b", "extra": "ignored"})
+	if got["cli-upload-1"] != "file_a" || got["cli-upload-2"] != "file_b" {
+		t.Fatalf("complete mappings = %#v", got)
+	}
+}

--- a/internal/cmd/variants/file_id_replacements_test.go
+++ b/internal/cmd/variants/file_id_replacements_test.go
@@ -7,44 +7,21 @@ import (
 	"github.com/antiwork/gumroad-cli/internal/richcontent"
 )
 
-func TestNewFileIDsSinceKeepsAfterOrder(t *testing.T) {
-	before := []variantExistingProductFile{{ID: "file_existing"}}
-	after := []variantExistingProductFile{
-		{ID: "file_existing"},
-		{ID: "file_new_a"},
-		{ID: "file_new_b"},
-	}
-	got := newFileIDsSince(before, after)
-	if len(got) != 2 || got[0] != "file_new_a" || got[1] != "file_new_b" {
-		t.Fatalf("newFileIDsSince = %#v, want [file_new_a file_new_b]", got)
-	}
-}
-
-func TestFileIDReplacementsRequiresMatchingCount(t *testing.T) {
+func TestCompleteFileIDMappingsRequiresEveryRef(t *testing.T) {
 	refs := []richcontent.FileRef{{FileID: "cli-upload-1"}, {FileID: "cli-upload-2"}}
-	_, err := fileIDReplacements(refs, []string{"file_only"})
+
+	_, err := completeFileIDMappings(refs, map[string]string{"cli-upload-1": "file_a"})
 	if err == nil {
-		t.Fatal("expected count mismatch")
+		t.Fatal("expected missing mapping error")
 	}
-	if !strings.Contains(err.Error(), "expected 2 new product file id") {
+	if !strings.Contains(err.Error(), "cli-upload-2") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	got, err := fileIDReplacements(refs, []string{"file_a", "file_b"})
+	got, err := completeFileIDMappings(refs, map[string]string{"cli-upload-1": "file_a", "cli-upload-2": "file_b", "extra": "ignored"})
 	if err != nil {
-		t.Fatalf("fileIDReplacements failed: %v", err)
+		t.Fatalf("completeFileIDMappings failed: %v", err)
 	}
-	if got["cli-upload-1"] != "file_a" || got["cli-upload-2"] != "file_b" {
-		t.Fatalf("replacements = %#v", got)
-	}
-}
-
-func TestCompleteFileIDMappingsRequiresEveryRef(t *testing.T) {
-	refs := []richcontent.FileRef{{FileID: "cli-upload-1"}, {FileID: "cli-upload-2"}}
-	if got := completeFileIDMappings(refs, map[string]string{"cli-upload-1": "file_a"}); got != nil {
-		t.Fatalf("partial mappings = %#v, want nil", got)
-	}
-	got := completeFileIDMappings(refs, map[string]string{"cli-upload-1": "file_a", "cli-upload-2": "file_b", "extra": "ignored"})
 	if got["cli-upload-1"] != "file_a" || got["cli-upload-2"] != "file_b" {
 		t.Fatalf("complete mappings = %#v", got)
 	}

--- a/internal/cmd/variants/file_id_replacements_test.go
+++ b/internal/cmd/variants/file_id_replacements_test.go
@@ -1,0 +1,40 @@
+package variants
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/richcontent"
+)
+
+func TestNewFileIDsSinceKeepsAfterOrder(t *testing.T) {
+	before := []variantExistingProductFile{{ID: "file_existing"}}
+	after := []variantExistingProductFile{
+		{ID: "file_existing"},
+		{ID: "file_new_a"},
+		{ID: "file_new_b"},
+	}
+	got := newFileIDsSince(before, after)
+	if len(got) != 2 || got[0] != "file_new_a" || got[1] != "file_new_b" {
+		t.Fatalf("newFileIDsSince = %#v, want [file_new_a file_new_b]", got)
+	}
+}
+
+func TestFileIDReplacementsRequiresMatchingCount(t *testing.T) {
+	refs := []richcontent.FileRef{{FileID: "cli-upload-1"}, {FileID: "cli-upload-2"}}
+	_, err := fileIDReplacements(refs, []string{"file_only"})
+	if err == nil {
+		t.Fatal("expected count mismatch")
+	}
+	if !strings.Contains(err.Error(), "expected 2 new product file id") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err := fileIDReplacements(refs, []string{"file_a", "file_b"})
+	if err != nil {
+		t.Fatalf("fileIDReplacements failed: %v", err)
+	}
+	if got["cli-upload-1"] != "file_a" || got["cli-upload-2"] != "file_b" {
+		t.Fatalf("replacements = %#v", got)
+	}
+}

--- a/internal/cmd/variants/file_updates.go
+++ b/internal/cmd/variants/file_updates.go
@@ -179,15 +179,12 @@ func runVariantUpdateWithFiles(
 	}
 	productBody["files"] = buildVariantProductFilesPayload(productState.Files, plannedUploads, uploadedURLs, fileRefs)
 
-	if _, err := client.PutJSON(productPath, productBody); err != nil {
-		return wrapVariantPartialUploadError(err, uploadedURLs)
-	}
-
-	createdIDs, err := createdProductFileIDs(client, productID, productState.Files)
+	productData, err := client.PutJSON(productPath, productBody)
 	if err != nil {
 		return wrapVariantPartialUploadError(err, uploadedURLs)
 	}
-	replacements, err := fileIDReplacements(fileRefs, createdIDs)
+
+	replacements, err := resolveCreatedFileIDs(client, productID, productData, productState.Files, fileRefs)
 	if err != nil {
 		return wrapVariantPartialUploadError(err, uploadedURLs)
 	}
@@ -238,6 +235,46 @@ func createdProductFileIDs(client *api.Client, productID string, before []varian
 		return nil, err
 	}
 	return newFileIDsSince(before, after.Files), nil
+}
+
+type productFileIDMappingsResponse struct {
+	FileIDMappings map[string]string `json:"file_id_mappings"`
+}
+
+func resolveCreatedFileIDs(
+	client *api.Client,
+	productID string,
+	productPutData json.RawMessage,
+	before []variantExistingProductFile,
+	fileRefs []richcontent.FileRef,
+) (map[string]string, error) {
+	resp, err := cmdutil.DecodeJSON[productFileIDMappingsResponse](productPutData)
+	if err != nil {
+		return nil, err
+	}
+	if mappings := completeFileIDMappings(fileRefs, resp.FileIDMappings); mappings != nil {
+		return mappings, nil
+	}
+	createdIDs, err := createdProductFileIDs(client, productID, before)
+	if err != nil {
+		return nil, err
+	}
+	return fileIDReplacements(fileRefs, createdIDs)
+}
+
+func completeFileIDMappings(refs []richcontent.FileRef, mappings map[string]string) map[string]string {
+	if len(refs) == 0 || len(mappings) == 0 {
+		return nil
+	}
+	complete := make(map[string]string, len(refs))
+	for _, ref := range refs {
+		mapped := mappings[ref.FileID]
+		if mapped == "" {
+			return nil
+		}
+		complete[ref.FileID] = mapped
+	}
+	return complete
 }
 
 func newFileIDsSince(before, after []variantExistingProductFile) []string {

--- a/internal/cmd/variants/file_updates.go
+++ b/internal/cmd/variants/file_updates.go
@@ -182,6 +182,21 @@ func runVariantUpdateWithFiles(
 	if _, err := client.PutJSON(productPath, productBody); err != nil {
 		return wrapVariantPartialUploadError(err, uploadedURLs)
 	}
+
+	createdIDs, err := createdProductFileIDs(client, productID, productState.Files)
+	if err != nil {
+		return wrapVariantPartialUploadError(err, uploadedURLs)
+	}
+	replacements, err := fileIDReplacements(fileRefs, createdIDs)
+	if err != nil {
+		return wrapVariantPartialUploadError(err, uploadedURLs)
+	}
+	richContent, err = richcontent.ReplaceFileEmbedIDs(richContent, replacements)
+	if err != nil {
+		return wrapVariantPartialUploadError(err, uploadedURLs)
+	}
+	variantBody = buildVariantUpdateJSONBody(params, richContent)
+
 	data, err := client.PutJSON(variantPath, variantBody)
 	if err != nil {
 		return wrapVariantPartialUploadError(err, uploadedURLs)
@@ -215,6 +230,47 @@ func fetchVariantProductFileState(client *api.Client, productID string) (variant
 		return variantProductFileState{}, err
 	}
 	return resp.Product, nil
+}
+
+func createdProductFileIDs(client *api.Client, productID string, before []variantExistingProductFile) ([]string, error) {
+	after, err := fetchVariantProductFileState(client, productID)
+	if err != nil {
+		return nil, err
+	}
+	return newFileIDsSince(before, after.Files), nil
+}
+
+func newFileIDsSince(before, after []variantExistingProductFile) []string {
+	seen := make(map[string]struct{}, len(before))
+	for _, file := range before {
+		if file.ID == "" {
+			continue
+		}
+		seen[file.ID] = struct{}{}
+	}
+	var created []string
+	for _, file := range after {
+		if file.ID == "" {
+			continue
+		}
+		if _, ok := seen[file.ID]; ok {
+			continue
+		}
+		created = append(created, file.ID)
+		seen[file.ID] = struct{}{}
+	}
+	return created
+}
+
+func fileIDReplacements(refs []richcontent.FileRef, created []string) (map[string]string, error) {
+	if len(created) != len(refs) {
+		return nil, fmt.Errorf("expected %d new product file id(s) after upload, got %d; not writing unresolved upload placeholders into variant content", len(refs), len(created))
+	}
+	replacements := make(map[string]string, len(refs))
+	for i, ref := range refs {
+		replacements[ref.FileID] = created[i]
+	}
+	return replacements, nil
 }
 
 func fetchVariantRichContentState(client *api.Client, variantPath string) (variantRichContentState, error) {

--- a/internal/cmd/variants/file_updates.go
+++ b/internal/cmd/variants/file_updates.go
@@ -184,7 +184,7 @@ func runVariantUpdateWithFiles(
 		return wrapVariantPartialUploadError(err, uploadedURLs)
 	}
 
-	replacements, err := resolveCreatedFileIDs(client, productID, productData, productState.Files, fileRefs)
+	replacements, err := resolveCreatedFileIDs(productData, fileRefs)
 	if err != nil {
 		return wrapVariantPartialUploadError(err, uploadedURLs)
 	}
@@ -229,85 +229,31 @@ func fetchVariantProductFileState(client *api.Client, productID string) (variant
 	return resp.Product, nil
 }
 
-func createdProductFileIDs(client *api.Client, productID string, before []variantExistingProductFile) ([]string, error) {
-	after, err := fetchVariantProductFileState(client, productID)
-	if err != nil {
-		return nil, err
-	}
-	return newFileIDsSince(before, after.Files), nil
-}
-
 type productFileIDMappingsResponse struct {
 	FileIDMappings map[string]string `json:"file_id_mappings"`
 }
 
 func resolveCreatedFileIDs(
-	client *api.Client,
-	productID string,
 	productPutData json.RawMessage,
-	before []variantExistingProductFile,
 	fileRefs []richcontent.FileRef,
 ) (map[string]string, error) {
 	resp, err := cmdutil.DecodeJSON[productFileIDMappingsResponse](productPutData)
 	if err != nil {
 		return nil, err
 	}
-	if mappings := completeFileIDMappings(fileRefs, resp.FileIDMappings); mappings != nil {
-		return mappings, nil
-	}
-	createdIDs, err := createdProductFileIDs(client, productID, before)
-	if err != nil {
-		return nil, err
-	}
-	return fileIDReplacements(fileRefs, createdIDs)
+	return completeFileIDMappings(fileRefs, resp.FileIDMappings)
 }
 
-func completeFileIDMappings(refs []richcontent.FileRef, mappings map[string]string) map[string]string {
-	if len(refs) == 0 || len(mappings) == 0 {
-		return nil
-	}
+func completeFileIDMappings(refs []richcontent.FileRef, mappings map[string]string) (map[string]string, error) {
 	complete := make(map[string]string, len(refs))
 	for _, ref := range refs {
 		mapped := mappings[ref.FileID]
 		if mapped == "" {
-			return nil
+			return nil, fmt.Errorf("product update response did not map uploaded file %s to a created product file id; not writing unresolved upload placeholders into variant content", ref.FileID)
 		}
 		complete[ref.FileID] = mapped
 	}
-	return complete
-}
-
-func newFileIDsSince(before, after []variantExistingProductFile) []string {
-	seen := make(map[string]struct{}, len(before))
-	for _, file := range before {
-		if file.ID == "" {
-			continue
-		}
-		seen[file.ID] = struct{}{}
-	}
-	var created []string
-	for _, file := range after {
-		if file.ID == "" {
-			continue
-		}
-		if _, ok := seen[file.ID]; ok {
-			continue
-		}
-		created = append(created, file.ID)
-		seen[file.ID] = struct{}{}
-	}
-	return created
-}
-
-func fileIDReplacements(refs []richcontent.FileRef, created []string) (map[string]string, error) {
-	if len(created) != len(refs) {
-		return nil, fmt.Errorf("expected %d new product file id(s) after upload, got %d; not writing unresolved upload placeholders into variant content", len(refs), len(created))
-	}
-	replacements := make(map[string]string, len(refs))
-	for i, ref := range refs {
-		replacements[ref.FileID] = created[i]
-	}
-	return replacements, nil
+	return complete, nil
 }
 
 func fetchVariantRichContentState(client *api.Client, variantPath string) (variantRichContentState, error) {

--- a/internal/cmd/variants/variants_test.go
+++ b/internal/cmd/variants/variants_test.go
@@ -45,12 +45,11 @@ func variantHandler(t *testing.T) http.HandlerFunc {
 type variantFileAttachServers struct {
 	s3 *httptest.Server
 
-	sharedContent        bool
-	omitCreatedFiles     bool
-	returnFileIDMappings bool
-	productJSON          map[string]any
-	variantJSON          map[string]any
-	variantRichContent   []map[string]any
+	sharedContent      bool
+	omitFileIDMappings bool
+	productJSON        map[string]any
+	variantJSON        map[string]any
+	variantRichContent []map[string]any
 
 	productGetCalls atomic.Int32
 	productPutCalls atomic.Int32
@@ -105,21 +104,12 @@ func (s *variantFileAttachServers) dispatch(t *testing.T) http.HandlerFunc {
 			switch r.Method {
 			case http.MethodGet:
 				s.productGetCalls.Add(1)
-				files := []map[string]any{
-					{"id": "file_existing", "name": "Existing.pdf"},
-				}
-				if s.productPutCalls.Load() > 0 && !s.omitCreatedFiles {
-					for i := 1; i <= int(s.completeSeq.Load()); i++ {
-						files = append(files, map[string]any{
-							"id":   fmt.Sprintf("file_uploaded_%d", i),
-							"name": "License.pdf",
-						})
-					}
-				}
 				testutil.JSON(t, w, map[string]any{
 					"product": map[string]any{
-						"id":                                     "p1",
-						"files":                                  files,
+						"id": "p1",
+						"files": []map[string]any{
+							{"id": "file_existing", "name": "Existing.pdf"},
+						},
 						"has_same_rich_content_for_all_variants": s.sharedContent,
 					},
 				})
@@ -129,7 +119,7 @@ func (s *variantFileAttachServers) dispatch(t *testing.T) http.HandlerFunc {
 					t.Fatalf("decode product JSON body: %v", err)
 				}
 				resp := map[string]any{"product": map[string]any{"id": "p1"}}
-				if s.returnFileIDMappings {
+				if !s.omitFileIDMappings {
 					mappings := map[string]string{}
 					if files, ok := s.productJSON["files"].([]any); ok {
 						n := 0
@@ -141,7 +131,7 @@ func (s *variantFileAttachServers) dispatch(t *testing.T) http.HandlerFunc {
 							externalID, _ := file["external_id"].(string)
 							if strings.HasPrefix(externalID, "cli-upload-") {
 								n++
-								mappings[externalID] = fmt.Sprintf("file_mapped_%d", n)
+								mappings[externalID] = fmt.Sprintf("file_uploaded_%d", n)
 							}
 						}
 					}
@@ -1049,8 +1039,8 @@ func TestUpdate_FileAppendsToVariantRichContent(t *testing.T) {
 	if strings.HasPrefix(ids[len(ids)-1], "cli-upload-") {
 		t.Fatalf("variant embed still used upload placeholder %q", ids[len(ids)-1])
 	}
-	if srv.productGetCalls.Load() != 2 {
-		t.Fatalf("product GET calls = %d, want 2", srv.productGetCalls.Load())
+	if srv.productGetCalls.Load() != 1 {
+		t.Fatalf("product GET calls = %d, want 1 (no recount after PUT)", srv.productGetCalls.Load())
 	}
 }
 
@@ -1136,10 +1126,8 @@ func TestUpdate_FileCreatesVariantRichContentWhenEmpty(t *testing.T) {
 	}
 }
 
-func TestUpdate_FilePrefersProductPutMappings(t *testing.T) {
+func TestUpdate_FileUsesProductPutMappings(t *testing.T) {
 	srv := newVariantFileAttachServers(t)
-	srv.returnFileIDMappings = true
-	srv.omitCreatedFiles = true
 	testutil.Setup(t, srv.dispatch(t))
 
 	path := writeVariantUploadFixture(t, "license bytes")
@@ -1157,14 +1145,14 @@ func TestUpdate_FilePrefersProductPutMappings(t *testing.T) {
 		t.Fatalf("product GET calls = %d, want 1 (no recount after PUT)", srv.productGetCalls.Load())
 	}
 	richContentPages := variantUpdateJSONRichContent(t, srv.variantJSON)
-	if ids := richcontent.FileEmbedIDs(richContentPages); !reflect.DeepEqual(ids, []string{"file_existing", "file_mapped_1"}) {
+	if ids := richcontent.FileEmbedIDs(richContentPages); !reflect.DeepEqual(ids, []string{"file_existing", "file_uploaded_1"}) {
 		t.Fatalf("variant rich_content fileEmbed ids = %#v, want mapping from product PUT", ids)
 	}
 }
 
-func TestUpdate_FileRefusesVariantPutWhenCreatedFileIDsMissing(t *testing.T) {
+func TestUpdate_FileRefusesVariantPutWhenMappingsMissing(t *testing.T) {
 	srv := newVariantFileAttachServers(t)
-	srv.omitCreatedFiles = true
+	srv.omitFileIDMappings = true
 	testutil.Setup(t, srv.dispatch(t))
 
 	path := writeVariantUploadFixture(t, "license bytes")
@@ -1177,9 +1165,9 @@ func TestUpdate_FileRefusesVariantPutWhenCreatedFileIDsMissing(t *testing.T) {
 	})
 	err := cmd.Execute()
 	if err == nil {
-		t.Fatal("expected missing created file id error")
+		t.Fatal("expected missing file id mapping error")
 	}
-	if !strings.Contains(err.Error(), "expected 1 new product file id") {
+	if !strings.Contains(err.Error(), "did not map uploaded file") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if srv.productPutCalls.Load() != 1 {

--- a/internal/cmd/variants/variants_test.go
+++ b/internal/cmd/variants/variants_test.go
@@ -46,6 +46,7 @@ type variantFileAttachServers struct {
 	s3 *httptest.Server
 
 	sharedContent      bool
+	omitCreatedFiles   bool
 	productJSON        map[string]any
 	variantJSON        map[string]any
 	variantRichContent []map[string]any
@@ -103,12 +104,21 @@ func (s *variantFileAttachServers) dispatch(t *testing.T) http.HandlerFunc {
 			switch r.Method {
 			case http.MethodGet:
 				s.productGetCalls.Add(1)
+				files := []map[string]any{
+					{"id": "file_existing", "name": "Existing.pdf"},
+				}
+				if s.productPutCalls.Load() > 0 && !s.omitCreatedFiles {
+					for i := 1; i <= int(s.completeSeq.Load()); i++ {
+						files = append(files, map[string]any{
+							"id":   fmt.Sprintf("file_uploaded_%d", i),
+							"name": "License.pdf",
+						})
+					}
+				}
 				testutil.JSON(t, w, map[string]any{
 					"product": map[string]any{
-						"id": "p1",
-						"files": []map[string]any{
-							{"id": "file_existing", "name": "Existing.pdf"},
-						},
+						"id":                                     "p1",
+						"files":                                  files,
 						"has_same_rich_content_for_all_variants": s.sharedContent,
 					},
 				})
@@ -1012,8 +1022,15 @@ func TestUpdate_FileAppendsToVariantRichContent(t *testing.T) {
 	if richContentPages[0]["id"] != "page_1" {
 		t.Fatalf("rich_content page id = %#v, want page_1", richContentPages[0]["id"])
 	}
-	if ids := richcontent.FileEmbedIDs(richContentPages); !reflect.DeepEqual(ids, []string{"file_existing", newFileID}) {
-		t.Fatalf("variant rich_content fileEmbed ids = %#v, want existing embed plus new upload", ids)
+	ids := richcontent.FileEmbedIDs(richContentPages)
+	if !reflect.DeepEqual(ids, []string{"file_existing", "file_uploaded_1"}) {
+		t.Fatalf("variant rich_content fileEmbed ids = %#v, want existing embed plus created file id", ids)
+	}
+	if strings.HasPrefix(ids[len(ids)-1], "cli-upload-") {
+		t.Fatalf("variant embed still used upload placeholder %q", ids[len(ids)-1])
+	}
+	if srv.productGetCalls.Load() != 2 {
+		t.Fatalf("product GET calls = %d, want 2", srv.productGetCalls.Load())
 	}
 }
 
@@ -1060,8 +1077,8 @@ func TestUpdate_FileAppendsWhenEmbedCountDiffers(t *testing.T) {
 	}
 
 	richContentPages := variantUpdateJSONRichContent(t, srv.variantJSON)
-	if ids := richcontent.FileEmbedIDs(richContentPages); !reflect.DeepEqual(ids, []string{"file_a", "file_b", newFileID}) {
-		t.Fatalf("variant rich_content fileEmbed ids = %#v, want existing embeds plus new upload", ids)
+	if ids := richcontent.FileEmbedIDs(richContentPages); !reflect.DeepEqual(ids, []string{"file_a", "file_b", "file_uploaded_1"}) {
+		t.Fatalf("variant rich_content fileEmbed ids = %#v, want existing embeds plus created file id", ids)
 	}
 }
 
@@ -1094,8 +1111,59 @@ func TestUpdate_FileCreatesVariantRichContentWhenEmpty(t *testing.T) {
 	}
 
 	richContentPages := variantUpdateJSONRichContent(t, srv.variantJSON)
-	if ids := richcontent.FileEmbedIDs(richContentPages); !reflect.DeepEqual(ids, []string{newFileID}) {
-		t.Fatalf("variant rich_content fileEmbed ids = %#v, want new upload only", ids)
+	if ids := richcontent.FileEmbedIDs(richContentPages); !reflect.DeepEqual(ids, []string{"file_uploaded_1"}) {
+		t.Fatalf("variant rich_content fileEmbed ids = %#v, want created file id only", ids)
+	}
+}
+
+func TestUpdate_FileRefusesVariantPutWhenCreatedFileIDsMissing(t *testing.T) {
+	srv := newVariantFileAttachServers(t)
+	srv.omitCreatedFiles = true
+	testutil.Setup(t, srv.dispatch(t))
+
+	path := writeVariantUploadFixture(t, "license bytes")
+	cmd := testutil.Command(newUpdateCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{
+		"v1",
+		"--product", "p1",
+		"--category", "vc1",
+		"--file", path,
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected missing created file id error")
+	}
+	if !strings.Contains(err.Error(), "expected 1 new product file id") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if srv.productPutCalls.Load() != 1 {
+		t.Fatalf("product PUT calls = %d, want 1", srv.productPutCalls.Load())
+	}
+	if srv.variantPutCalls.Load() != 0 {
+		t.Fatalf("variant PUT calls = %d, want 0", srv.variantPutCalls.Load())
+	}
+}
+
+func TestUpdate_FileMapsTwoUploadsInOrder(t *testing.T) {
+	srv := newVariantFileAttachServers(t)
+	srv.variantRichContent = []map[string]any{}
+	testutil.Setup(t, srv.dispatch(t))
+
+	first := writeVariantUploadFixture(t, "english")
+	second := writeVariantUploadFixture(t, "spanish")
+	cmd := testutil.Command(newUpdateCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{
+		"v1",
+		"--product", "p1",
+		"--category", "vc1",
+		"--file", first,
+		"--file", second,
+	})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	richContentPages := variantUpdateJSONRichContent(t, srv.variantJSON)
+	if ids := richcontent.FileEmbedIDs(richContentPages); !reflect.DeepEqual(ids, []string{"file_uploaded_1", "file_uploaded_2"}) {
+		t.Fatalf("variant rich_content fileEmbed ids = %#v, want created file ids in upload order", ids)
 	}
 }
 

--- a/internal/cmd/variants/variants_test.go
+++ b/internal/cmd/variants/variants_test.go
@@ -45,11 +45,12 @@ func variantHandler(t *testing.T) http.HandlerFunc {
 type variantFileAttachServers struct {
 	s3 *httptest.Server
 
-	sharedContent      bool
-	omitCreatedFiles   bool
-	productJSON        map[string]any
-	variantJSON        map[string]any
-	variantRichContent []map[string]any
+	sharedContent        bool
+	omitCreatedFiles     bool
+	returnFileIDMappings bool
+	productJSON          map[string]any
+	variantJSON          map[string]any
+	variantRichContent   []map[string]any
 
 	productGetCalls atomic.Int32
 	productPutCalls atomic.Int32
@@ -127,7 +128,26 @@ func (s *variantFileAttachServers) dispatch(t *testing.T) http.HandlerFunc {
 				if err := json.NewDecoder(r.Body).Decode(&s.productJSON); err != nil {
 					t.Fatalf("decode product JSON body: %v", err)
 				}
-				testutil.JSON(t, w, map[string]any{"product": map[string]any{"id": "p1"}})
+				resp := map[string]any{"product": map[string]any{"id": "p1"}}
+				if s.returnFileIDMappings {
+					mappings := map[string]string{}
+					if files, ok := s.productJSON["files"].([]any); ok {
+						n := 0
+						for _, raw := range files {
+							file, ok := raw.(map[string]any)
+							if !ok {
+								continue
+							}
+							externalID, _ := file["external_id"].(string)
+							if strings.HasPrefix(externalID, "cli-upload-") {
+								n++
+								mappings[externalID] = fmt.Sprintf("file_mapped_%d", n)
+							}
+						}
+					}
+					resp["file_id_mappings"] = mappings
+				}
+				testutil.JSON(t, w, resp)
 			default:
 				t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
 				http.Error(w, "unexpected", http.StatusMethodNotAllowed)
@@ -1113,6 +1133,32 @@ func TestUpdate_FileCreatesVariantRichContentWhenEmpty(t *testing.T) {
 	richContentPages := variantUpdateJSONRichContent(t, srv.variantJSON)
 	if ids := richcontent.FileEmbedIDs(richContentPages); !reflect.DeepEqual(ids, []string{"file_uploaded_1"}) {
 		t.Fatalf("variant rich_content fileEmbed ids = %#v, want created file id only", ids)
+	}
+}
+
+func TestUpdate_FilePrefersProductPutMappings(t *testing.T) {
+	srv := newVariantFileAttachServers(t)
+	srv.returnFileIDMappings = true
+	srv.omitCreatedFiles = true
+	testutil.Setup(t, srv.dispatch(t))
+
+	path := writeVariantUploadFixture(t, "license bytes")
+	cmd := testutil.Command(newUpdateCmd(), testutil.Yes(true))
+	cmd.SetArgs([]string{
+		"v1",
+		"--product", "p1",
+		"--category", "vc1",
+		"--file", path,
+		"--file-name", "License.pdf",
+	})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if srv.productGetCalls.Load() != 1 {
+		t.Fatalf("product GET calls = %d, want 1 (no recount after PUT)", srv.productGetCalls.Load())
+	}
+	richContentPages := variantUpdateJSONRichContent(t, srv.variantJSON)
+	if ids := richcontent.FileEmbedIDs(richContentPages); !reflect.DeepEqual(ids, []string{"file_existing", "file_mapped_1"}) {
+		t.Fatalf("variant rich_content fileEmbed ids = %#v, want mapping from product PUT", ids)
 	}
 }
 

--- a/internal/richcontent/files.go
+++ b/internal/richcontent/files.go
@@ -110,6 +110,20 @@ func FileEmbedIDs(richContent []map[string]any) []string {
 	return ids
 }
 
+func ReplaceFileEmbedIDs(richContent []map[string]any, replacements map[string]string) ([]map[string]any, error) {
+	if len(replacements) == 0 {
+		return Clone(richContent)
+	}
+	cloned, err := Clone(richContent)
+	if err != nil {
+		return nil, err
+	}
+	for _, page := range cloned {
+		replaceFileEmbedIDsInNode(page["description"], replacements)
+	}
+	return cloned, nil
+}
+
 func refsForExistingFiles(fileIDs []string) ([]FileRef, error) {
 	refs := make([]FileRef, len(fileIDs))
 	for i, fileID := range fileIDs {
@@ -194,6 +208,24 @@ func fileEmbedNode(ref FileRef) map[string]any {
 			"uid":       ref.EmbedUID,
 			"collapsed": false,
 		},
+	}
+}
+
+func replaceFileEmbedIDsInNode(node any, replacements map[string]string) {
+	current, ok := node.(map[string]any)
+	if !ok {
+		return
+	}
+	if id, ok := fileEmbedID(current); ok {
+		if next, found := replacements[id]; found {
+			attrs, _ := current["attrs"].(map[string]any)
+			attrs["id"] = next
+		}
+	}
+	if children, ok := current["content"].([]any); ok {
+		for _, child := range children {
+			replaceFileEmbedIDsInNode(child, replacements)
+		}
 	}
 }
 

--- a/internal/richcontent/files_test.go
+++ b/internal/richcontent/files_test.go
@@ -29,3 +29,30 @@ func TestAppendFileEmbedsKeepsExistingAndAddsNew(t *testing.T) {
 		t.Fatalf("page id = %#v, want page_1", next[0]["id"])
 	}
 }
+
+func TestReplaceFileEmbedIDsRewritesMatchingEmbedsOnly(t *testing.T) {
+	richContent := []map[string]any{{
+		"description": map[string]any{
+			"type": "doc",
+			"content": []any{
+				map[string]any{"type": "fileEmbed", "attrs": map[string]any{"id": "cli-upload-1", "uid": "keep-uid"}},
+				map[string]any{"type": "fileEmbed", "attrs": map[string]any{"id": "file_keep"}},
+			},
+		},
+	}}
+
+	next, err := ReplaceFileEmbedIDs(richContent, map[string]string{"cli-upload-1": "file_real"})
+	if err != nil {
+		t.Fatalf("ReplaceFileEmbedIDs failed: %v", err)
+	}
+	if ids := FileEmbedIDs(next); !reflect.DeepEqual(ids, []string{"file_real", "file_keep"}) {
+		t.Fatalf("file embed ids = %#v", ids)
+	}
+	attrs := next[0]["description"].(map[string]any)["content"].([]any)[0].(map[string]any)["attrs"].(map[string]any)
+	if attrs["uid"] != "keep-uid" {
+		t.Fatalf("uid = %#v, want keep-uid", attrs["uid"])
+	}
+	if FileEmbedIDs(richContent)[0] != "cli-upload-1" {
+		t.Fatal("ReplaceFileEmbedIDs mutated the input")
+	}
+}

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -665,7 +665,7 @@ gumroad variants delete <var_id> --product <id> --category <cat_id> --yes --json
 
 **All subcommands require** `--product` and `--category`.
 
-**Update flags:** `--name`, `--description`, `--price-difference`, `--max-purchase-count`, `--file` (repeatable), `--file-name`, `--file-description`. Use `variants update --file` only for products with per-variant Content. It appends each new file embed to the variant's existing page and leaves prior embeds intact. For shared Content, add files at the product level with `products update --file`.
+**Update flags:** `--name`, `--description`, `--price-difference`, `--max-purchase-count`, `--file` (repeatable), `--file-name`, `--file-description`. Use `variants update --file` only for products with per-variant Content. It appends each new file embed to the variant's existing page and leaves prior embeds intact. A live `--file` attach writes the created product file's id into the variant file embed so the purchase can resolve the file. `--dry-run` still shows the temporary `cli-upload-…` id because no file has been created yet. For shared Content, add files at the product level with `products update --file`.
 
 ### custom-fields — Manage custom fields
 


### PR DESCRIPTION
Live attach re-measured on prod after v2026.08.18.5 (includes #7285). Variant embed is a real product-file id.

- [x] Scope — `variants update --file` writes the created product-file id into the variant file embed, not a leftover `cli-upload-…` placeholder
- [x] Design — after the product files PUT, resolve ids solely from the response's `file_id_mappings` (added by antiwork/gumroad#7285, deployed in v2026.08.18.5); if any `cli-upload-*` ref is unmapped, refuse the variant PUT with an explicit error. The earlier re-GET + list-order diff fallback is removed — Greptile was right twice that it can attach a concurrently-added file or abort ambiguously
- [x] Build — `3e20249931b8d849bd7128481a0cc8213f56ddd5` on `fix/cli-variant-file-embed-ids`
- [x] QA — live attach on unpublished `https://gumclaw.gumroad.com/l/rxecr` after v2026.08.18.5: embed id `YP6WKnSXuQ9tD_Fz045lPA==` matches product file id (not `cli-upload-*`); product PUT then variant PUT with no GET between them (mappings path, the only path that remains). Hosted preview n/a
- [ ] Shipped
- [x] Market — n/a, CLI behavior fix
- [x] Sell — n/a

## What

`variants update --file` still creates the product file with a temporary `cli-upload-<uuid>` external id (the product PUT needs that). After that PUT succeeds, this branch rewrites the variant `fileEmbed` ids to the created files' real ids — taken from the PUT response's `file_id_mappings` — before the variant PUT.

## Why

The variant API resolves embeds with `ObfuscateIds.decrypt`. A `cli-upload-…` id decrypts to nothing, so the variant join is saved empty and the buyer's View Content page has no files. Product-level attach avoids this because files and rich content go in one request and the server remaps the placeholder. Variant attach is two requests and never remapped.

`file_id_mappings` is the only resolution path. An earlier revision fell back to re-GETting the product and diffing the file list when the mapping was missing; Greptile flagged (correctly, in two rounds) that any concurrent file add corrupts that diff — an equal-sized diff attaches the other client's file to the variant, a mismatch aborts after the uploads committed. The server-side mapping shipped in antiwork/gumroad#7285 (prod v2026.08.18.5), so the fallback is deleted: a missing or partial mapping now fails closed before the variant PUT (`product update response did not map uploaded file …`), which requires a CLI pointed at a pre-08.18.5 server and leaves the files attached at product level but not written into the variant — never someone else's file.

## Before / after

- Before: live attach sent `file_existing` plus `cli-upload-…` in the variant PUT. Delivery could not resolve the new file.
- After: dry-run still shows the temporary id (no file exists yet). Live attach writes the created file id from `file_id_mappings` (`file_uploaded_1` in the mock). If the server does not return a complete mapping, the variant PUT is refused.

![dry-run placeholder vs tests pinning the created id](https://i.ibb.co/0ykM5MhH/gcli-variant-file-embed-ids.gif)

Recorded against a local mock API. Dry-run prints `file_existing` + `cli-upload-…`. Focused tests then pass on the live remap.

## Test Results

Ran at `3e20249931b8d849bd7128481a0cc8213f56ddd5`:

- `go build ./...` — clean
- `go test ./internal/cmd/variants/ ./internal/richcontent/ -count=1 -cover` — ok; variants coverage 87.4% (gate 85%)
- `go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run ./internal/cmd/variants/ ./internal/richcontent/` — clean
- Mutation proof: making `completeFileIDMappings` skip unmapped refs instead of erroring turned `TestUpdate_FileRefusesVariantPutWhenMappingsMissing` and `TestCompleteFileIDMappingsRequiresEveryRef` red; restored, suite green
- Pins: mappings path uses exactly one product GET (`TestUpdate_FileUsesProductPutMappings` and the append test both assert GET count 1); missing/partial mapping refuses the variant PUT with 0 variant PUT calls; two uploads map per-ref (not positionally)

## QA steps

1. Point the CLI at a product with per-variant content and at least one existing file embed (server must be on v2026.08.18.5+ for `file_id_mappings`).
2. `gumroad variants update <id> --product <pid> --category <cat> --file ./new.pdf --dry-run --json --no-input --quiet`
3. Confirm `variant_request.body.rich_content` still contains the original embed and a `cli-upload-…` id.
4. Run the same command without `--dry-run`. Confirm the variant's stored file embed id is the created product file id, not `cli-upload-…`.

No hosted preview app applies; this is a CLI request-body change.

---

AI disclosure: grok-4.6 (build), claude-fable-5 (fallback removal round). Prompt/instructions: GitHub webhook for a variant file-attach delivery bug (`cli-upload` embeds never remapped). Follow autonomous-product-dev: claim, build, open a draft PR.

Premerge review: clean @ 3e20249931b8d849bd7128481a0cc8213f56ddd5
