### PR TITLE
Add schedule and unschedule verbs to audience-email CLI

### DIFF
--- a/internal/cmd/emails/emails.go
+++ b/internal/cmd/emails/emails.go
@@ -34,11 +34,13 @@ func NewEmailsCmd() *cobra.Command {
 		Use:   "emails",
 		Short: "Manage audience emails",
 		Long: "Manage Gumroad audience emails.\n\n" +
-			"Draft, preview, send, list, view, and delete broadcast emails. " +
+			"Draft, preview, send, schedule, unschedule, list, view, and delete broadcast emails. " +
 			"New emails are created as drafts by default; use `gumroad emails send-preview <id>` to review the preview URL before `gumroad emails send <id>`.",
 		Example: `  gumroad emails create --subject "New release" --body ./email.html
   gumroad emails create --subject "Product update" --body ./email.html --audience product --product <id>
   gumroad emails send-preview <id>
+  gumroad emails schedule <id> --at "2026-06-18T14:00:00Z"
+  gumroad emails unschedule <id>
   gumroad emails list --state draft --json
   gumroad emails view <id>
   gumroad emails send <id> --yes
@@ -50,6 +52,8 @@ func NewEmailsCmd() *cobra.Command {
 	cmd.AddCommand(newListCmd())
 	cmd.AddCommand(newViewCmd())
 	cmd.AddCommand(newSendCmd())
+	cmd.AddCommand(newScheduleCmd())
+	cmd.AddCommand(newUnscheduleCmd())
 	cmd.AddCommand(newDeleteCmd())
 
 	return cmd

--- a/internal/cmd/emails/emails_test.go
+++ b/internal/cmd/emails/emails_test.go
@@ -988,3 +988,98 @@ func TestDelete_CancelledOutputUsesSharedFormat(t *testing.T) {
 		t.Fatalf("unexpected cancel output: %q", out.String())
 	}
 }
+
+func TestSchedule_PostsScheduleEndpoint(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotForm url.Values
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm failed: %v", err)
+		}
+		gotForm = r.PostForm
+		scheduled := completeEmailPayload("email_123", "Launch", "scheduled")
+		scheduled["published_at"] = ""
+		scheduled["scheduled_at"] = "2026-06-18T14:00:00Z"
+		testutil.JSON(t, w, map[string]any{"email": scheduled})
+	})
+
+	cmd := testutil.Command(newScheduleCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"email_123", "--at", "2026-06-18T14:00:00Z"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != http.MethodPost || gotPath != "/emails/email_123/schedule" {
+		t.Fatalf("got %s %s, want POST /emails/email_123/schedule", gotMethod, gotPath)
+	}
+	if gotForm.Get("to_be_published_at") != "2026-06-18T14:00:00Z" {
+		t.Fatalf("to_be_published_at = %q", gotForm.Get("to_be_published_at"))
+	}
+	if !strings.Contains(out, "Scheduled email:") || !strings.Contains(out, "scheduled") {
+		t.Fatalf("unexpected schedule output: %q", out)
+	}
+}
+
+func TestSchedule_MissingAtReturnsUsageError(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("API must not be called without --at")
+	})
+
+	cmd := testutil.Command(newScheduleCmd())
+	cmd.SetArgs([]string{"email_123"})
+	err := cmd.Execute()
+
+	assertUsageError(t, err, "--at")
+}
+
+func TestSchedule_InvalidAtReturnsUsageError(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("API must not be called with an invalid timestamp")
+	})
+
+	cmd := testutil.Command(newScheduleCmd())
+	cmd.SetArgs([]string{"email_123", "--at", "not-a-time"})
+	err := cmd.Execute()
+
+	assertUsageError(t, err, "--at")
+}
+
+func TestSchedule_PlainOutputPrintsScheduledRow(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		scheduled := completeEmailPayload("email_123", "Launch", "scheduled")
+		scheduled["published_at"] = ""
+		scheduled["scheduled_at"] = "2026-06-18T14:00:00Z"
+		testutil.JSON(t, w, map[string]any{"email": scheduled})
+	})
+
+	cmd := testutil.Command(newScheduleCmd(), testutil.PlainOutput())
+	cmd.SetArgs([]string{"email_123", "--at", "2026-06-18T14:00:00Z"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if out != "email_123\tLaunch\tscheduled\t2026-06-18T14:00:00Z\n" {
+		t.Fatalf("got %q, want scheduled plain row", out)
+	}
+}
+
+func TestUnschedule_PostsUnscheduleEndpoint(t *testing.T) {
+	var gotMethod, gotPath string
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		draft := completeEmailPayload("email_123", "Launch", "draft")
+		draft["published_at"] = ""
+		draft["scheduled_at"] = ""
+		testutil.JSON(t, w, map[string]any{"email": draft})
+	})
+
+	cmd := testutil.Command(newUnscheduleCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"email_123"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotMethod != http.MethodPost || gotPath != "/emails/email_123/unschedule" {
+		t.Fatalf("got %s %s, want POST /emails/email_123/unschedule", gotMethod, gotPath)
+	}
+	if !strings.Contains(out, "Email email_123 unscheduled.") {
+		t.Fatalf("unexpected unschedule output: %q", out)
+	}
+}

--- a/internal/cmd/emails/emails_test.go
+++ b/internal/cmd/emails/emails_test.go
@@ -1041,7 +1041,68 @@ func TestSchedule_InvalidAtReturnsUsageError(t *testing.T) {
 	cmd.SetArgs([]string{"email_123", "--at", "not-a-time"})
 	err := cmd.Execute()
 
-	assertUsageError(t, err, "--at \"not-a-time\" is not a valid RFC3339 timestamp")
+	assertUsageError(t, err, "--at \"not-a-time\" is not a valid timestamp")
+}
+
+func TestSchedule_AcceptSellerTimezoneTimestamp(t *testing.T) {
+	var gotForm url.Values
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm failed: %v", err)
+		}
+		gotForm = r.PostForm
+		scheduled := completeEmailPayload("email_123", "Launch", "scheduled")
+		scheduled["published_at"] = ""
+		scheduled["scheduled_at"] = "2026-06-18T14:00:00Z"
+		testutil.JSON(t, w, map[string]any{"email": scheduled})
+	})
+
+	cmd := testutil.Command(newScheduleCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"email_123", "--at", "2026-06-18 14:00"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotForm.Get("to_be_published_at") != "2026-06-18 14:00" {
+		t.Fatalf("to_be_published_at = %q, want the verbatim seller-timezone string", gotForm.Get("to_be_published_at"))
+	}
+}
+
+func TestSchedule_ToBePublishedAtAlias(t *testing.T) {
+	var gotForm url.Values
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm failed: %v", err)
+		}
+		gotForm = r.PostForm
+		scheduled := completeEmailPayload("email_123", "Launch", "scheduled")
+		scheduled["published_at"] = ""
+		scheduled["scheduled_at"] = "2026-06-18T14:00:00Z"
+		testutil.JSON(t, w, map[string]any{"email": scheduled})
+	})
+
+	cmd := testutil.Command(newScheduleCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"email_123", "--to-be-published-at", "2026-06-18T14:00:00Z"})
+	testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if gotForm.Get("to_be_published_at") != "2026-06-18T14:00:00Z" {
+		t.Fatalf("to_be_published_at = %q, want the --to-be-published-at value", gotForm.Get("to_be_published_at"))
+	}
+}
+
+func TestSchedule_HumanOutputShowsScheduledTimestamp(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		scheduled := completeEmailPayload("email_123", "Launch", "scheduled")
+		scheduled["published_at"] = ""
+		scheduled["scheduled_at"] = "2026-06-18T14:00:00Z"
+		testutil.JSON(t, w, map[string]any{"email": scheduled})
+	})
+
+	cmd := testutil.Command(newScheduleCmd(), testutil.Quiet(false))
+	cmd.SetArgs([]string{"email_123", "--at", "2026-06-18T14:00:00Z"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	if !strings.Contains(out, "at 2026-06-18T14:00:00Z") {
+		t.Fatalf("human schedule output must show the scheduled timestamp: %q", out)
+	}
 }
 
 func TestSchedule_PlainOutputPrintsScheduledRow(t *testing.T) {

--- a/internal/cmd/emails/emails_test.go
+++ b/internal/cmd/emails/emails_test.go
@@ -1041,7 +1041,7 @@ func TestSchedule_InvalidAtReturnsUsageError(t *testing.T) {
 	cmd.SetArgs([]string{"email_123", "--at", "not-a-time"})
 	err := cmd.Execute()
 
-	assertUsageError(t, err, "--at")
+	assertUsageError(t, err, "--at \"not-a-time\" is not a valid RFC3339 timestamp")
 }
 
 func TestSchedule_PlainOutputPrintsScheduledRow(t *testing.T) {
@@ -1081,5 +1081,26 @@ func TestUnschedule_PostsUnscheduleEndpoint(t *testing.T) {
 	}
 	if !strings.Contains(out, "Email email_123 unscheduled.") {
 		t.Fatalf("unexpected unschedule output: %q", out)
+	}
+}
+
+func TestUnschedule_JSONExposesEmailAtTopLevel(t *testing.T) {
+	testutil.Setup(t, func(w http.ResponseWriter, r *http.Request) {
+		draft := completeEmailPayload("email_123", "Launch", "draft")
+		draft["published_at"] = ""
+		draft["scheduled_at"] = ""
+		testutil.JSON(t, w, map[string]any{"email": draft})
+	})
+
+	cmd := testutil.Command(newUnscheduleCmd(), testutil.JSONOutput())
+	cmd.SetArgs([]string{"email_123"})
+	out := testutil.CaptureStdout(func() { testutil.MustExecute(t, cmd) })
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	if _, ok := resp["email"]; !ok {
+		t.Fatalf("JSON response must expose .email at top level, got keys: %v", resp)
 	}
 }

--- a/internal/cmd/emails/schedule.go
+++ b/internal/cmd/emails/schedule.go
@@ -21,11 +21,10 @@ func newScheduleCmd() *cobra.Command {
 		Short: "Schedule an audience email",
 		Long: `Schedule an audience email to send at an absolute time.
 
-The timestamp is passed through to the API verbatim and must be a parseable
-form (e.g. RFC3339 like 2026-06-18T14:00:00Z). Calling schedule again with a
-different --at reschedules the email.`,
+The timestamp must be RFC3339 (e.g. 2026-06-18T14:00:00Z). Calling schedule
+again with a different --at reschedules the email.`,
 		Example: `  gumroad emails schedule <id> --at "2026-06-18T14:00:00Z"
-  gumroad emails schedule <id> --at "2026-06-18 14:00"
+  gumroad emails schedule <id> --at "2026-06-18T09:00:00-05:00"
   gumroad emails schedule <id> --at "2026-06-18T14:00:00Z" --json`,
 		Args: cmdutil.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {

--- a/internal/cmd/emails/schedule.go
+++ b/internal/cmd/emails/schedule.go
@@ -1,0 +1,61 @@
+package emails
+
+import (
+	"net/url"
+	"time"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+type scheduleEmailResponse struct {
+	Email emailRecord `json:"email"`
+}
+
+func newScheduleCmd() *cobra.Command {
+	var at string
+
+	cmd := &cobra.Command{
+		Use:   "schedule <id> --at <timestamp>",
+		Short: "Schedule an audience email",
+		Long: `Schedule an audience email to send at an absolute time.
+
+The timestamp is passed through to the API verbatim and must be a parseable
+form (e.g. RFC3339 like 2026-06-18T14:00:00Z). Calling schedule again with a
+different --at reschedules the email.`,
+		Example: `  gumroad emails schedule <id> --at "2026-06-18T14:00:00Z"
+  gumroad emails schedule <id> --at "2026-06-18 14:00"
+  gumroad emails schedule <id> --at "2026-06-18T14:00:00Z" --json`,
+		Args: cmdutil.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			if at == "" {
+				return cmdutil.MissingFlagError(c, "--at")
+			}
+			if _, err := time.Parse(time.RFC3339, at); err != nil {
+				return cmdutil.UsageErrorf(c, "--at: %v", err)
+			}
+
+			opts := cmdutil.OptionsFrom(c)
+			params := url.Values{}
+			params.Set("to_be_published_at", at)
+
+			return cmdutil.RunRequestDecoded[scheduleEmailResponse](opts, "Scheduling email...", "POST", cmdutil.JoinPath("emails", args[0], "schedule"), params, func(resp scheduleEmailResponse) error {
+				item := resp.Email
+				if opts.PlainOutput {
+					return output.PrintPlain(opts.Out(), [][]string{{item.ID, item.Subject, item.State, item.ScheduledAt}})
+				}
+				if opts.Quiet {
+					return nil
+				}
+				style := opts.Style()
+				return output.Writef(opts.Out(), "%s %s (%s) [%s]\n",
+					style.Bold("Scheduled email:"), item.Subject, style.Dim(item.ID), item.State)
+			})
+		},
+	}
+
+	cmd.Flags().StringVar(&at, "at", "", "When to send the email (required; RFC3339 timestamp)")
+
+	return cmd
+}

--- a/internal/cmd/emails/schedule.go
+++ b/internal/cmd/emails/schedule.go
@@ -19,20 +19,22 @@ func newScheduleCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "schedule <id> --at <timestamp>",
 		Short: "Schedule an audience email",
-		Long: `Schedule an audience email to send at an absolute time.
+		Long: `Schedule an audience email to send at a future time.
 
-The timestamp must be RFC3339 (e.g. 2026-06-18T14:00:00Z). Calling schedule
-again with a different --at reschedules the email.`,
+The timestamp may be RFC3339 (e.g. 2026-06-18T14:00:00Z) or a naive
+seller-timezone time (e.g. 2026-06-18 14:00); the API resolves the latter in
+the seller's timezone. Calling schedule again with a different timestamp
+reschedules the email.`,
 		Example: `  gumroad emails schedule <id> --at "2026-06-18T14:00:00Z"
-  gumroad emails schedule <id> --at "2026-06-18T09:00:00-05:00"
+  gumroad emails schedule <id> --to-be-published-at "2026-06-18 14:00"
   gumroad emails schedule <id> --at "2026-06-18T14:00:00Z" --json`,
 		Args: cmdutil.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
 			if at == "" {
 				return cmdutil.MissingFlagError(c, "--at")
 			}
-			if _, err := time.Parse(time.RFC3339, at); err != nil {
-				return cmdutil.UsageErrorf(c, "--at %q is not a valid RFC3339 timestamp (e.g. 2026-06-18T14:00:00Z)", at)
+			if !isValidScheduleTime(at) {
+				return cmdutil.UsageErrorf(c, "--at %q is not a valid timestamp (e.g. 2026-06-18T14:00:00Z or 2026-06-18 14:00)", at)
 			}
 
 			opts := cmdutil.OptionsFrom(c)
@@ -59,7 +61,25 @@ again with a different --at reschedules the email.`,
 		},
 	}
 
-	cmd.Flags().StringVar(&at, "at", "", "When to send the email (required; RFC3339 timestamp)")
+	cmd.Flags().StringVar(&at, "at", "", "When to send the email (required; RFC3339 or seller-timezone timestamp)")
+	cmd.Flags().StringVar(&at, "to-be-published-at", "", "Alias for --at")
 
 	return cmd
+}
+
+// isValidScheduleTime reports whether value parses as a timestamp, accepting
+// both RFC3339 and the naive seller-timezone form the API documents.
+func isValidScheduleTime(value string) bool {
+	layouts := []string{
+		time.RFC3339,
+		"2006-01-02T15:04",
+		"2006-01-02 15:04",
+		"2006-01-02",
+	}
+	for _, layout := range layouts {
+		if _, err := time.Parse(layout, value); err == nil {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/cmd/emails/schedule.go
+++ b/internal/cmd/emails/schedule.go
@@ -32,7 +32,7 @@ again with a different --at reschedules the email.`,
 				return cmdutil.MissingFlagError(c, "--at")
 			}
 			if _, err := time.Parse(time.RFC3339, at); err != nil {
-				return cmdutil.UsageErrorf(c, "--at: %v", err)
+				return cmdutil.UsageErrorf(c, "--at %q is not a valid RFC3339 timestamp (e.g. 2026-06-18T14:00:00Z)", at)
 			}
 
 			opts := cmdutil.OptionsFrom(c)

--- a/internal/cmd/emails/schedule.go
+++ b/internal/cmd/emails/schedule.go
@@ -48,6 +48,11 @@ again with a different --at reschedules the email.`,
 					return nil
 				}
 				style := opts.Style()
+				timeText := emailDisplayDate(item)
+				if timeText != "" {
+					return output.Writef(opts.Out(), "%s %s (%s) [%s] at %s\n",
+						style.Bold("Scheduled email:"), item.Subject, style.Dim(item.ID), item.State, timeText)
+				}
 				return output.Writef(opts.Out(), "%s %s (%s) [%s]\n",
 					style.Bold("Scheduled email:"), item.Subject, style.Dim(item.ID), item.State)
 			})

--- a/internal/cmd/emails/unschedule.go
+++ b/internal/cmd/emails/unschedule.go
@@ -1,0 +1,23 @@
+package emails
+
+import (
+	"net/url"
+
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+func newUnscheduleCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "unschedule <id>",
+		Short: "Unschedule an audience email",
+		Long:  "Cancel the scheduled send time on an audience email, returning it to draft so it can be edited or re-scheduled.",
+		Example: `  gumroad emails unschedule <id>
+  gumroad emails unschedule <id> --json`,
+		Args: cmdutil.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			return cmdutil.RunRequestWithSuccess(opts, "Unscheduling email...", "POST", cmdutil.JoinPath("emails", args[0], "unschedule"), url.Values{}, args[0], "Email "+args[0]+" unscheduled.")
+		},
+	}
+}

--- a/internal/cmd/emails/unschedule.go
+++ b/internal/cmd/emails/unschedule.go
@@ -17,7 +17,7 @@ func newUnscheduleCmd() *cobra.Command {
 		Args: cmdutil.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := cmdutil.OptionsFrom(c)
-			return cmdutil.RunRequestWithSuccess(opts, "Unscheduling email...", "POST", cmdutil.JoinPath("emails", args[0], "unschedule"), url.Values{}, args[0], "Email "+args[0]+" unscheduled.")
+			return cmdutil.RunRequestWithResource(opts, "Unscheduling email...", "POST", cmdutil.JoinPath("emails", args[0], "unschedule"), url.Values{}, "", "Email "+args[0]+" unscheduled.")
 		},
 	}
 }

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -451,7 +451,7 @@ gumroad emails delete <id> --yes --json --no-input
 
 **Create flags:** `--subject` (required), `--body` (required HTML file path, or `-` for stdin), `--audience` (all|customers|followers|product, default all), `--product` (required for product audience), `--send` (publish and send immediately).
 **List flags:** `--state` (published|scheduled|draft), `--all`, `--page-key`.
-**Schedule flags:** `--at` (required; RFC3339 timestamp, e.g. `2026-06-18T14:00:00Z`).
+**Schedule flags:** `--at` (required; RFC3339 e.g. `2026-06-18T14:00:00Z`, or a naive seller-timezone time e.g. `2026-06-18 14:00` which the API resolves in the seller's timezone). `--to-be-published-at` is an alias for `--at`.
 
 Use `--dry-run --json --no-input` to inspect create params without calling the API. Passing `--send` blasts the audience immediately; prefer the draft → `send-preview` URL → `send` workflow. `send-preview` emails a copy to the seller. Schedule a draft with `emails schedule <id> --at <timestamp>` (re-running with a new `--at` reschedules); `emails unschedule <id>` returns a scheduled email to draft.
 

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -450,7 +450,17 @@ gumroad emails delete <id> --yes --json --no-input
 **Create flags:** `--subject` (required), `--body` (required HTML file path, or `-` for stdin), `--audience` (all|customers|followers|product, default all), `--product` (required for product audience), `--send` (publish and send immediately).
 **List flags:** `--state` (published|scheduled|draft), `--all`, `--page-key`.
 
-Use `--dry-run --json --no-input` to inspect create params without calling the API. Passing `--send` blasts the audience immediately; prefer the draft → `send-preview` URL → `send` workflow. `send-preview` emails a copy to the seller. Scheduled emails can only be created in the web UI; the CLI can list and view them (`--state scheduled`) but not create them.
+Use `--dry-run --json --no-input` to inspect create params without calling the API. Passing `--send` blasts the audience immediately; prefer the draft → `send-preview` URL → `send` workflow. `send-preview` emails a copy to the seller.
+
+Schedule or unschedule a draft email:
+
+```sh
+# Schedule a draft to send at an absolute RFC3339 time; re-run with a new --at to reschedule.
+gumroad emails schedule <id> --at "2026-06-18T14:00:00Z" --json --no-input
+
+# Return a scheduled email to draft.
+gumroad emails unschedule <id> --json --no-input
+```
 
 ### workflows — Manage email workflows
 

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -70,7 +70,7 @@ Most responses are wrapped in `{"success": true, ...}` with resource-specific ke
 - `sales view` → `.sale` (includes `.currency`, the ISO code the sale is priced in — the same currency a refund amount is read in)
 - `sales export` → `.status`, `.recipient_email`
 - `sales summary` → `.gross_cents`, `.net_cents`, `.breakdown[]`
-- `emails list` → `.emails[]`, `emails view/create/send/schedule` → `.email`, `emails send-preview` → `.preview_url`, `emails delete/unschedule` → `.message`
+- `emails list` → `.emails[]`, `emails view/create/send/schedule/unschedule` → `.email`, `emails send-preview` → `.preview_url`, `emails delete` → `.message`
 - `workflows list` → `.workflows[]`, `workflows view` → `.workflow`, `workflows add-email/update-email` → `.email`
 - `payouts list` → `.payouts[]`, `payouts view/upcoming` → `.payout`
 - `subscribers list` → `.subscribers[]`, `subscribers view` → `.subscriber`
@@ -442,7 +442,7 @@ gumroad emails view <id> --json --no-input
 gumroad emails list --state draft --json --no-input
 gumroad emails list --state published --all --json --no-input
 
-# Send, schedule, or unschedule. Options taking --yes are confirmation-gated; agents must pass --yes.
+# Send, schedule, unschedule, or delete. Confirmation-gated verbs require --yes.
 gumroad emails send <id> --yes --json --no-input
 gumroad emails schedule <id> --at "2026-06-18T14:00:00Z" --json --no-input
 gumroad emails unschedule <id> --json --no-input
@@ -453,17 +453,7 @@ gumroad emails delete <id> --yes --json --no-input
 **List flags:** `--state` (published|scheduled|draft), `--all`, `--page-key`.
 **Schedule flags:** `--at` (required; RFC3339 timestamp, e.g. `2026-06-18T14:00:00Z`).
 
-Use `--dry-run --json --no-input` to inspect create params without calling the API. Passing `--send` blasts the audience immediately; prefer the draft → `send-preview` URL → `send` workflow. `send-preview` emails a copy to the seller.
-
-Schedule or unschedule a draft email:
-
-```sh
-# Schedule a draft to send at an absolute RFC3339 time; re-run with a new --at to reschedule.
-gumroad emails schedule <id> --at "2026-06-18T14:00:00Z" --json --no-input
-
-# Return a scheduled email to draft.
-gumroad emails unschedule <id> --json --no-input
-```
+Use `--dry-run --json --no-input` to inspect create params without calling the API. Passing `--send` blasts the audience immediately; prefer the draft → `send-preview` URL → `send` workflow. `send-preview` emails a copy to the seller. Schedule a draft with `emails schedule <id> --at <timestamp>` (re-running with a new `--at` reschedules); `emails unschedule <id>` returns a scheduled email to draft.
 
 ### workflows — Manage email workflows
 

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -45,7 +45,7 @@ Always follow these rules:
 - Storefront pages (slugged pages serving at `<username>.gumroad.com/<slug>`) use `gumroad pages list`, `gumroad pages create --title <title> [--slug <slug>] [path]` (with an HTML path or `-` the page is created as custom HTML; without one it starts empty for the in-app editor), `gumroad pages pull <slug>` to download a page's existing custom HTML so pull → edit → push is a real round trip (writes `<slug>.html`; `-o <path>` to choose, `-o -` for stdout; refuses to overwrite without `--force`; errors with a hint when the page has no custom HTML), `gumroad pages scaffold <slug>` to generate starter HTML for a rich-text page or a default profile from a static snapshot of its current render (same flags as pull; pushing the scaffold converts the page to custom HTML and replaces the dynamic storefront/editor experience), `gumroad pages push <slug> ./page.html` to replace a page with custom HTML, and `gumroad pages preview ./page.html` to run the backend sanitizer without publishing. The loop for going custom: `pull` (or `scaffold` when there's no custom HTML yet) → edit → `preview` → `push`. `--json`/`--jq` on `pull`/`scaffold` still write the file and additionally print the raw API response; combining them with `-o -` is rejected since both would own stdout. The special slug `profile` targets the profile landing page (`pull profile` downloads your published custom HTML, `scaffold profile` snapshots the default storefront render when none is published; push uses the same endpoints as `user page publish`). Custom HTML pages require the seller's `custom_html_pages` feature to be enabled; without it writes fail with an access message. Writes to slugged pages (`pages create`/`pages push <slug>`) also require the token to carry the `edit_profile` scope — tokens minted before the CLI requested that scope get a 403 telling them to re-run `gumroad auth login`.
 - Product rich content uses `gumroad products content list <id> --json --no-input` to inspect page IDs, `gumroad products content get <id> --json --no-input` to dump the shared `rich_content` page array, and `gumroad products content set <id> content.json --dry-run --json --no-input` to preview a whole-document replacement. Without an explicit path, whole-document `set` reads `./content.json`; `set --page` reads `./page.json`. Use `--page <page_id>` with `get`/`set` to edit one matching page object; `set --page` still sends a merged whole-document PUT. For per-variant content, pass both `--variant <variant_id>` and `--category <cat_id>`. Whole-document `set` deletes existing pages omitted from the JSON.
 - Custom HTML pages can use `data-gumroad-field="name"`, `data-gumroad-field="price"`, `data-gumroad-field="description"`, and `data-gumroad-action="buy"`. To preselect checkout state, add `data-gumroad-option="<variant name>"`, `data-gumroad-quantity="<integer>"`, `data-gumroad-price="<decimal>"`, or `data-gumroad-recurrence="monthly|quarterly|biannually|yearly|every_two_years"`. Production validates these values and falls back to product defaults when invalid. Prefer anchors for buy CTAs so production can add a checkout href; non-anchor buy elements also post to checkout.
-- Audience emails are created as drafts by default. Use `gumroad emails send-preview <id> --json --no-input` and inspect `.preview_url` before `gumroad emails send <id> --yes --json --no-input`. Creating with `--send` publishes and blasts immediately, so use `--dry-run` first and require explicit human approval.
+- Audience emails are created as drafts by default. Use `gumroad emails send-preview <id> --json --no-input` and inspect `.preview_url` before `gumroad emails send <id> --yes --json --no-input`. Creating with `--send` publishes and blasts immediately, so use `--dry-run` first and require explicit human approval. To schedule a send instead of blasting immediately, create the draft then `gumroad emails schedule <id> --at "<RFC3339>" --json --no-input`; `gumroad emails unschedule <id>` returns a scheduled email to draft.
 - Workflow email writes do not change the workflow publication state. Adding a step to a published workflow can schedule eligible past recipients. Changing a delay can reschedule recipients. Use `--dry-run` before each write.
 - If a command fails with a seller auth error, run `gumroad auth status --json --no-input` first. Agents can start seller auth with `gumroad auth login --no-input` and hand the printed approval URL to a human, or use an existing seller token via `GUMROAD_ACCESS_TOKEN` or `gumroad auth login --with-token`.
 - For admin commands in agents/CI, pass `--non-interactive` and set `GUMROAD_ADMIN_TOKEN`; interactive shells can store an admin token with `gumroad auth login --web`.
@@ -70,7 +70,7 @@ Most responses are wrapped in `{"success": true, ...}` with resource-specific ke
 - `sales view` → `.sale` (includes `.currency`, the ISO code the sale is priced in — the same currency a refund amount is read in)
 - `sales export` → `.status`, `.recipient_email`
 - `sales summary` → `.gross_cents`, `.net_cents`, `.breakdown[]`
-- `emails list` → `.emails[]`, `emails view/create/send` → `.email`, `emails send-preview` → `.preview_url`, `emails delete` → `.message`
+- `emails list` → `.emails[]`, `emails view/create/send/schedule` → `.email`, `emails send-preview` → `.preview_url`, `emails delete/unschedule` → `.message`
 - `workflows list` → `.workflows[]`, `workflows view` → `.workflow`, `workflows add-email/update-email` → `.email`
 - `payouts list` → `.payouts[]`, `payouts view/upcoming` → `.payout`
 - `subscribers list` → `.subscribers[]`, `subscribers view` → `.subscriber`
@@ -442,13 +442,16 @@ gumroad emails view <id> --json --no-input
 gumroad emails list --state draft --json --no-input
 gumroad emails list --state published --all --json --no-input
 
-# Send or delete. Both are confirmation-gated; agents must pass --yes.
+# Send, schedule, or unschedule. Options taking --yes are confirmation-gated; agents must pass --yes.
 gumroad emails send <id> --yes --json --no-input
+gumroad emails schedule <id> --at "2026-06-18T14:00:00Z" --json --no-input
+gumroad emails unschedule <id> --json --no-input
 gumroad emails delete <id> --yes --json --no-input
 ```
 
 **Create flags:** `--subject` (required), `--body` (required HTML file path, or `-` for stdin), `--audience` (all|customers|followers|product, default all), `--product` (required for product audience), `--send` (publish and send immediately).
 **List flags:** `--state` (published|scheduled|draft), `--all`, `--page-key`.
+**Schedule flags:** `--at` (required; RFC3339 timestamp, e.g. `2026-06-18T14:00:00Z`).
 
 Use `--dry-run --json --no-input` to inspect create params without calling the API. Passing `--send` blasts the audience immediately; prefer the draft → `send-preview` URL → `send` workflow. `send-preview` emails a copy to the seller.
 


### PR DESCRIPTION
## What

Add `gumroad emails schedule <id> --at <timestamp>` and `gumroad emails unschedule <id>` verbs to the audience-email CLI, matching the API endpoints shipped in antiwork/gumroad#7249 (`POST /v2/emails/:id/schedule` with `to_be_published_at`, and `POST /v2/emails/:id/unschedule`).

This closes the CLI half of gp#2153: automation could already inspect draft/scheduled/published emails and create/send them, but could not create or change schedules programmatically — that required the web UI.

## Why

A well-researched seller proposal asked for audience-email scheduling through the public API and CLI. The API half merged in #7249; these verbs complete the story so a script can schedule, reschedule (call `schedule` again with a new `--at`), and unschedule an email, then confirm state via the existing `view`/`list` commands.

## Before/After

**Before:** no `schedule`/`unschedule` subcommands — scheduling was web-UI-only.

**After:**
- `gumroad emails schedule <id> --at "2026-06-18T14:00:00Z"` — POSTs `to_be_published_at` to `/emails/<id>/schedule`; prints the resulting scheduled state and resolved timestamp. Re-calling with a different `--at` reschedules. `--to-be-published-at` is an alias for `--at` (the flag name the #7249 docs advertise).
- Timestamp accepts RFC3339 (`2026-06-18T14:00:00Z`) or a naive seller-timezone time (`2026-06-18 14:00`), which the API resolves in the seller's timezone.
- `gumroad emails unschedule <id>` — POSTs to `/emails/<id>/unschedule`; returns the email to draft. The response exposes `.email` at the top level (matching `emails delete` / `products unpublish`).

![demo](https://i.ibb.co/G4DxkTf2/demo.gif)

## Test Results

- `go build ./...` — clean
- `gofmt -l internal/cmd/emails/` — no output (formatted)
- `go vet ./internal/cmd/emails/` — clean
- `golangci-lint v1.64.8` (CI-pinned) on `./internal/cmd/emails/...` — clean
- `go test ./internal/cmd/emails/` — pass (9 new tests: schedule endpoint+param, seller-timezone timestamp, `--to-be-published-at` alias, missing/invalid `--at`, schedule human timestamp, schedule plain output, unschedule endpoint, unschedule JSON `.email` top-level, plus all pre-existing emails tests)
- `go test -cover ./internal/cmd/emails/` — 87.0% statements (above the 85% cmd coverage gate)
- `make test-cover` — all packages pass with `GUMROAD_*` env unset (the two `test/` integration failures occur only when a leaked `GUMROAD_ACCESS_TOKEN` overrides the fixtures; the whole suite is green once unset)
- QA audit (rounds 1–4): mutation-verified all 9 new tests at head — the unschedule `.email` top-level test fails on the pre-fix envelope, the human-timestamp test fails when the timestamp branch is removed, the alias test fails without `--to-be-published-at`, and the seller-timezone test fails under an RFC3339-only gate; Greptile's two P-findings (space-separated example; stale SKILL.md) verified fixed at head.

## QA steps

Read `internal/cmd/emails/schedule.go` and `unschedule.go`; run `go test ./internal/cmd/emails/ -run 'Schedule|Unschedule'`. The walkthrough GIF shows the verbs against a local mock API (schedule human output with RFC3339 and the `--to-be-published-at` seller-timezone alias, the invalid `--at` error, and unschedule in both human and JSON with `.email` top-level). Exercising against the live API requires a `GUMROAD_ACCESS_TOKEN` and a real email, which this environment does not have.

---

_AI disclosure: I am Gumclaw, a Hermes Agent. Model: grok-4.6 (default from `~/.hermes/config.yaml`). This change was authored autonomously following the autonomous-product-dev skill; no human drafted it._

Premerge review: clean @ 0e3ff3391ffc7753a9d83f0a4fdcfbe4521ad9c0
