### PR TITLE
Expose stored social verification evidence in the admin CLI

### DIFF
--- a/internal/cmd/admin/users/social_connections.go
+++ b/internal/cmd/admin/users/social_connections.go
@@ -1,0 +1,97 @@
+package users
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/antiwork/gumroad-cli/internal/admincmd"
+	"github.com/antiwork/gumroad-cli/internal/cmdutil"
+	"github.com/antiwork/gumroad-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+type socialConnectionsResponse struct {
+	SocialConnections []socialConnection `json:"social_connections"`
+}
+
+type socialConnection struct {
+	Platform                string `json:"platform"`
+	UID                     string `json:"uid"`
+	Handle                  string `json:"handle"`
+	CurrentlyLinked         bool   `json:"currently_linked"`
+	AccountCreatedAt        string `json:"account_created_at"`
+	FollowerCount           *int64 `json:"follower_count"`
+	PostCount               *int64 `json:"post_count"`
+	LastPostedAt            string `json:"last_posted_at"`
+	LastVerifiedAt          string `json:"last_verified_at"`
+	SharedIdentityUserCount int    `json:"shared_identity_user_count"`
+}
+
+func newSocialConnectionsCmd() *cobra.Command {
+	var lookup userLookupFlags
+	cmd := &cobra.Command{
+		Use:   "social-connections",
+		Short: "Read verified social evidence for risk review",
+		Long: `Read stored social verification evidence, including current-link state,
+verification timestamps, audience history, and shared identities. Historical
+verification is not proof of a current connection. Missing counts are unknown,
+not zero. This read-only command does not refresh providers, score eligibility,
+mark a seller compliant, or release payouts.`,
+		Example: `  gumroad admin users social-connections --user-id 2245593582708
+  gumroad admin users social-connections --email seller@example.com --json`,
+		Args: cmdutil.ExactArgs(0),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := cmdutil.OptionsFrom(c)
+			target, err := resolveUserLookupTarget(c, lookup)
+			if err != nil {
+				return err
+			}
+			return admincmd.RunGetDecoded[socialConnectionsResponse](opts, "Fetching social evidence...", "/users/social_connections", target.Values(), func(resp socialConnectionsResponse) error {
+				return renderSocialConnections(opts, resp)
+			})
+		},
+	}
+	addUserLookupFlags(cmd, &lookup)
+	return cmd
+}
+
+func renderSocialConnections(opts cmdutil.Options, resp socialConnectionsResponse) error {
+	rows := make([][]string, 0, len(resp.SocialConnections))
+	for _, v := range resp.SocialConnections {
+		rows = append(rows, []string{v.Platform, v.UID, v.Handle, strconv.FormatBool(v.CurrentlyLinked),
+			v.LastVerifiedAt, v.AccountCreatedAt, socialCount(v.FollowerCount), socialCount(v.PostCount),
+			v.LastPostedAt, strconv.Itoa(v.SharedIdentityUserCount)})
+	}
+	if opts.PlainOutput {
+		return output.PrintPlain(opts.Out(), rows)
+	}
+	if opts.Quiet {
+		return nil
+	}
+	if len(rows) == 0 {
+		return cmdutil.PrintInfo(opts, "No stored social verification evidence.")
+	}
+	if err := output.Writeln(opts.Out(), "Stored social evidence (not payout approval):"); err != nil {
+		return err
+	}
+	// One field per line keeps timestamps and identity evidence readable in narrow terminals.
+	labels := []string{"Platform", "Identity", "Handle", "Currently linked", "Last verified", "Account created", "Followers", "Posts", "Last posted", "Other users sharing identity"}
+	for _, row := range rows {
+		for i, value := range row {
+			if err := output.Writef(opts.Out(), "%s: %s\n", labels[i], output.EscapePlainField(fallback(value, "unknown"))); err != nil {
+				return err
+			}
+		}
+		if err := output.Writeln(opts.Out(), ""); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func socialCount(value *int64) string {
+	if value == nil {
+		return "unknown"
+	}
+	return fmt.Sprint(*value)
+}

--- a/internal/cmd/admin/users/social_connections.go
+++ b/internal/cmd/admin/users/social_connections.go
@@ -74,7 +74,6 @@ func renderSocialConnections(opts cmdutil.Options, resp socialConnectionsRespons
 	if err := output.Writeln(opts.Out(), "Stored social evidence (not payout approval):"); err != nil {
 		return err
 	}
-	// One field per line keeps timestamps and identity evidence readable in narrow terminals.
 	labels := []string{"Platform", "Identity", "Handle", "Currently linked", "Last verified", "Account created", "Followers", "Posts", "Last posted", "Other users sharing identity"}
 	for _, row := range rows {
 		for i, value := range row {

--- a/internal/cmd/admin/users/social_connections_test.go
+++ b/internal/cmd/admin/users/social_connections_test.go
@@ -1,0 +1,130 @@
+package users
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+const socialEvidenceFixture = `{"success":true,"user_id":"2245593582708","future_field":"preserved","social_connections":[{"platform":"instagram","uid":"1234","handle":"seller","currently_linked":false,"account_created_at":null,"follower_count":null,"post_count":0,"last_posted_at":null,"last_verified_at":"2026-09-01T12:00:00Z","shared_identity_user_count":2}]}`
+
+func TestSocialConnectionsLookupAndOutput(t *testing.T) {
+	for _, flag := range []string{"user-id", "email", "username"} {
+		t.Run(flag, func(t *testing.T) {
+			value := map[string]string{"user-id": "2245593582708", "email": "seller@example.com", "username": "seller"}[flag]
+			testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "GET" || r.URL.Path != "/internal/admin/users/social_connections" || r.URL.Query().Get(strings.ReplaceAll(flag, "-", "_")) != value {
+					t.Errorf("unexpected request %s %s", r.Method, r.URL)
+				}
+				testutil.RawJSON(t, w, socialEvidenceFixture)
+			})
+			var out bytes.Buffer
+			cmd := testutil.Command(NewUsersCmd(), testutil.Quiet(false), testutil.Stdout(&out))
+			cmd.SetArgs([]string{"social-connections", "--" + flag, value})
+			testutil.MustExecute(t, cmd)
+			for _, want := range []string{"not payout approval", "Currently linked: false", "Followers: unknown", "Posts: 0", "Account created: unknown", "Last verified: 2026-09-01T12:00:00Z", "Other users sharing identity: 2"} {
+				if !strings.Contains(out.String(), want) {
+					t.Errorf("missing %q in %s", want, out.String())
+				}
+			}
+		})
+	}
+}
+
+func TestSocialConnectionsOutputModes(t *testing.T) {
+	for _, mode := range []string{"json", "plain", "quiet", "jq"} {
+		t.Run(mode, func(t *testing.T) {
+			testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) { testutil.RawJSON(t, w, socialEvidenceFixture) })
+			var out bytes.Buffer
+			cmd := testutil.Command(newSocialConnectionsCmd(), testutil.Stdout(&out), testutil.JSONOutput())
+			if mode == "plain" {
+				cmd = testutil.Command(newSocialConnectionsCmd(), testutil.Stdout(&out), testutil.PlainOutput())
+			}
+			if mode == "quiet" {
+				cmd = testutil.Command(newSocialConnectionsCmd(), testutil.Stdout(&out), testutil.Quiet(true))
+			}
+			if mode == "jq" {
+				cmd = testutil.Command(newSocialConnectionsCmd(), testutil.Stdout(&out), testutil.JQ(".social_connections[0].currently_linked"))
+			}
+			cmd.SetArgs([]string{"--user-id", "2245593582708"})
+			testutil.MustExecute(t, cmd)
+			switch mode {
+			case "json":
+				var got, want any
+				if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+					t.Fatal(err)
+				}
+				if err := json.Unmarshal([]byte(socialEvidenceFixture), &want); err != nil {
+					t.Fatal(err)
+				}
+				a, _ := json.Marshal(got)
+				b, _ := json.Marshal(want)
+				if string(a) != string(b) {
+					t.Fatalf("JSON changed: %s", out.String())
+				}
+			case "plain":
+				want := "instagram\t1234\tseller\tfalse\t2026-09-01T12:00:00Z\t\tunknown\t0\t\t2\n"
+				if out.String() != want {
+					t.Fatalf("plain = %q", out.String())
+				}
+			case "quiet":
+				if out.Len() != 0 {
+					t.Fatalf("quiet output: %s", out.String())
+				}
+			case "jq":
+				if strings.TrimSpace(out.String()) != "false" {
+					t.Fatalf("jq: %s", out.String())
+				}
+			}
+		})
+	}
+}
+
+func TestSocialConnectionsEmptyAndEscaping(t *testing.T) {
+	for _, empty := range []bool{true, false} {
+		t.Run(map[bool]string{true: "empty", false: "escaping"}[empty], func(t *testing.T) {
+			testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+				if empty {
+					testutil.RawJSON(t, w, `{"success":true,"social_connections":[]}`)
+					return
+				}
+				testutil.RawJSON(t, w, strings.Replace(socialEvidenceFixture, `"seller"`, `"seller\n\u001b[31m"`, 1))
+			})
+			var out bytes.Buffer
+			cmd := testutil.Command(newSocialConnectionsCmd(), testutil.Stdout(&out), testutil.Quiet(false))
+			cmd.SetArgs([]string{"--username", "seller"})
+			testutil.MustExecute(t, cmd)
+			if empty && !strings.Contains(out.String(), "No stored social verification evidence.") {
+				t.Fatal(out.String())
+			}
+			if !empty && (strings.Contains(out.String(), "seller\n") || strings.Contains(out.String(), "\x1b[31m")) {
+				t.Fatalf("unescaped output %q", out.String())
+			}
+		})
+	}
+}
+
+func TestSocialConnectionsErrors(t *testing.T) {
+	t.Run("missing lookup", func(t *testing.T) {
+		testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) { t.Error("unexpected request") })
+		cmd := testutil.Command(newSocialConnectionsCmd())
+		if cmd.Execute() == nil {
+			t.Fatal("expected missing target error")
+		}
+	})
+	t.Run("server refusal", func(t *testing.T) {
+		testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+			testutil.RawJSON(t, w, `{"success":false,"message":"denied"}`)
+		})
+		cmd := testutil.Command(newSocialConnectionsCmd())
+		cmd.SetArgs([]string{"--username", "seller"})
+		if cmd.Execute() == nil {
+			t.Fatal("expected API error")
+		}
+	})
+}

--- a/internal/cmd/admin/users/social_connections_test.go
+++ b/internal/cmd/admin/users/social_connections_test.go
@@ -108,12 +108,26 @@ func TestSocialConnectionsEmptyAndEscaping(t *testing.T) {
 	}
 }
 
+func TestSocialConnectionsPlainEscaping(t *testing.T) {
+	testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+		testutil.RawJSON(t, w, strings.Replace(socialEvidenceFixture, `"seller"`, `"seller\tline\n\u001b[31m"`, 1))
+	})
+	var out bytes.Buffer
+	cmd := testutil.Command(newSocialConnectionsCmd(), testutil.Stdout(&out), testutil.PlainOutput())
+	cmd.SetArgs([]string{"--username", "seller"})
+	testutil.MustExecute(t, cmd)
+	if strings.Count(out.String(), "\n") != 1 || len(strings.Split(strings.TrimSuffix(out.String(), "\n"), "\t")) != 10 || strings.Contains(out.String(), "\x1b") {
+		t.Fatalf("invalid TSV row: %q", out.String())
+	}
+}
+
 func TestSocialConnectionsErrors(t *testing.T) {
 	t.Run("missing lookup", func(t *testing.T) {
 		testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) { t.Error("unexpected request") })
 		cmd := testutil.Command(newSocialConnectionsCmd())
-		if cmd.Execute() == nil {
-			t.Fatal("expected missing target error")
+		cmd.SetArgs([]string{})
+		if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "supply --email, --user-id, or --username") {
+			t.Fatalf("expected missing target error, got %v", err)
 		}
 	})
 	t.Run("server refusal", func(t *testing.T) {

--- a/internal/cmd/admin/users/users.go
+++ b/internal/cmd/admin/users/users.go
@@ -13,6 +13,7 @@ func NewUsersCmd() *cobra.Command {
 		Example: `  gumroad admin users info --email user@example.com
   gumroad admin users info --user-id 2245593582708
   gumroad admin users info --username sellerone
+  gumroad admin users social-connections --user-id 2245593582708
   gumroad admin users affiliates --user-id 2245593582708 --direction granted
   gumroad admin users comments list --user-id 2245593582708
   gumroad admin users comments add --user-id 2245593582708 --content "VAT exempt confirmed"
@@ -37,6 +38,7 @@ func NewUsersCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(newInfoCmd())
+	cmd.AddCommand(newSocialConnectionsCmd())
 	cmd.AddCommand(newAffiliatesCmd())
 	cmd.AddCommand(usercomments.NewCommentsCmd())
 	cmd.AddCommand(newComplianceCmd())

--- a/internal/cmd/admin/users/users_test.go
+++ b/internal/cmd/admin/users/users_test.go
@@ -178,6 +178,7 @@ func TestNewUsersCmdWiresSubcommands(t *testing.T) {
 	got := cmd.Commands()
 	want := []string{
 		"info",
+		"social-connections",
 		"affiliates",
 		"comments",
 		"compliance",

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -111,6 +111,7 @@ Most responses are wrapped in `{"success": true, ...}` with resource-specific ke
 - Not every `products` write verb is flat: `create`, `update`, `unpublish`, and `delete` return top-level fields, but `covers add`, `thumbnail set`, and `content set` still wrap their payload in the `{success, …, result}` envelope — read those under `.result`
 - `webhooks list` → `.resource_subscriptions[]`
 - `admin users info` → `.user` (includes `.user.stripe` Stripe Connect state — `connected`, and when connected `stripe_connect_account_id`, `stripe_dashboard_url`, and a `verification` block of flags/counts or an `error` subfield when the live Stripe lookup failed — and `.user.admin_links` impersonate/user/purchases/stripe-dashboard URLs)
+- `admin users social-connections` → `.social_connections[]` (stored verification, `currently_linked`, timestamps, nullable audience counts, and `shared_identity_user_count`; not a payout approval)
 - `admin users affiliates` → `.affiliates[]`
 - `admin users comments list` → `.comments[]`
 - `admin users comments add` → `.comment`
@@ -242,6 +243,14 @@ gumroad admin users radar --username sellerone --limit 50 --json --non-interacti
 gumroad admin users purchases --user-id 2245593582708 --status successful --has-early-fraud-warning=false --limit 50 --json --non-interactive --no-input
 gumroad admin users purchases --username sellerone --status successful --limit 50 --json --non-interactive --no-input
 gumroad admin users suspension --username sellerone --json --non-interactive --no-input
+
+# Stored social evidence is optional positive context, never payout approval.
+# Check currently_linked and last_verified_at; missing audience counts are unknown.
+gumroad admin users social-connections --email seller@example.com --json --non-interactive --no-input
+# --plain columns: platform, uid, handle, currently_linked, last_verified_at,
+# account_created_at, follower_count, post_count, last_posted_at, shared_identity_user_count.
+# Historical disconnected rows remain evidence, not a live link. This command does not
+# refresh providers or expose shadow scores; use normal identity/risk review before release.
 
 # Find related accounts by risk signals
 gumroad admin users related --email seller@example.com --signal ip --signal payment_address --json --non-interactive --no-input


### PR DESCRIPTION
## What

Adds `gumroad admin users social-connections`, a read-only view of the existing internal admin endpoint. Shows whether each connection is currently linked, when it was verified, account/post history, and shared-identity count. Unknown audience counts stay distinct from zero. JSON/JQ preserve the full server response; plain output has a documented column order.

This is one reviewer-tooling slice of https://github.com/antiwork/gumroad-private/issues/2371, not completion of that tracker. It does not add onboarding prompts, expose shadow scores, refresh providers, change eligibility, or release payouts.

## Why

Social verification is already collected and exposed by the Rails API, but the CLI had no command to read it. Reusing the existing admin client avoids a parallel authorization or scoring implementation. Disconnected historical evidence is explicitly not presented as a current connection or payout approval.

## Before/After

Recorded real main/branch binaries against a local API fixture matching the Rails serializer; no production accounts or writes. Main rejects the command; the branch renders disconnected evidence, unknown followers, zero posts, and shared identity. The recording was inspected by frame extraction and OCR. This is a CLI flow, not a hosted web UI.

https://github.com/user-attachments/assets/c11b8fd2-fe9d-4e08-9aec-86a95506973a

## Test Results

- [x] `make test-cover GOFLAGS=-p=1` — full suite and all coverage gates pass; admin users coverage 86.4%.
- [x] CI-pinned golangci-lint v1.64.8, gofmt and diff checks pass.
- [x] New command tested through all three lookup flags, JSON/JQ/plain/quiet output, unknown versus zero counts, empty results, target validation, server errors, and control-character escaping.
- [x] Mutation proof: forcing a disconnected identity to render as linked fails all three lookup cases; source restored byte-for-byte.
- [x] Development review and final Astra+Fable code/specs/comments/evidence audit completed. Earlier coverage findings and the redundant comment were fixed.
- [x] Current-head build/test CI: five successful checks, none pending or failed; Tastelint passes. A fresh Greptile pass is pending after the final push.
- [ ] Gianfranco: review the risk-evidence presentation and merge/release decision. Auto-merge is off because this output informs payout-hold reviews.

The initial parallel suite hit timeout-sensitive media-upload tests; the same failure reproduced on unchanged main. Serial package execution passed the complete suite without changing those tests. The command recording remains current: later commits only strengthen tests and remove a comment.

## QA steps

Run `gumroad admin users social-connections --help`, then use an authorized existing admin lookup with `--json` to inspect stored evidence. Compare `currently_linked`, verification timestamps, nullable counts and shared identities against the same server response in human/plain modes. This does not fetch fresh provider data, expose shadow scores, approve sellers or release payouts.

Premerge review: clean @ a5cd84483c62137ee5c9e5c0c89e0b58cb5ef926

---
AI-assisted with OpenAI GPT-6 Astra via Hermes. Instructions: drain qualifying backlog, make verified social evidence available to risk reviewers through the CLI, preserve read-only scope and unknown/current-link distinctions, add tests and real command evidence. No automatic payout release or rollout changes.

![gp2371-tests](https://github.com/user-attachments/assets/9e029d53-bdf6-48cd-9e65-6a814c681e3b)