### PR TITLE
test: make direct upload timeout tests deterministic

### DIFF
--- a/internal/cmd/media/media_test.go
+++ b/internal/cmd/media/media_test.go
@@ -36,6 +36,20 @@ var pngBytes = []byte{
 	0x89,
 }
 
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func timingOutDirectUploadClient(calls *atomic.Int32) *http.Client {
+	return &http.Client{Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		calls.Add(1)
+		<-r.Context().Done()
+		return nil, r.Context().Err()
+	})}
+}
+
 type mediaServers struct {
 	s3      *httptest.Server
 	s3Calls atomic.Int32
@@ -737,14 +751,8 @@ func TestPutDirectUpload_RetriesTransientFailureWithFreshBody(t *testing.T) {
 
 func TestPutDirectUpload_TimesOutEachAttempt(t *testing.T) {
 	var calls atomic.Int32
-	s3 := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		calls.Add(1)
-		time.Sleep(200 * time.Millisecond)
-		w.WriteHeader(http.StatusOK)
-	}))
-	t.Cleanup(s3.Close)
 	prevClient := s3HTTPClientForTesting
-	s3HTTPClientForTesting = s3.Client()
+	s3HTTPClientForTesting = timingOutDirectUploadClient(&calls)
 	t.Cleanup(func() { s3HTTPClientForTesting = prevClient })
 	prevTimeout := directUploadAttemptTimeout
 	directUploadAttemptTimeout = 20 * time.Millisecond
@@ -754,7 +762,7 @@ func TestPutDirectUpload_TimesOutEachAttempt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("describeMediaUpload: %v", err)
 	}
-	err = putDirectUpload(cmdutil.Options{Context: context.Background()}, plan, s3.URL+"/upload", nil)
+	err = putDirectUpload(cmdutil.Options{Context: context.Background()}, plan, "https://example.com/upload", nil)
 	if err == nil || !strings.Contains(err.Error(), "after 3 attempts") {
 		t.Fatalf("err = %v, want bounded retry failure", err)
 	}
@@ -765,14 +773,8 @@ func TestPutDirectUpload_TimesOutEachAttempt(t *testing.T) {
 
 func TestMediaUpload_DirectStateUnknownCarriesRecovery(t *testing.T) {
 	var s3Calls atomic.Int32
-	s3 := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		s3Calls.Add(1)
-		time.Sleep(200 * time.Millisecond)
-		w.WriteHeader(http.StatusOK)
-	}))
-	t.Cleanup(s3.Close)
 	prevClient := s3HTTPClientForTesting
-	s3HTTPClientForTesting = s3.Client()
+	s3HTTPClientForTesting = timingOutDirectUploadClient(&s3Calls)
 	t.Cleanup(func() { s3HTTPClientForTesting = prevClient })
 	prevTimeout := directUploadAttemptTimeout
 	directUploadAttemptTimeout = 20 * time.Millisecond
@@ -787,7 +789,7 @@ func TestMediaUpload_DirectStateUnknownCarriesRecovery(t *testing.T) {
 			"signed_id": "signed-1",
 			"key":       "abc123",
 			"direct_upload": map[string]any{
-				"url": s3.URL + "/upload",
+				"url": "https://example.com/upload",
 			},
 		})
 	})


### PR DESCRIPTION
## What

Stabilizes the two direct-upload timeout tests by replacing their delayed TLS handlers with a local `RoundTripper` that records each client attempt synchronously and returns the request-context deadline error.

## Why

The retry loop already makes three attempts, but the previous handler counter ran only after a canceled TLS request reached the server. On a slow final attempt, the client could return after cancellation before the handler began, intermittently producing `S3 calls = 2, want 3` despite all three retries occurring. The new transport observes the client boundary directly without changing production retry behavior.

## Before/After

[Terminal walkthrough (MP4)](https://github.com/keithah/gumroad-cli/raw/70fb49a3ca13616063a702e0f77bb3ada165c83e/walkthrough.mp4) — shows the exact candidate and 20 repeated focused test runs.

Before, the TLS handler could be scheduled after the final request had already timed out, so the test sometimes saw two handler entries despite three client attempts. After, the transport records client attempts synchronously.

## Test Results

![Focused direct-upload timeout tests passing locally](https://github.com/keithah/gumroad-cli/raw/70fb49a3ca13616063a702e0f77bb3ada165c83e/test-results.png)

- `go test -count=100 -run '^(TestPutDirectUpload_TimesOutEachAttempt|TestMediaUpload_DirectStateUnknownCarriesRecovery)$' ./internal/cmd/media`
- `make test-cover`
- `make lint`
- `make test-race`
- `go test -count=1 ./...`
- `go build ./cmd/gumroad`

---

### AI disclosure

Produced with OpenAI GPT-5.6-terra.

Prompts:
- “is the test related to map-dispatch? if so, we can include it”
- “oh, this is a general problem with gumroad-cli? if its a bug, then yeah, lets PR it, keep it concise, follow contributing, dont include planning docs”
