### PR TITLE
Show dated historical social shadow results in admin CLI

### DIFF
--- a/internal/cmd/admin/users/social_connections.go
+++ b/internal/cmd/admin/users/social_connections.go
@@ -1,11 +1,13 @@
 package users
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"strconv"
 
 	"github.com/antiwork/gumroad-cli/internal/admincmd"
+	"github.com/antiwork/gumroad-cli/internal/api"
 	"github.com/antiwork/gumroad-cli/internal/cmdutil"
 	"github.com/antiwork/gumroad-cli/internal/output"
 	"github.com/spf13/cobra"
@@ -19,8 +21,8 @@ type socialConnectionsResponse struct {
 type socialShadowEvaluation struct {
 	EvaluatedOn        string          `json:"evaluated_on"`
 	RecordedAt         string          `json:"recorded_at"`
-	Score              *int64          `json:"score"`
-	UnpaidBalanceCents *int64          `json:"unpaid_balance_cents"`
+	Score              *api.JSONInt    `json:"score"`
+	UnpaidBalanceCents *api.JSONInt    `json:"unpaid_balance_cents"`
 	WouldHaveReleased  *bool           `json:"would_have_released"`
 	HoldSource         string          `json:"hold_source"`
 	Signals            json.RawMessage `json:"signals"`
@@ -121,11 +123,11 @@ func renderSocialShadowEvaluation(opts cmdutil.Options, evaluation *socialShadow
 	rows := [][2]string{
 		{"Evaluated on", fallback(evaluation.EvaluatedOn, "unknown")},
 		{"Recorded at", fallback(evaluation.RecordedAt, "unknown")},
-		{"Stored score", socialCount(evaluation.Score)},
-		{"Unpaid balance at evaluation time (cents)", socialCount(evaluation.UnpaidBalanceCents)},
+		{"Stored score", socialNullableInt(evaluation.Score)},
+		{"Unpaid balance at evaluation time (cents)", socialNullableInt(evaluation.UnpaidBalanceCents)},
 		{"Would have released at evaluation time (shadow only)", outcome},
 		{"Hold source at evaluation time", fallback(evaluation.HoldSource, "unknown")},
-		{"Stored signals", fallback(string(evaluation.Signals), "unknown")},
+		{"Stored signals", socialSignals(evaluation.Signals)},
 	}
 	for _, row := range rows {
 		if err := output.Writef(opts.Out(), "%s: %s\n", row[0], output.EscapePlainField(row[1])); err != nil {
@@ -140,4 +142,19 @@ func socialCount(value *int64) string {
 		return "unknown"
 	}
 	return fmt.Sprint(*value)
+}
+
+func socialNullableInt(value *api.JSONInt) string {
+	if value == nil {
+		return "unknown"
+	}
+	return fmt.Sprint(int(*value))
+}
+
+func socialSignals(raw json.RawMessage) string {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return "unknown"
+	}
+	return string(trimmed)
 }

--- a/internal/cmd/admin/users/social_connections.go
+++ b/internal/cmd/admin/users/social_connections.go
@@ -17,13 +17,13 @@ type socialConnectionsResponse struct {
 }
 
 type socialShadowEvaluation struct {
-	EvaluatedOn         string          `json:"evaluated_on"`
-	RecordedAt          string          `json:"recorded_at"`
-	Score               *int64          `json:"score"`
-	UnpaidBalanceCents  *int64          `json:"unpaid_balance_cents"`
-	WouldHaveReleased   *bool           `json:"would_have_released"`
-	HoldSource          string          `json:"hold_source"`
-	Signals             json.RawMessage `json:"signals"`
+	EvaluatedOn        string          `json:"evaluated_on"`
+	RecordedAt         string          `json:"recorded_at"`
+	Score              *int64          `json:"score"`
+	UnpaidBalanceCents *int64          `json:"unpaid_balance_cents"`
+	WouldHaveReleased  *bool           `json:"would_have_released"`
+	HoldSource         string          `json:"hold_source"`
+	Signals            json.RawMessage `json:"signals"`
 }
 
 type socialConnection struct {

--- a/internal/cmd/admin/users/social_connections.go
+++ b/internal/cmd/admin/users/social_connections.go
@@ -19,8 +19,8 @@ type socialConnectionsResponse struct {
 type socialShadowEvaluation struct {
 	EvaluatedOn       string          `json:"evaluated_on"`
 	RecordedAt        string          `json:"recorded_at"`
-	Score             int             `json:"score"`
-	WouldHaveReleased bool            `json:"would_have_released"`
+	Score             *int64          `json:"score"`
+	WouldHaveReleased *bool           `json:"would_have_released"`
 	HoldSource        string          `json:"hold_source"`
 	Signals           json.RawMessage `json:"signals"`
 }
@@ -113,11 +113,15 @@ func renderSocialShadowEvaluation(opts cmdutil.Options, evaluation *socialShadow
 	if err := output.Writeln(opts.Out(), "Historical SHADOW evaluation (not current eligibility or payout authorization):"); err != nil {
 		return err
 	}
+	outcome := "unknown"
+	if evaluation.WouldHaveReleased != nil {
+		outcome = strconv.FormatBool(*evaluation.WouldHaveReleased)
+	}
 	rows := [][2]string{
 		{"Evaluated on", fallback(evaluation.EvaluatedOn, "unknown")},
 		{"Recorded at", fallback(evaluation.RecordedAt, "unknown")},
-		{"Stored score", strconv.Itoa(evaluation.Score)},
-		{"Would have released at evaluation time (shadow only)", strconv.FormatBool(evaluation.WouldHaveReleased)},
+		{"Stored score", socialCount(evaluation.Score)},
+		{"Would have released at evaluation time (shadow only)", outcome},
 		{"Hold source at evaluation time", fallback(evaluation.HoldSource, "unknown")},
 		{"Stored signals", fallback(string(evaluation.Signals), "unknown")},
 	}

--- a/internal/cmd/admin/users/social_connections.go
+++ b/internal/cmd/admin/users/social_connections.go
@@ -17,12 +17,13 @@ type socialConnectionsResponse struct {
 }
 
 type socialShadowEvaluation struct {
-	EvaluatedOn       string          `json:"evaluated_on"`
-	RecordedAt        string          `json:"recorded_at"`
-	Score             *int64          `json:"score"`
-	WouldHaveReleased *bool           `json:"would_have_released"`
-	HoldSource        string          `json:"hold_source"`
-	Signals           json.RawMessage `json:"signals"`
+	EvaluatedOn         string          `json:"evaluated_on"`
+	RecordedAt          string          `json:"recorded_at"`
+	Score               *int64          `json:"score"`
+	UnpaidBalanceCents  *int64          `json:"unpaid_balance_cents"`
+	WouldHaveReleased   *bool           `json:"would_have_released"`
+	HoldSource          string          `json:"hold_source"`
+	Signals             json.RawMessage `json:"signals"`
 }
 
 type socialConnection struct {
@@ -121,6 +122,7 @@ func renderSocialShadowEvaluation(opts cmdutil.Options, evaluation *socialShadow
 		{"Evaluated on", fallback(evaluation.EvaluatedOn, "unknown")},
 		{"Recorded at", fallback(evaluation.RecordedAt, "unknown")},
 		{"Stored score", socialCount(evaluation.Score)},
+		{"Unpaid balance at evaluation time (cents)", socialCount(evaluation.UnpaidBalanceCents)},
 		{"Would have released at evaluation time (shadow only)", outcome},
 		{"Hold source at evaluation time", fallback(evaluation.HoldSource, "unknown")},
 		{"Stored signals", fallback(string(evaluation.Signals), "unknown")},

--- a/internal/cmd/admin/users/social_connections.go
+++ b/internal/cmd/admin/users/social_connections.go
@@ -1,6 +1,7 @@
 package users
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 
@@ -11,7 +12,17 @@ import (
 )
 
 type socialConnectionsResponse struct {
-	SocialConnections []socialConnection `json:"social_connections"`
+	SocialConnections      []socialConnection      `json:"social_connections"`
+	LatestShadowEvaluation *socialShadowEvaluation `json:"latest_shadow_evaluation"`
+}
+
+type socialShadowEvaluation struct {
+	EvaluatedOn       string          `json:"evaluated_on"`
+	RecordedAt        string          `json:"recorded_at"`
+	Score             int             `json:"score"`
+	WouldHaveReleased bool            `json:"would_have_released"`
+	HoldSource        string          `json:"hold_source"`
+	Signals           json.RawMessage `json:"signals"`
 }
 
 type socialConnection struct {
@@ -36,7 +47,11 @@ func newSocialConnectionsCmd() *cobra.Command {
 verification timestamps, audience history, and shared identities. Historical
 verification is not proof of a current connection. Missing counts are unknown,
 not zero. This read-only command does not refresh providers, score eligibility,
-mark a seller compliant, or release payouts.`,
+mark a seller compliant, or release payouts. When available, it also shows the
+latest dated historical SHADOW evaluation, not current eligibility or payout
+authorization. Missing or null evaluations mean no snapshot was supplied, not a
+negative score. --plain keeps connection-only rows; use --json or --jq for the
+shadow snapshot.`,
 		Example: `  gumroad admin users social-connections --user-id 2245593582708
   gumroad admin users social-connections --email seller@example.com --json`,
 		Args: cmdutil.ExactArgs(0),
@@ -69,7 +84,10 @@ func renderSocialConnections(opts cmdutil.Options, resp socialConnectionsRespons
 		return nil
 	}
 	if len(rows) == 0 {
-		return cmdutil.PrintInfo(opts, "No stored social verification evidence.")
+		if err := cmdutil.PrintInfo(opts, "No stored social verification evidence."); err != nil {
+			return err
+		}
+		return renderSocialShadowEvaluation(opts, resp.LatestShadowEvaluation)
 	}
 	if err := output.Writeln(opts.Out(), "Stored social evidence (not payout approval):"); err != nil {
 		return err
@@ -82,6 +100,29 @@ func renderSocialConnections(opts cmdutil.Options, resp socialConnectionsRespons
 			}
 		}
 		if err := output.Writeln(opts.Out(), ""); err != nil {
+			return err
+		}
+	}
+	return renderSocialShadowEvaluation(opts, resp.LatestShadowEvaluation)
+}
+
+func renderSocialShadowEvaluation(opts cmdutil.Options, evaluation *socialShadowEvaluation) error {
+	if evaluation == nil {
+		return output.Writeln(opts.Out(), "No stored shadow evaluation supplied (not a negative score).")
+	}
+	if err := output.Writeln(opts.Out(), "Historical SHADOW evaluation (not current eligibility or payout authorization):"); err != nil {
+		return err
+	}
+	rows := [][2]string{
+		{"Evaluated on", fallback(evaluation.EvaluatedOn, "unknown")},
+		{"Recorded at", fallback(evaluation.RecordedAt, "unknown")},
+		{"Stored score", strconv.Itoa(evaluation.Score)},
+		{"Would have released at evaluation time (shadow only)", strconv.FormatBool(evaluation.WouldHaveReleased)},
+		{"Hold source at evaluation time", fallback(evaluation.HoldSource, "unknown")},
+		{"Stored signals", fallback(string(evaluation.Signals), "unknown")},
+	}
+	for _, row := range rows {
+		if err := output.Writef(opts.Out(), "%s: %s\n", row[0], output.EscapePlainField(row[1])); err != nil {
 			return err
 		}
 	}

--- a/internal/cmd/admin/users/social_shadow_test.go
+++ b/internal/cmd/admin/users/social_shadow_test.go
@@ -14,7 +14,7 @@ import (
 const shadowFixture = `{"mode":"historical_shadow","notice":"Stored shadow evidence only; not current eligibility or payout authorization.","evaluated_on":"2026-09-02","recorded_at":"2026-09-03T12:00:00Z","score":70,"would_have_released":true,"hold_source":"risk_state_not_reviewed","signals":{"platform":"twitter","components":{"followers":25}},"future_field":"preserved"}`
 
 func TestSocialShadowOutput(t *testing.T) {
-	for _, state := range []string{"missing", "null", "present", "no connections", "zero", "escaping"} {
+	for _, state := range []string{"missing", "null", "present", "no connections", "zero", "escaping", "null fields", "missing fields"} {
 		t.Run(state, func(t *testing.T) {
 			payload := map[string]any{}
 			if err := json.Unmarshal([]byte(socialEvidenceFixture), &payload); err != nil {
@@ -32,6 +32,14 @@ func TestSocialShadowOutput(t *testing.T) {
 					shadow["score"] = float64(0)
 					shadow["would_have_released"] = false
 					shadow["signals"] = nil
+				}
+				if state == "null fields" {
+					shadow["score"] = nil
+					shadow["would_have_released"] = nil
+				}
+				if state == "missing fields" {
+					delete(shadow, "score")
+					delete(shadow, "would_have_released")
 				}
 				if state == "escaping" {
 					shadow["hold_source"] = "bad\n\x1b[31m"
@@ -110,6 +118,9 @@ func TestSocialShadowOutput(t *testing.T) {
 								}
 							}
 							score, outcome := "70", "true"
+							if state == "null fields" || state == "missing fields" {
+								score, outcome = "unknown", "unknown"
+							}
 							if state == "zero" {
 								score, outcome = "0", "false"
 							}

--- a/internal/cmd/admin/users/social_shadow_test.go
+++ b/internal/cmd/admin/users/social_shadow_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/antiwork/gumroad-cli/internal/testutil"
 )
 
-const shadowFixture = `{"mode":"historical_shadow","notice":"Stored shadow evidence only; not current eligibility or payout authorization.","evaluated_on":"2026-09-02","recorded_at":"2026-09-03T12:00:00Z","score":70,"would_have_released":true,"hold_source":"risk_state_not_reviewed","signals":{"platform":"twitter","components":{"followers":25}},"future_field":"preserved"}`
+const shadowFixture = `{"mode":"historical_shadow","notice":"Stored shadow evidence only; not current eligibility or payout authorization.","evaluated_on":"2026-09-02","recorded_at":"2026-09-03T12:00:00Z","score":70,"unpaid_balance_cents":10000,"would_have_released":true,"hold_source":"risk_state_not_reviewed","signals":{"platform":"twitter","components":{"followers":25}},"future_field":"preserved"}`
 
 func TestSocialShadowOutput(t *testing.T) {
 	for _, state := range []string{"missing", "null", "present", "no connections", "zero", "escaping", "null fields", "missing fields"} {
@@ -30,15 +30,18 @@ func TestSocialShadowOutput(t *testing.T) {
 				}
 				if state == "zero" {
 					shadow["score"] = float64(0)
+					shadow["unpaid_balance_cents"] = float64(0)
 					shadow["would_have_released"] = false
 					shadow["signals"] = nil
 				}
 				if state == "null fields" {
 					shadow["score"] = nil
+					shadow["unpaid_balance_cents"] = nil
 					shadow["would_have_released"] = nil
 				}
 				if state == "missing fields" {
 					delete(shadow, "score")
+					delete(shadow, "unpaid_balance_cents")
 					delete(shadow, "would_have_released")
 				}
 				if state == "escaping" {
@@ -117,14 +120,14 @@ func TestSocialShadowOutput(t *testing.T) {
 									t.Fatalf("missing %q: %s", want, out.String())
 								}
 							}
-							score, outcome := "70", "true"
+							score, unpaid, outcome := "70", "10000", "true"
 							if state == "null fields" || state == "missing fields" {
-								score, outcome = "unknown", "unknown"
+								score, unpaid, outcome = "unknown", "unknown", "unknown"
 							}
 							if state == "zero" {
-								score, outcome = "0", "false"
+								score, unpaid, outcome = "0", "0", "false"
 							}
-							if !strings.Contains(out.String(), "Stored score: "+score) || !strings.Contains(out.String(), "Would have released at evaluation time (shadow only): "+outcome) {
+							if !strings.Contains(out.String(), "Stored score: "+score) || !strings.Contains(out.String(), "Unpaid balance at evaluation time (cents): "+unpaid) || !strings.Contains(out.String(), "Would have released at evaluation time (shadow only): "+outcome) {
 								t.Fatal(out.String())
 							}
 							if strings.Contains(out.String(), "\x1b[31m") || strings.Contains(out.String(), "bad\n") {

--- a/internal/cmd/admin/users/social_shadow_test.go
+++ b/internal/cmd/admin/users/social_shadow_test.go
@@ -1,0 +1,131 @@
+package users
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/antiwork/gumroad-cli/internal/testutil"
+)
+
+const shadowFixture = `{"mode":"historical_shadow","notice":"Stored shadow evidence only; not current eligibility or payout authorization.","evaluated_on":"2026-09-02","recorded_at":"2026-09-03T12:00:00Z","score":70,"would_have_released":true,"hold_source":"risk_state_not_reviewed","signals":{"platform":"twitter","components":{"followers":25}},"future_field":"preserved"}`
+
+func TestSocialShadowOutput(t *testing.T) {
+	for _, state := range []string{"missing", "null", "present", "no connections", "zero", "escaping"} {
+		t.Run(state, func(t *testing.T) {
+			payload := map[string]any{}
+			if err := json.Unmarshal([]byte(socialEvidenceFixture), &payload); err != nil {
+				t.Fatal(err)
+			}
+			if state != "missing" {
+				payload["latest_shadow_evaluation"] = nil
+			}
+			if state != "missing" && state != "null" {
+				shadow := map[string]any{}
+				if err := json.Unmarshal([]byte(shadowFixture), &shadow); err != nil {
+					t.Fatal(err)
+				}
+				if state == "zero" {
+					shadow["score"] = float64(0)
+					shadow["would_have_released"] = false
+					shadow["signals"] = nil
+				}
+				if state == "escaping" {
+					shadow["hold_source"] = "bad\n\x1b[31m"
+					shadow["recorded_at"] = "date\n\x1b[31m"
+				}
+				payload["latest_shadow_evaluation"] = shadow
+			}
+			if state == "no connections" {
+				payload["social_connections"] = []any{}
+			}
+			data, err := json.Marshal(payload)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, mode := range []string{"human", "json", "jq", "plain", "quiet"} {
+				t.Run(mode, func(t *testing.T) {
+					requests := 0
+					testutil.SetupAdmin(t, func(w http.ResponseWriter, r *http.Request) {
+						requests++
+						if r.Method != http.MethodGet || r.URL.Path != "/internal/admin/users/social_connections" {
+							t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+						}
+						testutil.RawJSON(t, w, string(data))
+					})
+					var out bytes.Buffer
+					cmd := testutil.Command(newSocialConnectionsCmd(), testutil.Stdout(&out), testutil.Quiet(false))
+					switch mode {
+					case "json":
+						cmd = testutil.Command(newSocialConnectionsCmd(), testutil.Stdout(&out), testutil.JSONOutput())
+					case "jq":
+						cmd = testutil.Command(newSocialConnectionsCmd(), testutil.Stdout(&out), testutil.JQ(".latest_shadow_evaluation"))
+					case "plain":
+						cmd = testutil.Command(newSocialConnectionsCmd(), testutil.Stdout(&out), testutil.PlainOutput())
+					case "quiet":
+						cmd = testutil.Command(newSocialConnectionsCmd(), testutil.Stdout(&out), testutil.Quiet(true))
+					}
+					cmd.SetArgs([]string{"--email", "seller@example.com"})
+					testutil.MustExecute(t, cmd)
+					if requests != 1 {
+						t.Fatalf("requests = %d", requests)
+					}
+					switch mode {
+					case "json", "jq":
+						var got any
+						if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+							t.Fatal(err)
+						}
+						var want any = payload
+						if mode == "jq" {
+							want = payload["latest_shadow_evaluation"]
+						}
+						if !reflect.DeepEqual(got, want) {
+							t.Fatalf("output changed: %s", out.String())
+						}
+					case "quiet":
+						if out.Len() != 0 {
+							t.Fatal(out.String())
+						}
+					case "plain":
+						want := "instagram\t1234\tseller\tfalse\t2026-09-01T12:00:00Z\t\tunknown\t0\t\t2\n"
+						if state == "no connections" {
+							want = ""
+						}
+						if out.String() != want {
+							t.Fatalf("plain schema changed: %q", out.String())
+						}
+					case "human":
+						if state == "missing" || state == "null" {
+							if !strings.Contains(out.String(), "No stored shadow evaluation supplied (not a negative score).") || strings.Contains(out.String(), "Stored score:") {
+								t.Fatal(out.String())
+							}
+						} else {
+							for _, want := range []string{"Historical SHADOW evaluation (not current eligibility or payout authorization)", "Evaluated on: 2026-09-02", "Stored signals:"} {
+								if !strings.Contains(out.String(), want) {
+									t.Fatalf("missing %q: %s", want, out.String())
+								}
+							}
+							score, outcome := "70", "true"
+							if state == "zero" {
+								score, outcome = "0", "false"
+							}
+							if !strings.Contains(out.String(), "Stored score: "+score) || !strings.Contains(out.String(), "Would have released at evaluation time (shadow only): "+outcome) {
+								t.Fatal(out.String())
+							}
+							if strings.Contains(out.String(), "\x1b[31m") || strings.Contains(out.String(), "bad\n") {
+								t.Fatalf("unescaped: %q", out.String())
+							}
+						}
+						if state != "no connections" && !strings.Contains(out.String(), "Currently linked: false") {
+							t.Fatal("lost connections")
+						}
+					}
+				})
+			}
+		})
+	}
+}

--- a/internal/cmd/admin/users/social_shadow_test.go
+++ b/internal/cmd/admin/users/social_shadow_test.go
@@ -126,6 +126,9 @@ func TestSocialShadowOutput(t *testing.T) {
 							}
 							if state == "zero" {
 								score, unpaid, outcome = "0", "0", "false"
+								if !strings.Contains(out.String(), "Stored signals: unknown\n") {
+									t.Fatalf("null signals not rendered as unknown: %s", out.String())
+								}
 							}
 							if !strings.Contains(out.String(), "Stored score: "+score) || !strings.Contains(out.String(), "Unpaid balance at evaluation time (cents): "+unpaid) || !strings.Contains(out.String(), "Would have released at evaluation time (shadow only): "+outcome) {
 								t.Fatal(out.String())

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -111,7 +111,7 @@ Most responses are wrapped in `{"success": true, ...}` with resource-specific ke
 - Not every `products` write verb is flat: `create`, `update`, `unpublish`, and `delete` return top-level fields, but `covers add`, `thumbnail set`, and `content set` still wrap their payload in the `{success, …, result}` envelope — read those under `.result`
 - `webhooks list` → `.resource_subscriptions[]`
 - `admin users info` → `.user` (includes `.user.stripe` Stripe Connect state — `connected`, and when connected `stripe_connect_account_id`, `stripe_dashboard_url`, and a `verification` block of flags/counts or an `error` subfield when the live Stripe lookup failed — and `.user.admin_links` impersonate/user/purchases/stripe-dashboard URLs)
-- `admin users social-connections` → `.social_connections[]` (stored verification, `currently_linked`, timestamps, nullable audience counts, and `shared_identity_user_count`) and optional `.latest_shadow_evaluation` (null or missing without a supplied snapshot; otherwise `mode: historical_shadow`, `evaluated_on`, `recorded_at`, stored `score`, `would_have_released`, `hold_source`, `signals`). Historical shadow evidence is not current eligibility or payout authorization.
+- `admin users social-connections` → `.social_connections[]` (stored verification, `currently_linked`, timestamps, nullable audience counts, and `shared_identity_user_count`) and optional `.latest_shadow_evaluation` (null or missing without a supplied snapshot; otherwise `mode: historical_shadow`, `evaluated_on`, `recorded_at`, stored `score`, `unpaid_balance_cents`, `would_have_released`, `hold_source`, `signals`). Historical shadow evidence is not current eligibility or payout authorization.
 - `admin users affiliates` → `.affiliates[]`
 - `admin users comments list` → `.comments[]`
 - `admin users comments add` → `.comment`
@@ -253,7 +253,8 @@ gumroad admin users social-connections --email seller@example.com --json --non-i
 # --plain columns: platform, uid, handle, currently_linked, last_verified_at,
 # account_created_at, follower_count, post_count, last_posted_at, shared_identity_user_count.
 # Historical disconnected rows remain evidence, not a live link. This command does not
-# refresh providers or expose shadow scores; use normal identity/risk review before release.
+# refresh providers or authorize payouts; human mode may show a Stored score from a
+# historical shadow snapshot only. Use normal identity/risk review before release.
 
 # Find related accounts by risk signals
 gumroad admin users related --email seller@example.com --signal ip --signal payment_address --json --non-interactive --no-input

--- a/skills/gumroad/SKILL.md
+++ b/skills/gumroad/SKILL.md
@@ -111,7 +111,7 @@ Most responses are wrapped in `{"success": true, ...}` with resource-specific ke
 - Not every `products` write verb is flat: `create`, `update`, `unpublish`, and `delete` return top-level fields, but `covers add`, `thumbnail set`, and `content set` still wrap their payload in the `{success, …, result}` envelope — read those under `.result`
 - `webhooks list` → `.resource_subscriptions[]`
 - `admin users info` → `.user` (includes `.user.stripe` Stripe Connect state — `connected`, and when connected `stripe_connect_account_id`, `stripe_dashboard_url`, and a `verification` block of flags/counts or an `error` subfield when the live Stripe lookup failed — and `.user.admin_links` impersonate/user/purchases/stripe-dashboard URLs)
-- `admin users social-connections` → `.social_connections[]` (stored verification, `currently_linked`, timestamps, nullable audience counts, and `shared_identity_user_count`; not a payout approval)
+- `admin users social-connections` → `.social_connections[]` (stored verification, `currently_linked`, timestamps, nullable audience counts, and `shared_identity_user_count`) and optional `.latest_shadow_evaluation` (null or missing without a supplied snapshot; otherwise `mode: historical_shadow`, `evaluated_on`, `recorded_at`, stored `score`, `would_have_released`, `hold_source`, `signals`). Historical shadow evidence is not current eligibility or payout authorization.
 - `admin users affiliates` → `.affiliates[]`
 - `admin users comments list` → `.comments[]`
 - `admin users comments add` → `.comment`
@@ -246,6 +246,9 @@ gumroad admin users suspension --username sellerone --json --non-interactive --n
 
 # Stored social evidence is optional positive context, never payout approval.
 # Check currently_linked and last_verified_at; missing audience counts are unknown.
+# Historical SHADOW results describe evaluated_on, never current eligibility or payout authority.
+# Missing/null shadow snapshots are not negative scores. --plain remains connection-only;
+# use --json or --jq .latest_shadow_evaluation to read the snapshot.
 gumroad admin users social-connections --email seller@example.com --json --non-interactive --no-input
 # --plain columns: platform, uid, handle, currently_linked, last_verified_at,
 # account_created_at, follower_count, post_count, last_posted_at, shared_identity_user_count.


### PR DESCRIPTION
## September 8 CI repair

The new unpaid-balance field left the Go struct out of `gofmt` alignment, failing the quality job at `e204895582ec2aaed7fabac8f5594ae2ca3ea697`. Commit `7c7d49bda8e153f8d20b5d428d4eca414d85dee1` changes whitespace only and preserves Gianfranco's field and rendering behavior.

- Full environment-clean `make test-cover` passed, including coverage gates. The first local attempt inherited a token that overrode the integration-test credential and failed authentication; removing the inherited token restored the test environment without changing tests.
- CI-pinned `golangci-lint v1.64.8`, focused `TestSocial` tests, `gofmt`, and `git diff --check` pass. The installed newer linter does not accept this repository's configuration, so the CI-pinned version was used.
- Current-head Astra + Fable panel: zero accepted/actionable findings from both engines; TruffleHog clean.
- The video and the older results below are historical evidence, not a new recording of the unpaid-balance field. This sweep does not claim current-head media acceptance, request final review, merge, or arm auto-merge. Gianfranco retains ownership of the risk-evidence change.

Premerge review: clean @ 7c7d49bda8e153f8d20b5d428d4eca414d85dee1

## What
Show the latest historical SHADOW evaluation in `gumroad admin users social-connections`, with evaluation/recording dates, stored score/outcome, hold source and signals. Explicitly not current eligibility or payout authorization.

## Why
Consume the optional field from https://github.com/antiwork/gumroad/pull/7534 without rescoring or mutations. Older servers remain supported: missing/null snapshots are not negative scores, and absent score/outcome fields remain unknown rather than becoming zero/false. `--plain` preserves its connection-only schema; JSON/JQ retain the complete response.

## Before/After
Before: connections only. After: connections plus dated historical evidence, including when no current connection remains. This local terminal recording replays actual Rails controller responses captured with synthetic fixtures, not production data. It shows old-server compatibility, null snapshots, dated results, JSON/JQ and the underlying read-only query proof. CLI binary built from the current head; no UI, provider or money action.

https://github.com/user-attachments/assets/9a7491e4-1bc2-440e-953c-3bb9901466c2

QA: `go test ./internal/cmd/admin/users/ -run TestSocial -count=1`; against a configured test API run `gumroad admin users social-connections --email "$TEST_SELLER_EMAIL"`, then `--jq .latest_shadow_evaluation`. Verify the historical date/warning and unchanged connection rows. `--plain` deliberately excludes the snapshot to preserve its existing ten-column contract.

## Test Results
- Environment-clean `make test-cover GOFLAGS=-p=1`: full suite and coverage gates pass at the current head.
- CI-pinned `go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run ./internal/...`: passes. `gofmt` and `git diff --check` pass; before/after binaries built successfully.
- Human/JSON/JQ/plain/quiet coverage: missing/null/present snapshots, no connections, zero/false, hostile strings, and null/missing numeric/boolean fields. One GET only; JSON unknown fields preserved.
- Removing shadow rendering reddens the new output tests; original source restored. API companion separately proves scoped/date-ordered reads and unchanged seller/evaluation rows.
- Local Astra dev review clean. Astra+Fable round 1 found unknown scalar values rendered as zero/false; fixed with nullable fields and regression cases. Round 2 is clean at the current head.
- Final code/spec/comment and evidence audit complete: inspected the real terminal frames, historical date/warnings and scoped SQL proof. No manufactured test screenshot; actual checks listed here.
- Current-head CI passes. Gianfranco reviews this risk-evidence consumer. No auto-merge. Either PR may merge first; the CLI does not show a snapshot until the optional API field is deployed. Nothing deployed/released here.

Historical premerge review: clean @ 4175e475bed15c75e3645a93c3ba7d1a55558766

---
AI disclosure: OpenAI GPT-6 Astra (`openai/gpt-6-astra`). Prompt: expose latest stored social shadow evidence in the existing read-only API and CLI; date/label historical results, preserve older-server behavior and connection output, verify all modes, and do not alter scoring, holds, flags, credentials or move money. Follow-up: preserve unknown scalar fields instead of displaying zero/false.
